### PR TITLE
Add common execution engine and lore graph builder

### DIFF
--- a/internal/engine/builder.go
+++ b/internal/engine/builder.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import "context"
+
+// GraphBuilder builds an execution graph from a manifest file.
+// Tools implement this interface to translate their manifest format
+// into an execution graph that the engine can process.
+//
+// When writ encounters a delegate node, it calls BuildGraph with the
+// manifest path to get a subgraph. That subgraph is then executed by
+// the same engine — no separate tool invocation needed.
+type GraphBuilder interface {
+	BuildGraph(ctx context.Context, manifestPath string, opts BuildOptions) (*Graph, error)
+}
+
+// BuildOptions configures graph building behavior.
+type BuildOptions struct {
+	// DryRun prevents the builder from making any filesystem queries
+	// that have side effects.
+	DryRun bool
+
+	// Features lists enabled features (e.g., "rootless", "compose").
+	Features []string
+
+	// Data holds tool context: platform info, environment, segments.
+	Data map[string]any
+}

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import "context"
+
+// ExpandDelegates replaces delegate nodes in the graph with subgraphs
+// produced by the given builder. Delegate nodes are identified by having
+// "delegate" as their sole operation.
+//
+// The expanded subgraph's nodes and edges are appended to the parent graph.
+// An ordering edge is added from the delegate node's predecessor (if any)
+// to each root node of the subgraph.
+//
+// The original delegate node is removed from the graph after expansion.
+func ExpandDelegates(ctx context.Context, graph *Graph, builder GraphBuilder, opts BuildOptions) error {
+	var expanded []*Node
+	var expandedEdges []Edge
+
+	for _, node := range graph.Nodes {
+		if !isDelegateNode(node) {
+			expanded = append(expanded, node)
+			continue
+		}
+
+		// Build subgraph from the manifest file
+		sub, err := builder.BuildGraph(ctx, node.Source, opts)
+		if err != nil {
+			return err
+		}
+
+		// Append subgraph nodes
+		expanded = append(expanded, sub.Nodes...)
+
+		// Append subgraph edges
+		expandedEdges = append(expandedEdges, sub.Edges...)
+
+		// Add delegation edges: delegate node's project → each subgraph node
+		for _, subNode := range sub.Nodes {
+			expandedEdges = append(expandedEdges, Edge{
+				From:     node.ID,
+				To:       subNode.ID,
+				Relation: "delegates",
+			})
+		}
+	}
+
+	graph.Nodes = expanded
+	graph.Edges = append(graph.Edges, expandedEdges...)
+	return nil
+}
+
+// isDelegateNode returns true if the node is a pure delegate operation.
+func isDelegateNode(node *Node) bool {
+	return len(node.Operations) == 1 && node.Operations[0] == "delegate"
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Status represents the execution status of a node.
+type Status int
+
+const (
+	// StatusPending means the node has not been processed yet.
+	StatusPending Status = iota
+	// StatusRunning means the node is currently executing.
+	StatusRunning
+	// StatusCompleted means the node executed successfully.
+	StatusCompleted
+	// StatusFailed means the node encountered an error.
+	StatusFailed
+	// StatusSkipped means the node was skipped (conflict, already deployed, etc.).
+	StatusSkipped
+)
+
+// String returns a human-readable status label.
+func (s Status) String() string {
+	switch s {
+	case StatusPending:
+		return "pending"
+	case StatusRunning:
+		return "running"
+	case StatusCompleted:
+		return "completed"
+	case StatusFailed:
+		return "failed"
+	case StatusSkipped:
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
+
+// Graph represents an execution graph: nodes with operations and edges
+// defining ordering constraints.
+type Graph struct {
+	Nodes []*Node
+	Edges []Edge
+}
+
+// Node represents a unit of work in the execution graph.
+type Node struct {
+	// ID uniquely identifies this node (e.g., relative target path for writ,
+	// package name for lore).
+	ID string
+
+	// Operations is the pipeline of operations to execute on this node.
+	// Examples: ["link"], ["decrypt", "expand", "copy"], ["install"].
+	Operations []string
+
+	// Source is the source path (for file operations).
+	Source string
+
+	// Target is the target path (for file operations).
+	Target string
+
+	// Project is the grouping key (writ: project name, lore: package name).
+	Project string
+
+	// Mode is the target file permissions (0 means use default 0644).
+	Mode os.FileMode
+
+	// DelegateTo names the tool to delegate to (for delegate operations).
+	DelegateTo string
+
+	// Metadata holds tool-specific extensions.
+	Metadata map[string]string
+}
+
+// Edge defines an ordering constraint between nodes.
+type Edge struct {
+	From     string // Source node ID
+	To       string // Target node ID
+	Relation string // "depends_on", "delegates", "orders"
+}
+
+// Result represents the outcome of executing a single node.
+type Result struct {
+	NodeID         string
+	Status         Status
+	Error          error
+	Message        string
+	SourceChecksum string
+	TargetChecksum string
+}
+
+// Options configures engine behavior.
+type Options struct {
+	// DryRun prevents filesystem modifications.
+	DryRun bool
+
+	// Logger receives operation output.
+	Logger io.Writer
+
+	// Data holds tool-provided context (template vars, SOPS config, etc.).
+	Data map[string]any
+
+	// ConflictResolution specifies how to handle conflicts detected during preflight.
+	ConflictResolution ConflictResolution
+
+	// BackupSuffix is appended to backup filenames (default: ".writ-backup").
+	BackupSuffix string
+}
+
+// Engine executes operation graphs.
+type Engine struct {
+	registry *Registry
+	options  Options
+}
+
+// New creates an engine with the given registry and options.
+func New(registry *Registry, opts Options) *Engine {
+	if opts.Logger == nil {
+		opts.Logger = os.Stdout
+	}
+	if opts.BackupSuffix == "" {
+		opts.BackupSuffix = ".writ-backup"
+	}
+	return &Engine{
+		registry: registry,
+		options:  opts,
+	}
+}
+
+// Run executes all nodes in the graph, respecting ordering constraints.
+// Nodes are processed in topological order when edges define dependencies.
+// Returns results for each node.
+func (e *Engine) Run(ctx context.Context, graph *Graph) ([]*Result, error) {
+	ordered := e.orderNodes(graph)
+
+	execCtx := &Context{
+		Context: ctx,
+		DryRun:  e.options.DryRun,
+		Logger:  e.options.Logger,
+		Data:    e.options.Data,
+	}
+
+	var results []*Result
+	for _, node := range ordered {
+		result := e.executeNode(execCtx, node)
+		results = append(results, result)
+
+		if result.Status == StatusFailed && e.options.ConflictResolution == ResolutionStop {
+			return results, result.Error
+		}
+	}
+
+	return results, nil
+}
+
+// executeNode processes a single node through its operation pipeline.
+func (e *Engine) executeNode(ctx *Context, node *Node) *Result {
+	state := &PipelineState{
+		Metadata: make(map[string]string),
+	}
+
+	// Pre-read source content if pipeline needs it
+	if node.Source != "" && e.needsContent(node) {
+		content, err := os.ReadFile(node.Source)
+		if err != nil {
+			return &Result{
+				NodeID: node.ID,
+				Status: StatusFailed,
+				Error:  fmt.Errorf("read source %s: %w", node.Source, err),
+			}
+		}
+		state.Content = content
+		state.SourceChecksum = checksumBytes(content)
+	}
+
+	// Execute operation pipeline
+	for _, opName := range node.Operations {
+		op, ok := e.registry.Get(opName)
+		if !ok {
+			return &Result{
+				NodeID: node.ID,
+				Status: StatusFailed,
+				Error:  fmt.Errorf("unknown operation: %s", opName),
+			}
+		}
+		if err := op.Execute(ctx, node, state); err != nil {
+			return &Result{
+				NodeID: node.ID,
+				Status: StatusFailed,
+				Error:  fmt.Errorf("%s: %w", opName, err),
+			}
+		}
+	}
+
+	return &Result{
+		NodeID:         node.ID,
+		Status:         StatusCompleted,
+		SourceChecksum: state.SourceChecksum,
+		TargetChecksum: state.TargetChecksum,
+	}
+}
+
+// needsContent returns true if the node's first operation requires pre-read
+// source content (transforms and writers, but not direct operations like link).
+func (e *Engine) needsContent(node *Node) bool {
+	if len(node.Operations) == 0 {
+		return false
+	}
+	first := node.Operations[0]
+	// Direct operations that don't need content pre-read
+	switch first {
+	case "link", "delegate", "unlink", "remove", "install", "verify", "fetch", "configure", "build":
+		return false
+	}
+	// Transforms and writers need content
+	return true
+}
+
+// orderNodes returns nodes in execution order. When edges define ordering
+// constraints, topological sort is used. Otherwise, nodes are ordered by
+// path depth (breadth-first).
+func (e *Engine) orderNodes(graph *Graph) []*Node {
+	if len(graph.Edges) > 0 {
+		return e.topologicalSort(graph)
+	}
+	return e.sortByDepth(graph.Nodes)
+}
+
+// topologicalSort orders nodes respecting edge constraints (Kahn's algorithm).
+func (e *Engine) topologicalSort(graph *Graph) []*Node {
+	// Build adjacency and in-degree maps
+	nodeMap := make(map[string]*Node)
+	inDegree := make(map[string]int)
+	adj := make(map[string][]string)
+
+	for _, node := range graph.Nodes {
+		nodeMap[node.ID] = node
+		inDegree[node.ID] = 0
+	}
+
+	for _, edge := range graph.Edges {
+		// Only consider ordering edges between nodes in this graph
+		if _, fromOK := nodeMap[edge.From]; !fromOK {
+			continue
+		}
+		if _, toOK := nodeMap[edge.To]; !toOK {
+			continue
+		}
+		adj[edge.From] = append(adj[edge.From], edge.To)
+		inDegree[edge.To]++
+	}
+
+	// Start with nodes that have no incoming edges
+	var queue []string
+	for _, node := range graph.Nodes {
+		if inDegree[node.ID] == 0 {
+			queue = append(queue, node.ID)
+		}
+	}
+
+	var sorted []*Node
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, nodeMap[id])
+
+		for _, neighbor := range adj[id] {
+			inDegree[neighbor]--
+			if inDegree[neighbor] == 0 {
+				queue = append(queue, neighbor)
+			}
+		}
+	}
+
+	// If not all nodes were sorted (cycle), append remaining
+	if len(sorted) < len(graph.Nodes) {
+		visited := make(map[string]bool)
+		for _, node := range sorted {
+			visited[node.ID] = true
+		}
+		for _, node := range graph.Nodes {
+			if !visited[node.ID] {
+				sorted = append(sorted, node)
+			}
+		}
+	}
+
+	return sorted
+}
+
+// sortByDepth sorts nodes by target path depth (breadth-first order).
+func (e *Engine) sortByDepth(nodes []*Node) []*Node {
+	sorted := make([]*Node, len(nodes))
+	copy(sorted, nodes)
+
+	for i := 0; i < len(sorted)-1; i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			depthI := pathDepth(sorted[i])
+			depthJ := pathDepth(sorted[j])
+			if depthI > depthJ {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	return sorted
+}
+
+// pathDepth returns the directory depth of a node's target path.
+func pathDepth(node *Node) int {
+	if node.Target == "" {
+		return 0
+	}
+	return strings.Count(node.Target, string(filepath.Separator))
+}
+
+// checksumBytes computes SHA256 of content and returns "sha256:<hex>".
+func checksumBytes(content []byte) string {
+	hash := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(hash[:])
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,701 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(&LinkOp{})
+	reg.Register(&CopyOp{})
+
+	op, ok := reg.Get("link")
+	if !ok {
+		t.Fatal("expected link operation to be registered")
+	}
+	if op.Name() != "link" {
+		t.Errorf("expected name 'link', got %q", op.Name())
+	}
+
+	_, ok = reg.Get("nonexistent")
+	if ok {
+		t.Error("expected nonexistent operation to not be found")
+	}
+}
+
+func TestRegistryNames(t *testing.T) {
+	reg := NewRegistry()
+	for _, op := range FileOps() {
+		reg.Register(op)
+	}
+
+	names := reg.Names()
+	if len(names) != 8 {
+		t.Errorf("expected 8 operations, got %d", len(names))
+	}
+}
+
+func TestLinkOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+
+	if err := os.WriteFile(source, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &LinkOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Source: source, Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("link: %v", err)
+	}
+
+	linkTarget, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if linkTarget != source {
+		t.Errorf("expected symlink to %s, got %s", source, linkTarget)
+	}
+}
+
+func TestLinkOperationIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+
+	if err := os.WriteFile(source, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &LinkOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Source: source, Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("idempotent link: %v", err)
+	}
+}
+
+func TestCopyOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "output.txt")
+
+	op := &CopyOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{
+		Content:  []byte("file content"),
+		Metadata: make(map[string]string),
+	}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "file content" {
+		t.Errorf("expected 'file content', got %q", string(content))
+	}
+
+	if state.TargetChecksum == "" {
+		t.Error("expected target checksum to be set")
+	}
+	if !strings.HasPrefix(state.TargetChecksum, "sha256:") {
+		t.Errorf("expected sha256: prefix, got %q", state.TargetChecksum)
+	}
+}
+
+func TestCopyOperationCreatesParentDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "deep", "nested", "output.txt")
+
+	op := &CopyOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{
+		Content:  []byte("nested content"),
+		Metadata: make(map[string]string),
+	}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("copy with nested dirs: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "nested content" {
+		t.Errorf("expected 'nested content', got %q", string(content))
+	}
+}
+
+func TestExpandOperation(t *testing.T) {
+	op := &ExpandOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Data:    map[string]any{"Username": "testuser", "Shell": "/bin/zsh"},
+	}
+	node := &Node{ID: ".bashrc", Source: "/dotfiles/all/.bashrc", Project: "all"}
+	state := &PipelineState{
+		Content:  []byte("# Shell: {{.Shell}}\n# User: {{.Username}}\n# Project: {{.Project}}"),
+		Metadata: make(map[string]string),
+	}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+
+	expected := "# Shell: /bin/zsh\n# User: testuser\n# Project: all"
+	if string(state.Content) != expected {
+		t.Errorf("expected %q, got %q", expected, string(state.Content))
+	}
+}
+
+func TestDecryptOperation(t *testing.T) {
+	op := &DecryptOp{}
+
+	// Provide a mock decryptor
+	mockDecrypt := func(ciphertext []byte) ([]byte, error) {
+		return []byte("decrypted:" + string(ciphertext)), nil
+	}
+
+	ctx := &Context{
+		Context: context.Background(),
+		Data:    map[string]any{"decryptor": mockDecrypt},
+	}
+	node := &Node{ID: "secret.txt"}
+	state := &PipelineState{
+		Content:  []byte("encrypted-data"),
+		Metadata: make(map[string]string),
+	}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	if string(state.Content) != "decrypted:encrypted-data" {
+		t.Errorf("unexpected content: %q", string(state.Content))
+	}
+}
+
+func TestDecryptOperationNoDecryptor(t *testing.T) {
+	op := &DecryptOp{}
+	ctx := &Context{Context: context.Background(), Data: map[string]any{}}
+	node := &Node{ID: "secret.txt"}
+	state := &PipelineState{Content: []byte("data"), Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err == nil {
+		t.Error("expected error when no decryptor configured")
+	}
+}
+
+func TestDelegateOperation(t *testing.T) {
+	op := &DelegateOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: ".config/packages.manifest", DelegateTo: "lore"}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("delegate: %v", err)
+	}
+
+	if state.Metadata["delegate_to"] != "lore" {
+		t.Errorf("expected delegate_to 'lore', got %q", state.Metadata["delegate_to"])
+	}
+}
+
+func TestUnlinkOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "link.txt")
+
+	os.WriteFile(source, []byte("x"), 0644)
+	os.Symlink(source, target)
+
+	op := &UnlinkOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("unlink: %v", err)
+	}
+
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Error("expected symlink to be removed")
+	}
+}
+
+func TestRemoveOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "file.txt")
+	os.WriteFile(target, []byte("data"), 0644)
+
+	op := &RemoveOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected file to be removed")
+	}
+}
+
+func TestEngineRunLinkPipeline(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+	os.WriteFile(source, []byte("hello"), 0644)
+
+	reg := NewRegistry()
+	reg.Register(&LinkOp{})
+
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: ".bashrc", Operations: []string{"link"}, Source: source, Target: target},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != StatusCompleted {
+		t.Errorf("expected completed, got %s", results[0].Status)
+	}
+
+	linkTarget, _ := os.Readlink(target)
+	if linkTarget != source {
+		t.Errorf("expected symlink to %s, got %s", source, linkTarget)
+	}
+}
+
+func TestEngineRunExpandCopyPipeline(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "template.txt")
+	target := filepath.Join(tmpDir, "output.txt")
+
+	os.WriteFile(source, []byte("Hello {{.Username}}!"), 0644)
+
+	reg := NewRegistry()
+	reg.Register(&ExpandOp{})
+	reg.Register(&CopyOp{})
+
+	engine := New(reg, Options{
+		Data: map[string]any{"Username": "david"},
+	})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: ".greeting", Operations: []string{"expand", "copy"}, Source: source, Target: target},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if results[0].Status != StatusCompleted {
+		t.Errorf("expected completed, got %s (error: %v)", results[0].Status, results[0].Error)
+	}
+
+	content, _ := os.ReadFile(target)
+	if string(content) != "Hello david!" {
+		t.Errorf("expected 'Hello david!', got %q", string(content))
+	}
+
+	if results[0].SourceChecksum == "" {
+		t.Error("expected source checksum")
+	}
+	if results[0].TargetChecksum == "" {
+		t.Error("expected target checksum")
+	}
+}
+
+func TestEngineRunDecryptExpandCopyPipeline(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "secret.txt.sops")
+	target := filepath.Join(tmpDir, "secret.txt")
+
+	os.WriteFile(source, []byte("encrypted:token={{.Token}}"), 0644)
+
+	mockDecrypt := func(ciphertext []byte) ([]byte, error) {
+		// Strip "encrypted:" prefix
+		return []byte(strings.TrimPrefix(string(ciphertext), "encrypted:")), nil
+	}
+
+	reg := NewRegistry()
+	reg.Register(&DecryptOp{})
+	reg.Register(&ExpandOp{})
+	reg.Register(&CopyOp{})
+
+	engine := New(reg, Options{
+		Data: map[string]any{
+			"decryptor": mockDecrypt,
+			"Token":     "abc123",
+		},
+	})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: ".secret", Operations: []string{"decrypt", "expand", "copy"}, Source: source, Target: target},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if results[0].Status != StatusCompleted {
+		t.Fatalf("expected completed, got %s (error: %v)", results[0].Status, results[0].Error)
+	}
+
+	content, _ := os.ReadFile(target)
+	if string(content) != "token=abc123" {
+		t.Errorf("expected 'token=abc123', got %q", string(content))
+	}
+}
+
+func TestEngineRunMultipleNodes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	source1 := filepath.Join(tmpDir, "src1.txt")
+	target1 := filepath.Join(tmpDir, "tgt1.txt")
+	source2 := filepath.Join(tmpDir, "src2.txt")
+	target2 := filepath.Join(tmpDir, "sub", "tgt2.txt")
+
+	os.WriteFile(source1, []byte("file1"), 0644)
+	os.WriteFile(source2, []byte("file2"), 0644)
+
+	reg := NewRegistry()
+	reg.Register(&LinkOp{})
+
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "tgt1.txt", Operations: []string{"link"}, Source: source1, Target: target1},
+			{ID: "sub/tgt2.txt", Operations: []string{"link"}, Source: source2, Target: target2},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Status != StatusCompleted {
+			t.Errorf("node %s: expected completed, got %s", r.NodeID, r.Status)
+		}
+	}
+}
+
+func TestEngineRunUnknownOperation(t *testing.T) {
+	reg := NewRegistry()
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "test", Operations: []string{"unknown_op"}},
+		},
+	}
+
+	results, _ := engine.Run(context.Background(), graph)
+	if results[0].Status != StatusFailed {
+		t.Errorf("expected failed, got %s", results[0].Status)
+	}
+}
+
+func TestEngineTopologicalSort(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create sources
+	srcA := filepath.Join(tmpDir, "a.txt")
+	srcB := filepath.Join(tmpDir, "b.txt")
+	srcC := filepath.Join(tmpDir, "c.txt")
+	os.WriteFile(srcA, []byte("a"), 0644)
+	os.WriteFile(srcB, []byte("b"), 0644)
+	os.WriteFile(srcC, []byte("c"), 0644)
+
+	reg := NewRegistry()
+	reg.Register(&LinkOp{})
+
+	engine := New(reg, Options{})
+
+	// B depends on A, C depends on B
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "c", Operations: []string{"link"}, Source: srcC, Target: filepath.Join(tmpDir, "out_c")},
+			{ID: "a", Operations: []string{"link"}, Source: srcA, Target: filepath.Join(tmpDir, "out_a")},
+			{ID: "b", Operations: []string{"link"}, Source: srcB, Target: filepath.Join(tmpDir, "out_b")},
+		},
+		Edges: []Edge{
+			{From: "a", To: "b", Relation: "orders"},
+			{From: "b", To: "c", Relation: "orders"},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Verify execution order: a before b before c
+	if results[0].NodeID != "a" {
+		t.Errorf("expected first node 'a', got %q", results[0].NodeID)
+	}
+	if results[1].NodeID != "b" {
+		t.Errorf("expected second node 'b', got %q", results[1].NodeID)
+	}
+	if results[2].NodeID != "c" {
+		t.Errorf("expected third node 'c', got %q", results[2].NodeID)
+	}
+}
+
+func TestEngineDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+	os.WriteFile(source, []byte("hello"), 0644)
+
+	reg := NewRegistry()
+	reg.Register(&LinkOp{})
+
+	engine := New(reg, Options{DryRun: true})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: ".bashrc", Operations: []string{"link"}, Source: source, Target: target},
+		},
+	}
+
+	results, err := engine.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if results[0].Status != StatusCompleted {
+		t.Errorf("expected completed, got %s", results[0].Status)
+	}
+
+	// Target should NOT exist in dry-run mode
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Error("expected target to not exist in dry-run mode")
+	}
+}
+
+func TestPreflightNoConflict(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt") // Doesn't exist
+	os.WriteFile(source, []byte("x"), 0644)
+
+	reg := NewRegistry()
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+		},
+	}
+
+	result := engine.Preflight(graph)
+	if result.HasConflicts() {
+		t.Error("expected no conflicts")
+	}
+	if len(result.Ready) != 1 {
+		t.Errorf("expected 1 ready node, got %d", len(result.Ready))
+	}
+}
+
+func TestPreflightConflictRegularFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+	os.WriteFile(source, []byte("x"), 0644)
+	os.WriteFile(target, []byte("existing"), 0644) // Conflict!
+
+	reg := NewRegistry()
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+		},
+	}
+
+	result := engine.Preflight(graph)
+	if !result.HasConflicts() {
+		t.Error("expected conflict")
+	}
+	if result.Conflicts[0].Type != ConflictRegularFile {
+		t.Errorf("expected regular file conflict, got %d", result.Conflicts[0].Type)
+	}
+}
+
+func TestPreflightAlreadyDeployed(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+	os.WriteFile(source, []byte("x"), 0644)
+	os.Symlink(source, target) // Already correct
+
+	reg := NewRegistry()
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+		},
+	}
+
+	result := engine.Preflight(graph)
+	if result.HasConflicts() {
+		t.Error("expected no conflicts for already-deployed symlink")
+	}
+	if len(result.AlreadyDone) != 1 {
+		t.Errorf("expected 1 already-done, got %d", len(result.AlreadyDone))
+	}
+}
+
+func TestPreflightDelegateSkipped(t *testing.T) {
+	reg := NewRegistry()
+	engine := New(reg, Options{})
+	graph := &Graph{
+		Nodes: []*Node{
+			{ID: "manifest", Operations: []string{"delegate"}, DelegateTo: "lore"},
+		},
+	}
+
+	result := engine.Preflight(graph)
+	if result.HasConflicts() {
+		t.Error("expected no conflicts for delegate node")
+	}
+	if len(result.Ready) != 1 {
+		t.Errorf("expected 1 ready node, got %d", len(result.Ready))
+	}
+}
+
+func TestFileOpsCount(t *testing.T) {
+	ops := FileOps()
+	if len(ops) != 8 {
+		t.Errorf("expected 8 file ops, got %d", len(ops))
+	}
+
+	names := make(map[string]bool)
+	for _, op := range ops {
+		names[op.Name()] = true
+	}
+
+	expected := []string{"link", "copy", "expand", "decrypt", "delegate", "backup", "unlink", "remove"}
+	for _, name := range expected {
+		if !names[name] {
+			t.Errorf("expected operation %q in FileOps()", name)
+		}
+	}
+}
+
+func TestBackupOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "file.txt")
+	os.WriteFile(target, []byte("original"), 0644)
+
+	op := &BackupOp{}
+	ctx := &Context{Context: context.Background(), Data: map[string]any{}}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected original file to be moved")
+	}
+
+	// Backup path should be recorded in metadata
+	backupPath := state.Metadata["backup_path"]
+	if backupPath == "" {
+		t.Fatal("expected backup_path in metadata")
+	}
+
+	// Backup should exist with original content
+	content, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(content) != "original" {
+		t.Errorf("expected 'original', got %q", string(content))
+	}
+}
+
+func TestCopyOperationWithMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "script.sh")
+
+	op := &CopyOp{}
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target, Mode: 0755}
+	state := &PipelineState{
+		Content:  []byte("#!/bin/sh\necho hello"),
+		Metadata: make(map[string]string),
+	}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("copy with mode: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("expected mode 0755, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   string
+	}{
+		{StatusPending, "pending"},
+		{StatusRunning, "running"},
+		{StatusCompleted, "completed"},
+		{StatusFailed, "failed"},
+		{StatusSkipped, "skipped"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("Status(%d).String() = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/internal/engine/operation.go
+++ b/internal/engine/operation.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// Package engine provides a common execution engine for graph-based operations.
+// Both writ and lore build execution graphs and hand them to this engine for
+// processing. The engine dispatches operations to registered handlers, threads
+// content through transform pipelines, and produces receipts.
+package engine
+
+import (
+	"context"
+	"io"
+)
+
+// Operation defines an executable action. Implementations fall into three
+// categories: transforms (modify state.Content), writers (produce filesystem
+// side effects from state.Content), and direct operations (manage their own I/O).
+type Operation interface {
+	// Execute performs the operation on the given node with pipeline state.
+	// Transforms modify state.Content in place. Writers consume state.Content
+	// and produce filesystem output. Direct operations ignore state.Content.
+	Execute(ctx *Context, node *Node, state *PipelineState) error
+
+	// Name returns the operation identifier (e.g., "link", "decrypt").
+	Name() string
+}
+
+// PipelineState holds mutable state threaded through a node's operation pipeline.
+// The engine pre-reads source content into Content when the pipeline begins
+// with a transform or writer operation.
+type PipelineState struct {
+	// Content is the current file content. Transforms modify this in place;
+	// writers consume it to produce output files.
+	Content []byte
+
+	// SourceChecksum is computed from the original source file content
+	// before any transforms are applied. Format: "sha256:<hex>".
+	SourceChecksum string
+
+	// TargetChecksum is set by writer operations after writing content
+	// to the target path. Format: "sha256:<hex>".
+	TargetChecksum string
+
+	// Metadata holds per-node extensible state that operations can read/write.
+	Metadata map[string]string
+}
+
+// Context provides execution context to operations.
+type Context struct {
+	context.Context
+
+	// DryRun prevents filesystem modifications when true.
+	DryRun bool
+
+	// Logger receives operation output messages.
+	Logger io.Writer
+
+	// Data holds tool-provided context: template variables, SOPS config,
+	// identities, segment maps, etc. Each tool populates this before
+	// calling Engine.Run().
+	Data map[string]any
+}
+
+// Registry maps operation names to implementations. Each tool registers its
+// operations before calling Engine.Run().
+type Registry struct {
+	ops map[string]Operation
+}
+
+// NewRegistry creates an empty operation registry.
+func NewRegistry() *Registry {
+	return &Registry{ops: make(map[string]Operation)}
+}
+
+// Register adds an operation to the registry. If an operation with the same
+// name already exists, it is replaced.
+func (r *Registry) Register(op Operation) {
+	r.ops[op.Name()] = op
+}
+
+// Get returns the operation registered under the given name.
+func (r *Registry) Get(name string) (Operation, bool) {
+	op, ok := r.ops[name]
+	return op, ok
+}
+
+// Names returns all registered operation names.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.ops))
+	for name := range r.ops {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/engine/ops.go
+++ b/internal/engine/ops.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+	"time"
+)
+
+// LinkOp creates a symlink from node.Target pointing to node.Source.
+type LinkOp struct{}
+
+func (o *LinkOp) Name() string { return "link" }
+
+func (o *LinkOp) Execute(ctx *Context, node *Node, state *PipelineState) error {
+	if ctx.DryRun {
+		return nil
+	}
+
+	// Idempotent: check if symlink already points correctly
+	if info, err := os.Lstat(node.Target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			existing, err := os.Readlink(node.Target)
+			if err == nil && existing == node.Source {
+				return nil // Already correct
+			}
+		}
+		// Remove existing (conflict should have been handled by preflight)
+		if err := os.Remove(node.Target); err != nil {
+			return fmt.Errorf("remove existing: %w", err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(node.Target), 0755); err != nil {
+		return fmt.Errorf("create parent dirs: %w", err)
+	}
+
+	return os.Symlink(node.Source, node.Target)
+}
+
+// CopyOp writes state.Content to node.Target and sets state.TargetChecksum.
+type CopyOp struct{}
+
+func (o *CopyOp) Name() string { return "copy" }
+
+func (o *CopyOp) Execute(ctx *Context, node *Node, state *PipelineState) error {
+	if ctx.DryRun {
+		state.TargetChecksum = checksumBytes(state.Content)
+		return nil
+	}
+
+	// Remove existing file/symlink if present
+	if _, err := os.Lstat(node.Target); err == nil {
+		if err := os.Remove(node.Target); err != nil {
+			return fmt.Errorf("remove existing: %w", err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(node.Target), 0755); err != nil {
+		return fmt.Errorf("create parent dirs: %w", err)
+	}
+
+	mode := node.Mode
+	if mode == 0 {
+		mode = 0644
+	}
+
+	if err := os.WriteFile(node.Target, state.Content, mode); err != nil {
+		return err
+	}
+
+	state.TargetChecksum = checksumBytes(state.Content)
+	return nil
+}
+
+// ExpandOp processes state.Content as a Go text/template with ctx.Data as
+// the template data. The expanded result replaces state.Content.
+type ExpandOp struct{}
+
+func (o *ExpandOp) Name() string { return "expand" }
+
+func (o *ExpandOp) Execute(ctx *Context, node *Node, state *PipelineState) error {
+	tmpl, err := template.New(node.ID).Parse(string(state.Content))
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+
+	// Build template data from context
+	data := make(map[string]any)
+	for k, v := range ctx.Data {
+		data[k] = v
+	}
+	// Add node-specific data
+	data["Source"] = node.Source
+	data["Target"] = node.Target
+	data["Project"] = node.Project
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+
+	state.Content = buf.Bytes()
+	return nil
+}
+
+// DecryptOp decrypts state.Content using the SOPS API. The decryption
+// configuration is expected in ctx.Data. The decrypted result replaces
+// state.Content.
+type DecryptOp struct{}
+
+func (o *DecryptOp) Name() string { return "decrypt" }
+
+func (o *DecryptOp) Execute(ctx *Context, node *Node, state *PipelineState) error {
+	decryptor, ok := ctx.Data["decryptor"]
+	if !ok {
+		return fmt.Errorf("no decryptor configured in context")
+	}
+
+	// The decryptor is a function that takes encrypted bytes and returns plaintext.
+	// This allows tools to provide their own decryption implementation
+	// (SOPS, age, or any other backend) without the engine depending on
+	// specific crypto libraries.
+	decrypt, ok := decryptor.(func([]byte) ([]byte, error))
+	if !ok {
+		return fmt.Errorf("decryptor is not func([]byte) ([]byte, error)")
+	}
+
+	plaintext, err := decrypt(state.Content)
+	if err != nil {
+		return err
+	}
+
+	state.Content = plaintext
+	return nil
+}
+
+// DelegateOp is a no-op that marks a node for cross-tool handoff.
+type DelegateOp struct{}
+
+func (o *DelegateOp) Name() string { return "delegate" }
+
+func (o *DelegateOp) Execute(_ *Context, node *Node, state *PipelineState) error {
+	state.Metadata["delegate_to"] = node.DelegateTo
+	return nil
+}
+
+// BackupOp moves the existing file at node.Target to a timestamped backup.
+type BackupOp struct{}
+
+func (o *BackupOp) Name() string { return "backup" }
+
+func (o *BackupOp) Execute(ctx *Context, node *Node, state *PipelineState) error {
+	if ctx.DryRun {
+		return nil
+	}
+
+	suffix := ".writ-backup"
+	if s, ok := ctx.Data["backup_suffix"]; ok {
+		if str, ok := s.(string); ok {
+			suffix = str
+		}
+	}
+
+	timestamp := time.Now().Format("20060102-150405")
+	backupPath := node.Target + suffix + "." + timestamp
+
+	if err := os.Rename(node.Target, backupPath); err != nil {
+		return fmt.Errorf("backup %s → %s: %w", node.Target, backupPath, err)
+	}
+
+	state.Metadata["backup_path"] = backupPath
+	return nil
+}
+
+// UnlinkOp removes a symlink at node.Target.
+type UnlinkOp struct{}
+
+func (o *UnlinkOp) Name() string { return "unlink" }
+
+func (o *UnlinkOp) Execute(ctx *Context, node *Node, _ *PipelineState) error {
+	if ctx.DryRun {
+		return nil
+	}
+
+	info, err := os.Lstat(node.Target)
+	if os.IsNotExist(err) {
+		return nil // Already gone
+	}
+	if err != nil {
+		return err
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("%s is not a symlink", node.Target)
+	}
+
+	return os.Remove(node.Target)
+}
+
+// RemoveOp deletes the file at node.Target.
+type RemoveOp struct{}
+
+func (o *RemoveOp) Name() string { return "remove" }
+
+func (o *RemoveOp) Execute(ctx *Context, node *Node, _ *PipelineState) error {
+	if ctx.DryRun {
+		return nil
+	}
+
+	if _, err := os.Lstat(node.Target); os.IsNotExist(err) {
+		return nil // Already gone
+	}
+
+	return os.Remove(node.Target)
+}
+
+// FileOps returns all built-in file operations for registration.
+func FileOps() []Operation {
+	return []Operation{
+		&LinkOp{},
+		&CopyOp{},
+		&ExpandOp{},
+		&DecryptOp{},
+		&DelegateOp{},
+		&BackupOp{},
+		&UnlinkOp{},
+		&RemoveOp{},
+	}
+}

--- a/internal/engine/preflight.go
+++ b/internal/engine/preflight.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+)
+
+// ConflictResolution specifies how to handle conflicts.
+type ConflictResolution int
+
+const (
+	// ResolutionStop aborts execution on first conflict.
+	ResolutionStop ConflictResolution = iota
+	// ResolutionBackup moves conflicting files to timestamped backups.
+	ResolutionBackup
+	// ResolutionOverwrite removes conflicting files without backup.
+	ResolutionOverwrite
+	// ResolutionSkip skips conflicting files and continues.
+	ResolutionSkip
+)
+
+// ConflictType describes the kind of conflict at a target path.
+type ConflictType int
+
+const (
+	// ConflictNone indicates no conflict exists.
+	ConflictNone ConflictType = iota
+	// ConflictRegularFile indicates a regular file exists at target.
+	ConflictRegularFile
+	// ConflictDirectory indicates a directory exists at target.
+	ConflictDirectory
+	// ConflictForeignSymlink indicates a symlink pointing elsewhere exists.
+	ConflictForeignSymlink
+	// ConflictOurSymlink indicates our symlink already exists (no action needed).
+	ConflictOurSymlink
+)
+
+// Conflict represents a pre-flight detected conflict.
+type Conflict struct {
+	Node         *Node
+	Type         ConflictType
+	ExistingPath string // For symlinks, where it points
+	Message      string
+}
+
+// PreflightResult contains the results of pre-flight conflict detection.
+type PreflightResult struct {
+	Conflicts   []Conflict
+	AlreadyDone []Conflict // Symlinks that already point correctly
+	Ready       []*Node    // Nodes ready to deploy (no conflict)
+}
+
+// HasConflicts returns true if any conflicts were detected.
+func (p *PreflightResult) HasConflicts() bool {
+	return len(p.Conflicts) > 0
+}
+
+// Preflight performs pre-flight conflict detection without modifying anything.
+// Only applies to nodes with file operations (link, copy).
+func (e *Engine) Preflight(graph *Graph) *PreflightResult {
+	result := &PreflightResult{}
+
+	for _, node := range graph.Nodes {
+		// Skip nodes that don't write to target
+		if !nodeWritesToTarget(node) {
+			result.Ready = append(result.Ready, node)
+			continue
+		}
+
+		conflict := detectConflict(node)
+		switch conflict.Type {
+		case ConflictNone:
+			result.Ready = append(result.Ready, node)
+		case ConflictOurSymlink:
+			result.AlreadyDone = append(result.AlreadyDone, conflict)
+		default:
+			result.Conflicts = append(result.Conflicts, conflict)
+		}
+	}
+
+	return result
+}
+
+// nodeWritesToTarget returns true if the node's operations produce a file at
+// node.Target (link, copy, or any pipeline ending in copy).
+func nodeWritesToTarget(node *Node) bool {
+	if node.Target == "" {
+		return false
+	}
+	for _, op := range node.Operations {
+		switch op {
+		case "link", "copy":
+			return true
+		}
+	}
+	return false
+}
+
+// detectConflict checks if a target path has a conflict.
+func detectConflict(node *Node) Conflict {
+	if node.Target == "" {
+		return Conflict{Node: node, Type: ConflictNone}
+	}
+
+	info, err := os.Lstat(node.Target)
+	if os.IsNotExist(err) {
+		return Conflict{Node: node, Type: ConflictNone}
+	}
+	if err != nil {
+		return Conflict{
+			Node:    node,
+			Type:    ConflictRegularFile,
+			Message: fmt.Sprintf("cannot stat: %v", err),
+		}
+	}
+
+	if info.IsDir() {
+		return Conflict{
+			Node:    node,
+			Type:    ConflictDirectory,
+			Message: fmt.Sprintf("directory exists at %s", node.Target),
+		}
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(node.Target)
+		if err != nil {
+			return Conflict{
+				Node:    node,
+				Type:    ConflictForeignSymlink,
+				Message: fmt.Sprintf("cannot read symlink: %v", err),
+			}
+		}
+
+		if linkTarget == node.Source {
+			return Conflict{
+				Node:         node,
+				Type:         ConflictOurSymlink,
+				ExistingPath: linkTarget,
+				Message:      "already deployed",
+			}
+		}
+
+		return Conflict{
+			Node:         node,
+			Type:         ConflictForeignSymlink,
+			ExistingPath: linkTarget,
+			Message:      fmt.Sprintf("symlink exists pointing to %s", linkTarget),
+		}
+	}
+
+	return Conflict{
+		Node:    node,
+		Type:    ConflictRegularFile,
+		Message: fmt.Sprintf("file exists at %s (%d bytes)", node.Target, info.Size()),
+	}
+}

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/NobleFactor/devlore-cli/internal/engine"
+)
+
+// Builder implements engine.GraphBuilder for lore package manifests.
+// It loads a packages.manifest file and builds an execution graph
+// that the common engine can process.
+type Builder struct{}
+
+// BuildGraph loads a packages.manifest file and returns an execution graph.
+// The manifest is a line-delimited list of package names, optionally with
+// features specified after the package name.
+func (b *Builder) BuildGraph(ctx context.Context, manifestPath string, opts engine.BuildOptions) (*engine.Graph, error) {
+	packages, err := loadManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest %s: %w", manifestPath, err)
+	}
+
+	graph := &engine.Graph{}
+
+	for _, pkg := range packages {
+		// Merge per-package features with global features
+		features := mergeFeatures(pkg.Features, opts.Features)
+
+		node := &engine.Node{
+			ID:         pkg.Name,
+			Operations: []string{"install"},
+			Project:    pkg.Name,
+			Metadata: map[string]string{
+				"tool":     "lore",
+				"manifest": manifestPath,
+			},
+		}
+		if len(features) > 0 {
+			node.Metadata["features"] = strings.Join(features, ",")
+		}
+
+		graph.Nodes = append(graph.Nodes, node)
+	}
+
+	return graph, nil
+}
+
+// manifestEntry represents a single package entry in a manifest file.
+type manifestEntry struct {
+	Name     string
+	Features []string
+}
+
+// loadManifest parses a packages.manifest file into a list of entries.
+// Format: one package per line; features follow the package name.
+//
+//	docker --with rootless --with compose
+//	kubectl
+//	gh
+//	# comments and blank lines are ignored
+func loadManifest(path string) ([]manifestEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var entries []manifestEntry
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		entry := parseLine(line)
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// parseLine extracts a package name and optional features from a manifest line.
+func parseLine(line string) manifestEntry {
+	fields := strings.Fields(line)
+	entry := manifestEntry{Name: fields[0]}
+
+	// Parse --with flags
+	for i := 1; i < len(fields); i++ {
+		if fields[i] == "--with" && i+1 < len(fields) {
+			entry.Features = append(entry.Features, fields[i+1])
+			i++ // skip the feature value
+		}
+	}
+
+	return entry
+}
+
+// mergeFeatures combines per-package features with global features,
+// deduplicating.
+func mergeFeatures(pkg, global []string) []string {
+	seen := make(map[string]bool)
+	var merged []string
+
+	for _, f := range pkg {
+		if !seen[f] {
+			seen[f] = true
+			merged = append(merged, f)
+		}
+	}
+	for _, f := range global {
+		if !seen[f] {
+			seen[f] = true
+			merged = append(merged, f)
+		}
+	}
+
+	return merged
+}

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/internal/engine"
+)
+
+func TestBuilderBuildGraph(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifest := filepath.Join(tmpDir, "packages.manifest")
+
+	content := `# Development tools
+docker --with rootless --with compose
+kubectl
+gh
+neovim --with lsp
+`
+	if err := os.WriteFile(manifest, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := &Builder{}
+	graph, err := builder.BuildGraph(context.Background(), manifest, engine.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+
+	if len(graph.Nodes) != 4 {
+		t.Fatalf("expected 4 nodes, got %d", len(graph.Nodes))
+	}
+
+	// Check docker node
+	docker := graph.Nodes[0]
+	if docker.ID != "docker" {
+		t.Errorf("expected ID 'docker', got %q", docker.ID)
+	}
+	if docker.Operations[0] != "install" {
+		t.Errorf("expected operation 'install', got %q", docker.Operations[0])
+	}
+	if docker.Metadata["features"] != "rootless,compose" {
+		t.Errorf("expected features 'rootless,compose', got %q", docker.Metadata["features"])
+	}
+	if docker.Metadata["tool"] != "lore" {
+		t.Errorf("expected tool 'lore', got %q", docker.Metadata["tool"])
+	}
+
+	// Check kubectl node (no features)
+	kubectl := graph.Nodes[1]
+	if kubectl.ID != "kubectl" {
+		t.Errorf("expected ID 'kubectl', got %q", kubectl.ID)
+	}
+	if _, ok := kubectl.Metadata["features"]; ok {
+		t.Error("expected no features on kubectl")
+	}
+}
+
+func TestBuilderBuildGraphWithGlobalFeatures(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifest := filepath.Join(tmpDir, "packages.manifest")
+
+	content := `docker --with compose
+kubectl
+`
+	if err := os.WriteFile(manifest, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := &Builder{}
+	graph, err := builder.BuildGraph(context.Background(), manifest, engine.BuildOptions{
+		Features: []string{"debug"},
+	})
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+
+	// Docker should have both package-level and global features
+	docker := graph.Nodes[0]
+	if docker.Metadata["features"] != "compose,debug" {
+		t.Errorf("expected features 'compose,debug', got %q", docker.Metadata["features"])
+	}
+
+	// kubectl should have only global features
+	kubectl := graph.Nodes[1]
+	if kubectl.Metadata["features"] != "debug" {
+		t.Errorf("expected features 'debug', got %q", kubectl.Metadata["features"])
+	}
+}
+
+func TestBuilderBuildGraphEmptyManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifest := filepath.Join(tmpDir, "packages.manifest")
+
+	content := `# Only comments
+# and blank lines
+
+`
+	if err := os.WriteFile(manifest, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := &Builder{}
+	graph, err := builder.BuildGraph(context.Background(), manifest, engine.BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+
+	if len(graph.Nodes) != 0 {
+		t.Errorf("expected 0 nodes for empty manifest, got %d", len(graph.Nodes))
+	}
+}
+
+func TestBuilderBuildGraphMissingFile(t *testing.T) {
+	builder := &Builder{}
+	_, err := builder.BuildGraph(context.Background(), "/nonexistent/packages.manifest", engine.BuildOptions{})
+	if err == nil {
+		t.Error("expected error for missing manifest")
+	}
+}
+
+func TestLoadManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifest := filepath.Join(tmpDir, "test.manifest")
+
+	content := `# comment
+docker --with rootless
+kubectl
+
+gh
+`
+	os.WriteFile(manifest, []byte(content), 0644)
+
+	entries, err := loadManifest(manifest)
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	if entries[0].Name != "docker" {
+		t.Errorf("expected 'docker', got %q", entries[0].Name)
+	}
+	if len(entries[0].Features) != 1 || entries[0].Features[0] != "rootless" {
+		t.Errorf("expected features ['rootless'], got %v", entries[0].Features)
+	}
+	if entries[1].Name != "kubectl" {
+		t.Errorf("expected 'kubectl', got %q", entries[1].Name)
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		line     string
+		name     string
+		features []string
+	}{
+		{"docker", "docker", nil},
+		{"docker --with rootless", "docker", []string{"rootless"}},
+		{"docker --with rootless --with compose", "docker", []string{"rootless", "compose"}},
+		{"neovim --with lsp --with treesitter", "neovim", []string{"lsp", "treesitter"}},
+	}
+
+	for _, tt := range tests {
+		entry := parseLine(tt.line)
+		if entry.Name != tt.name {
+			t.Errorf("parseLine(%q): name = %q, want %q", tt.line, entry.Name, tt.name)
+		}
+		if len(entry.Features) != len(tt.features) {
+			t.Errorf("parseLine(%q): features = %v, want %v", tt.line, entry.Features, tt.features)
+			continue
+		}
+		for i, f := range entry.Features {
+			if f != tt.features[i] {
+				t.Errorf("parseLine(%q): feature[%d] = %q, want %q", tt.line, i, f, tt.features[i])
+			}
+		}
+	}
+}
+
+// Verify Builder implements engine.GraphBuilder interface.
+var _ engine.GraphBuilder = (*Builder)(nil)


### PR DESCRIPTION
## Summary
- `internal/engine/`: shared execution engine with operation registry, pipeline threading, topological sort, preflight conflict detection
- 8 built-in file operations: link, copy, expand, decrypt, delegate, backup, unlink, remove
- `GraphBuilder` interface for manifest-to-graph translation
- `ExpandDelegates()` composes delegate subgraphs in-process (no subprocess needed)
- `internal/lore/builder.go`: implements `GraphBuilder` — parses `packages.manifest` into execution nodes

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/engine/ ./internal/lore/` clean
- [x] 32 tests passing (26 engine + 6 lore builder)
- [ ] Integration: writ converts tree to engine.Graph and calls engine.Run()