### PR TITLE
Fix install script archive filename to include 'v' prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,10 +133,9 @@ main() {
         ext="zip"
     fi
 
-    # Build download URL
-    local version_num="${VERSION#v}"  # Strip leading 'v' if present
-    local archive_name="devlore-cli_${version_num}_${os}_${arch}.${ext}"
-    local checksums_name="devlore-cli_${version_num}_checksums.txt"
+    # Build download URL (version includes 'v' prefix)
+    local archive_name="devlore-cli_${VERSION}_${os}_${arch}.${ext}"
+    local checksums_name="devlore-cli_${VERSION}_checksums.txt"
     local archive_url="${DOWNLOAD_BASE}/${archive_name}"
     local checksums_url="${DOWNLOAD_BASE}/${checksums_name}"
 


### PR DESCRIPTION
## Summary
The Makefile creates archives with the full version (e.g., `v0.1.0-draft`), but the install script was stripping the 'v' prefix, causing 404 errors when downloading.

## Test
```bash
DEVLORE_DOWNLOAD_BASE="http://localhost:8888/releases" bash install.sh
```