### PR TITLE
Give release/* branches their own preview environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,11 +80,15 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Determine target branch based on source
-          # main, release/*, tags → production (main)
+          # main, tags → production (main)
+          # release/* → release preview (same branch name)
           # develop → preview (develop)
           TARGET_BRANCH="develop"
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.ref }}" == refs/heads/release/* ]] || [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TARGET_BRANCH="main"
+          elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+            # Preserve release branch name for preview environment
+            TARGET_BRANCH="${{ github.ref_name }}"
           fi
 
           git checkout "$TARGET_BRANCH" || git checkout -b "$TARGET_BRANCH"


### PR DESCRIPTION
## Summary
Update branch mapping so release/* branches get their own preview environment instead of going directly to production.

| devlore-cli branch | Website branch | Environment |
|-------------------|----------------|-------------|
| `develop` | `develop` | Preview |
| `release/1.0` | `release/1.0` | Preview |
| `main` | `main` | Production |
| tags | `main` | Production |

## Rationale
Allows testing release candidates in isolation before merging to main.