### PR TITLE
Add explicit permissions to docs-publish workflow

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -3,7 +3,10 @@ name: Publish CLI Docs
 
 on:
   push:
-    branches: [develop, 'release*', main]
+    branches: [develop, "release*", main]
+
+permissions:
+  contents: read
 
 jobs:
   generate-and-pr:


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to fix workflow file issue
- Use consistent double-quote style for branch patterns

## Test plan
- [ ] docs-publish workflow runs after merge to develop