### PR TITLE
Add CLI doc generator, guides, and docs-publish workflow

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: SSPL-1.0
+name: Publish CLI Docs
+
+on:
+  push:
+    branches: [develop, 'release*', main]
+
+jobs:
+  generate-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CLI repo
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CLI docs
+        run: go run ./cmd/docgen --output-dir=generated-docs/cli --version=${{ steps.version.outputs.version }}
+
+      - name: Checkout site repo
+        uses: actions/checkout@v4
+        with:
+          repository: NobleFactor/devlore.noblefactor.com
+          token: ${{ secrets.SITE_DEPLOY_TOKEN }}
+          path: site
+
+      - name: Update site content
+        run: |
+          rm -rf site/src/content/cli/
+          cp -r generated-docs/cli/ site/src/content/cli/
+          rm -rf site/src/content/guides/
+          cp -r docs/guides/ site/src/content/guides/
+
+      - name: Create PR on site repo
+        working-directory: site
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DEPLOY_TOKEN }}
+        run: |
+          BRANCH="cli-docs/update-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/content/cli/ src/content/guides/
+          if git diff --cached --quiet; then
+            echo "No changes to docs, skipping PR."
+            exit 0
+          fi
+          git commit -m "Update docs from devlore-cli@${GITHUB_SHA::7}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Update CLI documentation" \
+            --body "Automated update from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA}).
+
+Triggered by push to \`${GITHUB_REF_NAME}\` branch.
+
+Includes CLI reference (generated) and guides (hand-written)." \
+            --base develop

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+docs/cli/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(BUILD_DATE)"
 
-.PHONY: all build clean test vet lint shell-lint check dev
+.PHONY: all build clean test vet lint shell-lint check dev docs
 
 all: build
 
@@ -35,3 +35,6 @@ check: vet lint shell-lint test
 dev:
 	git config core.hooksPath .githooks
 	@echo "Hooks activated: .githooks/pre-commit"
+
+docs:
+	go run ./cmd/docgen --output-dir=docs/cli --version=$(VERSION)

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// Command docgen generates Docker-style CLI reference documentation
+// for the writ and lore commands.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NobleFactor/devlore-cli/internal/lore"
+	"github.com/NobleFactor/devlore-cli/internal/tools/docgen"
+	"github.com/NobleFactor/devlore-cli/internal/writ"
+)
+
+func main() {
+	outputDir := flag.String("output-dir", "docs/cli", "Output directory for generated docs")
+	version := flag.String("version", "dev", "Version string for generated docs")
+	flag.Parse()
+
+	if err := run(*outputDir, *version); err != nil {
+		fmt.Fprintf(os.Stderr, "docgen: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(outputDir, version string) error {
+	fmt.Println("Generating CLI reference documentation...")
+
+	writCmd := writ.NewRootCmd()
+	fmt.Printf("\nwrit (%d commands):\n", countCommands(writCmd))
+	if err := docgen.GenerateTree(writCmd, outputDir, "writ", version); err != nil {
+		return fmt.Errorf("generating writ docs: %w", err)
+	}
+
+	loreCmd := lore.NewRootCmd()
+	fmt.Printf("\nlore (%d commands):\n", countCommands(loreCmd))
+	if err := docgen.GenerateTree(loreCmd, outputDir, "lore", version); err != nil {
+		return fmt.Errorf("generating lore docs: %w", err)
+	}
+
+	fmt.Println("\nDone.")
+	return nil
+}
+
+func countCommands(cmd *cobra.Command) int {
+	count := 0
+	for _, c := range cmd.Commands() {
+		if !c.Hidden && c.Name() != "help" && c.Name() != "completion" && c.Name() != "man" && c.Name() != "version" {
+			count++
+			count += countCommands(c)
+		}
+	}
+	return count
+}

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,133 @@
+---
+title: "Getting Started"
+description: "Install DevLore and deploy your first environment"
+tool: "devlore"
+category: "tutorial"
+order: 1
+---
+
+# Getting Started with DevLore
+
+DevLore is a two-tool suite for managing portable development environments.
+**Writ** manages your dotfiles and configuration through platform-aware symlinks.
+**Lore** handles software installation by capturing tribal knowledge about packages.
+
+Together, they let you declare your environment once and deploy it everywhere you work.
+
+## What you'll learn
+
+- Install writ and lore
+- Initialize an environment repository
+- Deploy your first project
+- Install software from a manifest
+
+## Install
+
+Download the latest release for your platform:
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/NobleFactor/devlore-cli/releases/latest/download/writ-darwin-arm64 -o writ
+curl -L https://github.com/NobleFactor/devlore-cli/releases/latest/download/lore-darwin-arm64 -o lore
+
+# Linux (amd64)
+curl -L https://github.com/NobleFactor/devlore-cli/releases/latest/download/writ-linux-amd64 -o writ
+curl -L https://github.com/NobleFactor/devlore-cli/releases/latest/download/lore-linux-amd64 -o lore
+
+chmod +x writ lore
+sudo mv writ lore /usr/local/bin/
+```
+
+Or use the self-install command for shell completions and man pages:
+
+```bash
+writ self-install --prefix=~/.local
+lore self-install --prefix=~/.local
+```
+
+## Initialize a repository
+
+A writ repository is a directory containing your dotfiles organized into projects.
+Each project is a subdirectory whose files get symlinked to your home directory.
+
+```bash
+writ repo init --layer=personal
+```
+
+This creates a new git repository at `~/.local/share/devlore/repos/personal/` with
+the standard directory structure.
+
+## Create your first project
+
+A project is simply a directory in your repository. Files inside it mirror
+the structure of your home directory:
+
+```bash
+cd ~/.local/share/devlore/repos/personal/
+mkdir -p noblefactor/.config/git
+
+# Move your existing gitconfig into the project
+mv ~/.config/git/config noblefactor/.config/git/config
+
+# Add more files
+cp ~/.zshrc noblefactor/.zshrc
+```
+
+## Deploy the project
+
+```bash
+writ add noblefactor
+```
+
+Writ creates symlinks from your home directory to the project files:
+
+```
+~/.zshrc → repos/personal/noblefactor/.zshrc
+~/.config/git/config → repos/personal/noblefactor/.config/git/config
+```
+
+## Check status
+
+```bash
+writ status noblefactor
+```
+
+```
+noblefactor (personal)
+  ✓ Linked  .zshrc
+  ✓ Linked  .config/git/config
+```
+
+## Add software with lore
+
+If your project includes a `packages.manifest` file, writ automatically
+delegates to lore for software installation:
+
+```yaml
+# noblefactor/packages.manifest
+packages:
+  - gh
+  - jq
+  - ripgrep
+  - neovim
+```
+
+```bash
+writ add noblefactor
+# → symlinks configuration files
+# → calls lore to install gh, jq, ripgrep, neovim
+```
+
+Or install packages directly with lore:
+
+```bash
+lore deploy gh jq ripgrep neovim
+```
+
+## Next steps
+
+- [Manage environments](/guides/writ/manage-environments/) — Learn conflict handling, removal, and upgrades
+- [Platform awareness](/guides/writ/platform-awareness/) — Configure platform-specific variants
+- [Secrets management](/guides/writ/secrets/) — Encrypt sensitive files with age
+- [Deploy packages](/guides/lore/deploy-packages/) — Use lore's four-phase pipeline
+- [Create manifests](/guides/lore/create-manifests/) — Package tribal knowledge for sharing

