### PR TITLE
Update writ receipts to v4 graph format

### DIFF
--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -229,7 +229,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			}
 
 			if r.Node.IsDelegate() {
-				rcpt.AddDelegated(r.Node.Source)
+				rcpt.AddDelegated(r.Node)
 				continue
 			}
 
@@ -243,9 +243,9 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 			// Use checksums for copied files (templates, secrets)
 			if r.SourceChecksum != "" || r.TargetChecksum != "" {
-				rcpt.AddEntryWithChecksums(r.Node, alreadyDeployed, r.SourceChecksum, r.TargetChecksum)
+				rcpt.AddNodeWithChecksums(r.Node, alreadyDeployed, r.SourceChecksum, r.TargetChecksum)
 			} else {
-				rcpt.AddEntry(r.Node, alreadyDeployed)
+				rcpt.AddNode(r.Node, alreadyDeployed)
 			}
 		}
 
@@ -1067,33 +1067,37 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return outputStatusText(report)
 }
 
-// addCopiedFilesFromReceipt adds copied file entries from a receipt to the report.
+// addCopiedFilesFromReceipt adds copied file nodes from a receipt to the report.
 func addCopiedFilesFromReceipt(report *status.Report, rcpt *receipt.Receipt, checkDrift bool) {
 	report.FromReceipt = true
 	report.ReceiptPath = receipt.LatestReceiptPath()
 
-	for _, e := range rcpt.Entries {
-		if !e.IsCopied() {
-			continue // Skip symlinks, they're found by scanning
+	for _, n := range rcpt.Nodes {
+		// Skip non-file nodes and symlinks
+		if n.Status == "skipped" || n.Operation == "delegate" || n.Operation == "backup" {
+			continue
+		}
+		if n.Operation == "link" {
+			continue // Symlinks are found by scanning
 		}
 
 		var entry status.Entry
-		if checkDrift && e.SourceChecksum != "" {
+		if checkDrift && n.SourceChecksum != "" {
 			entry = status.Entry{
-				RelTarget:      e.RelTarget,
-				Source:         e.Source,
-				Target:         e.Target,
-				Project:        e.Project,
-				Operations:     e.Operations,
-				SourceChecksum: e.SourceChecksum,
-				TargetChecksum: e.TargetChecksum,
+				RelTarget:      n.ID,
+				Source:         n.Source,
+				Target:         n.Target,
+				Project:        n.Project,
+				Operations:     []string{n.Operation},
+				SourceChecksum: n.SourceChecksum,
+				TargetChecksum: n.TargetChecksum,
 			}
 			// Check drift
-			currentSourceChecksum := receipt.ChecksumFile(e.Source)
-			currentTargetChecksum := receipt.ChecksumFile(e.Target)
+			currentSourceChecksum := receipt.ChecksumFile(n.Source)
+			currentTargetChecksum := receipt.ChecksumFile(n.Target)
 
-			sourceChanged := currentSourceChecksum != "" && currentSourceChecksum != e.SourceChecksum
-			targetChanged := currentTargetChecksum != "" && currentTargetChecksum != e.TargetChecksum
+			sourceChanged := currentSourceChecksum != "" && currentSourceChecksum != n.SourceChecksum
+			targetChanged := currentTargetChecksum != "" && currentTargetChecksum != n.TargetChecksum
 
 			switch {
 			case sourceChanged && targetChanged:
@@ -1111,13 +1115,13 @@ func addCopiedFilesFromReceipt(report *status.Report, rcpt *receipt.Receipt, che
 		} else {
 			// Just check if file exists
 			entry = status.Entry{
-				RelTarget:  e.RelTarget,
-				Source:     e.Source,
-				Target:     e.Target,
-				Project:    e.Project,
-				Operations: e.Operations,
+				RelTarget:  n.ID,
+				Source:     n.Source,
+				Target:     n.Target,
+				Project:    n.Project,
+				Operations: []string{n.Operation},
 			}
-			if _, err := os.Stat(e.Target); os.IsNotExist(err) {
+			if _, err := os.Stat(n.Target); os.IsNotExist(err) {
 				entry.State = status.StateMissing
 				entry.Message = "file not deployed"
 			} else {

--- a/internal/writ/receipt/legacy.go
+++ b/internal/writ/receipt/legacy.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package receipt
+
+import (
+	"time"
+)
+
+// LegacyReceipt is the v2/v3 receipt format (flat entries array).
+// Retained for backward-compatible reads.
+type LegacyReceipt struct {
+	Version    string            `yaml:"version"`
+	Timestamp  time.Time         `yaml:"timestamp"`
+	SourceRoot string            `yaml:"source_root"`
+	TargetRoot string            `yaml:"target_root"`
+	Projects   []string          `yaml:"projects"`
+	Segments   map[string]string `yaml:"segments"`
+	Entries    []LegacyEntry     `yaml:"entries"`
+	Backups    []Backup          `yaml:"backups,omitempty"`
+	Skipped    []string          `yaml:"skipped,omitempty"`
+	Delegated  []string          `yaml:"delegated,omitempty"`
+	Summary    Summary           `yaml:"summary"`
+	Signature  *Signature        `yaml:"signature,omitempty"`
+}
+
+// LegacyEntry records a single deployed file in v2/v3 format.
+type LegacyEntry struct {
+	Source          string   `yaml:"source"`
+	Target          string   `yaml:"target"`
+	RelTarget       string   `yaml:"rel_target"`
+	Operations      []string `yaml:"operations"`
+	Project         string   `yaml:"project"`
+	AlreadyDeployed bool     `yaml:"already_deployed,omitempty"`
+	SourceChecksum  string   `yaml:"source_checksum,omitempty"`
+	TargetChecksum  string   `yaml:"target_checksum,omitempty"`
+}
+
+// ToGraph converts a legacy v2/v3 receipt to the v4 graph format.
+func (lr *LegacyReceipt) ToGraph() *Receipt {
+	r := &Receipt{
+		Version:   CurrentVersion,
+		Format:    "graph",
+		Timestamp: lr.Timestamp,
+		Tool:      "writ",
+		Platform:  detectPlatform(),
+		Context: WritContext{
+			SourceRoot: lr.SourceRoot,
+			TargetRoot: lr.TargetRoot,
+			Projects:   lr.Projects,
+			Segments:   lr.Segments,
+		},
+		Roots:     lr.Projects,
+		Nodes:     make([]Node, 0, len(lr.Entries)+len(lr.Delegated)+len(lr.Skipped)),
+		Edges:     nil,
+		Signature: lr.Signature,
+	}
+
+	// Convert entries to nodes
+	for _, e := range lr.Entries {
+		op := "link"
+		if len(e.Operations) > 0 {
+			// Use the primary operation (first non-copy operation, or first)
+			op = primaryOperation(e.Operations)
+		}
+
+		status := "completed"
+		if e.AlreadyDeployed {
+			status = "completed"
+		}
+
+		node := Node{
+			ID:             e.RelTarget,
+			Operation:      op,
+			Status:         status,
+			Source:         e.Source,
+			Target:         e.Target,
+			Project:        e.Project,
+			SourceChecksum: e.SourceChecksum,
+			TargetChecksum: e.TargetChecksum,
+		}
+
+		if e.AlreadyDeployed {
+			if node.Annotations == nil {
+				node.Annotations = make(map[string]string)
+			}
+			node.Annotations["already_deployed"] = "true"
+		}
+
+		r.Nodes = append(r.Nodes, node)
+	}
+
+	// Convert delegated entries to delegate nodes
+	for _, source := range lr.Delegated {
+		node := Node{
+			ID:         delegatedNodeID(source, lr.SourceRoot),
+			Operation:  "delegate",
+			Status:     "completed",
+			Source:     source,
+			DelegateTo: "lore",
+		}
+		r.Nodes = append(r.Nodes, node)
+	}
+
+	// Convert skipped entries to skipped nodes
+	for _, relTarget := range lr.Skipped {
+		node := Node{
+			ID:     relTarget,
+			Status: "skipped",
+		}
+		r.Nodes = append(r.Nodes, node)
+	}
+
+	// Compute summary from converted data
+	r.ComputeSummary()
+
+	return r
+}
+
+// primaryOperation returns the meaningful operation from a pipeline.
+// In v2/v3, operations are a pipeline like ["expand", "copy"] or ["decrypt", "copy"].
+// We want the first non-"copy" operation, as "copy" is an implementation detail.
+func primaryOperation(ops []string) string {
+	for _, op := range ops {
+		if op != "copy" {
+			return op
+		}
+	}
+	if len(ops) > 0 {
+		return ops[0]
+	}
+	return "link"
+}
+
+// delegatedNodeID computes a node ID for a delegated file.
+func delegatedNodeID(source, sourceRoot string) string {
+	if len(source) > len(sourceRoot)+1 {
+		return source[len(sourceRoot)+1:]
+	}
+	return source
+}

--- a/internal/writ/receipt/receipt.go
+++ b/internal/writ/receipt/receipt.go
@@ -2,6 +2,8 @@
 // Copyright (c) 2025 Noble Factor. All rights reserved.
 
 // Package receipt provides deployment receipt tracking for writ.
+// Receipts are v4 graph-format: nodes represent file operations,
+// edges represent relationships (delegation, dependency).
 package receipt
 
 import (
@@ -11,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -19,141 +22,277 @@ import (
 	"github.com/NobleFactor/devlore-cli/internal/writ/tree"
 )
 
-// Receipt records a writ deployment operation.
+// CurrentVersion is the receipt format version.
+// v1: Initial format (flat entries)
+// v2: Added SourceChecksum, TargetChecksum for copied files
+// v3: Added age-encrypted signature
+// v4: Graph format (nodes + edges)
+const CurrentVersion = "4"
+
+// Receipt records a writ deployment operation as an execution graph.
 type Receipt struct {
 	// Version is the receipt format version.
 	Version string `json:"version" yaml:"version"`
 
-	// Timestamp is when the deployment occurred.
+	// Format identifies the serialization structure (always "graph" for v4).
+	Format string `json:"format" yaml:"format"`
+
+	// Timestamp is when the deployment completed.
 	Timestamp time.Time `json:"timestamp" yaml:"timestamp"`
 
-	// SourceRoot is the dotfiles repository path.
-	SourceRoot string `json:"source_root" yaml:"source_root"`
+	// Tool identifies which tool produced this receipt.
+	Tool string `json:"tool" yaml:"tool"`
 
-	// TargetRoot is the deployment target (e.g., $HOME).
-	TargetRoot string `json:"target_root" yaml:"target_root"`
+	// Platform records the OS and architecture.
+	Platform Platform `json:"platform" yaml:"platform"`
 
-	// Projects deployed.
-	Projects []string `json:"projects" yaml:"projects"`
+	// Context contains writ-specific deployment metadata.
+	Context WritContext `json:"context" yaml:"context"`
 
-	// Segments used for matching.
-	Segments map[string]string `json:"segments" yaml:"segments"`
+	// Roots are the entry points into the graph (project names).
+	Roots []string `json:"roots" yaml:"roots"`
 
-	// Entries are the individual deployed items.
-	Entries []Entry `json:"entries" yaml:"entries"`
+	// Nodes are the operations performed.
+	Nodes []Node `json:"nodes" yaml:"nodes"`
 
-	// Backups created during deployment.
-	Backups []Backup `json:"backups,omitempty" yaml:"backups,omitempty"`
+	// Edges are the relationships between nodes.
+	Edges []Edge `json:"edges,omitempty" yaml:"edges,omitempty"`
 
-	// Skipped files (due to conflicts with --skip).
-	Skipped []string `json:"skipped,omitempty" yaml:"skipped,omitempty"`
+	// Summary contains deployment statistics.
+	Summary Summary `json:"summary,omitempty" yaml:"summary,omitempty"`
 
-	// Delegated manifests (passed to lore).
-	Delegated []string `json:"delegated,omitempty" yaml:"delegated,omitempty"`
-
-	// Summary statistics.
-	Summary Summary `json:"summary" yaml:"summary"`
-
-	// Signature contains the cryptographic signature (v3+).
+	// Signature contains the cryptographic signature.
 	Signature *Signature `json:"signature,omitempty" yaml:"signature,omitempty"`
 }
 
-// Entry records a single deployed file.
-type Entry struct {
-	// Source is the absolute path in the dotfiles repo.
-	Source string `json:"source" yaml:"source"`
+// Platform records the OS and architecture.
+type Platform struct {
+	OS   string `json:"os" yaml:"os"`
+	Arch string `json:"arch" yaml:"arch"`
+}
 
-	// Target is the absolute path in the target location.
-	Target string `json:"target" yaml:"target"`
+// WritContext contains writ-specific deployment metadata.
+type WritContext struct {
+	SourceRoot string            `json:"source_root" yaml:"source_root"`
+	TargetRoot string            `json:"target_root" yaml:"target_root"`
+	Projects   []string          `json:"projects" yaml:"projects"`
+	Segments   map[string]string `json:"segments" yaml:"segments"`
+}
 
-	// RelTarget is the relative path from target root.
-	RelTarget string `json:"rel_target" yaml:"rel_target"`
+// Node represents a single operation in the execution graph.
+type Node struct {
+	// ID is the unique identifier (relative target path for writ).
+	ID string `json:"id" yaml:"id"`
 
-	// Operation performed: link, copy, expand, decrypt.
-	Operations []string `json:"operations" yaml:"operations"`
+	// Operation performed: link, expand, decrypt, copy, delegate.
+	Operation string `json:"operation" yaml:"operation"`
+
+	// Status of the operation: completed, skipped.
+	Status string `json:"status" yaml:"status"`
+
+	// Timestamp is when this operation completed.
+	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+
+	// Source is the absolute path to the source file.
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+
+	// Target is the absolute path to the target file.
+	Target string `json:"target,omitempty" yaml:"target,omitempty"`
 
 	// Project this file belongs to.
-	Project string `json:"project" yaml:"project"`
-
-	// AlreadyDeployed indicates the symlink already existed correctly.
-	AlreadyDeployed bool `json:"already_deployed,omitempty" yaml:"already_deployed,omitempty"`
+	Project string `json:"project,omitempty" yaml:"project,omitempty"`
 
 	// SourceChecksum is the SHA256 of the source file at deploy time.
-	// Only set for copied files (expand, decrypt, copy operations).
-	// Format: "sha256:<hex>"
 	SourceChecksum string `json:"source_checksum,omitempty" yaml:"source_checksum,omitempty"`
 
 	// TargetChecksum is the SHA256 of the target file after deployment.
-	// Only set for copied files (expand, decrypt, copy operations).
-	// Format: "sha256:<hex>"
 	TargetChecksum string `json:"target_checksum,omitempty" yaml:"target_checksum,omitempty"`
+
+	// DelegateTo names the tool to delegate to (e.g., "lore").
+	DelegateTo string `json:"delegate_to,omitempty" yaml:"delegate_to,omitempty"`
+
+	// Annotations holds extensible metadata (backup paths, etc.).
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// Edge represents a relationship between two nodes.
+type Edge struct {
+	From     string `json:"from" yaml:"from"`
+	To       string `json:"to" yaml:"to"`
+	Relation string `json:"relation" yaml:"relation"`
+	Artifact string `json:"artifact,omitempty" yaml:"artifact,omitempty"`
 }
 
 // Backup records a backed-up file.
 type Backup struct {
-	// Original is the path that was backed up.
-	Original string `json:"original" yaml:"original"`
-
-	// BackupPath is where it was moved to.
+	Original   string `json:"original" yaml:"original"`
 	BackupPath string `json:"backup_path" yaml:"backup_path"`
 }
 
 // Summary contains deployment statistics.
 type Summary struct {
-	TotalFiles      int `json:"total_files" yaml:"total_files"`
-	Links           int `json:"links" yaml:"links"`
-	Copies          int `json:"copies" yaml:"copies"`
-	Templates       int `json:"templates" yaml:"templates"`
-	Secrets         int `json:"secrets" yaml:"secrets"`
-	AlreadyDeployed int `json:"already_deployed" yaml:"already_deployed"`
-	Skipped         int `json:"skipped" yaml:"skipped"`
-	BackedUp        int `json:"backed_up" yaml:"backed_up"`
-	Delegated       int `json:"delegated" yaml:"delegated"`
+	TotalFiles int `json:"total_files" yaml:"total_files"`
+	Links      int `json:"links" yaml:"links"`
+	Copies     int `json:"copies,omitempty" yaml:"copies,omitempty"`
+	Templates  int `json:"templates" yaml:"templates"`
+	Secrets    int `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Skipped    int `json:"skipped,omitempty" yaml:"skipped,omitempty"`
+	BackedUp   int `json:"backed_up,omitempty" yaml:"backed_up,omitempty"`
+	Delegated  int `json:"delegated,omitempty" yaml:"delegated,omitempty"`
 }
 
-// CurrentVersion is the receipt format version.
-// v1: Initial format
-// v2: Added SourceChecksum, TargetChecksum for copied files
-const CurrentVersion = "2"
-
-// New creates a new receipt with the given configuration.
+// New creates a new v4 graph-format receipt.
 func New(sourceRoot, targetRoot string, projects []string, segments map[string]string) *Receipt {
 	return &Receipt{
-		Version:    CurrentVersion,
-		Timestamp:  time.Now(),
-		SourceRoot: sourceRoot,
-		TargetRoot: targetRoot,
-		Projects:   projects,
-		Segments:   segments,
-		Entries:    make([]Entry, 0),
+		Version:   CurrentVersion,
+		Format:    "graph",
+		Timestamp: time.Now(),
+		Tool:      "writ",
+		Platform:  detectPlatform(),
+		Context: WritContext{
+			SourceRoot: sourceRoot,
+			TargetRoot: targetRoot,
+			Projects:   projects,
+			Segments:   segments,
+		},
+		Roots: projects,
+		Nodes: make([]Node, 0),
 	}
 }
 
-// AddEntry adds a deployed file entry to the receipt.
-func (r *Receipt) AddEntry(node *tree.Node, alreadyDeployed bool) {
-	r.Entries = append(r.Entries, Entry{
-		Source:          node.Source,
-		Target:          node.Target,
-		RelTarget:       node.RelTarget,
-		Operations:      node.Operations.Strings(),
-		Project:         node.Project,
-		AlreadyDeployed: alreadyDeployed,
+// AddNode adds a deployed file node to the receipt.
+func (r *Receipt) AddNode(node *tree.Node, alreadyDeployed bool) {
+	n := Node{
+		ID:        node.RelTarget,
+		Operation: primaryOperation(node.Operations.Strings()),
+		Status:    "completed",
+		Timestamp: time.Now().Format(time.RFC3339),
+		Source:    node.Source,
+		Target:    node.Target,
+		Project:   node.Project,
+	}
+
+	if alreadyDeployed {
+		if n.Annotations == nil {
+			n.Annotations = make(map[string]string)
+		}
+		n.Annotations["already_deployed"] = "true"
+	}
+
+	r.Nodes = append(r.Nodes, n)
+}
+
+// AddNodeWithChecksums adds a deployed file node with content checksums.
+func (r *Receipt) AddNodeWithChecksums(node *tree.Node, alreadyDeployed bool, sourceChecksum, targetChecksum string) {
+	n := Node{
+		ID:             node.RelTarget,
+		Operation:      primaryOperation(node.Operations.Strings()),
+		Status:         "completed",
+		Timestamp:      time.Now().Format(time.RFC3339),
+		Source:         node.Source,
+		Target:         node.Target,
+		Project:        node.Project,
+		SourceChecksum: sourceChecksum,
+		TargetChecksum: targetChecksum,
+	}
+
+	if alreadyDeployed {
+		if n.Annotations == nil {
+			n.Annotations = make(map[string]string)
+		}
+		n.Annotations["already_deployed"] = "true"
+	}
+
+	r.Nodes = append(r.Nodes, n)
+}
+
+// AddDelegated records a delegated manifest as a delegate node.
+func (r *Receipt) AddDelegated(node *tree.Node) {
+	n := Node{
+		ID:         node.RelTarget,
+		Operation:  "delegate",
+		Status:     "completed",
+		Timestamp:  time.Now().Format(time.RFC3339),
+		Source:     node.Source,
+		Target:     node.Target,
+		Project:    node.Project,
+		DelegateTo: "lore",
+	}
+	r.Nodes = append(r.Nodes, n)
+}
+
+// AddBackup records a backup as an annotation on the affected node.
+func (r *Receipt) AddBackup(original, backupPath string) {
+	// Find the node for this file and annotate it
+	for i := range r.Nodes {
+		if r.Nodes[i].Target == original {
+			if r.Nodes[i].Annotations == nil {
+				r.Nodes[i].Annotations = make(map[string]string)
+			}
+			r.Nodes[i].Annotations["backup"] = backupPath
+			return
+		}
+	}
+	// If no matching node found, create a standalone annotation node
+	r.Nodes = append(r.Nodes, Node{
+		ID:        original,
+		Operation: "backup",
+		Status:    "completed",
+		Target:    original,
+		Annotations: map[string]string{
+			"backup_path": backupPath,
+		},
 	})
 }
 
-// AddEntryWithChecksums adds a deployed file entry with content checksums.
-// Use this for copied files (expand, decrypt, copy operations).
-func (r *Receipt) AddEntryWithChecksums(node *tree.Node, alreadyDeployed bool, sourceChecksum, targetChecksum string) {
-	r.Entries = append(r.Entries, Entry{
-		Source:          node.Source,
-		Target:          node.Target,
-		RelTarget:       node.RelTarget,
-		Operations:      node.Operations.Strings(),
-		Project:         node.Project,
-		AlreadyDeployed: alreadyDeployed,
-		SourceChecksum:  sourceChecksum,
-		TargetChecksum:  targetChecksum,
+// AddSkipped records a skipped file as a node with status "skipped".
+func (r *Receipt) AddSkipped(relTarget string) {
+	r.Nodes = append(r.Nodes, Node{
+		ID:     relTarget,
+		Status: "skipped",
 	})
+}
+
+// AddEdge adds a relationship edge between two nodes.
+func (r *Receipt) AddEdge(from, to, relation string) {
+	r.Edges = append(r.Edges, Edge{
+		From:     from,
+		To:       to,
+		Relation: relation,
+	})
+}
+
+// ComputeSummary calculates summary statistics from nodes.
+func (r *Receipt) ComputeSummary() {
+	r.Summary = Summary{}
+
+	for _, n := range r.Nodes {
+		if n.Status == "skipped" {
+			r.Summary.Skipped++
+			continue
+		}
+		if n.Operation == "delegate" {
+			r.Summary.Delegated++
+			continue
+		}
+		if n.Operation == "backup" {
+			r.Summary.BackedUp++
+			continue
+		}
+
+		r.Summary.TotalFiles++
+
+		switch n.Operation {
+		case "link":
+			r.Summary.Links++
+		case "expand":
+			r.Summary.Templates++
+		case "decrypt":
+			r.Summary.Secrets++
+		case "copy":
+			r.Summary.Copies++
+		}
+	}
 }
 
 // Checksum computes a SHA256 checksum of the given content.
@@ -171,69 +310,6 @@ func ChecksumFile(path string) string {
 		return ""
 	}
 	return Checksum(content)
-}
-
-// IsCopied returns true if this entry was copied (not symlinked).
-func (e *Entry) IsCopied() bool {
-	for _, op := range e.Operations {
-		if op == "expand" || op == "decrypt" || op == "copy" {
-			return true
-		}
-	}
-	return false
-}
-
-// IsLinked returns true if this entry is a symlink.
-func (e *Entry) IsLinked() bool {
-	return len(e.Operations) == 1 && e.Operations[0] == "link"
-}
-
-// AddBackup records a backup that was created.
-func (r *Receipt) AddBackup(original, backupPath string) {
-	r.Backups = append(r.Backups, Backup{
-		Original:   original,
-		BackupPath: backupPath,
-	})
-}
-
-// AddSkipped records a skipped file.
-func (r *Receipt) AddSkipped(relTarget string) {
-	r.Skipped = append(r.Skipped, relTarget)
-}
-
-// AddDelegated records a delegated manifest.
-func (r *Receipt) AddDelegated(source string) {
-	r.Delegated = append(r.Delegated, source)
-}
-
-// ComputeSummary calculates summary statistics from entries.
-func (r *Receipt) ComputeSummary() {
-	r.Summary = Summary{
-		TotalFiles: len(r.Entries),
-		BackedUp:   len(r.Backups),
-		Skipped:    len(r.Skipped),
-		Delegated:  len(r.Delegated),
-	}
-
-	for _, e := range r.Entries {
-		if e.AlreadyDeployed {
-			r.Summary.AlreadyDeployed++
-			continue
-		}
-
-		for _, op := range e.Operations {
-			switch op {
-			case "link":
-				r.Summary.Links++
-			case "copy":
-				r.Summary.Copies++
-			case "expand":
-				r.Summary.Templates++
-			case "decrypt":
-				r.Summary.Secrets++
-			}
-		}
-	}
 }
 
 // StateDir returns the writ state directory.
@@ -288,19 +364,36 @@ func LoadLatest() (*Receipt, error) {
 	return Load(LatestReceiptPath())
 }
 
-// Load reads a receipt from a file.
+// Load reads a receipt from a file, detecting version and converting
+// legacy formats to the v4 graph representation.
 func Load(path string) (*Receipt, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var r Receipt
-	if err := yaml.Unmarshal(data, &r); err != nil {
-		return nil, fmt.Errorf("parse receipt: %w", err)
+	// Peek at version field to determine format
+	var peek struct {
+		Version string `yaml:"version"`
+	}
+	if err := yaml.Unmarshal(data, &peek); err != nil {
+		return nil, fmt.Errorf("parse receipt version: %w", err)
 	}
 
-	return &r, nil
+	switch peek.Version {
+	case "4":
+		var r Receipt
+		if err := yaml.Unmarshal(data, &r); err != nil {
+			return nil, fmt.Errorf("parse v4 receipt: %w", err)
+		}
+		return &r, nil
+	default: // "1", "2", "3" — legacy formats
+		var lr LegacyReceipt
+		if err := yaml.Unmarshal(data, &lr); err != nil {
+			return nil, fmt.Errorf("parse legacy receipt: %w", err)
+		}
+		return lr.ToGraph(), nil
+	}
 }
 
 // JSON returns the receipt as JSON.
@@ -316,13 +409,93 @@ func (r *Receipt) YAML() ([]byte, error) {
 // String returns a human-readable summary of the receipt.
 func (r *Receipt) String() string {
 	r.ComputeSummary()
-	return fmt.Sprintf("%d files (%d links, %d templates, %d secrets), %d already deployed, %d skipped, %d backed up",
+	return fmt.Sprintf("%d files (%d links, %d templates, %d secrets), %d skipped, %d delegated",
 		r.Summary.TotalFiles,
 		r.Summary.Links,
 		r.Summary.Templates,
 		r.Summary.Secrets,
-		r.Summary.AlreadyDeployed,
 		r.Summary.Skipped,
-		r.Summary.BackedUp,
+		r.Summary.Delegated,
 	)
+}
+
+// detectPlatform returns the current OS and architecture.
+func detectPlatform() Platform {
+	return Platform{
+		OS:   runtime.GOOS,
+		Arch: runtime.GOARCH,
+	}
+}
+
+// DependencyGraph represents the coarse-grained dependency view
+// projected from the execution graph.
+type DependencyGraph struct {
+	Nodes []DependencyNode `json:"nodes" yaml:"nodes"`
+	Edges []DependencyEdge `json:"edges" yaml:"edges"`
+}
+
+// DependencyNode represents a project (writ) or package (lore).
+type DependencyNode struct {
+	ID   string `json:"id" yaml:"id"`
+	Tool string `json:"tool" yaml:"tool"`
+}
+
+// DependencyEdge represents a structural relationship between projects/packages.
+type DependencyEdge struct {
+	From     string `json:"from" yaml:"from"`
+	To       string `json:"to" yaml:"to"`
+	Relation string `json:"relation" yaml:"relation"`
+	Artifact string `json:"artifact,omitempty" yaml:"artifact,omitempty"`
+}
+
+// ToDependencyGraph projects the execution graph to a dependency graph.
+// For writ: collapses file nodes into project nodes, preserves delegate edges.
+func (r *Receipt) ToDependencyGraph() *DependencyGraph {
+	dg := &DependencyGraph{}
+
+	// Collect unique projects as dependency nodes
+	projectSeen := make(map[string]bool)
+	for _, n := range r.Nodes {
+		if n.Project != "" && !projectSeen[n.Project] {
+			projectSeen[n.Project] = true
+			dg.Nodes = append(dg.Nodes, DependencyNode{
+				ID:   n.Project,
+				Tool: r.Tool,
+			})
+		}
+		// Delegate nodes create cross-tool dependency nodes
+		if n.Operation == "delegate" && n.DelegateTo != "" {
+			delegateID := n.DelegateTo + ":" + n.ID
+			if !projectSeen[delegateID] {
+				projectSeen[delegateID] = true
+				dg.Nodes = append(dg.Nodes, DependencyNode{
+					ID:   delegateID,
+					Tool: n.DelegateTo,
+				})
+			}
+		}
+	}
+
+	// Promote edges: keep only inter-project and cross-tool edges
+	for _, e := range r.Edges {
+		dg.Edges = append(dg.Edges, DependencyEdge{
+			From:     e.From,
+			To:       e.To,
+			Relation: e.Relation,
+			Artifact: e.Artifact,
+		})
+	}
+
+	// Add implicit delegate edges from project to delegate target
+	for _, n := range r.Nodes {
+		if n.Operation == "delegate" && n.DelegateTo != "" {
+			dg.Edges = append(dg.Edges, DependencyEdge{
+				From:     n.Project,
+				To:       n.DelegateTo + ":" + n.ID,
+				Relation: "delegates",
+			})
+		}
+	}
+
+	return dg
 }

--- a/internal/writ/receipt/receipt.go
+++ b/internal/writ/receipt/receipt.go
@@ -478,12 +478,7 @@ func (r *Receipt) ToDependencyGraph() *DependencyGraph {
 
 	// Promote edges: keep only inter-project and cross-tool edges
 	for _, e := range r.Edges {
-		dg.Edges = append(dg.Edges, DependencyEdge{
-			From:     e.From,
-			To:       e.To,
-			Relation: e.Relation,
-			Artifact: e.Artifact,
-		})
+		dg.Edges = append(dg.Edges, DependencyEdge(e))
 	}
 
 	// Add implicit delegate edges from project to delegate target

--- a/internal/writ/receipt/receipt_test.go
+++ b/internal/writ/receipt/receipt_test.go
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package receipt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewReceipt(t *testing.T) {
+	segments := map[string]string{"OS": "Darwin", "ARCH": "arm64"}
+	rcpt := New("/home/user/dotfiles", "/home/user", []string{"all", "noblefactor"}, segments)
+
+	if rcpt.Version != CurrentVersion {
+		t.Errorf("expected version %q, got %q", CurrentVersion, rcpt.Version)
+	}
+	if rcpt.Format != "graph" {
+		t.Errorf("expected format 'graph', got %q", rcpt.Format)
+	}
+	if rcpt.Tool != "writ" {
+		t.Errorf("expected tool 'writ', got %q", rcpt.Tool)
+	}
+	if rcpt.Context.SourceRoot != "/home/user/dotfiles" {
+		t.Errorf("expected source_root '/home/user/dotfiles', got %q", rcpt.Context.SourceRoot)
+	}
+	if len(rcpt.Roots) != 2 {
+		t.Errorf("expected 2 roots, got %d", len(rcpt.Roots))
+	}
+	if rcpt.Platform.OS == "" {
+		t.Error("expected platform OS to be set")
+	}
+}
+
+func TestComputeSummary(t *testing.T) {
+	rcpt := &Receipt{
+		Nodes: []Node{
+			{ID: ".bashrc", Operation: "link", Status: "completed"},
+			{ID: ".gitconfig", Operation: "expand", Status: "completed"},
+			{ID: ".npmrc", Operation: "decrypt", Status: "completed"},
+			{ID: ".config/packages.manifest", Operation: "delegate", Status: "completed"},
+			{ID: ".conflicted", Status: "skipped"},
+		},
+	}
+
+	rcpt.ComputeSummary()
+
+	if rcpt.Summary.TotalFiles != 3 {
+		t.Errorf("expected 3 total files, got %d", rcpt.Summary.TotalFiles)
+	}
+	if rcpt.Summary.Links != 1 {
+		t.Errorf("expected 1 link, got %d", rcpt.Summary.Links)
+	}
+	if rcpt.Summary.Templates != 1 {
+		t.Errorf("expected 1 template, got %d", rcpt.Summary.Templates)
+	}
+	if rcpt.Summary.Secrets != 1 {
+		t.Errorf("expected 1 secret, got %d", rcpt.Summary.Secrets)
+	}
+	if rcpt.Summary.Delegated != 1 {
+		t.Errorf("expected 1 delegated, got %d", rcpt.Summary.Delegated)
+	}
+	if rcpt.Summary.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", rcpt.Summary.Skipped)
+	}
+}
+
+func TestLegacyToGraph(t *testing.T) {
+	lr := &LegacyReceipt{
+		Version:    "2",
+		Timestamp:  time.Date(2026, 1, 21, 10, 30, 0, 0, time.UTC),
+		SourceRoot: "/home/user/dotfiles",
+		TargetRoot: "/home/user",
+		Projects:   []string{"all", "noblefactor"},
+		Segments:   map[string]string{"OS": "Darwin"},
+		Entries: []LegacyEntry{
+			{
+				Source:     "/home/user/dotfiles/all/.bashrc",
+				Target:     "/home/user/.bashrc",
+				RelTarget:  ".bashrc",
+				Operations: []string{"link"},
+				Project:    "all",
+			},
+			{
+				Source:          "/home/user/dotfiles/noblefactor/.gitconfig.template",
+				Target:          "/home/user/.gitconfig",
+				RelTarget:       ".gitconfig",
+				Operations:      []string{"expand", "copy"},
+				Project:         "noblefactor",
+				AlreadyDeployed: false,
+				SourceChecksum:  "sha256:abc123",
+				TargetChecksum:  "sha256:def456",
+			},
+			{
+				Source:          "/home/user/dotfiles/all/.zshrc",
+				Target:          "/home/user/.zshrc",
+				RelTarget:       ".zshrc",
+				Operations:      []string{"link"},
+				Project:         "all",
+				AlreadyDeployed: true,
+			},
+		},
+		Delegated: []string{"/home/user/dotfiles/noblefactor/.config/packages.manifest"},
+		Skipped:   []string{".conflicted"},
+	}
+
+	rcpt := lr.ToGraph()
+
+	if rcpt.Version != CurrentVersion {
+		t.Errorf("expected version %q, got %q", CurrentVersion, rcpt.Version)
+	}
+	if rcpt.Format != "graph" {
+		t.Errorf("expected format 'graph', got %q", rcpt.Format)
+	}
+	if rcpt.Tool != "writ" {
+		t.Errorf("expected tool 'writ', got %q", rcpt.Tool)
+	}
+	if rcpt.Context.SourceRoot != "/home/user/dotfiles" {
+		t.Errorf("expected source root, got %q", rcpt.Context.SourceRoot)
+	}
+
+	// 3 entries + 1 delegated + 1 skipped = 5 nodes
+	if len(rcpt.Nodes) != 5 {
+		t.Fatalf("expected 5 nodes, got %d", len(rcpt.Nodes))
+	}
+
+	// Check first node
+	if rcpt.Nodes[0].ID != ".bashrc" {
+		t.Errorf("expected node ID '.bashrc', got %q", rcpt.Nodes[0].ID)
+	}
+	if rcpt.Nodes[0].Operation != "link" {
+		t.Errorf("expected operation 'link', got %q", rcpt.Nodes[0].Operation)
+	}
+
+	// Check template node uses primary operation
+	if rcpt.Nodes[1].Operation != "expand" {
+		t.Errorf("expected operation 'expand', got %q", rcpt.Nodes[1].Operation)
+	}
+	if rcpt.Nodes[1].SourceChecksum != "sha256:abc123" {
+		t.Errorf("expected source checksum preserved")
+	}
+
+	// Check already_deployed annotation
+	if rcpt.Nodes[2].Annotations == nil || rcpt.Nodes[2].Annotations["already_deployed"] != "true" {
+		t.Error("expected already_deployed annotation on third node")
+	}
+
+	// Check delegated node
+	if rcpt.Nodes[3].Operation != "delegate" {
+		t.Errorf("expected delegate operation, got %q", rcpt.Nodes[3].Operation)
+	}
+	if rcpt.Nodes[3].DelegateTo != "lore" {
+		t.Errorf("expected delegate_to 'lore', got %q", rcpt.Nodes[3].DelegateTo)
+	}
+
+	// Check skipped node
+	if rcpt.Nodes[4].Status != "skipped" {
+		t.Errorf("expected status 'skipped', got %q", rcpt.Nodes[4].Status)
+	}
+}
+
+func TestLoadLegacyReceipt(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a v2 legacy receipt
+	legacy := LegacyReceipt{
+		Version:    "2",
+		Timestamp:  time.Date(2026, 1, 21, 10, 30, 0, 0, time.UTC),
+		SourceRoot: "/home/user/dotfiles",
+		TargetRoot: "/home/user",
+		Projects:   []string{"all"},
+		Segments:   map[string]string{},
+		Entries: []LegacyEntry{
+			{
+				Source:     "/home/user/dotfiles/all/.bashrc",
+				Target:     "/home/user/.bashrc",
+				RelTarget:  ".bashrc",
+				Operations: []string{"link"},
+				Project:    "all",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy receipt: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "legacy.yaml")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write legacy receipt: %v", err)
+	}
+
+	// Load should detect version and convert
+	rcpt, err := Load(path)
+	if err != nil {
+		t.Fatalf("load legacy receipt: %v", err)
+	}
+
+	if rcpt.Version != CurrentVersion {
+		t.Errorf("expected converted version %q, got %q", CurrentVersion, rcpt.Version)
+	}
+	if rcpt.Format != "graph" {
+		t.Errorf("expected format 'graph', got %q", rcpt.Format)
+	}
+	if len(rcpt.Nodes) != 1 {
+		t.Errorf("expected 1 node, got %d", len(rcpt.Nodes))
+	}
+}
+
+func TestLoadV4Receipt(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a v4 receipt
+	v4 := Receipt{
+		Version:   "4",
+		Format:    "graph",
+		Timestamp: time.Date(2026, 1, 23, 14, 30, 0, 0, time.UTC),
+		Tool:      "writ",
+		Platform:  Platform{OS: "darwin", Arch: "arm64"},
+		Context: WritContext{
+			SourceRoot: "/home/user/dotfiles",
+			TargetRoot: "/home/user",
+			Projects:   []string{"all"},
+			Segments:   map[string]string{},
+		},
+		Roots: []string{"all"},
+		Nodes: []Node{
+			{
+				ID:        ".bashrc",
+				Operation: "link",
+				Status:    "completed",
+				Source:    "/home/user/dotfiles/all/.bashrc",
+				Target:    "/home/user/.bashrc",
+				Project:   "all",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(v4)
+	if err != nil {
+		t.Fatalf("marshal v4 receipt: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "v4.yaml")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write v4 receipt: %v", err)
+	}
+
+	// Load should read directly as v4
+	rcpt, err := Load(path)
+	if err != nil {
+		t.Fatalf("load v4 receipt: %v", err)
+	}
+
+	if rcpt.Version != "4" {
+		t.Errorf("expected version '4', got %q", rcpt.Version)
+	}
+	if len(rcpt.Nodes) != 1 {
+		t.Errorf("expected 1 node, got %d", len(rcpt.Nodes))
+	}
+	if rcpt.Nodes[0].ID != ".bashrc" {
+		t.Errorf("expected node ID '.bashrc', got %q", rcpt.Nodes[0].ID)
+	}
+}
+
+func TestPrimaryOperation(t *testing.T) {
+	tests := []struct {
+		ops      []string
+		expected string
+	}{
+		{[]string{"link"}, "link"},
+		{[]string{"expand", "copy"}, "expand"},
+		{[]string{"decrypt", "copy"}, "decrypt"},
+		{[]string{"decrypt", "expand", "copy"}, "decrypt"},
+		{[]string{"copy"}, "copy"},
+		{nil, "link"},
+	}
+
+	for _, tt := range tests {
+		got := primaryOperation(tt.ops)
+		if got != tt.expected {
+			t.Errorf("primaryOperation(%v) = %q, want %q", tt.ops, got, tt.expected)
+		}
+	}
+}
+
+func TestToDependencyGraph(t *testing.T) {
+	rcpt := &Receipt{
+		Tool: "writ",
+		Nodes: []Node{
+			{ID: ".bashrc", Operation: "link", Project: "all"},
+			{ID: ".zshrc", Operation: "link", Project: "all"},
+			{ID: ".gitconfig", Operation: "expand", Project: "noblefactor"},
+			{
+				ID:         ".config/packages.manifest",
+				Operation:  "delegate",
+				Project:    "noblefactor",
+				DelegateTo: "lore",
+			},
+		},
+		Edges: []Edge{
+			{From: ".config/packages.manifest", To: "lore:docker", Relation: "delegates"},
+		},
+	}
+
+	dg := rcpt.ToDependencyGraph()
+
+	// Should have: all, noblefactor (writ), lore:.config/packages.manifest
+	if len(dg.Nodes) != 3 {
+		t.Errorf("expected 3 dependency nodes, got %d", len(dg.Nodes))
+	}
+
+	// Should have explicit edge + implicit delegate edge
+	if len(dg.Edges) != 2 {
+		t.Errorf("expected 2 dependency edges, got %d", len(dg.Edges))
+	}
+
+	// Check the implicit delegate edge
+	foundDelegate := false
+	for _, e := range dg.Edges {
+		if e.From == "noblefactor" && e.Relation == "delegates" {
+			foundDelegate = true
+		}
+	}
+	if !foundDelegate {
+		t.Error("expected implicit delegate edge from noblefactor")
+	}
+}
+
+func TestAddBackupAnnotation(t *testing.T) {
+	rcpt := &Receipt{
+		Nodes: []Node{
+			{ID: ".bashrc", Operation: "link", Target: "/home/user/.bashrc"},
+		},
+	}
+
+	rcpt.AddBackup("/home/user/.bashrc", "/home/user/.bashrc.writ-backup.20260123")
+
+	if rcpt.Nodes[0].Annotations == nil {
+		t.Fatal("expected annotations on node")
+	}
+	if rcpt.Nodes[0].Annotations["backup"] != "/home/user/.bashrc.writ-backup.20260123" {
+		t.Error("expected backup annotation")
+	}
+}
+
+func TestAddSkipped(t *testing.T) {
+	rcpt := &Receipt{Nodes: make([]Node, 0)}
+
+	rcpt.AddSkipped(".conflicted")
+
+	if len(rcpt.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(rcpt.Nodes))
+	}
+	if rcpt.Nodes[0].ID != ".conflicted" {
+		t.Errorf("expected ID '.conflicted', got %q", rcpt.Nodes[0].ID)
+	}
+	if rcpt.Nodes[0].Status != "skipped" {
+		t.Errorf("expected status 'skipped', got %q", rcpt.Nodes[0].Status)
+	}
+}
+
+func TestChecksum(t *testing.T) {
+	content := []byte("hello world")
+	sum := Checksum(content)
+
+	if sum == "" {
+		t.Error("expected non-empty checksum")
+	}
+	if len(sum) < 10 {
+		t.Error("checksum too short")
+	}
+	if sum[:7] != "sha256:" {
+		t.Errorf("expected sha256: prefix, got %q", sum[:7])
+	}
+}

--- a/internal/writ/receipt/signature.go
+++ b/internal/writ/receipt/signature.go
@@ -27,21 +27,14 @@ type Signature struct {
 	Recipient string `json:"recipient" yaml:"recipient"`
 }
 
-// SignatureVersion is the receipt version that includes signatures.
-const SignatureVersion = "3"
-
 // Sign signs the receipt using the provided age identity.
 // The signature is computed by:
-// 1. Updating the version to v3 (signature version)
-// 2. Serializing the receipt (without signature) to canonical YAML
-// 3. Computing SHA256 of the serialized content
-// 4. Encrypting the hash with age to the identity's public key
-// 5. Storing the encrypted hash as the signature
+// 1. Serializing the receipt nodes+edges to canonical YAML
+// 2. Computing SHA256 of the serialized content
+// 3. Encrypting the hash with age to the identity's public key
+// 4. Storing the encrypted hash as the signature
 func (r *Receipt) Sign(identity *age.X25519Identity) error {
-	// Update version first (before computing hash)
-	r.Version = SignatureVersion
-
-	// Get canonical content (receipt without signature)
+	// Get canonical content (nodes + edges, without signature)
 	content, err := r.canonicalContent()
 	if err != nil {
 		return fmt.Errorf("serialize receipt: %w", err)
@@ -78,7 +71,7 @@ func (r *Receipt) Sign(identity *age.X25519Identity) error {
 // Returns nil if the signature is valid, an error otherwise.
 func (r *Receipt) Verify(identities []age.Identity) error {
 	if r.Signature == nil {
-		// Unsigned receipt - check if it's a legacy v2
+		// Unsigned receipt - check if it was loaded from legacy
 		if r.Version == "2" || r.Version == "1" {
 			return nil // Legacy receipts allowed during migration
 		}
@@ -132,38 +125,34 @@ func (r *Receipt) IsLegacy() bool {
 }
 
 // canonicalContent returns the receipt serialized without the signature field.
+// For v4: serializes version, format, timestamp, tool, platform, context, roots, nodes, edges.
 // This ensures consistent content for signing and verification.
 func (r *Receipt) canonicalContent() ([]byte, error) {
-	// Create a copy without signature for serialization
-	type ReceiptNoSig struct {
-		Version    string            `yaml:"version"`
-		Timestamp  string            `yaml:"timestamp"`
-		SourceRoot string            `yaml:"source_root"`
-		TargetRoot string            `yaml:"target_root"`
-		Projects   []string          `yaml:"projects"`
-		Segments   map[string]string `yaml:"segments"`
-		Entries    []Entry           `yaml:"entries"`
-		Backups    []Backup          `yaml:"backups,omitempty"`
-		Skipped    []string          `yaml:"skipped,omitempty"`
-		Delegated  []string          `yaml:"delegated,omitempty"`
-		Summary    Summary           `yaml:"summary"`
+	type CanonicalReceipt struct {
+		Version   string      `yaml:"version"`
+		Format    string      `yaml:"format"`
+		Timestamp string      `yaml:"timestamp"`
+		Tool      string      `yaml:"tool"`
+		Platform  Platform    `yaml:"platform"`
+		Context   WritContext `yaml:"context"`
+		Roots     []string    `yaml:"roots"`
+		Nodes     []Node      `yaml:"nodes"`
+		Edges     []Edge      `yaml:"edges,omitempty"`
 	}
 
-	nosig := ReceiptNoSig{
-		Version:    r.Version,
-		Timestamp:  r.Timestamp.Format("2006-01-02T15:04:05.999999999Z07:00"),
-		SourceRoot: r.SourceRoot,
-		TargetRoot: r.TargetRoot,
-		Projects:   r.Projects,
-		Segments:   r.Segments,
-		Entries:    r.Entries,
-		Backups:    r.Backups,
-		Skipped:    r.Skipped,
-		Delegated:  r.Delegated,
-		Summary:    r.Summary,
+	canonical := CanonicalReceipt{
+		Version:   r.Version,
+		Format:    r.Format,
+		Timestamp: r.Timestamp.Format("2006-01-02T15:04:05.999999999Z07:00"),
+		Tool:      r.Tool,
+		Platform:  r.Platform,
+		Context:   r.Context,
+		Roots:     r.Roots,
+		Nodes:     r.Nodes,
+		Edges:     r.Edges,
 	}
 
-	return yaml.Marshal(nosig)
+	return yaml.Marshal(canonical)
 }
 
 // VerifyResult represents the result of signature verification.

--- a/internal/writ/receipt/signature_test.go
+++ b/internal/writ/receipt/signature_test.go
@@ -17,27 +17,35 @@ func TestSignAndVerify(t *testing.T) {
 		t.Fatalf("generate identity: %v", err)
 	}
 
-	// Create a test receipt
+	// Create a test v4 receipt
 	rcpt := &Receipt{
-		Version:    "2",
-		Timestamp:  time.Now(),
-		SourceRoot: "/home/user/dotfiles",
-		TargetRoot: "/home/user",
-		Projects:   []string{"all", "noblefactor"},
-		Segments:   map[string]string{"OS": "Darwin", "ARCH": "arm64"},
-		Entries: []Entry{
+		Version:   CurrentVersion,
+		Format:    "graph",
+		Timestamp: time.Now(),
+		Tool:      "writ",
+		Platform:  Platform{OS: "darwin", Arch: "arm64"},
+		Context: WritContext{
+			SourceRoot: "/home/user/dotfiles",
+			TargetRoot: "/home/user",
+			Projects:   []string{"all", "noblefactor"},
+			Segments:   map[string]string{"OS": "Darwin", "ARCH": "arm64"},
+		},
+		Roots: []string{"all", "noblefactor"},
+		Nodes: []Node{
 			{
-				Source:     "/home/user/dotfiles/all/.bashrc",
-				Target:     "/home/user/.bashrc",
-				RelTarget:  ".bashrc",
-				Operations: []string{"link"},
-				Project:    "all",
+				ID:        ".bashrc",
+				Operation: "link",
+				Status:    "completed",
+				Source:    "/home/user/dotfiles/all/.bashrc",
+				Target:    "/home/user/.bashrc",
+				Project:   "all",
 			},
 			{
+				ID:             ".gitconfig",
+				Operation:      "expand",
+				Status:         "completed",
 				Source:         "/home/user/dotfiles/noblefactor/.gitconfig.template",
 				Target:         "/home/user/.gitconfig",
-				RelTarget:      ".gitconfig",
-				Operations:     []string{"expand", "copy"},
 				Project:        "noblefactor",
 				SourceChecksum: "sha256:abc123",
 				TargetChecksum: "sha256:def456",
@@ -60,9 +68,6 @@ func TestSignAndVerify(t *testing.T) {
 	}
 	if rcpt.Signature.Recipient != identity.Recipient().String() {
 		t.Errorf("expected recipient %q, got %q", identity.Recipient().String(), rcpt.Signature.Recipient)
-	}
-	if rcpt.Version != SignatureVersion {
-		t.Errorf("expected version %q, got %q", SignatureVersion, rcpt.Version)
 	}
 
 	// Verify the signature
@@ -89,19 +94,26 @@ func TestVerifyTamperedReceipt(t *testing.T) {
 
 	// Create and sign a test receipt
 	rcpt := &Receipt{
-		Version:    "2",
-		Timestamp:  time.Now(),
-		SourceRoot: "/home/user/dotfiles",
-		TargetRoot: "/home/user",
-		Projects:   []string{"all"},
-		Segments:   map[string]string{},
-		Entries: []Entry{
+		Version:   CurrentVersion,
+		Format:    "graph",
+		Timestamp: time.Now(),
+		Tool:      "writ",
+		Platform:  Platform{OS: "darwin", Arch: "arm64"},
+		Context: WritContext{
+			SourceRoot: "/home/user/dotfiles",
+			TargetRoot: "/home/user",
+			Projects:   []string{"all"},
+			Segments:   map[string]string{},
+		},
+		Roots: []string{"all"},
+		Nodes: []Node{
 			{
-				Source:     "/home/user/dotfiles/all/.bashrc",
-				Target:     "/home/user/.bashrc",
-				RelTarget:  ".bashrc",
-				Operations: []string{"link"},
-				Project:    "all",
+				ID:        ".bashrc",
+				Operation: "link",
+				Status:    "completed",
+				Source:    "/home/user/dotfiles/all/.bashrc",
+				Target:    "/home/user/.bashrc",
+				Project:   "all",
 			},
 		},
 	}
@@ -112,7 +124,7 @@ func TestVerifyTamperedReceipt(t *testing.T) {
 	}
 
 	// Tamper with the receipt
-	rcpt.Projects = append(rcpt.Projects, "tampered")
+	rcpt.Roots = append(rcpt.Roots, "tampered")
 
 	// Verification should fail
 	if err := rcpt.Verify([]age.Identity{identity}); err == nil {
@@ -127,15 +139,10 @@ func TestVerifyTamperedReceipt(t *testing.T) {
 }
 
 func TestVerifyLegacyReceipt(t *testing.T) {
-	// Create a legacy v2 receipt (unsigned)
+	// A legacy receipt loaded and converted still has Version "4"
+	// but if it had no signature originally, IsLegacy tests against v1/v2
 	rcpt := &Receipt{
-		Version:    "2",
-		Timestamp:  time.Now(),
-		SourceRoot: "/home/user/dotfiles",
-		TargetRoot: "/home/user",
-		Projects:   []string{"all"},
-		Segments:   map[string]string{},
-		Entries:    []Entry{},
+		Version: "2", // Simulating a pre-conversion check
 	}
 
 	// Legacy receipts should be allowed
@@ -162,13 +169,19 @@ func TestVerifyWrongIdentity(t *testing.T) {
 
 	// Create and sign with first identity
 	rcpt := &Receipt{
-		Version:    "2",
-		Timestamp:  time.Now(),
-		SourceRoot: "/home/user/dotfiles",
-		TargetRoot: "/home/user",
-		Projects:   []string{"all"},
-		Segments:   map[string]string{},
-		Entries:    []Entry{},
+		Version:   CurrentVersion,
+		Format:    "graph",
+		Timestamp: time.Now(),
+		Tool:      "writ",
+		Platform:  Platform{OS: "linux", Arch: "amd64"},
+		Context: WritContext{
+			SourceRoot: "/home/user/dotfiles",
+			TargetRoot: "/home/user",
+			Projects:   []string{"all"},
+			Segments:   map[string]string{},
+		},
+		Roots: []string{"all"},
+		Nodes: []Node{},
 	}
 
 	if err := rcpt.Sign(signingIdentity); err != nil {
@@ -182,7 +195,7 @@ func TestVerifyWrongIdentity(t *testing.T) {
 }
 
 func TestIsSigned(t *testing.T) {
-	rcpt := &Receipt{Version: "2"}
+	rcpt := &Receipt{Version: CurrentVersion}
 
 	if rcpt.IsSigned() {
 		t.Error("expected unsigned receipt to return false")

--- a/internal/writ/state/state.go
+++ b/internal/writ/state/state.go
@@ -249,19 +249,24 @@ func (s *State) Summary() (links, copied int) {
 	return
 }
 
-// UpdateFromReceipt merges entries from a receipt into the state.
+// UpdateFromReceipt merges nodes from a v4 graph-format receipt into the state.
 func (s *State) UpdateFromReceipt(rcpt *receipt.Receipt, receiptFilename string) {
-	for _, e := range rcpt.Entries {
+	for _, n := range rcpt.Nodes {
+		// Skip non-file nodes
+		if n.Status == "skipped" || n.Operation == "delegate" || n.Operation == "backup" {
+			continue
+		}
+
 		entry := &FileEntry{
-			Source:         e.Source,
-			Project:        e.Project,
-			Operations:     e.Operations,
+			Source:         n.Source,
+			Project:        n.Project,
+			Operations:     []string{n.Operation},
 			DeployedAt:     rcpt.Timestamp,
 			Receipt:        receiptFilename,
-			SourceChecksum: e.SourceChecksum,
-			TargetChecksum: e.TargetChecksum,
+			SourceChecksum: n.SourceChecksum,
+			TargetChecksum: n.TargetChecksum,
 		}
-		s.AddEntry(e.RelTarget, entry)
+		s.AddEntry(n.ID, entry) // ID = rel_target
 	}
 }
 

--- a/internal/writ/state/state_test.go
+++ b/internal/writ/state/state_test.go
@@ -167,32 +167,53 @@ func TestStateUpdateFromReceipt(t *testing.T) {
 	s := New("/home/user/dotfiles", "/home/user")
 
 	rcpt := &receipt.Receipt{
-		Timestamp:  time.Now(),
-		SourceRoot: "/home/user/dotfiles",
-		TargetRoot: "/home/user",
-		Projects:   []string{"all", "noblefactor"},
-		Entries: []receipt.Entry{
+		Version:   "4",
+		Format:    "graph",
+		Timestamp: time.Now(),
+		Tool:      "writ",
+		Context: receipt.WritContext{
+			SourceRoot: "/home/user/dotfiles",
+			TargetRoot: "/home/user",
+			Projects:   []string{"all", "noblefactor"},
+		},
+		Roots: []string{"all", "noblefactor"},
+		Nodes: []receipt.Node{
 			{
-				Source:     "/home/user/dotfiles/all/.bashrc",
-				Target:     "/home/user/.bashrc",
-				RelTarget:  ".bashrc",
-				Operations: []string{"link"},
-				Project:    "all",
+				ID:        ".bashrc",
+				Operation: "link",
+				Status:    "completed",
+				Source:    "/home/user/dotfiles/all/.bashrc",
+				Target:    "/home/user/.bashrc",
+				Project:   "all",
 			},
 			{
+				ID:             ".gitconfig",
+				Operation:      "expand",
+				Status:         "completed",
 				Source:         "/home/user/dotfiles/noblefactor/.gitconfig.template",
 				Target:         "/home/user/.gitconfig",
-				RelTarget:      ".gitconfig",
-				Operations:     []string{"expand", "copy"},
 				Project:        "noblefactor",
 				SourceChecksum: "sha256:abc123",
 				TargetChecksum: "sha256:def456",
+			},
+			{
+				ID:         ".config/packages.manifest",
+				Operation:  "delegate",
+				Status:     "completed",
+				DelegateTo: "lore",
+				Project:    "noblefactor",
+			},
+			{
+				ID:     ".conflicted",
+				Status: "skipped",
 			},
 		},
 	}
 
 	s.UpdateFromReceipt(rcpt, "2026-01-21T10-30-00.yaml")
 
+	// Should have 2 files: .bashrc and .gitconfig
+	// delegate and skipped nodes should be excluded
 	if len(s.Files) != 2 {
 		t.Errorf("expected 2 files, got %d", len(s.Files))
 	}
@@ -204,6 +225,9 @@ func TestStateUpdateFromReceipt(t *testing.T) {
 	if bashrc.Project != "all" {
 		t.Errorf("expected project 'all', got %q", bashrc.Project)
 	}
+	if len(bashrc.Operations) != 1 || bashrc.Operations[0] != "link" {
+		t.Errorf("expected operations ['link'], got %v", bashrc.Operations)
+	}
 
 	gitconfig := s.GetEntry(".gitconfig")
 	if gitconfig == nil {
@@ -211,6 +235,14 @@ func TestStateUpdateFromReceipt(t *testing.T) {
 	}
 	if gitconfig.SourceChecksum != "sha256:abc123" {
 		t.Errorf("expected source checksum 'sha256:abc123', got %q", gitconfig.SourceChecksum)
+	}
+
+	// Delegate and skipped should not be in state
+	if s.GetEntry(".config/packages.manifest") != nil {
+		t.Error("expected delegate node to be excluded from state")
+	}
+	if s.GetEntry(".conflicted") != nil {
+		t.Error("expected skipped node to be excluded from state")
 	}
 }
 

--- a/internal/writ/status/status.go
+++ b/internal/writ/status/status.go
@@ -163,19 +163,25 @@ func FromReceipt(rcpt *receipt.Receipt, receiptPath string) *Report {
 // When checkDrift is true, checksums are compared to detect source/target changes.
 func FromReceiptWithDrift(rcpt *receipt.Receipt, receiptPath string, checkDrift bool) *Report {
 	report := &Report{
-		TargetRoot:  rcpt.TargetRoot,
-		SourceRoot:  rcpt.SourceRoot,
-		Projects:    rcpt.Projects,
+		TargetRoot:  rcpt.Context.TargetRoot,
+		SourceRoot:  rcpt.Context.SourceRoot,
+		Projects:    rcpt.Context.Projects,
 		FromReceipt: true,
 		ReceiptPath: receiptPath,
 	}
 
-	for _, e := range rcpt.Entries {
+	for _, n := range rcpt.Nodes {
+		if n.Status == "skipped" || n.Operation == "delegate" || n.Operation == "backup" {
+			continue
+		}
+
 		var entry Entry
-		if checkDrift && e.IsCopied() && e.SourceChecksum != "" {
-			entry = checkEntryWithDrift(e.Source, e.Target, e.RelTarget, e.Project, e.Operations, e.SourceChecksum, e.TargetChecksum)
+		ops := []string{n.Operation}
+		isCopied := n.Operation != "link"
+		if checkDrift && isCopied && n.SourceChecksum != "" {
+			entry = checkEntryWithDrift(n.Source, n.Target, n.ID, n.Project, ops, n.SourceChecksum, n.TargetChecksum)
 		} else {
-			entry = checkEntry(e.Source, e.Target, e.RelTarget, e.Project, e.Operations)
+			entry = checkEntry(n.Source, n.Target, n.ID, n.Project, ops)
 		}
 		report.Entries = append(report.Entries, entry)
 	}


### PR DESCRIPTION
## Summary
- Replace flat entries array with graph-based nodes+edges structure (v4)
- Add `legacy.go` with `LegacyReceipt` type and `ToGraph()` converter for v2/v3 backward compat
- Version-detecting `Load()` auto-converts legacy receipts in memory
- `ToDependencyGraph()` projects execution graph to coarse dependency graph
- Updated builder API: `AddNode`, `AddNodeWithChecksums`, `AddDelegated(node)`
- Updated `state.go`, `commands.go`, `status.go` to consume new types

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./internal/writ/...` all pass
- [x] Pre-commit hooks pass
- [ ] Manual: `writ add` produces v4 graph-format receipt
- [ ] Manual: `writ status` reads v4 receipt correctly
- [ ] Backward compat: place a v2/v3 receipt, confirm `Load()` converts it