### PR TITLE
Fix YAML block scalar indentation in docs-publish workflow

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -59,11 +59,12 @@ jobs:
           fi
           git commit -m "Update docs from devlore-cli@${GITHUB_SHA::7}"
           git push origin "$BRANCH"
+          BODY="Automated update from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA}).
+
+          Triggered by push to \`${GITHUB_REF_NAME}\` branch.
+
+          Includes CLI reference (generated) and guides (hand-written)."
           gh pr create \
             --title "Update CLI documentation" \
-            --body "Automated update from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA}).
-
-Triggered by push to \`${GITHUB_REF_NAME}\` branch.
-
-Includes CLI reference (generated) and guides (hand-written)." \
+            --body "$BODY" \
             --base develop


### PR DESCRIPTION
## Summary
- Fix the actual cause of docs-publish workflow failure: unindented lines in the YAML literal block scalar broke GitHub's YAML parser
- Extract multi-line PR body into a shell variable with proper indentation
- Validated with `actionlint`

## Test plan
- [x] `actionlint` passes
- [ ] docs-publish workflow runs after merge to develop