--- a/docs/guides/lore/create-manifests.md
+++ b/docs/guides/lore/create-manifests.md
@@ -1,0 +1,197 @@
+---
+title: "Create Manifests"
+description: "Write and publish package lifecycle manifests"
+tool: "lore"
+category: "tutorial"
+order: 4
+---
+
+# Create Manifests
+
+A package manifest defines how to install, configure, and verify a piece of
+software. This guide covers creating manifests from scratch, using AI assistance,
+and publishing to the registry.
+
+## Scaffold a manifest
+
+Generate the directory structure for a new manifest:
+
+```bash
+lore manifest create mypackage
+```
+
+This creates:
+
+```
+staging/mypackage/
+├── lifecycle.yaml      # Package metadata and phase declarations
+├── prepare.star        # Prepare phase script
+├── install.star        # Install phase script
+├── provision.star      # Provision phase script
+└── verify.star         # Verify phase script
+```
+
+### AI-assisted creation
+
+Use AI to generate a manifest from upstream documentation:
+
+```bash
+lore manifest create postgresql --ai --from-url https://postgresql.org/download/
+```
+
+Or from an existing setup script:
+
+```bash
+lore manifest create pandoc --from ~/scripts/install-pandoc/
+```
+
+## The lifecycle file
+
+`lifecycle.yaml` defines package metadata and declares which phases exist:
+
+```yaml
+name: mypackage
+version: "1.0"
+description: "Brief description of what this package provides"
+homepage: https://example.com
+platforms:
+  - darwin
+  - linux
+features:
+  - name: completions
+    description: "Install shell completions"
+  - name: plugins
+    description: "Install recommended plugins"
+phases:
+  prepare: prepare.star
+  install: install.star
+  provision: provision.star
+  verify: verify.star
+```
+
+## Writing phase scripts
+
+Phase scripts are written in [Starlark](https://github.com/bazelbuild/starlark),
+a Python-like language designed for configuration. Each script must define
+a `main(ctx)` function.
+
+### The context object
+
+The `ctx` argument provides:
+
+| Method | Description |
+|--------|-------------|
+| `ctx.run(cmd)` | Execute a shell command |
+| `ctx.pmm.install(pkgs)` | Install via native package manager |
+| `ctx.pmm.remove(pkgs)` | Remove via native package manager |
+| `ctx.feature(name)` | Check if a feature is enabled |
+| `ctx.platform` | Current platform (`darwin`, `linux`) |
+| `ctx.arch` | Architecture (`amd64`, `arm64`) |
+| `ctx.user` | Current username |
+| `ctx.home` | Home directory path |
+| `ctx.codename` | OS codename (e.g., `jammy`) |
+| `ctx.assert_success(r)` | Assert command succeeded |
+| `ctx.assert_contains(s, sub)` | Assert string contains substring |
+
+### Example: complete manifest
+
+```python
+# install.star
+def main(ctx):
+    if ctx.platform == "darwin":
+        ctx.pmm.install(["mypackage"])
+    elif ctx.platform == "linux":
+        # Download binary for Linux
+        url = "https://github.com/example/releases/download/v1.0/mypackage-{}-{}".format(
+            ctx.platform, ctx.arch)
+        ctx.run("curl -L {} -o /tmp/mypackage".format(url))
+        ctx.run("sudo install /tmp/mypackage /usr/local/bin/mypackage")
+```
+
+```python
+# provision.star
+def main(ctx):
+    if ctx.feature("completions"):
+        ctx.run("mypackage completion zsh > ~/.local/share/zsh/completions/_mypackage")
+```
+
+```python
+# verify.star
+def main(ctx):
+    result = ctx.run("mypackage --version")
+    ctx.assert_success(result)
+    ctx.assert_contains(result.stdout, "1.0")
+```
+
+## Validate a manifest
+
+Check your manifest for errors before publishing:
+
+```bash
+lore manifest validate mypackage
+```
+
+Validates:
+
+- Schema conformance (lifecycle.yaml structure)
+- Phase files exist (referenced .star files are present)
+- Starlark syntax (files parse without errors)
+- Contract compliance (each phase has `main()` function)
+- Feature consistency (features used in scripts match declarations)
+- Platform coverage (conditionals cover declared platforms)
+
+## Test a manifest
+
+Dry-run on your current system:
+
+```bash
+lore manifest test mypackage
+lore manifest test mypackage --with completions
+lore manifest test mypackage --debug
+```
+
+Break at a specific phase:
+
+```bash
+lore manifest test mypackage --break install
+```
+
+## Update a manifest
+
+Add features or platform support to an existing manifest:
+
+```bash
+lore manifest update mypackage --add-feature gpu-support
+lore manifest update mypackage --add-platform windows
+```
+
+Import updates from upstream documentation:
+
+```bash
+lore manifest update docker --from-url https://docs.docker.com/engine/install/
+```
+
+## Publish to the registry
+
+Submit a validated manifest for community review:
+
+```bash
+lore publish mypackage
+```
+
+This:
+
+1. Runs final validation
+2. Creates a pull request on the registry repository
+3. Triggers automated testing on macOS, Linux, and Windows
+
+The manifest is available to all lore users once the PR is merged.
+
+## View manifest details
+
+```bash
+lore manifest show mypackage
+```
+
+Shows the full lifecycle definition, platform support, features, and
+phase scripts.

--- a/docs/guides/lore/deploy-packages.md
+++ b/docs/guides/lore/deploy-packages.md
@@ -1,0 +1,171 @@
+---
+title: "Deploy Packages"
+description: "Install software using lore's package deployment system"
+tool: "lore"
+category: "tutorial"
+order: 2
+---
+
+# Deploy Packages
+
+This guide covers installing software with lore, from simple single-package
+installs to manifest-driven deployments with features and receipts.
+
+## Install packages directly
+
+Specify packages by name on the command line:
+
+```bash
+lore deploy kubectl gh docker
+```
+
+Lore resolves each package from the registry, determines the best installation
+method for your platform, and runs the four-phase pipeline.
+
+## Enable features
+
+Packages can offer optional features. Enable them with `--with`:
+
+```bash
+lore deploy docker --with rootless --with compose --with buildx
+```
+
+Features control which steps run during installation. A package's available
+features are listed in its manifest.
+
+## Deploy from manifests
+
+Use `@` to deploy from a manifest file:
+
+```bash
+lore deploy @packages.manifest
+```
+
+Deploy from multiple manifests:
+
+```bash
+lore deploy @base.manifest @team.manifest
+```
+
+Mix manifests with direct packages:
+
+```bash
+lore deploy @team.manifest neovim --with lsp
+```
+
+## Confidence levels
+
+When lore resolves a package, it assigns a confidence level based on how
+well the manifest matches your platform:
+
+| Level | Meaning | Behavior |
+|-------|---------|----------|
+| HIGH | Native package manager, well-tested | Installs automatically |
+| MEDIUM | Custom script, good platform match | Installs automatically |
+| LOW | Uncertain match or untested platform | Prompts for confirmation |
+
+Control low-confidence behavior:
+
+```bash
+# Skip all LOW CONFIDENCE items
+lore deploy @manifest --known-only
+
+# Proceed without prompting
+lore deploy @manifest --force
+```
+
+## Parallel installation
+
+Install multiple packages concurrently:
+
+```bash
+lore deploy @manifest --parallel=4
+```
+
+Packages with dependencies are still ordered correctly.
+
+## Dry run
+
+Preview what lore would do without making changes:
+
+```bash
+lore deploy --dry-run kubectl gh docker
+```
+
+## Receipts
+
+Every deployment produces a receipt recording what was installed:
+
+```bash
+# Save to specific path
+lore deploy @manifest --receipt=~/deployments/workstation.yaml
+```
+
+Receipts are stored in `~/.local/state/lore/receipts/` by default.
+
+## Upgrade packages
+
+Upgrade previously deployed packages to newer versions:
+
+```bash
+lore upgrade @workstation
+```
+
+This re-runs the pipeline for each package, using the latest manifest
+from the registry.
+
+## Reconcile state
+
+Compare what should be installed against actual system state:
+
+```bash
+lore reconcile @workstation
+```
+
+Reports drift: missing binaries, changed versions, or removed configurations.
+
+## Decommission packages
+
+Remove packages and clean up their resources:
+
+```bash
+# Remove specific packages
+lore decommission docker kubectl
+
+# Remove from receipt
+lore decommission @workstation
+
+# Remove only orphaned packages (not referenced by any manifest)
+lore decommission --orphans-only
+```
+
+## Integration with writ
+
+When writ deploys a project containing `packages.manifest`, it automatically
+calls lore:
+
+```bash
+writ add noblefactor
+# → Symlinks config files
+# → Calls: lore deploy @packages.manifest
+```
+
+When writ removes a project:
+
+```bash
+writ remove --decommission noblefactor
+# → Removes symlinks
+# → Calls: lore decommission --orphans-only
+```
+
+## Inspect packages
+
+View detailed information about a deployed or available package:
+
+```bash
+lore inspect docker
+lore inspect kubectl --format yaml
+```
+
+Shows the resolved manifest, platform support, features, dependencies,
+and deployment history.

--- a/docs/guides/lore/index.md
+++ b/docs/guides/lore/index.md
@@ -1,0 +1,91 @@
+---
+title: "Lore Overview"
+description: "Cross-platform package deployment that captures tribal knowledge"
+tool: "lore"
+category: "overview"
+order: 1
+---
+
+# Lore Overview
+
+Lore is a cross-platform package deployment tool that captures tribal knowledge
+about installing software. It delegates to native package managers when possible
+and provides custom deployment scripts when necessary.
+
+## Why lore
+
+"Install this package" is rarely the whole story:
+
+- **Docker** requires adding vendor repositories, removing conflicting packages,
+  and installing five separate components
+- **Pandoc** needs a PDF engine, which needs LaTeX, which needs tlmgr to
+  install packages that aren't documented anywhere
+- **kubectl** needs specific versions matched to your cluster, plus plugins,
+  plus shell completions that aren't installed by default
+
+Lore captures this knowledge once and shares it forever.
+What took someone hours to figure out, you get in minutes.
+
+## Core concepts
+
+### Four-phase pipeline
+
+Every package deployment follows a structured pipeline:
+
+```
+prepare → install → provision → verify
+```
+
+| Phase | Purpose | Example |
+|-------|---------|---------|
+| **Prepare** | Pre-install setup | Add APT repositories, import GPG keys |
+| **Install** | Package installation | `brew install`, `apt install`, download binary |
+| **Provision** | Post-install config | Enable systemd services, create config files |
+| **Verify** | Validation | Check binary exists, verify version, test connectivity |
+
+### Package manifests
+
+A manifest is a YAML file defining a package's installation lifecycle.
+Each phase can use native package managers or custom Starlark scripts:
+
+```yaml
+name: docker
+version: "24.0"
+platforms: [darwin, linux]
+features: [rootless, compose, buildx]
+phases:
+  prepare: prepare.star
+  install: install.star
+  provision: provision.star
+  verify: verify.star
+```
+
+### Registry
+
+The DevLore Registry is a community-maintained collection of package manifests.
+Lore resolves packages from the registry, selecting the right installation
+method for your platform.
+
+### Receipts
+
+Every deployment produces a receipt recording what was installed, which
+phases ran, and the resulting state. Receipts enable upgrades, reconciliation,
+and decommissioning.
+
+### Features
+
+Packages can declare optional features that are enabled at deploy time:
+
+```bash
+lore deploy docker --with rootless --with compose
+```
+
+Features control which steps run in each phase, allowing a single manifest
+to handle multiple installation variants.
+
+## Guides
+
+- [Deploy packages](/guides/lore/deploy-packages/) — Install software using lore
+- [The pipeline](/guides/lore/pipeline/) — Understand the four-phase deployment model
+- [Create manifests](/guides/lore/create-manifests/) — Write and publish package manifests
+- [Work with the registry](/guides/lore/registry/) — Search, inspect, and contribute packages

--- a/docs/guides/lore/pipeline.md
+++ b/docs/guides/lore/pipeline.md
@@ -1,0 +1,185 @@
+---
+title: "The Pipeline"
+description: "Understand lore's four-phase deployment model"
+tool: "lore"
+category: "concept"
+order: 3
+---
+
+# The Four-Phase Pipeline
+
+Every package deployment in lore follows a structured four-phase pipeline.
+This model separates concerns, enables partial re-runs, and makes the
+installation process auditable and reproducible.
+
+## Pipeline overview
+
+```
+┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ Prepare  │───>│ Install  │───>│ Provision│───>│  Verify  │
+│          │    │          │    │          │    │          │
+│ Pre-reqs │    │ Package  │    │ Post-cfg │    │ Validate │
+└──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+Each phase runs independently and can succeed or fail without affecting the
+structure of subsequent phases. If a phase fails, the pipeline stops and
+reports which phase failed and why.
+
+## Phase 1: Prepare
+
+**Purpose:** Set up prerequisites before installation.
+
+Common prepare actions:
+
+- Add package repository sources (APT repos, Homebrew taps)
+- Import GPG signing keys
+- Remove conflicting packages
+- Create required users or groups
+- Download and cache large files
+
+```python
+# prepare.star — Docker on Ubuntu
+def main(ctx):
+    # Add Docker's official GPG key
+    ctx.run("curl -fsSL https://download.docker.com/linux/ubuntu/gpg | "
+            "sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg")
+
+    # Add repository
+    ctx.run("echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] "
+            "https://download.docker.com/linux/ubuntu {} stable' | "
+            "sudo tee /etc/apt/sources.list.d/docker.list".format(ctx.codename))
+
+    ctx.run("sudo apt-get update")
+```
+
+## Phase 2: Install
+
+**Purpose:** Install the package using the appropriate method.
+
+Installation methods (in order of preference):
+
+1. **Native package manager** — `brew install`, `apt install`, `dnf install`
+2. **Binary download** — Fetch pre-built binary from upstream
+3. **Build from source** — Clone and compile
+4. **Custom script** — Arbitrary installation logic
+
+```python
+# install.star — Docker on Ubuntu
+def main(ctx):
+    packages = [
+        "docker-ce",
+        "docker-ce-cli",
+        "containerd.io",
+        "docker-buildx-plugin",
+    ]
+
+    if ctx.feature("compose"):
+        packages.append("docker-compose-plugin")
+
+    ctx.pmm.install(packages)
+```
+
+## Phase 3: Provision
+
+**Purpose:** Configure the installed software for use.
+
+Common provision actions:
+
+- Enable and start system services
+- Create default configuration files
+- Set up shell completions
+- Add user to required groups
+- Create data directories
+
+```python
+# provision.star — Docker on Ubuntu
+def main(ctx):
+    # Add user to docker group
+    ctx.run("sudo usermod -aG docker {}".format(ctx.user))
+
+    # Enable and start service
+    ctx.run("sudo systemctl enable docker")
+    ctx.run("sudo systemctl start docker")
+
+    if ctx.feature("rootless"):
+        ctx.run("dockerd-rootless-setuptool.sh install")
+```
+
+## Phase 4: Verify
+
+**Purpose:** Confirm the installation succeeded.
+
+Common verification checks:
+
+- Binary exists and is executable
+- Version matches expected
+- Service is running
+- Network connectivity works
+- Configuration is valid
+
+```python
+# verify.star — Docker
+def main(ctx):
+    # Check binary exists
+    result = ctx.run("docker --version")
+    ctx.assert_contains(result.stdout, "Docker version")
+
+    # Check service is running
+    result = ctx.run("docker info")
+    ctx.assert_success(result)
+
+    # Check compose if enabled
+    if ctx.feature("compose"):
+        result = ctx.run("docker compose version")
+        ctx.assert_success(result)
+```
+
+## Features in the pipeline
+
+Features control which steps run within each phase. A package manifest
+declares available features, and users enable them at deploy time:
+
+```bash
+lore deploy docker --with rootless --with compose
+```
+
+Inside phase scripts, check for enabled features:
+
+```python
+def main(ctx):
+    # Always install core
+    ctx.pmm.install(["docker-ce", "docker-ce-cli", "containerd.io"])
+
+    # Conditional on feature
+    if ctx.feature("compose"):
+        ctx.pmm.install(["docker-compose-plugin"])
+
+    if ctx.feature("buildx"):
+        ctx.pmm.install(["docker-buildx-plugin"])
+```
+
+## Testing the pipeline
+
+Dry-run a manifest to see what each phase would do:
+
+```bash
+lore manifest test docker
+lore manifest test docker --with rootless --debug
+```
+
+Break at a specific phase for interactive debugging:
+
+```bash
+lore manifest test docker --break provision
+```
+
+## Audit trail
+
+Every phase execution is logged to the security audit log:
+
+```bash
+lore audit --event phase --package docker
+```
+
+Shows timestamps, exit codes, and operations performed in each phase.

--- a/docs/guides/lore/registry.md
+++ b/docs/guides/lore/registry.md
@@ -1,0 +1,172 @@
+---
+title: "The Registry"
+description: "Search, inspect, and contribute packages to the DevLore Registry"
+tool: "lore"
+category: "concept"
+order: 5
+---
+
+# The Registry
+
+The DevLore Registry is a community-maintained collection of package manifests.
+It captures tribal knowledge about installing software — the repositories to add,
+the dependencies to resolve, the configuration steps that upstream docs don't mention.
+
+## How it works
+
+When you run `lore deploy kubectl`, lore:
+
+1. Checks the local registry cache for a `kubectl` manifest
+2. Resolves the best installation method for your platform
+3. Runs the four-phase pipeline defined in the manifest
+
+The registry is a git repository. Your local cache is synchronized with
+`lore update`.
+
+## Search for packages
+
+```bash
+lore search kubectl
+lore search --platform darwin docker
+```
+
+Search returns matching packages with their descriptions and platform support.
+
+## Inspect a package
+
+View full details before installing:
+
+```bash
+lore inspect docker
+lore inspect kubectl --format yaml
+```
+
+Shows:
+
+- Package name, version, description
+- Supported platforms
+- Available features
+- Dependencies
+- Phase scripts
+- Deployment history (if previously installed)
+
+## Resolve installation method
+
+See how a package would be installed on your system without actually
+installing it:
+
+```bash
+lore resolve docker
+```
+
+```
+docker (v24.0) on darwin/arm64:
+  prepare: Add Docker repository
+  install: brew install --cask docker
+  provision: -
+  verify: docker --version
+```
+
+## Update the registry cache
+
+Synchronize your local cache with the central registry:
+
+```bash
+lore update
+```
+
+This fetches the latest manifests, new packages, and updated installation
+methods.
+
+## Contribute a package
+
+The registry grows through community contributions. To add a package:
+
+1. Create and test the manifest locally:
+
+```bash
+lore manifest create mypackage
+# ... write phase scripts ...
+lore manifest validate mypackage
+lore manifest test mypackage
+```
+
+2. Publish to the registry:
+
+```bash
+lore publish mypackage
+```
+
+3. The automated CI runs your manifest on macOS, Linux, and Windows
+4. Community reviewers check the manifest
+5. Once merged, the package is available to all users
+
+## Security
+
+### Audit log
+
+Every package fetch and installation is recorded in the audit log:
+
+```bash
+lore audit
+lore audit --since 7d --package docker
+```
+
+Events logged:
+
+| Event | Description |
+|-------|-------------|
+| `pmm.fetch` | Package fetched with signature status |
+| `pmm.verify` | Signature verification result |
+| `privilege.request` | Sudo/elevation request |
+| `binary.download` | Upstream binary download with hash |
+| `phase.execute` | Pipeline phase execution |
+
+### Signature verification
+
+Manifests in the registry are signed. Lore verifies signatures before
+execution and logs verification results to the audit log.
+
+### Privilege escalation
+
+When a phase script requires `sudo`, lore records the escalation request
+in the audit log with the exact command being elevated.
+
+## Air-gapped environments
+
+For systems without internet access, create self-extracting bundles:
+
+```bash
+lore bundle @manifest -o workstation-bundle.sh --platform linux/fedora
+```
+
+The bundle includes all manifests, phase scripts, and downloaded artifacts
+needed for offline deployment.
+
+Transfer the bundle to the air-gapped system and run it:
+
+```bash
+./workstation-bundle.sh
+```
+
+## Onboarding from documentation
+
+Extract package requirements from existing wiki pages or scripts:
+
+```bash
+lore onboard --from https://wiki.acme.com/backend-setup
+```
+
+Lore uses AI to:
+
+1. Parse installation steps from the document
+2. Match them to known registry packages
+3. Flag organization-specific items for review
+4. Generate a `packages.manifest` and config files
+
+Then deploy the result:
+
+```bash
+lore deploy @packages.manifest
+writ adopt --from-receipt
+```

--- a/docs/guides/writ/index.md
+++ b/docs/guides/writ/index.md
@@ -1,0 +1,112 @@
+---
+title: "Writ Overview"
+description: "Environment manager with platform-aware symlinks"
+tool: "writ"
+category: "overview"
+order: 1
+---
+
+# Writ Overview
+
+Writ orchestrates your portable environment — configuration, scripts, utilities,
+templates, and software manifests. One command deploys your environment.
+Platform-aware projects adapt automatically. Templates handle machine-specific values.
+
+## Why writ
+
+Environment management shouldn't require:
+
+- Manual symlink creation across dozens of files
+- Platform-specific setup scripts that drift out of sync
+- Secret values leaking into git repositories
+- Rebuilding everything from memory on a new machine
+
+Writ solves this by letting you declare your environment once and deploy it
+everywhere you work.
+
+## Core concepts
+
+### Projects
+
+A project is a directory in your repository whose contents mirror your home
+directory structure. When deployed, each file becomes a symlink:
+
+```
+repos/personal/noblefactor/
+├── .zshrc                    → ~/.zshrc
+├── .config/
+│   ├── git/config            → ~/.config/git/config
+│   └── nvim/init.lua         → ~/.config/nvim/init.lua
+└── .local/bin/
+    └── my-script             → ~/.local/bin/my-script
+```
+
+### Layered repositories
+
+Writ supports multiple repositories with defined precedence:
+
+```
+personal > team > base
+```
+
+When files from different layers target the same path, the higher-precedence
+layer wins. This lets organizations provide shared defaults that individuals
+can override:
+
+```bash
+writ repo init --layer=base        # Company-wide defaults
+writ repo init --layer=team        # Team-specific config
+writ repo init --layer=personal    # Your personal preferences
+```
+
+### Platform awareness
+
+Projects can include platform-specific variants. Writ detects your OS
+and selects the right files automatically:
+
+```
+noblefactor/
+├── .zshrc                    # Shared across all platforms
+├── .zshrc.Darwin             # macOS override
+├── .zshrc.Linux              # Linux override
+└── .config/
+    └── alacritty.toml.Darwin # macOS-only file
+```
+
+### Templates
+
+Files with `.tmpl` extension are processed as Go templates during deployment.
+The rendered output is copied (not symlinked) to the target:
+
+```
+# .gitconfig.tmpl
+[user]
+    name = {{.UserName}}
+    email = {{.UserEmail}}
+```
+
+Template variables come from `writ configure` or the config file.
+
+### Secrets
+
+Files ending in `.age` are decrypted during deployment using your SSH key
+or age identity. The decrypted content is copied to the target:
+
+```
+noblefactor/
+└── .config/
+    └── github/token.age      # Encrypted at rest, decrypted on deploy
+```
+
+### State tracking
+
+Each deployment produces a state file recording what was deployed, with
+checksums for drift detection. State files can be optionally signed for
+tamper detection.
+
+## Guides
+
+- [Manage environments](/guides/writ/manage-environments/) — Deploy, update, and remove projects
+- [Platform awareness](/guides/writ/platform-awareness/) — Configure platform-specific variants
+- [Secrets management](/guides/writ/secrets/) — Encrypt sensitive files with age
+- [Repositories](/guides/writ/repositories/) — Manage layered repositories

--- a/docs/guides/writ/manage-environments.md
+++ b/docs/guides/writ/manage-environments.md
@@ -1,0 +1,195 @@
+---
+title: "Manage Environments"
+description: "Deploy, update, and remove configuration projects"
+tool: "writ"
+category: "tutorial"
+order: 2
+---
+
+# Manage Environments
+
+This guide covers the full lifecycle of managing your environment with writ:
+deploying projects, handling conflicts, checking status, upgrading templates,
+and removing deployments.
+
+## Deploy projects
+
+Deploy one or more projects from your repository:
+
+```bash
+writ add noblefactor
+writ add noblefactor thenobles
+```
+
+Use `all` to deploy every project in the repository:
+
+```bash
+writ add all
+```
+
+### Conflict resolution
+
+When a target file already exists and isn't a writ-managed symlink, you have
+four strategies:
+
+```bash
+# Stop on first conflict (default)
+writ add noblefactor
+
+# Back up conflicting files with timestamps
+writ add --conflict=backup noblefactor
+
+# Overwrite without backup
+writ add --conflict=overwrite noblefactor
+
+# Skip conflicting files and continue
+writ add --conflict=skip noblefactor
+```
+
+### Custom segments
+
+Override platform detection with custom segment values:
+
+```bash
+writ add -s ROLE=desktop noblefactor
+writ add -s ROLE=server -s DISPLAY=headless noblefactor
+```
+
+### Dry run
+
+Preview what writ would do without making changes:
+
+```bash
+writ add --dry-run noblefactor
+```
+
+## Check status
+
+View the state of deployed projects:
+
+```bash
+# Scan all deployed files
+writ status
+
+# Check specific project
+writ status noblefactor
+```
+
+Status indicators:
+
+| Symbol | Meaning |
+|--------|---------|
+| `✓ Linked` | Symlink exists and points to project |
+| `✓ Copied` | Template/secret was copied and exists |
+| `⚠ Conflict` | File exists but isn't a writ symlink |
+| `✗ Missing` | Project file has no corresponding symlink |
+| `? Orphan` | Symlink points to nonexistent source |
+
+### Drift detection
+
+Check whether templates or secrets have been modified since deployment:
+
+```bash
+writ status --drift
+```
+
+Drift indicators:
+
+| Symbol | Meaning |
+|--------|---------|
+| `↑ Stale` | Source changed since deployment |
+| `M Modified` | Target was edited locally |
+| `! Conflict` | Both source and target changed |
+
+## Upgrade templates and secrets
+
+When source templates or secrets change, regenerate the copied files:
+
+```bash
+# Upgrade all copied files
+writ upgrade
+
+# Upgrade specific project
+writ upgrade noblefactor
+
+# Force overwrite locally modified files
+writ upgrade --force
+```
+
+Upgrade only affects copied files (templates and decrypted secrets).
+Symlinks always point to the source and don't need upgrading.
+
+## Adopt existing files
+
+Bring existing configuration files under writ management:
+
+```bash
+# Adopt a single file
+writ adopt noblefactor .zshrc
+
+# Adopt multiple files
+writ adopt noblefactor .zshrc .bashrc .config/nvim/init.lua
+
+# Adopt an entire directory recursively
+writ adopt noblefactor .config/nvim
+
+# Adopt into team layer
+writ adopt --layer=team shared .editorconfig
+```
+
+The file is moved into the project directory and replaced with a symlink.
+
+### Adopt from lore receipt
+
+After installing software with lore, adopt the generated configuration:
+
+```bash
+writ adopt --from-receipt
+```
+
+This reads the lore deployment receipt and moves any generated config files
+into your environment repository.
+
+## Remove deployments
+
+Remove deployed files for a project:
+
+```bash
+writ remove noblefactor
+```
+
+Safety behavior depends on state tracking:
+
+| State | Behavior |
+|-------|----------|
+| Signed state file | Safe removal with drift detection |
+| Unsigned state file | Warning, requires `--force` |
+| No state file | Error: cannot safely remove |
+
+### Decommission software
+
+Remove both configuration and associated software:
+
+```bash
+writ remove --decommission noblefactor
+```
+
+This delegates to `lore decommission --orphans-only` to remove packages
+that were installed via the project's `packages.manifest` and are no longer
+referenced by any other project.
+
+## Inspect details
+
+Get detailed information about a project or specific file:
+
+```bash
+# Project details
+writ inspect noblefactor
+
+# Specific file details (source, checksums, drift status)
+writ inspect ~/.zshrc
+
+# Alternative output formats
+writ inspect noblefactor --format yaml
+writ inspect noblefactor --format json
+```

--- a/docs/guides/writ/platform-awareness.md
+++ b/docs/guides/writ/platform-awareness.md
@@ -1,0 +1,114 @@
+---
+title: "Platform Awareness"
+description: "Configure platform-specific variants for cross-platform environments"
+tool: "writ"
+category: "concept"
+order: 3
+---
+
+# Platform Awareness
+
+Writ automatically detects your operating system and selects platform-specific
+file variants during deployment. This lets you maintain a single repository
+that works across macOS, Linux, and Windows.
+
+## How it works
+
+When deploying a project, writ checks each file for platform-specific suffixes.
+If a variant matching your current platform exists, it takes precedence over
+the base file.
+
+Platform suffixes are appended to the filename:
+
+```
+.zshrc              # Base file (used when no platform variant matches)
+.zshrc.Darwin       # Used on macOS
+.zshrc.Linux        # Used on Linux
+.zshrc.Windows      # Used on Windows
+```
+
+The deployed symlink always points to the correct variant without the suffix:
+
+```bash
+# On macOS:
+~/.zshrc → repos/personal/noblefactor/.zshrc.Darwin
+
+# On Linux:
+~/.zshrc → repos/personal/noblefactor/.zshrc.Linux
+```
+
+## Platform detection
+
+Writ detects the following platform values automatically:
+
+| Value | System |
+|-------|--------|
+| `Darwin` | macOS (any architecture) |
+| `Linux` | Linux distributions |
+| `Windows` | Windows (via WSL or native) |
+
+## Directory variants
+
+Entire directories can have platform suffixes. All files within a
+platform-specific directory are deployed only on that platform:
+
+```
+noblefactor/
+├── .config/
+│   ├── alacritty/              # Shared config
+│   │   └── alacritty.toml
+│   ├── alacritty.Darwin/       # macOS-specific alacritty config
+│   │   └── alacritty.toml
+│   └── systemd.Linux/          # Linux-only systemd units
+│       └── user/
+│           └── backup.service
+```
+
+## Custom segments
+
+Beyond OS detection, writ supports custom segments for more granular control.
+Define segments at deploy time:
+
+```bash
+writ add -s ROLE=desktop noblefactor
+writ add -s ROLE=server noblefactor
+```
+
+Name files with segment suffixes:
+
+```
+.config/
+├── polybar/config.ROLE=desktop     # Only on desktop machines
+└── nginx/nginx.conf.ROLE=server    # Only on servers
+```
+
+Multiple segments can be combined:
+
+```bash
+writ add -s ROLE=desktop -s DISPLAY=hidpi noblefactor
+```
+
+## Precedence rules
+
+When multiple variants could apply, writ uses this precedence order:
+
+1. Most specific match (platform + custom segments)
+2. Platform-only match
+3. Base file (no suffix)
+
+If no variant matches and no base file exists, the file is skipped.
+
+## Platform-specific packages
+
+The same mechanism works for `packages.manifest` files, allowing
+platform-specific software lists:
+
+```
+noblefactor/
+├── packages.manifest           # Common packages (jq, gh, ripgrep)
+├── packages.manifest.Darwin    # macOS packages (brew-only tools)
+└── packages.manifest.Linux     # Linux packages (apt/dnf-only tools)
+```
+
+Writ merges the base manifest with the platform-specific one before
+delegating to lore.

--- a/docs/guides/writ/repositories.md
+++ b/docs/guides/writ/repositories.md
@@ -1,0 +1,146 @@
+---
+title: "Repositories"
+description: "Manage layered environment repositories"
+tool: "writ"
+category: "tutorial"
+order: 5
+---
+
+# Repositories
+
+Writ organizes your environment files into layered repositories. Each layer
+has a defined precedence, letting organizations provide shared defaults
+that individuals can override.
+
+## Layer precedence
+
+```
+personal > team > base
+```
+
+When files from different layers target the same path, the higher-precedence
+layer wins:
+
+| Layer | Purpose | Example |
+|-------|---------|---------|
+| `base` | Organization-wide defaults | Company security policies, shared tooling |
+| `team` | Team-specific config | Backend team's database tools, frontend linting |
+| `personal` | Individual preferences | Editor config, shell aliases, custom scripts |
+
+## Initialize a repository
+
+Create a new empty repository:
+
+```bash
+# Personal layer (default location: ~/.local/share/devlore/repos/personal/)
+writ repo init --layer=personal
+
+# Team layer
+writ repo init --layer=team
+```
+
+Clone an existing repository:
+
+```bash
+writ repo init --layer=personal git@github.com:me/dotfiles.git
+writ repo init --layer=team git@github.com:company/team-configs.git
+```
+
+For advanced git options, clone manually then register:
+
+```bash
+git clone --branch main --depth 1 git@github.com:co/repo.git ~/repo
+writ repo add --layer=team ~/repo
+```
+
+## Register an existing repository
+
+If you already have a dotfiles directory, register it without cloning:
+
+```bash
+writ repo add --layer=personal ~/Workspace/Personal/Home/Configs
+```
+
+## List repositories
+
+```bash
+writ repo list
+```
+
+```
+Layer      Path                                          Status
+personal   ~/.local/share/devlore/repos/personal/       ok
+team       ~/.local/share/devlore/repos/team/           ok
+```
+
+## Remove a repository
+
+Unregister a repository from writ (does not delete files):
+
+```bash
+writ repo remove --layer=team
+```
+
+To also clean up deployed files, remove projects first:
+
+```bash
+writ remove all --layer=team
+writ repo remove --layer=team
+```
+
+## Repository structure
+
+A repository contains one or more projects (subdirectories), plus optional
+metadata files:
+
+```
+repos/personal/
+├── .age-recipients          # Encryption recipients
+├── .gitignore
+├── noblefactor/             # Project: personal config
+│   ├── .zshrc
+│   ├── .config/git/config
+│   └── packages.manifest
+├── thenobles/               # Project: family-shared config
+│   └── .config/shared/
+└── work/                    # Project: work-specific overrides
+    ├── .config/git/config   # Overrides noblefactor's git config
+    └── .npmrc
+```
+
+## Multi-layer deployment
+
+Deploy from multiple layers simultaneously:
+
+```bash
+writ add all
+```
+
+Writ scans all registered repositories and deploys projects from each.
+When the same file path appears in multiple layers, the highest-precedence
+layer wins silently.
+
+To see which layer a file comes from:
+
+```bash
+writ inspect ~/.config/git/config
+```
+
+## Configuration storage
+
+Repository registrations are stored in `~/.config/devlore/config.yaml`:
+
+```yaml
+writ:
+  repos:
+    personal: ~/.local/share/devlore/repos/personal
+    team: ~/.local/share/devlore/repos/team
+  target: Home
+```
+
+Edit directly or use:
+
+```bash
+writ config set writ.repos.team /path/to/team-repo
+writ config get writ.repos
+```

--- a/docs/guides/writ/secrets.md
+++ b/docs/guides/writ/secrets.md
@@ -1,0 +1,131 @@
+---
+title: "Secrets Management"
+description: "Encrypt sensitive files with age for safe storage in git"
+tool: "writ"
+category: "tutorial"
+order: 4
+---
+
+# Secrets Management
+
+Writ uses [age encryption](https://age-encryption.org/) to store sensitive files
+(API tokens, credentials, private keys) in your repository. Files are encrypted
+at rest and decrypted during deployment.
+
+## How it works
+
+Files ending in `.age` are treated as encrypted secrets. During `writ add`,
+they are decrypted using your identity (SSH key or age key) and the plaintext
+is copied to the target location.
+
+```
+noblefactor/
+└── .config/
+    ├── github/token.age        # Encrypted in git
+    └── ssh/config              # Normal symlink
+```
+
+After deployment:
+
+```
+~/.config/github/token          # Decrypted copy (not a symlink)
+~/.config/ssh/config            # Symlink to source
+```
+
+## Setup
+
+### Recipients file
+
+Create a `.age-recipients` file in your repository root listing the public keys
+of machines that should be able to decrypt secrets:
+
+```
+# .age-recipients
+# Work laptop (SSH key)
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... work-laptop
+
+# Home desktop (age key)
+age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+```
+
+### Identity resolution
+
+Writ resolves your decryption identity from:
+
+1. SSH keys in `~/.ssh/` (ed25519 and RSA keys work with age)
+2. Age identity file at `~/.config/age/identity.txt`
+3. Custom path via `--identity` flag
+
+## Encrypt a file
+
+```bash
+writ secrets encrypt .config/github/token
+```
+
+This encrypts the file to all recipients in `.age-recipients` and produces
+`.config/github/token.age`. The original plaintext file is removed.
+
+## Decrypt a file
+
+```bash
+# Output to stdout
+writ secrets decrypt .config/github/token.age
+
+# Write to file
+writ secrets decrypt -o .config/github/token .config/github/token.age
+```
+
+## Edit encrypted files
+
+Edit a secret in place without manually decrypting and re-encrypting:
+
+```bash
+writ secrets edit .config/github/token.age
+```
+
+This decrypts to a temporary file, opens `$EDITOR`, and re-encrypts when
+the editor exits.
+
+## Rekey secrets
+
+When you add a new machine or revoke access, update `.age-recipients` and
+re-encrypt all secrets:
+
+```bash
+writ secrets rekey
+```
+
+This decrypts and re-encrypts every `.age` file in the repository to match
+the current recipients list. The operation is idempotent.
+
+### Common rekey scenarios
+
+| Scenario | Action |
+|----------|--------|
+| New machine | Add its public key to `.age-recipients`, run `rekey` |
+| Revoked machine | Remove its key from `.age-recipients`, run `rekey` |
+| Rotated keys | Update key in `.age-recipients`, run `rekey` |
+
+## Upgrade secrets after source changes
+
+When an encrypted source file changes (e.g., after pulling from git),
+regenerate the decrypted copy:
+
+```bash
+writ upgrade noblefactor
+```
+
+This re-decrypts `.age` files and copies the updated plaintext to target
+locations, respecting drift detection for locally modified files.
+
+## Security model
+
+| Property | Guarantee |
+|----------|-----------|
+| At rest | Encrypted with age (X25519 + ChaCha20-Poly1305) |
+| In transit | Encrypted in git (only ciphertext committed) |
+| On deploy | Decrypted copy written to target with restricted permissions |
+| Key management | Recipients file in repo, identity stays on machine |
+
+Secrets are never symlinked — they are always copied so the plaintext
+never appears inside the git repository tree.

--- a/internal/tools/docgen/generator.go
+++ b/internal/tools/docgen/generator.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package docgen
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// skipCommands lists command names to skip when generating docs.
+var skipCommands = map[string]bool{
+	"help":       true,
+	"completion": true,
+	"man":        true,
+	"version":    true,
+}
+
+// GenerateTree walks a Cobra command tree and generates a markdown file
+// for each non-hidden, non-skipped command.
+func GenerateTree(cmd *cobra.Command, outDir, toolName, version string) error {
+	return walkTree(cmd, outDir, toolName, version)
+}
+
+func walkTree(cmd *cobra.Command, outDir, toolName, version string) error {
+	if shouldSkip(cmd) {
+		return nil
+	}
+
+	if err := generatePage(cmd, outDir, toolName, version); err != nil {
+		return fmt.Errorf("generating %s: %w", fullCommandName(cmd), err)
+	}
+
+	for _, child := range cmd.Commands() {
+		if err := walkTree(child, outDir, toolName, version); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func shouldSkip(cmd *cobra.Command) bool {
+	if cmd.Hidden {
+		return true
+	}
+	return skipCommands[cmd.Name()]
+}
+
+func generatePage(cmd *cobra.Command, outDir, toolName, version string) error {
+	data := BuildPageData(cmd, toolName, version)
+
+	var buf bytes.Buffer
+	if err := pageTemplate.Execute(&buf, data); err != nil {
+		return fmt.Errorf("executing template: %w", err)
+	}
+
+	filePath := outputPath(cmd, outDir)
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(filePath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", filePath, err)
+	}
+
+	fmt.Printf("  %s\n", filePath)
+	return nil
+}
+
+// outputPath computes the file path for a given command.
+// Root commands: outDir/writ.md
+// Subcommands: outDir/writ/add.md
+// Nested: outDir/writ/repo/init.md
+func outputPath(cmd *cobra.Command, outDir string) string {
+	parts := commandParts(cmd)
+
+	if len(parts) == 1 {
+		// Root command: writ.md
+		return filepath.Join(outDir, parts[0]+".md")
+	}
+
+	// Subcommands: writ/add.md or writ/repo/init.md
+	dir := filepath.Join(outDir, strings.Join(parts[:len(parts)-1], string(filepath.Separator)))
+	return filepath.Join(dir, parts[len(parts)-1]+".md")
+}
+
+func commandParts(cmd *cobra.Command) []string {
+	var parts []string
+	for c := cmd; c != nil; c = c.Parent() {
+		parts = append([]string{c.Name()}, parts...)
+	}
+	return parts
+}

--- a/internal/tools/docgen/template.go
+++ b/internal/tools/docgen/template.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// Package docgen generates Docker-style CLI reference documentation
+// in Markdown with Astro frontmatter from Cobra command trees.
+package docgen
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// PageData holds all data needed to render a CLI reference page.
+type PageData struct {
+	Title       string
+	Description string
+	Tool        string
+	Command     string
+	Parent      string
+	Generated   string
+	Version     string
+	Usage       string
+	Long        string
+	Options     []FlagInfo
+	GlobalFlags []FlagInfo
+	Examples    string
+	ParentCmd   *ParentInfo
+	Children    []ChildInfo
+}
+
+// FlagInfo holds display information for a single flag.
+type FlagInfo struct {
+	Name        string
+	Default     string
+	Description string
+}
+
+// ParentInfo holds a reference to the parent command.
+type ParentInfo struct {
+	Name        string
+	Description string
+	Path        string
+}
+
+// ChildInfo holds a reference to a child command.
+type ChildInfo struct {
+	Name        string
+	Description string
+	Path        string
+}
+
+var pageTemplate = template.Must(template.New("page").Parse(`---
+title: "{{ .Title }}"
+description: "{{ .Description }}"
+tool: "{{ .Tool }}"
+command: "{{ .Command }}"
+parent: "{{ .Parent }}"
+generated: "{{ .Generated }}"
+version: "{{ .Version }}"
+---
+
+# {{ .Title }}
+
+{{ .Description }}
+
+## Usage
+
+` + "```" + `
+{{ .Usage }}
+` + "```" + `
+{{ if .Long }}
+## Description
+
+{{ .Long }}
+{{ end }}{{ if .Options }}
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+{{ range .Options }}| ` + "`{{ .Name }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
+{{ end }}{{ end }}{{ if .GlobalFlags }}
+## Global Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+{{ range .GlobalFlags }}| ` + "`{{ .Name }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
+{{ end }}{{ end }}{{ if .Examples }}
+## Examples
+
+` + "```bash" + `
+{{ .Examples }}
+` + "```" + `
+{{ end }}{{ if .ParentCmd }}
+## Parent Command
+
+| Command | Description |
+|---------|-------------|
+| [{{ .ParentCmd.Name }}]({{ .ParentCmd.Path }}) | {{ .ParentCmd.Description }} |
+{{ end }}{{ if .Children }}
+## Child Commands
+
+| Command | Description |
+|---------|-------------|
+{{ range .Children }}| [{{ .Name }}]({{ .Path }}) | {{ .Description }} |
+{{ end }}{{ end }}`))
+
+// BuildPageData extracts page data from a Cobra command.
+func BuildPageData(cmd *cobra.Command, toolName, version string) PageData {
+	fullName := fullCommandName(cmd)
+	parent := parentCommandName(cmd)
+
+	data := PageData{
+		Title:       fullName,
+		Description: cmd.Short,
+		Tool:        toolName,
+		Command:     cmd.Name(),
+		Parent:      parent,
+		Generated:   time.Now().UTC().Format(time.RFC3339),
+		Version:     version,
+		Usage:       cmd.UseLine(),
+		Long:        strings.TrimSpace(cmd.Long),
+		Options:     collectFlags(cmd.LocalFlags()),
+		GlobalFlags: collectInheritedFlags(cmd),
+		Examples:    trimExampleLines(cmd.Example),
+	}
+
+	if cmd.HasParent() && cmd.Parent().Name() != "" {
+		data.ParentCmd = &ParentInfo{
+			Name:        fullCommandName(cmd.Parent()),
+			Description: cmd.Parent().Short,
+			Path:        commandPath(cmd.Parent(), toolName),
+		}
+	}
+
+	for _, child := range cmd.Commands() {
+		if shouldSkip(child) {
+			continue
+		}
+		data.Children = append(data.Children, ChildInfo{
+			Name:        fullCommandName(child),
+			Description: child.Short,
+			Path:        commandPath(child, toolName),
+		})
+	}
+
+	return data
+}
+
+func fullCommandName(cmd *cobra.Command) string {
+	parts := []string{}
+	for c := cmd; c != nil; c = c.Parent() {
+		parts = append([]string{c.Name()}, parts...)
+	}
+	return strings.Join(parts, " ")
+}
+
+func parentCommandName(cmd *cobra.Command) string {
+	if cmd.HasParent() {
+		return fullCommandName(cmd.Parent())
+	}
+	return ""
+}
+
+func commandPath(cmd *cobra.Command, toolName string) string {
+	parts := []string{}
+	for c := cmd; c != nil; c = c.Parent() {
+		parts = append([]string{c.Name()}, parts...)
+	}
+	return "/cli/" + strings.Join(parts, "/") + "/"
+}
+
+func collectFlags(flags *pflag.FlagSet) []FlagInfo {
+	var result []FlagInfo
+	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		name := formatFlagName(f)
+		result = append(result, FlagInfo{
+			Name:        name,
+			Default:     formatDefault(f),
+			Description: f.Usage,
+		})
+	})
+	return result
+}
+
+func collectInheritedFlags(cmd *cobra.Command) []FlagInfo {
+	return collectFlags(cmd.InheritedFlags())
+}
+
+func formatFlagName(f *pflag.Flag) string {
+	if f.Shorthand != "" {
+		return fmt.Sprintf("--%s, -%s", f.Name, f.Shorthand)
+	}
+	return "--" + f.Name
+}
+
+func formatDefault(f *pflag.Flag) string {
+	if f.DefValue == "" {
+		return `""`
+	}
+	return f.DefValue
+}
+
+func trimExampleLines(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/scripts/rotate-site-deploy-token
+++ b/scripts/rotate-site-deploy-token
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: SSPL-1.0
+# rotate-site-deploy-token — Create or rotate the SITE_DEPLOY_TOKEN secret
+#
+# Usage: ./scripts/rotate-site-deploy-token
+#
+# This script:
+#   1. Verifies gh CLI is authenticated
+#   2. Opens the GitHub UI to create a fine-grained PAT
+#   3. Reads the token from stdin
+#   4. Validates the token has correct permissions
+#   5. Sets it as a repository secret on devlore-cli
+#
+# Run periodically to rotate before the token expires.
+
+set -euo pipefail
+
+CLI_REPO="NobleFactor/devlore-cli"
+SITE_REPO="NobleFactor/devlore.noblefactor.com"
+SECRET_NAME="SITE_DEPLOY_TOKEN"
+PAT_URL="https://github.com/settings/personal-access-tokens/new"
+
+info() { printf '\033[1;34m%s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m%s\033[0m\n' "$*" >&2; }
+error() {
+    printf '\033[1;31m%s\033[0m\n' "$*" >&2
+    exit 1
+}
+
+# --- Preflight checks ---
+
+command -v gh >/dev/null 2>&1 || error "gh CLI not found. Install: https://cli.github.com"
+gh auth status >/dev/null 2>&1 || error "Not authenticated. Run: gh auth login"
+
+info "=== SITE_DEPLOY_TOKEN Rotation ==="
+echo ""
+
+# --- Check existing secret ---
+
+if gh secret list --repo "$CLI_REPO" 2>/dev/null | grep -q "$SECRET_NAME"; then
+    warn "Existing $SECRET_NAME secret found. This will replace it."
+    echo ""
+fi
+
+# --- Instructions ---
+
+info "Step 1: Create a fine-grained Personal Access Token"
+echo ""
+echo "  Repository access: Only select repositories → $SITE_REPO"
+echo ""
+echo "  Required permissions:"
+echo "    Contents:       Read and write"
+echo "    Pull requests:  Read and write"
+echo ""
+echo "  Expiration: 90 days (recommended) or custom"
+echo "  Token name: devlore-cli-docs-publish"
+echo ""
+
+# --- Open browser ---
+
+read -rp "Open GitHub in browser to create token? [Y/n] " open_browser
+if [[ "${open_browser:-Y}" =~ ^[Yy]?$ ]]; then
+    if command -v open >/dev/null 2>&1; then
+        open "$PAT_URL"
+    elif command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "$PAT_URL"
+    else
+        echo "  Open manually: $PAT_URL"
+    fi
+    echo ""
+fi
+
+# --- Read token ---
+
+info "Step 2: Paste the token"
+echo ""
+read -rsp "Token (hidden): " token
+echo ""
+
+[[ -n "$token" ]] || error "No token provided."
+
+# --- Validate token ---
+
+info "Validating token..."
+
+# Check token can access the site repo
+http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $token" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$SITE_REPO")
+
+if [[ "$http_code" == "200" ]]; then
+    info "  ✓ Token can access $SITE_REPO"
+elif [[ "$http_code" == "401" ]]; then
+    error "  ✗ Token is invalid (401 Unauthorized)"
+elif [[ "$http_code" == "403" ]]; then
+    error "  ✗ Token lacks access to $SITE_REPO (403 Forbidden)"
+elif [[ "$http_code" == "404" ]]; then
+    error "  ✗ Token cannot see $SITE_REPO (404 — check repository permissions)"
+else
+    error "  ✗ Unexpected response: HTTP $http_code"
+fi
+
+# Check Contents read permission via API
+contents_check=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $token" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$SITE_REPO/contents/README.md")
+
+if [[ "$contents_check" == "200" ]]; then
+    info "  ✓ Token can read repository contents"
+else
+    warn "  ⚠ Could not verify contents access (HTTP $contents_check)"
+fi
+
+# --- Set secret ---
+
+info "Step 3: Setting repository secret..."
+echo ""
+
+echo "$token" | gh secret set "$SECRET_NAME" --repo "$CLI_REPO"
+
+info "  ✓ $SECRET_NAME set on $CLI_REPO"
+echo ""
+
+# --- Summary ---
+
+info "Done! The docs-publish workflow will use this token on next push to develop/release*/main."
+echo ""
+echo "  To verify: push a commit to develop and check the workflow run."
+echo "  To rotate: run this script again before the token expires."
+echo ""
+
+# --- Reminder for expiration ---
+
+echo "Tip: Set a calendar reminder to rotate this token before expiration."
+echo "     Run: ./scripts/rotate-site-deploy-token"


### PR DESCRIPTION
## Summary

- Adds a `cmd/docgen` tool that walks both writ and lore Cobra command trees and generates Docker-style CLI reference pages (markdown with Astro frontmatter)
- Adds `docs/guides/` with 10 hand-written overview docs covering getting started, writ concepts (environments, platform awareness, secrets, repositories), and lore concepts (deployment, pipeline, manifests, registry)
- Adds `.github/workflows/docs-publish.yaml` that triggers on push to develop/release*/main, generates CLI docs, and opens a PR on the site repo with both generated reference pages and hand-written guides
- Adds `docs` Makefile target and `.gitignore` entry for generated output

## Test plan

- [x] `go build ./cmd/docgen/` compiles cleanly
- [x] `go vet ./internal/tools/docgen/ ./cmd/docgen/` passes
- [x] `make docs` generates 63 CLI reference pages (32 writ + 29 lore + 2 roots)
- [x] Generated markdown has correct frontmatter, options tables, parent/child links
- [x] Pre-commit hooks pass
- [ ] Workflow runs on push to develop (requires SITE_DEPLOY_TOKEN secret)