### PR TITLE
Standardize platform terminology: Common, Unix, Fedora

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,10 @@ before:
   hooks:
     - go mod tidy
 
+after:
+  hooks:
+    - ./packaging/macports/generate-portfile.sh {{ .Version }}
+
 builds:
   - id: writ
     binary: writ
@@ -94,24 +98,50 @@ release:
     ```
 
     Or download the appropriate archive below.
+  extra_files:
+    - glob: ./dist/Portfile
+      name_template: Portfile
 
-# Homebrew tap (future)
-# brews:
-#   - repository:
-#       owner: NobleFactor
-#       name: homebrew-tap
-#     homepage: https://devlore.noblefactor.com
-#     description: DevLore CLI - writ and lore tools
-#     license: Apache-2.0
-#     install: |
-#       bin.install "writ"
-#       bin.install "lore"
+# Linux packages (deb/rpm)
+nfpms:
+  - id: devlore-cli
+    package_name: devlore-cli
+    vendor: NobleFactor
+    homepage: https://devlore.noblefactor.com
+    maintainer: NobleFactor <support@noblefactor.com>
+    description: DevLore CLI - writ and lore tools for documentation generation
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/devlore-cli/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/devlore-cli/README.md
 
-# Winget (future)
-# winget:
-#   - publisher: NobleFactor
-#     short_description: DevLore CLI tools
-#     license: Apache-2.0
-#     repository:
-#       owner: microsoft
-#       name: winget-pkgs
+# Homebrew formula (generates but does not publish)
+brews:
+  - repository:
+      owner: NobleFactor
+      name: homebrew-tap
+    skip_upload: true
+    directory: Formula
+    homepage: https://devlore.noblefactor.com
+    description: DevLore CLI - writ and lore tools
+    license: Apache-2.0
+    install: |
+      bin.install "writ"
+      bin.install "lore"
+
+# Winget manifest (generates but does not publish)
+winget:
+  - publisher: NobleFactor
+    publisher_url: https://noblefactor.com
+    short_description: DevLore CLI tools
+    license: Apache-2.0
+    skip_upload: true
+    repository:
+      owner: NobleFactor
+      name: winget-pkgs

--- a/TODO-claude.md
+++ b/TODO-claude.md
@@ -1,0 +1,575 @@
+# DevLore CLI Documentation TODO
+
+This file tracks documentation gaps, incomplete features, and pending decisions identified during a comprehensive review on 2025-01-25. Each item includes sufficient context for remediation without requiring additional research.
+
+---
+
+## 1. Missing Documentation
+
+### 1.1 Troubleshooting Guide
+
+**Status:** Not started
+**Priority:** High
+**Location:** Should be created at `docs/guides/troubleshooting.md`
+
+**Context:** No standalone troubleshooting document exists. Users encountering errors have no guidance.
+
+**Should cover:**
+- `lore deploy` failures: permission errors, network failures, package not found
+- `writ add` conflicts: symlink already exists, file conflicts between layers
+- Broken symlinks: detection and repair
+- Rollback procedures: how to undo a bad deployment
+- State file corruption: detection and recovery
+- Debugging techniques: verbose output flags, log locations
+
+**Cross-references needed:**
+- `docs/guides/lore/deploy-packages.md` mentions receipts but not failure recovery
+- `docs/guides/writ/manage-environments.md` mentions conflicts but not resolution
+
+---
+
+### 1.2 Writ + Lore Integration Workflow
+
+**Status:** Not started
+**Priority:** High
+**Location:** Should be created at `docs/guides/integration.md` or added to getting-started.md
+
+**Context:** Both tools document their side of the integration separately:
+- `docs/guides/writ/manage-environments.md` (lines 142-159): shows `writ add` calling `lore deploy`
+- `docs/guides/lore/deploy-packages.md` (lines 142-159): shows same flow from lore's perspective
+
+**Should cover:**
+- Complete end-to-end workflow: writ add → lore deploy → verify → writ status
+- When to use lore standalone vs integrated with writ
+- Error propagation: what happens if lore fails during writ add?
+- Partial success handling: some packages deployed, some failed
+- Manual intervention points
+
+**Gap:** Users cannot understand the full system without reading both tool guides and mentally merging them.
+
+---
+
+### 1.3 Migration Guide from Other Tools
+
+**Status:** Not started
+**Priority:** Medium
+**Location:** Should be created at `docs/guides/migration.md`
+
+**Context:** No documentation for users coming from:
+- **GNU Stow**: symlink-based dotfiles manager
+- **chezmoi**: template-based dotfiles manager with state tracking
+- **dotbot**: YAML-configured dotfiles bootstrapper
+- **Manual scripts**: users with custom install.sh scripts
+
+**Should cover:**
+- Conceptual mapping: how stow concepts map to writ concepts
+- Import procedures: how to convert existing dotfiles repo to writ structure
+- Coexistence: can writ manage some files while stow manages others?
+- One-time migration scripts or commands if applicable
+
+---
+
+### 1.4 Receipt Format and Schema
+
+**Status:** Not started
+**Priority:** Medium
+**Location:** Should be added to `docs/guides/lore/deploy-packages.md` or new `docs/reference/receipts.md`
+
+**Context:** Receipts are mentioned in multiple places but never defined:
+- `docs/guides/lore/deploy-packages.md` (lines 95-104): "Every deployment produces a receipt"
+- Line 101: `--receipt=~/deployments/workstation.yaml`
+- Line 104: "Receipts are stored in `~/.local/state/lore/receipts/` by default"
+
+**Should cover:**
+- YAML schema for receipt files
+- Fields: package name, version, timestamp, phase results, platform, features enabled
+- How receipts interact with `lore reconcile`, `lore upgrade`, `lore decommission`
+- Backup and archiving guidance
+- Machine portability: can receipts be shared across machines?
+
+---
+
+### 1.5 Audit Log API and Storage
+
+**Status:** Not started
+**Priority:** Medium
+**Location:** Should be added to `docs/guides/lore/registry.md` or new `docs/reference/audit.md`
+
+**Context:** Audit features documented sparsely in `docs/guides/lore/registry.md` (lines 106-133):
+- Commands shown: `lore audit`, `lore audit --since 7d`, `lore audit --package docker`
+- Event types listed in table (lines 117-123): pmm.fetch, pmm.verify, pmm.install, etc.
+
+**Should cover:**
+- Complete event type catalog with descriptions
+- Event schema (JSON/YAML structure)
+- Storage location and format
+- Retention configuration
+- Querying and filtering syntax
+- Export formats for compliance reporting
+- Integration with external logging systems (syslog, etc.)
+
+---
+
+### 1.6 State File Management and Recovery
+
+**Status:** Not started
+**Priority:** Medium
+**Location:** Should be added to `docs/guides/writ/repositories.md` or new `docs/reference/state.md`
+
+**Context:** State files are implied throughout writ documentation but never explained:
+- How writ tracks which files are managed
+- Where state is stored
+- State file format/schema
+
+**Should cover:**
+- State file locations (per-repo, global)
+- Schema and format
+- Synchronization across machines (git-based? manual?)
+- Corruption detection and recovery
+- State rebuild from filesystem (if possible)
+
+---
+
+### 1.7 Bundle Format for Air-Gapped Environments
+
+**Status:** Not started
+**Priority:** Low
+**Location:** Should be added to `docs/guides/lore/registry.md`
+
+**Context:** Bundle feature introduced in `docs/guides/lore/registry.md` (lines 135-150):
+- Command: `lore bundle @manifest -o workstation-bundle.sh --platform linux/fedora`
+- Creates self-extracting archive for offline installation
+
+**Should cover:**
+- Bundle internal structure (what's included: binaries, manifests, checksums?)
+- Size considerations and optimization
+- Signature verification for security
+- Manual extraction procedure (if self-extractor fails)
+- Platform-specific bundle requirements
+- Troubleshooting extraction failures
+
+---
+
+### 1.8 Bindgen User Guide
+
+**Status:** Not started
+**Priority:** Low
+**Location:** Should be created at `docs/guides/bindgen.md` or `docs/tools/bindgen.md`
+
+**Context:** Bindgen exists but is only documented in internal READMEs:
+- `cmd/bindgen/README.md` (line 7): "Proof of concept. This is an experiment..."
+- `internal/bindgen/cobra/README.md` (line 5): "Status: Proof of Concept (Working)"
+- Line 58: "Not production-ready — use as development accelerator"
+
+**Current issues documented internally (lines 42-58):**
+- Extractor captures all 144 commands but misses ~60% of flags
+- 4 open issues with Medium to Critical severity
+
+**Should cover:**
+- What bindgen does: generates lore manifests from existing CLI tools
+- When to use it: bootstrapping new manifests, not production use
+- Workflow: generate → review → edit → validate
+- Known limitations and what to check in output
+- Relationship to main writ/lore tools
+
+**Decision needed:** Should bindgen be promoted to user-facing tool or remain internal?
+
+---
+
+## 2. Incomplete Features
+
+### 2.1 Starlark API Documentation
+
+**Status:** Incomplete
+**Priority:** High
+**Location:** `docs/guides/lore/create-manifests.md` (lines 78-94)
+
+**Context:** Table shows `ctx` methods but entries are minimal:
+- `ctx.run()` - run shell commands
+- `ctx.pmm.install()` - install via package manager
+- `ctx.pmm.remove()` - remove via package manager
+- `ctx.feature()` - check feature flags
+- Others listed but not explained
+
+**Missing:**
+- Complete PMM method list (what besides install/remove?)
+- Return types for `ctx.run()` (only mentioned in verify examples)
+- Error handling patterns (try/catch? return codes?)
+- Chaining operations
+- Which methods require elevation vs unprivileged
+- Available built-in functions beyond ctx
+
+**Action:** Expand table with full method signatures, return types, and examples.
+
+---
+
+### 2.2 Manifest Validation Criteria
+
+**Status:** Incomplete
+**Priority:** Medium
+**Location:** `docs/guides/lore/create-manifests.md` (lines 126-141)
+
+**Context:** Validation checks listed:
+- Schema validation
+- Phase file existence
+- Starlark syntax
+- Contract compliance
+- Feature consistency
+- Platform coverage
+
+**Missing:**
+- What "contract compliance" means (no definition anywhere)
+- Error message examples for each validation failure
+- How to fix common validation errors
+- Validation strictness levels (warnings vs errors)
+
+**Action:** Add subsections explaining each validation check with failure examples.
+
+---
+
+### 2.3 Onboarding from Documentation Feature
+
+**Status:** Incomplete (possibly aspirational)
+**Priority:** Low
+**Location:** `docs/guides/lore/registry.md` (lines 152-172)
+
+**Context:** Advanced AI-assisted feature:
+- Command: `lore onboard --from https://wiki.acme.com/backend-setup`
+- Claims AI will parse docs, match packages, flag org-specific items
+
+**Missing:**
+- What makes documentation parseable (format requirements?)
+- Confidence levels and thresholds
+- Review workflow before deployment
+- Real test case (example uses fictional URL)
+- Current implementation status (working? planned?)
+
+**Decision needed:** Is this feature implemented or aspirational documentation?
+
+---
+
+### 2.4 Windows Support
+
+**Status:** Inconsistent
+**Priority:** Medium
+**Location:** Multiple files
+
+**Context:**
+- `docs/guides/writ/platform-awareness.md` (line 48): "Windows (via WSL or native)"
+- `docs/guides/lore/create-manifests.md` (lines 57-59): manifest example shows `platforms: [darwin, linux]` — no windows
+- `docs/guides/lore/pipeline.md`: no Windows examples
+- `.goreleaser.yaml`: builds Windows binaries
+
+**Missing:**
+- Clear statement of current Windows support level
+- WSL vs native distinction
+- Which features work on Windows, which don't
+- Windows-specific installation instructions
+
+**Action:** Audit all platform references and create consistent Windows support statement.
+
+---
+
+## 3. Pending Decisions
+
+### 3.1 apt/yum Repository Service
+
+**Status:** Decision needed
+**Location:** `wiki/Releasing.md` (line 135)
+
+**Context:** Line states: "For apt/yum repos, consider services like Gemfury or Packagecloud"
+
+**Options:**
+- **Gemfury**: Free for public packages, simple API, supports apt/yum
+- **Packagecloud**: Similar features, different pricing
+- **Self-hosted**: Full control, more maintenance
+- **GitHub Releases only**: No repo, users download directly
+
+**Considerations:**
+- Cost (public vs private packages)
+- API for automation (GoReleaser integration)
+- User experience (apt-get install vs curl | bash)
+- Maintenance burden
+
+**Decision needed before:** Enabling auto-publish in `.goreleaser.yaml`
+
+---
+
+### 3.2 Authentication Removal Timeline
+
+**Status:** Decision needed
+**Location:** `wiki/Releasing.md` (line 99)
+
+**Context:** Table states:
+```
+| Production | devlore.noblefactor.com | Currently yes, later no |
+```
+
+**Questions:**
+- When will auth be removed? (Version milestone? Date?)
+- What triggers the change? (Public launch? Documentation complete?)
+- Should docs mention this temporary state or be written for post-auth world?
+
+**Action needed:** Define timeline or remove ambiguous "later" reference.
+
+---
+
+### 3.3 Bindgen Promotion Decision
+
+**Status:** Decision needed
+**Location:** `cmd/bindgen/README.md`, `internal/bindgen/cobra/README.md`
+
+**Context:** Tool exists and partially works but is marked experimental:
+- "Proof of concept"
+- "Not production-ready"
+- Known issues: misses ~60% of flags
+
+**Options:**
+- **Promote**: Add to main docs, fix known issues, release as supported tool
+- **Keep internal**: Development aid only, not user-facing
+- **Remove**: If not useful, delete to reduce maintenance
+
+**Considerations:**
+- User demand for manifest generation assistance
+- Maintenance cost of supporting another tool
+- Risk of users relying on buggy output
+
+---
+
+### 3.4 XDG Path Naming Convention
+
+**Status:** Decision needed (see Inconsistencies section)
+**Location:** Multiple files
+
+**Context:** Documentation uses both:
+- `~/.local/share/lore/` and `$XDG_DATA_HOME/lore/`
+- `~/.local/share/devlore/` and `~/.config/devlore/`
+
+**Question:** Should paths use `lore`, `devlore`, or `devlore-cli`?
+
+**Considerations:**
+- `lore` is shorter but may conflict with other tools
+- `devlore` matches project name
+- Changing now may break existing users (if any)
+
+**Action needed:** Choose one convention and update all documentation.
+
+---
+
+## 4. Inconsistencies (To Address Separately)
+
+The following inconsistencies were identified and should be addressed one at a time after deduplication is complete:
+
+1. **Installation methods**: README vs getting-started use different approaches
+2. **XDG paths**: `lore/` vs `devlore/` naming
+3. **Config paths**: `$XDG_CONFIG_HOME/lore/` vs `~/.config/devlore/`
+4. **Windows support**: mentioned inconsistently across docs
+5. **Auth requirement**: "Currently yes, later no" needs timeline
+6. **Command naming**: `lore manifest create` vs potential `lore create`
+7. **XDG variables**: mentioned but not used consistently
+
+These are documented here for reference. Address after deduplication work is complete.
+
+---
+
+## 5. Execution Graph Engine
+
+This section tracks the implementation work needed for the lore execution engine. The engine must process `packages-manifest.{yaml,json}` files and execute the four-phase pipeline (prepare → install → provision → verify) for each package.
+
+### 5.1 Current State (Completed)
+
+**Packages Manifest Foundation:**
+- `packages-manifest.{yaml,json}` format defined and documented
+- Schema embedded in writ (`schema/packages-manifest.json`)
+- Manifest loading and validation (`internal/writ/manifest/manifest.go`)
+- Graph builder implements `engine.GraphBuilder` interface (`internal/writ/manifest/builder.go`)
+- Two entry points:
+  - `BuildGraph(ctx, manifestPath, opts)` — load, validate, build from file
+  - `BuildGraphFromManifest(ctx, manifest, opts)` — build from pre-parsed manifest
+
+**Engine Infrastructure:**
+- `engine.GraphBuilder` interface defined (`internal/engine/builder.go`)
+- `engine.ExpandDelegates()` replaces delegate nodes with subgraphs (`internal/engine/compose.go`)
+- Basic operation registry and pipeline execution (`internal/engine/`)
+- Writ receipt and state management (`internal/writ/receipt/`, `internal/writ/state/`)
+
+### 5.2 Engine Pipeline (To Implement)
+
+```
+packages-manifest.yaml
+        │
+        ▼
+┌───────────────────┐
+│  manifest.Builder │  ✓ COMPLETE
+│  (parse manifest) │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ Registry Resolver │  ○ NOT STARTED
+│ (find package)    │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ Pipeline Loader   │  ○ NOT STARTED
+│ (deploy/upgrade/  │
+│  decommission)    │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ Starlark Executor │  ○ PARTIAL (internal/starlark/ exists)
+│ (run phase code)  │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ Engine.Run()      │  ✓ EXISTS (needs lore ops)
+│ (execute graph)   │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ Receipt Writer    │  ✓ EXISTS (writ receipts work)
+│ (save results)    │
+└───────────────────┘
+```
+
+### 5.3 Registry Resolver
+
+**Status:** Not started
+**Priority:** High
+**Location:** Should be `internal/lore/registry/` or `internal/registry/`
+
+**Requirements:**
+- Given a package name (e.g., "docker"), find it in the registry
+- Registry location: `$XDG_DATA_HOME/devlore/registry/` or remote
+- Return the package manifest path or error if not found
+- Handle package versioning (latest, pinned, ranges)
+- Support local registry overrides for development
+
+**Interface sketch:**
+```go
+type Resolver interface {
+    Resolve(ctx context.Context, name string, opts ResolveOptions) (*Package, error)
+}
+
+type Package struct {
+    Name        string
+    Version     string
+    ManifestDir string   // Path to lifecycle.yaml and phase scripts
+    Platforms   []string // Supported platforms
+    Features    []string // Available features
+}
+```
+
+### 5.4 Pipeline Loader
+
+**Status:** Not started
+**Priority:** High
+**Location:** Should be `internal/lore/pipeline/`
+
+**Requirements:**
+- Load `lifecycle.yaml` from package manifest directory
+- Select correct pipeline based on operation:
+  - `deploy`: prepare → install → provision → verify
+  - `upgrade`: prepare → install → provision → verify (with version diff)
+  - `decommission`: unprovision → uninstall → cleanup
+- Load Starlark phase scripts (`prepare.star`, `install.star`, etc.)
+- Validate phase scripts exist and parse correctly
+
+**Interface sketch:**
+```go
+type Loader interface {
+    LoadPipeline(ctx context.Context, pkg *Package, operation Operation) (*Pipeline, error)
+}
+
+type Operation int
+const (
+    OpDeploy Operation = iota
+    OpUpgrade
+    OpDecommission
+)
+
+type Pipeline struct {
+    Phases []Phase
+}
+
+type Phase struct {
+    Name   string           // "prepare", "install", "provision", "verify"
+    Script string           // Path to .star file
+    Code   *starlark.Program // Parsed Starlark
+}
+```
+
+### 5.5 Starlark Executor
+
+**Status:** Partial (`internal/starlark/` exists but needs work)
+**Priority:** High
+**Location:** `internal/starlark/`
+
+**Requirements:**
+- Execute phase scripts with `ctx` object providing:
+  - `ctx.run(cmd)` — run shell commands
+  - `ctx.pmm.install(packages)` — install via package manager
+  - `ctx.pmm.remove(packages)` — remove via package manager
+  - `ctx.feature(name)` — check if feature is enabled
+  - `ctx.os`, `ctx.arch`, `ctx.distro` — platform info
+  - `ctx.user`, `ctx.home` — user info
+- Capture stdout/stderr for audit logging
+- Handle errors and return structured results
+- Support dry-run mode (no side effects)
+
+**Context object (Starlark builtins):**
+```python
+# prepare.star example
+def main(ctx):
+    if ctx.os == "linux":
+        ctx.run("curl -fsSL https://example.com/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/example.gpg")
+        ctx.run("sudo apt-get update")
+
+    if ctx.feature("compose"):
+        ctx.log("Compose feature enabled")
+```
+
+### 5.6 Lore Operations
+
+**Status:** Not started
+**Priority:** High
+**Location:** `internal/engine/ops.go` (extend existing)
+
+**Requirements:**
+Add operations for lore's four-phase pipeline:
+- `PrepareOp` — run prepare.star
+- `InstallOp` — run install.star (delegates to PMM or custom)
+- `ProvisionOp` — run provision.star
+- `VerifyOp` — run verify.star
+
+Each operation:
+1. Loads the phase script
+2. Executes via Starlark executor
+3. Captures results in `PipelineState`
+4. Records to audit log
+
+### 5.7 Lore Receipt Format
+
+**Status:** Not started (writ receipts exist, lore needs its own)
+**Priority:** Medium
+**Location:** `internal/lore/receipt/`
+
+**Requirements:**
+- Record what was installed, which phases ran, results
+- Store in `~/.local/state/lore/receipts/`
+- Enable `lore upgrade`, `lore reconcile`, `lore decommission`
+- Include: package name, version, timestamp, platform, features enabled, phase results
+
+---
+
+## 6. Change Log
+
+| Date | Action | Details |
+|------|--------|---------|
+| 2025-01-25 | Created | Initial documentation review findings |
+| 2025-01-25 | Updated | Added packages-manifest format, schema, validation |
+| 2025-01-25 | Updated | Added Section 5: Engine Development Roadmap |

--- a/TODO.md
+++ b/TODO.md
@@ -415,6 +415,15 @@ packages-manifest.yaml
 │ (find package)    │
 └────────┬──────────┘
          │
+    ┌────┴────┐
+    │ OR      │
+    ▼         ▼
+┌───────────────────┐
+│Interactive Console│  ○ NOT STARTED (5.8)
+│ (AI-assisted      │
+│  manifest author) │
+└────────┬──────────┘
+         │
          ▼
 ┌───────────────────┐
 │ Pipeline Loader   │  ○ NOT STARTED
@@ -593,6 +602,61 @@ Each operation:
 - Store in `~/.local/state/lore/receipts/`
 - Enable `lore upgrade`, `lore reconcile`, `lore decommission`
 - Include: package name, version, timestamp, platform, features enabled, phase results
+
+### 5.8 Interactive Console (Bubble Tea)
+
+**Status:** Not started
+**Priority:** High (enables AI-assisted manifest authoring)
+**Location:** `internal/console/` or `internal/tui/`
+**Design dependency:** [noblefactor/TODO.md DESIGN-001](https://github.com/NobleFactor/noblefactor/blob/main/TODO.md) — AI-Assisted Manifest Authoring
+
+**Context:**
+AI-assisted manifest authoring requires a Claude Code-style interactive console: streaming AI responses, scrollable conversation history, multi-line user input. This is the UX layer for DESIGN-001's stepwise refinement workflow.
+
+**Stack:**
+```
+charmbracelet/bubbletea   — Core TUI framework (Elm architecture)
+charmbracelet/bubbles     — Components: viewport (scroll), textarea (input)
+charmbracelet/glamour     — Markdown rendering in terminal
+charmbracelet/lipgloss    — Styling (colors, borders, layout)
+```
+
+**Requirements:**
+- Streaming text display (AI responses appear incrementally)
+- Scrollable conversation history (viewport)
+- Multi-line user input (textarea)
+- Markdown rendering (code blocks, lists, emphasis)
+- Mode switching: flip into interactive console when `lore init --assist` or similar
+
+**Interface sketch:**
+```go
+// Console is the interactive conversation interface
+type Console struct {
+    viewport viewport.Model  // Scrollable history
+    textarea textarea.Model  // User input
+    history  []Message       // Conversation log
+    // ...
+}
+
+// Run enters interactive mode, returns when user exits
+func (c *Console) Run(ctx context.Context) (*Result, error)
+
+// Result contains the outcome of the conversation
+type Result struct {
+    Manifest *manifest.Manifest  // Generated packages-manifest
+    Aborted  bool                // User cancelled
+}
+```
+
+**Commands that use the console:**
+- `lore init --assist` — AI-assisted manifest creation
+- `lore manifest create` — Interactive manifest authoring
+- Future: `lore add --assist` — AI help finding packages
+
+**References:**
+- [Chat-TUI](https://www.nickhedberg.com/blog/projects/chat-tui.md) — Example chat interface with Bubble Tea
+- [Bubble Tea docs](https://github.com/charmbracelet/bubbletea)
+- [Glamour](https://github.com/charmbracelet/glamour) — Terminal markdown rendering
 
 ---
 
@@ -897,3 +961,4 @@ internal/bindgen/cobra/
 | 2025-01-25 | Updated | Added design sync rule at top of file |
 | 2025-01-25 | Synced | Updated ADR-051 with `layer` field for multi-layer support (context.layers, node.layer) |
 | 2025-01-25 | Updated | Registry Resolver (5.3) blocked on DESIGN-001: AI-Assisted Manifest Authoring |
+| 2025-01-25 | Added | Section 5.8: Interactive Console (Bubble Tea) for AI-assisted manifest authoring |

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,7 @@
-# DevLore CLI Documentation TODO
+# Implementation TODO
+
+**Scope:** Implementation gaps, product documentation, code issues
+**Sister file:** [noblefactor/TODO.md](https://github.com/NobleFactor/noblefactor/blob/main/TODO.md) — Design docs, business strategy, process items
 
 This file tracks documentation gaps, incomplete features, and pending decisions identified during a comprehensive review on 2025-01-25. Each item includes sufficient context for remediation without requiring additional research.
 
@@ -566,10 +569,178 @@ Each operation:
 
 ---
 
-## 6. Change Log
+## 6. Multi-Layer Repository Processing
+
+This section tracks the implementation work needed for writ to process multiple repository layers (base → team → personal) with proper precedence.
+
+### 6.1 Current State
+
+**What exists:**
+- `writ repo` commands support `--layer` flag with values: base, team, personal
+- `writ repo list` displays repos in precedence order: base, team, personal
+- `getConfiguredRepos()` retrieves all configured repos with their layer info
+- Design docs describe layer merging and collision resolution
+
+**What's missing:**
+- Deploy only processes a single repo (`cli.GetString("writ", "repo", true)`)
+- No code to iterate repos in layer order
+- No cross-layer collision detection during build
+- No layer-aware receipts/state tracking
+
+### 6.2 Required Changes
+
+**Status:** Not started
+**Priority:** High
+**Location:** `internal/writ/commands.go`, `internal/writ/tree/builder.go`
+
+**Requirements:**
+
+1. **Collect repos in order:**
+   ```go
+   // commands.go - replace single repo lookup
+   layerOrder := []string{"base", "team", "personal"}
+   var repos []RepoConfig
+   for _, layer := range layerOrder {
+       if repo := getConfiguredRepo(layer); repo != "" {
+           repos = append(repos, RepoConfig{Layer: layer, Path: repo})
+       }
+   }
+   ```
+
+2. **Build merged graph:**
+   - Process repos in order: base first, personal last
+   - Later layers override earlier layers for same target path
+   - Track which layer each node came from
+
+3. **Update tree.BuildConfig:**
+   ```go
+   type BuildConfig struct {
+       // Current: single SourceRoot
+       // Needed: multiple sources with layer info
+       Sources    []LayerSource  // Ordered: base, team, personal
+       TargetRoot string
+       Projects   []string
+       Segments   segment.Segments
+   }
+
+   type LayerSource struct {
+       Layer string  // "base", "team", or "personal"
+       Path  string  // Repo path
+   }
+   ```
+
+4. **Layer-aware collision detection:**
+   - Current: specificity-based (segment suffix count)
+   - Needed: layer takes precedence over specificity
+   - personal > team > base, regardless of segment specificity
+
+5. **Update receipts and state:**
+   - Track which layer each deployed file came from
+   - Enable layer-specific removal (`writ remove --layer=team`)
+
+### 6.3 Design Reference
+
+From `02-writ-prd.md`:
+> Writ supports layered repositories with precedence: base → team → personal.
+> When files conflict, the higher-precedence layer wins (personal > team > base).
+
+From `commands.go:1807-1808`:
+```go
+Writ supports layered repositories with precedence: base → team → personal.
+When files conflict, the higher-precedence layer wins (personal > team > base).
+```
+
+The help text documents the feature, but the implementation is incomplete.
+
+---
+
+## 7. Bindgen Tool
+
+This section consolidates all bindgen-related issues from `cmd/bindgen/README.md` and `internal/bindgen/cobra/README.md`. Bindgen is a proof-of-concept tool for generating Starlark bindings from CLI metadata.
+
+### 7.1 Current Status
+
+**Status:** Proof of concept (not production-ready)
+**Decision needed:** Promote to user-facing tool, keep internal, or remove? (See Section 3.3)
+
+**What works:**
+- Package discovery and AST loading via `golang.org/x/tools/go/packages`
+- Extracts `cobra.Command` struct literals (Use, Short, Long, Deprecated, Hidden)
+- Extracts flag definitions from `flags.StringVarP()`, `BoolVar()`, etc.
+- Type inference from method names (StringSlice → string_list)
+- Qualified command names using package directory prefixes
+
+**Test results (docker-cli v27.4.1):**
+- Extracted: 144 commands, 272 flags
+- Missing: ~60% of flags due to receiver detection limitations
+
+### 7.2 Extractor Issues
+
+| Issue | Severity | Status | Location |
+|-------|----------|--------|----------|
+| Limited receiver detection | Medium | Open | `extractor.go:373-384` |
+| Helper function flags missed | Medium | Open | N/A |
+| No subcommand hierarchy tree | Low | Open | N/A |
+| Silent unquote failures | Low | Open | `extractor.go:332, 455` |
+| Dead `fset` parameter | Low | Open | `extractor.go:168` |
+
+**Limited receiver detection:** `isFlagReceiver()` only matches `flags` or `f` as variable names. Misses `opts.Flags()`, `copts.AddFlags()`, `fs`, `flagSet`, etc.
+
+**Helper function flags:** Flags added via `addFlags(cmd)` or `addCommonFlags(cmd)` helper functions are not captured.
+
+### 7.3 Generator Issues
+
+| Issue | Severity | Status | Location |
+|-------|----------|--------|----------|
+| Command name not split | Critical | Open | `codegen.go` template |
+| No positional args | Critical | Open | `codegen.go` template |
+| Stub template broken | Medium | Open | `stubgen.go:9` |
+
+**Command name not split:** Emits `container_run` as single arg instead of `container`, `run` as separate args. Commands don't execute.
+
+**No positional args:** Generated code can't pass image names, container IDs, file paths, etc.
+
+**Stub template broken:** `title` function undefined, IDE stubs don't generate.
+
+### 7.4 Next Steps (Priority Order)
+
+1. **Improve receiver detection** — Track variable assignments or match more patterns (`fs`, `flagSet`, `opts.Flags()`)
+2. **Handle helper functions** — Track flags added via helper functions like `addFlags()`
+3. **Fix command name splitting** — Split `container_run` → `["container", "run"]`
+4. **Add positional argument support** — Generate code to handle required positional args
+5. **Fix stub template** — Define or import `title` function
+6. **Add tests** — Unit tests for extraction logic
+
+### 7.5 Future Directions
+
+From `cmd/bindgen/README.md`:
+- Parse fish/zsh completions for better flag enumeration
+- Support OpenAPI specs where CLI wraps an API (e.g., gh, kubectl)
+- Man page parsing for richer documentation
+- Integration with existing binding definitions (merge parsed + manual)
+
+### 7.6 Files
+
+```
+cmd/bindgen/
+├── main.go              # CLI with extract-cobra subcommand
+└── README.md            # Usage documentation
+
+internal/bindgen/cobra/
+├── extractor.go         # Main extraction logic (~430 lines)
+├── codegen.go           # Go binding generation
+├── stubgen.go           # Starlark stub generation
+└── README.md            # Detailed technical notes
+```
+
+---
+
+## 8. Change Log
 
 | Date | Action | Details |
 |------|--------|---------|
 | 2025-01-25 | Created | Initial documentation review findings |
 | 2025-01-25 | Updated | Added packages-manifest format, schema, validation |
 | 2025-01-25 | Updated | Added Section 5: Engine Development Roadmap |
+| 2025-01-25 | Updated | Added Section 6: Multi-Layer Repository Processing |
+| 2025-01-25 | Updated | Added Section 7: Bindgen Tool (consolidated from READMEs) |

--- a/TODO.md
+++ b/TODO.md
@@ -426,15 +426,15 @@ packages-manifest.yaml
          │
          ▼
 ┌───────────────────┐
-│ Pipeline Loader   │  ○ NOT STARTED
+│ Pipeline Loader   │  ⚠️ PARTIAL (lifecycle loading works)
 │ (deploy/upgrade/  │
 │  decommission)    │
 └────────┬──────────┘
          │
          ▼
 ┌───────────────────┐
-│ Starlark Executor │  ○ PARTIAL (internal/starlark/ exists)
-│ (run phase code)  │
+│ Starlark Bindings │  ⚠️ NEEDS REDESIGN (ADR-051 graph model)
+│ (build exec graph)│
 └────────┬──────────┘
          │
          ▼
@@ -508,72 +508,112 @@ type Package struct {
 
 ### 5.4 Pipeline Loader
 
-**Status:** Not started
+**Status:** ✓ PARTIAL — Lifecycle loading works, but executor needs graph-building integration
 **Priority:** High
-**Location:** Should be `internal/lore/pipeline/`
+**Location:** `internal/lore/pipeline/lifecycle.go`, `internal/lore/pipeline/executor.go`
 
-**Requirements:**
-- Load `lifecycle.yaml` from package manifest directory
-- Select correct pipeline based on operation:
-  - `deploy`: prepare → install → provision → verify
-  - `upgrade`: prepare → install → provision → verify (with version diff)
-  - `decommission`: unprovision → uninstall → cleanup
-- Load Starlark phase scripts (`prepare.star`, `install.star`, etc.)
-- Validate phase scripts exist and parse correctly
+**What's implemented:**
+- `Lifecycle` type loads and parses `lifecycle.yaml`
+- `LoadLifecycle(packageDir)` loads from package directory
+- `LoadLifecycleFromRegistry(registryDir, pkgName)` loads from registry
+- Operations defined: `OpDeploy`, `OpUpgrade`, `OpDecommission`
+- Phase order: `PhaseOrder = []string{"prepare", "install", "provision", "verify"}`
+- Decommission order: `DecommissionPhaseOrder = []string{"unprovision", "uninstall", "cleanup"}`
+- Features: `EnabledFeatures(explicit)` merges explicit enables with defaults
+- Settings: `ResolvedSettings(explicit)` merges explicit settings with defaults
 
-**Interface sketch:**
-```go
-type Loader interface {
-    LoadPipeline(ctx context.Context, pkg *Package, operation Operation) (*Pipeline, error)
-}
+**What's missing (per ADR-051):**
+- Executor should collect graph from Starlark scripts, not execute immediately
+- Graph should be passed to `Engine.Run()` for execution
+- Receipt should be the completed execution graph
 
-type Operation int
-const (
-    OpDeploy Operation = iota
-    OpUpgrade
-    OpDecommission
-)
+### 5.5 Starlark Bindings — Analysis Then Execute Model
 
-type Pipeline struct {
-    Phases []Phase
-}
-
-type Phase struct {
-    Name   string           // "prepare", "install", "provision", "verify"
-    Script string           // Path to .star file
-    Code   *starlark.Program // Parsed Starlark
-}
-```
-
-### 5.5 Starlark Executor
-
-**Status:** Partial (`internal/starlark/` exists but needs work)
+**Status:** ⚠️ NEEDS REDESIGN — Current implementation executes immediately; ADR-051 requires graph building
 **Priority:** High
-**Location:** `internal/starlark/`
+**Location:** `internal/starlark/bindings.go` (needs rewrite)
+**Design reference:** [ADR-051 Section 11.2](https://github.com/NobleFactor/noblefactor/blob/main/devlore/design/adr/051-receipt-as-execution-graph.md)
 
-**Requirements:**
-- Execute phase scripts with `ctx` object providing:
-  - `ctx.run(cmd)` — run shell commands
-  - `ctx.pmm.install(packages)` — install via package manager
-  - `ctx.pmm.remove(packages)` — remove via package manager
-  - `ctx.feature(name)` — check if feature is enabled
-  - `ctx.os`, `ctx.arch`, `ctx.distro` — platform info
-  - `ctx.user`, `ctx.home` — user info
-- Capture stdout/stderr for audit logging
-- Handle errors and return structured results
-- Support dry-run mode (no side effects)
+**Problem:** Current bindings execute side effects immediately (`package.install()` runs `apt install`). ADR-051 specifies a two-phase model where Starlark builds a graph, then the engine executes it.
 
-**Context object (Starlark builtins):**
+#### Phase Function Signature
+
+Each pipeline phase receives three inputs representing distinct concerns:
+
 ```python
-# prepare.star example
-def main(ctx):
-    if ctx.os == "linux":
-        ctx.run("curl -fsSL https://example.com/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/example.gpg")
-        ctx.run("sudo apt-get update")
-
-    if ctx.feature("compose"):
-        ctx.log("Compose feature enabled")
+def install(system, package, plan):
+    #        ↓        ↓       ↓
+    #      where    what     how
 ```
+
+| Input | Purpose | Access |
+|-------|---------|--------|
+| `system` | Query target environment | Read-only (immediate) |
+| `package` | Package metadata and features | Read-only (immediate) |
+| `plan` | Build execution graph | Write (deferred execution) |
+
+#### Binding Methods
+
+| Input | Methods | Description |
+|-------|---------|-------------|
+| `system` | `has(pm)`, `installed(pkg)`, `version(pkg)`, `path(p)`, `which(cmd)`, `platform()` | Query environment |
+| `package` | `name`, `version`, `feature(name)`, `setting(name, default)` | Package metadata |
+| `plan` | `install()`, `remove()`, `download()`, `extract()`, `write_file()`, `configure()`, `verify()` | Add operations to graph |
+
+#### Scripts Express Intent, Not Commands
+
+**CRITICAL:** Phase scripts NEVER invoke package managers or shell commands directly.
+
+```python
+# CORRECT: Express intent
+plan.install("docker-ce")
+plan.remove("docker.io")
+
+# WRONG: Never shell out to package managers
+plan.run("apt install docker-ce")      # ❌
+plan.run("brew install docker")        # ❌
+```
+
+The host binding layer maps intent to platform-specific commands. The engine
+batches operations (one `apt install` for all packages). Platform selection
+happens via writ segments (`install.star.Debian` vs `install.star.Fedora`),
+not conditionals in scripts.
+
+#### Example
+
+```python
+def install(system, package, plan):
+    # Query system state
+    if system.has("apt"):
+        plan.install("docker.io")
+    elif system.has("brew"):
+        plan.install("docker", cask=True)
+
+    # Check package features (enabled via --with)
+    if package.feature("rootless"):
+        plan.install("uidmap")
+        plan.run("dockerd-rootless-setuptool.sh --install")
+
+    # Promise-based data flow
+    tarball = plan.download(url="https://example.com/app.tar.gz")
+    plan.extract(tarball, dest="/usr/local")  # depends on tarball
+```
+
+#### Implementation Tasks
+
+1. Create `SystemBindings` struct — read-only environment queries
+2. Create `PackageBindings` struct — package metadata and feature checks
+3. Create `PlanBindings` struct — graph-building operations that return promises
+4. Update executor to pass three inputs to phase functions
+5. Collect graph from `plan` after Starlark completes
+6. Pass graph to `Engine.Run()` for execution
+
+**What exists today (needs rework):**
+- `internal/starlark/bindings.go` — Immediate execution model (wrong)
+- `internal/lore/pipeline/executor.go` — Runs scripts but doesn't collect graph
+- `cmd/pipeline/main.go` — Standalone PoC with immediate execution
+
+**Open design item:** Phase-to-phase transitions (state passing between prepare → install → provision → verify)
 
 ### 5.6 Lore Operations
 
@@ -950,7 +990,65 @@ internal/bindgen/cobra/
 
 ---
 
-## 8. Change Log
+## 8. Package Directory Structure Migration
+
+**Status:** Not started
+**Priority:** High
+**Blocking:** Pipeline loader, registry packages
+
+The package directory structure was formalized in RFC Section 9.3 (2025-01-26). Existing code and packages use the old flat structure and must be migrated.
+
+### 8.1 Formal Structure (ABNF)
+
+```abnf
+package         = "lifecycle.yaml" 1*platform-dir
+platform-dir    = platform "/" 1*pipeline-dir
+platform        = "Common" / "Darwin" / "Linux" / "Unix" / "Windows" / "Linux.Debian" / "Linux.Fedora"
+pipeline-dir    = pipeline "/" 1*phase-script
+pipeline        = "Deploy" / "Upgrade" / "Decommission"
+phase-script    = phase ".star"
+deploy-phase    = "prepare" / "install" / "provision" / "verify"
+decom-phase     = "unprovision" / "uninstall" / "cleanup"
+```
+
+### 8.2 Migration Tasks
+
+| Task | Location | Status |
+|------|----------|--------|
+| Remove `Phases map[string]string` from Lifecycle struct | `internal/lore/pipeline/lifecycle.go` | Not started |
+| Add phase discovery from directory structure | `internal/lore/pipeline/lifecycle.go` | Not started |
+| Update `GetPhaseScript()` to use platform/pipeline path | `internal/lore/pipeline/lifecycle.go` | Not started |
+| Migrate docker package to `Linux.Debian/Deploy/` structure | `devlore-registry/packages/docker/` | Not started |
+| Migrate kubectl package to `all/Deploy/` structure | `devlore-registry/packages/kubectl/` | Not started |
+| Migrate remaining 8 packages | `devlore-registry/packages/*/` | Not started |
+| Remove `phases:` from lifecycle.yaml files | `devlore-registry/packages/*/lifecycle.yaml` | Not started |
+| Update platform names to capitalized | `devlore-registry/packages/*/lifecycle.yaml` | Not started |
+
+### 8.3 Documents Updated (2025-01-26)
+
+| Document | Section | Change |
+|----------|---------|--------|
+| RFC (02-devlore-rfc.md) | 9.2 | Removed `phases:` from example, capitalized platforms |
+| RFC (02-devlore-rfc.md) | 9.3 | NEW: ABNF grammar, platform/pipeline directories, examples |
+| RFC (02-devlore-rfc.md) | 17.2 | Updated Fetch paths for nested structure |
+| RFC (02-devlore-rfc.md) | 18.1 | Updated registry structure examples |
+| ADR-051 | 11.2 | Three-input API, segment directory syntax (not suffix) |
+| lifecycle.json | NEW | JSON Schema for lifecycle.yaml (no `phases:` field) |
+| schema.go | | Added `LifecycleSchema` embed |
+| AUTHORING.md | 3.1-3.5 | Complete rewrite for new structure and three-input API |
+
+### 8.4 Documents NOT YET Updated
+
+| Document | Issue |
+|----------|-------|
+| Lore PRD (02-lore-prd.md) | May have old package structure references |
+| Existing lifecycle.yaml files | Still have `phases:` section and lowercase platforms |
+
+**Note:** ADR-051 Section 11.2 updated (2025-01-26) — fixed segment directory syntax.
+
+---
+
+## 9. Change Log
 
 | Date | Action | Details |
 |------|--------|---------|
@@ -965,3 +1063,5 @@ internal/bindgen/cobra/
 | 2025-01-25 | Synced | Updated ADR-051 with `layer` field for multi-layer support (context.layers, node.layer) |
 | 2025-01-25 | Updated | Registry Resolver (5.3) blocked on DESIGN-001: AI-Assisted Manifest Authoring |
 | 2025-01-25 | Added | Section 5.8: Interactive Console (Bubble Tea) for AI-assisted manifest authoring |
+| 2025-01-25 | Partial | Sections 5.4-5.5: Lifecycle loading implemented, but bindings need redesign per ADR-051 (graph-building model) |
+| 2025-01-25 | Design | Refined Starlark API: `def install(system, package, plan)` — three inputs for read/read/write concerns. Updated ADR-051 Section 11.2 |

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,8 @@
 **Scope:** Implementation gaps, product documentation, code issues
 **Sister file:** [noblefactor/TODO.md](https://github.com/NobleFactor/noblefactor/blob/main/TODO.md) — Design docs, business strategy, process items
 
+> **RULE:** All implementation and documentation work MUST be checked against the design docs in `noblefactor/devlore/`. Goal: Keep implementation and design in sync. Find and resolve inconsistencies, redundancies, and gaps as we progress.
+
 This file tracks documentation gaps, incomplete features, and pending decisions identified during a comprehensive review on 2025-01-25. Each item includes sufficient context for remediation without requiring additional research.
 
 ---
@@ -409,7 +411,7 @@ packages-manifest.yaml
          │
          ▼
 ┌───────────────────┐
-│ Registry Resolver │  ○ NOT STARTED
+│ Registry Resolver │  ⊘ BLOCKED (DESIGN-001)
 │ (find package)    │
 └────────┬──────────┘
          │
@@ -441,16 +443,40 @@ packages-manifest.yaml
 
 ### 5.3 Registry Resolver
 
-**Status:** Not started
+**Status:** Blocked on design
 **Priority:** High
 **Location:** Should be `internal/lore/registry/` or `internal/registry/`
+**Design dependency:** [noblefactor/TODO.md DESIGN-001](https://github.com/NobleFactor/noblefactor/blob/main/TODO.md) — AI-Assisted Manifest Authoring
 
-**Requirements:**
-- Given a package name (e.g., "docker"), find it in the registry
+**Context:**
+The resolver handles exact package lookups with federated resolution through the registry to native package managers.
+
+**Resolution order (federated search):**
+1. **Registry first** (highest priority) — lore packages with cross-platform mappings
+2. **Native PM fallback** — if not in registry, try native PM directly
+
+**Cross-platform mapping:**
+The registry contains lore packages that know their native PM equivalents:
+```yaml
+# docker lore package knows:
+packages:
+  brew: docker
+  apt: docker.io
+  winget: Docker.Desktop
+```
+User says `lore add docker` → resolver finds lore package → uses `apt: docker.io` on Ubuntu.
+
+**Resolver requirements:**
+- Given a package name (e.g., "docker"), find it in registry first
 - Registry location: `$XDG_DATA_HOME/devlore/registry/` or remote
-- Return the package manifest path or error if not found
+- If in registry: use lore package with cross-platform mappings
+- If not in registry: fall back to native PM (exact name match)
 - Handle package versioning (latest, pinned, ranges)
 - Support local registry overrides for development
+
+**Non-match behavior:**
+- No match in registry or native PM: Error with message
+- No fuzzy suggestions — discovery is via AI-assisted authoring (DESIGN-001)
 
 **Interface sketch:**
 ```go
@@ -464,6 +490,7 @@ type Package struct {
     ManifestDir string   // Path to lifecycle.yaml and phase scripts
     Platforms   []string // Supported platforms
     Features    []string // Available features
+    NativeName  string   // Platform-specific name (e.g., "docker.io" on apt)
 }
 ```
 
@@ -573,72 +600,195 @@ Each operation:
 
 This section tracks the implementation work needed for writ to process multiple repository layers (base → team → personal) with proper precedence.
 
-### 6.1 Current State
-
-**What exists:**
-- `writ repo` commands support `--layer` flag with values: base, team, personal
-- `writ repo list` displays repos in precedence order: base, team, personal
-- `getConfiguredRepos()` retrieves all configured repos with their layer info
-- Design docs describe layer merging and collision resolution
-
-**What's missing:**
-- Deploy only processes a single repo (`cli.GetString("writ", "repo", true)`)
-- No code to iterate repos in layer order
-- No cross-layer collision detection during build
-- No layer-aware receipts/state tracking
-
-### 6.2 Required Changes
-
-**Status:** Not started
+**Status:** ✓ COMPLETE (2025-01-25)
 **Priority:** High
-**Location:** `internal/writ/commands.go`, `internal/writ/tree/builder.go`
 
-**Requirements:**
+### 6.1 Commands Requiring Multi-Layer Processing
 
-1. **Collect repos in order:**
-   ```go
-   // commands.go - replace single repo lookup
-   layerOrder := []string{"base", "team", "personal"}
-   var repos []RepoConfig
-   for _, layer := range layerOrder {
-       if repo := getConfiguredRepo(layer); repo != "" {
-           repos = append(repos, RepoConfig{Layer: layer, Path: repo})
-       }
-   }
-   ```
+| Command | Needs Layers | Reason |
+|---------|--------------|--------|
+| `writ add` | Yes | Deploys from all layers, personal overrides team overrides base |
+| `writ remove` | Yes | Must know which layer(s) deployed each file |
+| `writ regenerate` | Yes | Re-processes templates/secrets from all layers |
+| `writ status` | Yes | Shows status across all layers |
+| `writ projects` | Yes | Lists projects from all configured repos |
+| `writ adopt` | Partial | Targets single layer (via `--layer` flag) but must check for conflicts |
 
-2. **Build merged graph:**
-   - Process repos in order: base first, personal last
-   - Later layers override earlier layers for same target path
-   - Track which layer each node came from
+**Commands NOT needing layer processing:**
+- `writ migrate` — single repo migration
+- `writ init` — creates single repo
+- `writ config` — system configuration
+- `writ repo *` — manages repo config itself
+- `writ secrets *` — operates within single repo
+- `writ receipt *` — reads historical data
 
-3. **Update tree.BuildConfig:**
-   ```go
-   type BuildConfig struct {
-       // Current: single SourceRoot
-       // Needed: multiple sources with layer info
-       Sources    []LayerSource  // Ordered: base, team, personal
-       TargetRoot string
-       Projects   []string
-       Segments   segment.Segments
-   }
+### 6.2 Processing Order
 
-   type LayerSource struct {
-       Layer string  // "base", "team", or "personal"
-       Path  string  // Repo path
-   }
-   ```
+**Layer order:** base → team → personal (personal wins conflicts)
 
-4. **Layer-aware collision detection:**
-   - Current: specificity-based (segment suffix count)
-   - Needed: layer takes precedence over specificity
-   - personal > team > base, regardless of segment specificity
+**Within each repo:** System → Home
+- `<repo>/System/` → target `/` (if exists)
+- `<repo>/Home/` → target `$HOME` (if exists)
 
-5. **Update receipts and state:**
-   - Track which layer each deployed file came from
-   - Enable layer-specific removal (`writ remove --layer=team`)
+### 6.3 Implementation Plan
 
-### 6.3 Design Reference
+#### Phase 1: Data Structures
+
+**6.3.1 LayerSource type** (`internal/writ/layer.go` — NEW)
+```go
+type LayerSource struct {
+    Layer  string // "base", "team", "personal"
+    Path   string // Repo root path
+    Order  int    // 0=base, 1=team, 2=personal (for sorting)
+}
+
+var LayerOrder = []string{"base", "team", "personal"}
+
+type TargetSpec struct {
+    SourceDir  string  // "System" or "Home"
+    TargetRoot string  // "/" or "$HOME"
+}
+
+var TargetOrder = []TargetSpec{
+    {"System", "/"},
+    {"Home", os.Getenv("HOME")},
+}
+```
+
+**6.3.2 Update BuildConfig** (`internal/writ/tree/builder.go`)
+```go
+type BuildConfig struct {
+    Sources    []LayerSource  // Replaces single SourceRoot
+    TargetRoot string         // Default target (for backwards compat)
+    Projects   []string
+    Segments   segment.Segments
+}
+```
+
+**6.3.3 Update BuildResult** (`internal/writ/tree/builder.go`)
+```go
+type BuildResult struct {
+    Graph       *engine.Graph
+    Sources     []LayerSource  // All sources processed
+    TargetRoot  string
+    // ... existing fields ...
+
+    // New: track which layer each node came from
+    NodeLayers  map[string]string  // node.ID → layer name
+}
+```
+
+#### Phase 2: Collection Logic
+
+**6.3.4 collectLayerSources()** (`internal/writ/layer.go`)
+```go
+func collectLayerSources() ([]LayerSource, error) {
+    var sources []LayerSource
+    for i, layer := range LayerOrder {
+        if path := getConfiguredRepo(layer); path != "" {
+            sources = append(sources, LayerSource{
+                Layer: layer,
+                Path:  path,
+                Order: i,
+            })
+        }
+    }
+    return sources, nil
+}
+```
+
+#### Phase 3: Build Graph Updates
+
+**6.3.5 Modify tree.Build()** — Process all layers and targets
+```go
+func Build(cfg BuildConfig) (*BuildResult, error) {
+    result := &BuildResult{
+        Graph:      &engine.Graph{},
+        Sources:    cfg.Sources,
+        NodeLayers: make(map[string]string),
+    }
+
+    nodesByTarget := make(map[string]nodeEntry)
+
+    // Process layers in order: base → team → personal
+    for _, source := range cfg.Sources {
+        // Process targets in order: System → Home
+        for _, target := range TargetOrder {
+            sourceDir := filepath.Join(source.Path, target.SourceDir)
+            if !dirExists(sourceDir) {
+                continue
+            }
+
+            nodes, err := walkDirectoryWithLayer(sourceDir, target.TargetRoot, source)
+            // ... collision detection with layer precedence ...
+        }
+    }
+
+    return result, nil
+}
+```
+
+**6.3.6 Layer-aware collision resolution**
+```go
+// personal > team > base, regardless of specificity
+if newLayer.Order > existing.Layer.Order {
+    // New layer wins (e.g., personal beats team)
+    winner = new
+} else if newLayer.Order == existing.Layer.Order {
+    // Same layer: use specificity (segment suffix count)
+    if newSpecificity > existing.Specificity {
+        winner = new
+    }
+}
+```
+
+#### Phase 4: Command Updates
+
+**6.3.7 writ add** — Use collectLayerSources()
+**6.3.8 writ remove** — Load state to determine which layer deployed each file
+**6.3.9 writ status** — Build graph from all layers, show layer info in output
+**6.3.10 writ projects** — List projects from all configured repos with layer indicator
+**6.3.11 writ regenerate** — Process all layers for templates/secrets
+
+#### Phase 5: State & Receipt Updates
+
+**6.3.12 Track layer in state** (`internal/writ/state/state.go`)
+```go
+type FileEntry struct {
+    // ... existing fields ...
+    Layer string `json:"layer" yaml:"layer"`  // NEW
+}
+```
+
+**6.3.13 Track layer in receipts** (`internal/writ/receipt/receipt.go`)
+```go
+type WritContext struct {
+    // ... existing fields ...
+    Layers []string `json:"layers" yaml:"layers"`  // Layers processed
+}
+```
+
+### 6.4 Files to Modify
+
+| File | Changes |
+|------|---------|
+| `internal/writ/layer.go` | NEW: LayerSource, LayerOrder, TargetOrder, collectLayerSources() |
+| `internal/writ/tree/builder.go` | BuildConfig.Sources, BuildResult.NodeLayers, layer-aware collision |
+| `internal/writ/commands.go` | runAdd, runRemove, runStatus, runProjects, runRegenerate |
+| `internal/writ/state/state.go` | FileEntry.Layer field |
+| `internal/writ/receipt/receipt.go` | WritContext.Layers field |
+| `internal/writ/status/status.go` | Layer-aware status reporting |
+
+### 6.5 Test Cases
+
+1. **Single layer** — backwards compatible, works like today
+2. **Two layers, no conflict** — base + personal, disjoint files
+3. **Two layers, conflict** — personal overrides base for same target
+4. **Three layers** — base → team → personal cascade
+5. **System + Home** — System files deployed before Home files
+6. **Layer + specificity** — personal/all beats team/project.Darwin
+
+### 6.6 Design Reference
 
 From `02-writ-prd.md`:
 > Writ supports layered repositories with precedence: base → team → personal.
@@ -649,8 +799,6 @@ From `commands.go:1807-1808`:
 Writ supports layered repositories with precedence: base → team → personal.
 When files conflict, the higher-precedence layer wins (personal > team > base).
 ```
-
-The help text documents the feature, but the implementation is incomplete.
 
 ---
 
@@ -744,3 +892,8 @@ internal/bindgen/cobra/
 | 2025-01-25 | Updated | Added Section 5: Engine Development Roadmap |
 | 2025-01-25 | Updated | Added Section 6: Multi-Layer Repository Processing |
 | 2025-01-25 | Updated | Added Section 7: Bindgen Tool (consolidated from READMEs) |
+| 2025-01-25 | Completed | Section 6: Multi-layer processing implemented (layer.go, builder.go, commands.go, state.go, receipt.go) |
+| 2025-01-25 | Updated | Added prune empty dirs to remove/unlink operations (engine/ops.go, writ/commands.go) |
+| 2025-01-25 | Updated | Added design sync rule at top of file |
+| 2025-01-25 | Synced | Updated ADR-051 with `layer` field for multi-layer support (context.layers, node.layer) |
+| 2025-01-25 | Updated | Registry Resolver (5.3) blocked on DESIGN-001: AI-Assisted Manifest Authoring |

--- a/TODO.md
+++ b/TODO.md
@@ -487,6 +487,9 @@ User says `lore add docker` → resolver finds lore package → uses `apt: docke
 - No match in registry or native PM: Error with message
 - No fuzzy suggestions — discovery is via AI-assisted authoring (DESIGN-001)
 
+**Design rationale (2025-01-25):**
+Fuzzy search was rejected as a solution. Users who don't know package names need AI-assisted conversation to build a manifest, not better string matching. The resolver does exact lookup; discovery is a separate concern handled by the interactive console (5.8).
+
 **Interface sketch:**
 ```go
 type Resolver interface {

--- a/cmd/bindgen/README.md
+++ b/cmd/bindgen/README.md
@@ -107,9 +107,6 @@ The input is `--help` output, not reflection or OpenAPI specs.
 - Generated code needs manual review before production use
 - No automated testing of generated bindings
 
-## Future Directions
+## Issues and Roadmap
 
-- Parse fish/zsh completions for better flag enumeration
-- Support OpenAPI specs where CLI wraps an API (e.g., gh, kubectl)
-- Man page parsing for richer documentation
-- Integration with existing binding definitions (merge parsed + manual)
+See [TODO.md Section 7: Bindgen Tool](../../TODO.md#7-bindgen-tool) for tracked issues, next steps, and future directions.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -100,16 +100,17 @@ noblefactor (personal)
 
 ## Add software with lore
 
-If your project includes a `packages.manifest` file, writ automatically
+If your project includes a `packages-manifest.yaml` file, writ automatically
 delegates to lore for software installation:
 
 ```yaml
-# noblefactor/packages.manifest
+# noblefactor/packages-manifest.yaml
 packages:
   - gh
   - jq
   - ripgrep
-  - neovim
+  - neovim:
+      with: [lsp]
 ```
 
 ```bash
@@ -117,6 +118,8 @@ writ add noblefactor
 # → symlinks configuration files
 # → calls lore to install gh, jq, ripgrep, neovim
 ```
+
+See [Packages Manifest](/guides/writ/packages-manifest/) for the full format reference.
 
 Or install packages directly with lore:
 

--- a/docs/guides/lore/deploy-packages.md
+++ b/docs/guides/lore/deploy-packages.md
@@ -30,27 +30,27 @@ Packages can offer optional features. Enable them with `--with`:
 lore deploy docker --with rootless --with compose --with buildx
 ```
 
-Features control which steps run during installation. A package's available
-features are listed in its manifest.
+Features control which steps run during installation. See [The Pipeline](/guides/lore/pipeline/#features-in-the-pipeline)
+for how features interact with phase scripts.
 
 ## Deploy from manifests
 
 Use `@` to deploy from a manifest file:
 
 ```bash
-lore deploy @packages.manifest
+lore deploy @packages-manifest.yaml
 ```
 
 Deploy from multiple manifests:
 
 ```bash
-lore deploy @base.manifest @team.manifest
+lore deploy @base-packages.yaml @team-packages.yaml
 ```
 
 Mix manifests with direct packages:
 
 ```bash
-lore deploy @team.manifest neovim --with lsp
+lore deploy @team-packages.yaml neovim --with lsp
 ```
 
 ## Confidence levels
@@ -141,13 +141,13 @@ lore decommission --orphans-only
 
 ## Integration with writ
 
-When writ deploys a project containing `packages.manifest`, it automatically
+When writ deploys a project containing `packages-manifest.yaml`, it automatically
 calls lore:
 
 ```bash
 writ add noblefactor
 # → Symlinks config files
-# → Calls: lore deploy @packages.manifest
+# → Calls: lore deploy @packages-manifest.yaml
 ```
 
 When writ removes a project:

--- a/docs/guides/lore/index.md
+++ b/docs/guides/lore/index.md
@@ -30,35 +30,17 @@ What took someone hours to figure out, you get in minutes.
 
 ### Four-phase pipeline
 
-Every package deployment follows a structured pipeline:
+Every package deployment follows a structured pipeline: **prepare → install → provision → verify**.
+This model separates concerns, enables partial re-runs, and makes installation auditable.
 
-```
-prepare → install → provision → verify
-```
-
-| Phase | Purpose | Example |
-|-------|---------|---------|
-| **Prepare** | Pre-install setup | Add APT repositories, import GPG keys |
-| **Install** | Package installation | `brew install`, `apt install`, download binary |
-| **Provision** | Post-install config | Enable systemd services, create config files |
-| **Verify** | Validation | Check binary exists, verify version, test connectivity |
+See [The Pipeline](/guides/lore/pipeline/) for detailed phase documentation.
 
 ### Package manifests
 
-A manifest is a YAML file defining a package's installation lifecycle.
-Each phase can use native package managers or custom Starlark scripts:
+A manifest is a YAML file defining a package's installation lifecycle, including
+metadata, platform support, optional features, and phase scripts (Starlark).
 
-```yaml
-name: docker
-version: "24.0"
-platforms: [darwin, linux]
-features: [rootless, compose, buildx]
-phases:
-  prepare: prepare.star
-  install: install.star
-  provision: provision.star
-  verify: verify.star
-```
+See [Create Manifests](/guides/lore/create-manifests/) for the full specification.
 
 ### Registry
 

--- a/docs/guides/lore/registry.md
+++ b/docs/guides/lore/registry.md
@@ -162,11 +162,11 @@ Lore uses AI to:
 1. Parse installation steps from the document
 2. Match them to known registry packages
 3. Flag organization-specific items for review
-4. Generate a `packages.manifest` and config files
+4. Generate a `packages-manifest.yaml` and config files
 
 Then deploy the result:
 
 ```bash
-lore deploy @packages.manifest
+lore deploy @packages-manifest.yaml
 writ adopt --from-receipt
 ```

--- a/docs/guides/writ/index.md
+++ b/docs/guides/writ/index.md
@@ -43,34 +43,28 @@ repos/personal/noblefactor/
 
 ### Layered repositories
 
-Writ supports multiple repositories with defined precedence:
+Writ supports multiple repositories with defined precedence (`personal > team > base`).
+When files from different layers target the same path, the higher-precedence layer wins.
+This lets organizations provide shared defaults that individuals can override.
 
-```
-personal > team > base
-```
-
-When files from different layers target the same path, the higher-precedence
-layer wins. This lets organizations provide shared defaults that individuals
-can override:
-
-```bash
-writ repo init --layer=base        # Company-wide defaults
-writ repo init --layer=team        # Team-specific config
-writ repo init --layer=personal    # Your personal preferences
-```
+See [Repositories](/guides/writ/repositories/) for setup and configuration.
 
 ### Platform awareness
 
-Projects can include platform-specific variants. Writ detects your OS
-and selects the right files automatically:
+Projects can have platform-specific variants using directory suffixes.
+Writ detects your OS and deploys matching directories automatically:
 
 ```
-noblefactor/
-├── .zshrc                    # Shared across all platforms
-├── .zshrc.Darwin             # macOS override
-├── .zshrc.Linux              # Linux override
-└── .config/
-    └── alacritty.toml.Darwin # macOS-only file
+noblefactor/           # Base project (all platforms)
+├── .zshrc
+└── .config/nvim/
+
+noblefactor.Darwin/    # macOS-specific additions
+├── .zshrc             # Overrides base .zshrc on macOS
+└── .config/alacritty/
+
+noblefactor.Linux/     # Linux-specific additions
+└── .config/systemd/
 ```
 
 ### Templates
@@ -108,5 +102,6 @@ tamper detection.
 
 - [Manage environments](/guides/writ/manage-environments/) — Deploy, update, and remove projects
 - [Platform awareness](/guides/writ/platform-awareness/) — Configure platform-specific variants
+- [Packages manifest](/guides/writ/packages-manifest/) — Declare software dependencies
 - [Secrets management](/guides/writ/secrets/) — Encrypt sensitive files with age
 - [Repositories](/guides/writ/repositories/) — Manage layered repositories

--- a/docs/guides/writ/manage-environments.md
+++ b/docs/guides/writ/manage-environments.md
@@ -48,12 +48,8 @@ writ add --conflict=skip noblefactor
 
 ### Custom segments
 
-Override platform detection with custom segment values:
-
-```bash
-writ add -s ROLE=desktop noblefactor
-writ add -s ROLE=server -s DISPLAY=headless noblefactor
-```
+Override platform detection with custom segment values (e.g., `-s ROLE=desktop`).
+See [Platform Awareness](/guides/writ/platform-awareness/#custom-segments) for details.
 
 ### Dry run
 
@@ -175,7 +171,7 @@ writ remove --decommission noblefactor
 ```
 
 This delegates to `lore decommission --orphans-only` to remove packages
-that were installed via the project's `packages.manifest` and are no longer
+that were installed via the project's `packages-manifest.yaml` and are no longer
 referenced by any other project.
 
 ## Inspect details

--- a/docs/guides/writ/packages-manifest.md
+++ b/docs/guides/writ/packages-manifest.md
@@ -1,0 +1,175 @@
+---
+title: "Packages Manifest"
+description: "Declare software dependencies for writ projects"
+tool: "writ"
+category: "reference"
+order: 4
+---
+
+# Packages Manifest
+
+A `packages-manifest.yaml` (or `.json`) file declares software dependencies for
+a writ project. When you run `writ add`, writ delegates to lore to install
+packages from the manifest.
+
+## Location
+
+Place the manifest in your project directory:
+
+```
+$XDG_DATA_HOME/devlore/repos/personal/
+└── Home/
+    └── noblefactor/
+        ├── packages-manifest.yaml
+        ├── .zshrc
+        └── .config/
+            └── nvim/
+                └── init.lua
+```
+
+## Format
+
+Each package is either a simple name or a single-key map with options:
+
+```yaml
+packages:
+  # Simple packages
+  - gh
+  - jq
+  - ripgrep
+
+  # Packages with features
+  - neovim:
+      with: [lsp, treesitter]
+  - docker:
+      with: [rootless, compose]
+```
+
+### Simple packages
+
+For packages without options, use a plain string:
+
+```yaml
+packages:
+  - gh
+  - jq
+  - ripgrep
+```
+
+### Packages with features
+
+To enable optional features, use a single-key map where the key is the package
+name and the value contains a `with` array:
+
+```yaml
+packages:
+  - neovim:
+      with: [lsp, treesitter]
+  - docker:
+      with: [rootless, compose, buildx]
+```
+
+Features are passed to lore as `--with` flags. Available features for each
+package are defined in the lore registry.
+
+## How it works
+
+```
+writ add noblefactor
+  │
+  ├── Create symlinks for configuration files
+  │
+  └── Found packages-manifest.yaml
+      └── Delegate to: lore deploy @packages-manifest.yaml
+          │
+          └── For each package:
+              ├── Resolve from registry
+              └── Run four-phase pipeline
+```
+
+Writ manages configuration (symlinks, templates, secrets). Lore manages software
+installation. The manifest bridges the two.
+
+## Package resolution
+
+Package names in the manifest are resolved against the lore registry. The
+registry contains full lifecycle manifests with:
+
+- Platform-specific installation methods
+- Prepare, install, provision, verify phases
+- Package manager selection logic
+
+You don't specify *how* to install packages in the manifest—that knowledge
+lives in the registry.
+
+### Package manager preference
+
+On macOS, where both Homebrew and MacPorts are common, set your preference in
+the lore configuration (not per-package):
+
+```yaml
+# ~/.config/devlore/config.yaml
+lore:
+  macos:
+    package_manager: port  # prefer MacPorts, fall back to Homebrew
+```
+
+## Layer merging
+
+When multiple layers (base, team, personal) contain package manifests, they
+merge with precedence:
+
+```
+base/packages-manifest.yaml      →  foundational packages
+  ↓
+team/packages-manifest.yaml      →  team-specific additions
+  ↓
+personal/packages-manifest.yaml  →  personal overrides
+```
+
+Packages are deduplicated by name. A package in a higher layer (personal)
+overrides the same package from a lower layer (base), including its features.
+
+## Platform variants
+
+Package manifests follow the same segment matching as other project files.
+Place platform-specific manifests in variant directories:
+
+```
+Home/
+├── noblefactor/
+│   └── packages-manifest.yaml       # Common packages
+├── noblefactor.Darwin/
+│   └── packages-manifest.yaml       # macOS-only packages
+└── noblefactor.Linux/
+    └── packages-manifest.yaml       # Linux-only packages
+```
+
+On macOS, packages from both `noblefactor/` and `noblefactor.Darwin/` are
+merged. See [Platform Awareness](/guides/writ/platform-awareness/) for details.
+
+## JSON format
+
+The manifest can also be written as JSON:
+
+```json
+{
+  "packages": [
+    "gh",
+    "jq",
+    "ripgrep",
+    {"neovim": {"with": ["lsp", "treesitter"]}},
+    {"docker": {"with": ["rootless", "compose"]}}
+  ]
+}
+```
+
+## Schema
+
+The embedded JSON schema is available via:
+
+```bash
+writ schema packages-manifest
+```
+
+This outputs the schema for editor integration and validation.

--- a/docs/guides/writ/platform-awareness.md
+++ b/docs/guides/writ/platform-awareness.md
@@ -9,106 +9,128 @@ order: 3
 # Platform Awareness
 
 Writ automatically detects your operating system and selects platform-specific
-file variants during deployment. This lets you maintain a single repository
+project variants during deployment. This lets you maintain a single repository
 that works across macOS, Linux, and Windows.
 
 ## How it works
 
-When deploying a project, writ checks each file for platform-specific suffixes.
-If a variant matching your current platform exists, it takes precedence over
-the base file.
-
-Platform suffixes are appended to the filename:
+Platform-awareness uses **directory-level segment matching**. Project directories
+can have suffixes indicating which platforms they apply to:
 
 ```
-.zshrc              # Base file (used when no platform variant matches)
-.zshrc.Darwin       # Used on macOS
-.zshrc.Linux        # Used on Linux
-.zshrc.Windows      # Used on Windows
+Home/
+├── noblefactor/              # Base project (all platforms)
+├── noblefactor.Darwin/       # macOS-specific variant
+├── noblefactor.Linux/        # Linux-specific variant
+└── noblefactor.Linux.Debian/ # Debian/Ubuntu-specific variant
 ```
 
-The deployed symlink always points to the correct variant without the suffix:
+When you run `writ add noblefactor`, writ deploys files from:
+1. The base `noblefactor/` directory (always)
+2. Any variant directories that match your current platform
 
-```bash
-# On macOS:
-~/.zshrc → repos/personal/noblefactor/.zshrc.Darwin
+On macOS, both `noblefactor/` and `noblefactor.Darwin/` are deployed.
+On Debian Linux, `noblefactor/`, `noblefactor.Linux/`, and `noblefactor.Linux.Debian/`
+are all deployed. Files in more specific variants override files from less specific ones.
 
-# On Linux:
-~/.zshrc → repos/personal/noblefactor/.zshrc.Linux
-```
+## Segment detection
 
-## Platform detection
+Writ detects segments automatically in this order:
 
-Writ detects the following platform values automatically:
+| Segment | Detection | Example values |
+|---------|-----------|----------------|
+| OS | `uname -s` | `Darwin`, `Linux`, `Windows` |
+| DISTRO | `/etc/os-release` | `Debian`, `Ubuntu`, `Fedora`, `RHEL` |
+| ARCH | `uname -m` | `amd64`, `arm64` |
 
-| Value | System |
-|-------|--------|
-| `Darwin` | macOS (any architecture) |
-| `Linux` | Linux distributions |
-| `Windows` | Windows (via WSL or native) |
+Segments are matched in order: OS → DISTRO → ARCH → custom. Empty or unset
+segments are skipped during matching.
 
-## Directory variants
+## Directory matching examples
 
-Entire directories can have platform suffixes. All files within a
-platform-specific directory are deployed only on that platform:
+Given these project variants on a macOS ARM machine (OS=Darwin, ARCH=arm64):
 
-```
-noblefactor/
-├── .config/
-│   ├── alacritty/              # Shared config
-│   │   └── alacritty.toml
-│   ├── alacritty.Darwin/       # macOS-specific alacritty config
-│   │   └── alacritty.toml
-│   └── systemd.Linux/          # Linux-only systemd units
-│       └── user/
-│           └── backup.service
-```
+| Directory | Matches | Why |
+|-----------|---------|-----|
+| `noblefactor` | Yes | Base name, no suffixes |
+| `noblefactor.Darwin` | Yes | OS matches |
+| `noblefactor.Darwin.arm64` | Yes | OS + ARCH match (DISTRO skipped) |
+| `noblefactor.Linux` | No | OS doesn't match |
+| `noblefactor.Debian` | No | DISTRO not set on macOS |
+| `noblefactor.arm64` | Yes | ARCH matches |
 
 ## Custom segments
 
-Beyond OS detection, writ supports custom segments for more granular control.
-Define segments at deploy time:
+Beyond automatic detection, writ supports custom segments for more granular control.
+Specify segments at deploy time:
 
 ```bash
 writ add -s ROLE=desktop noblefactor
 writ add -s ROLE=server noblefactor
 ```
 
-Name files with segment suffixes:
+Create directories with custom segment suffixes:
 
 ```
-.config/
-├── polybar/config.ROLE=desktop     # Only on desktop machines
-└── nginx/nginx.conf.ROLE=server    # Only on servers
+Home/
+├── noblefactor/                    # All machines
+├── noblefactor.Darwin/             # macOS only
+├── noblefactor.desktop/            # ROLE=desktop
+├── noblefactor.Darwin.desktop/     # macOS + ROLE=desktop
+└── noblefactor.server/             # ROLE=server
 ```
 
 Multiple segments can be combined:
 
 ```bash
-writ add -s ROLE=desktop -s DISPLAY=hidpi noblefactor
+writ add -s ROLE=desktop -s SITE=aws noblefactor
+```
+
+## File organization
+
+Files within a project directory don't have platform suffixes—the suffixes are
+on the directory name. Place platform-specific files in the appropriate variant
+directory:
+
+```
+Home/
+├── noblefactor/
+│   ├── .zshrc                # Shared shell config
+│   ├── .gitconfig            # Shared git config
+│   └── packages-manifest.yaml   # Common packages
+├── noblefactor.Darwin/
+│   ├── .zshrc                # macOS shell config (overrides base)
+│   └── packages-manifest.yaml   # macOS-only packages (merged with base)
+└── noblefactor.Linux/
+    ├── .zshrc                # Linux shell config (overrides base)
+    └── packages-manifest.yaml   # Linux-only packages (merged with base)
 ```
 
 ## Precedence rules
 
-When multiple variants could apply, writ uses this precedence order:
+When multiple variants provide the same file, writ uses the most specific match:
 
-1. Most specific match (platform + custom segments)
+1. Most specific match (platform + all custom segments)
 2. Platform-only match
-3. Base file (no suffix)
+3. Base project (no suffix)
 
-If no variant matches and no base file exists, the file is skipped.
+For `packages-manifest.yaml` files, variants are **merged** rather than replaced.
+This lets you define common packages in the base and platform-specific packages
+in variants.
 
-## Platform-specific packages
+## The `all` project
 
-The same mechanism works for `packages.manifest` files, allowing
-platform-specific software lists:
+The project name `all` is reserved and has special behavior:
+
+- **Always matched**: `all` and its variants (`all.Darwin`, `all.Linux`, etc.)
+  are included for every `writ add` operation
+- **Implicit inclusion**: Users don't need to specify `all`—it's automatic
+- **Base configuration**: Use `all/` for configuration that applies everywhere
 
 ```
-noblefactor/
-├── packages.manifest           # Common packages (jq, gh, ripgrep)
-├── packages.manifest.Darwin    # macOS packages (brew-only tools)
-└── packages.manifest.Linux     # Linux packages (apt/dnf-only tools)
+Home/
+├── all/                      # Config for all machines (automatic)
+├── all.Darwin/               # macOS additions (automatic on macOS)
+├── noblefactor/              # Personal project (explicit)
+└── microsoft/                # Work project (explicit)
 ```
-
-Writ merges the base manifest with the platform-specific one before
-delegating to lore.

--- a/docs/guides/writ/repositories.md
+++ b/docs/guides/writ/repositories.md
@@ -100,7 +100,7 @@ repos/personal/
 ├── noblefactor/             # Project: personal config
 │   ├── .zshrc
 │   ├── .config/git/config
-│   └── packages.manifest
+│   └── packages-manifest.yaml
 ├── thenobles/               # Project: family-shared config
 │   └── .config/shared/
 └── work/                    # Project: work-specific overrides

--- a/docs/plans/unified-segment-resolution.md
+++ b/docs/plans/unified-segment-resolution.md
@@ -1,0 +1,359 @@
+# Unified Segment Resolution — Update Plan
+
+**Date:** 2026-01-26
+**Status:** Draft
+
+## Summary
+
+Lore and writ segments use the same resolution mechanism. Pipelines are constructed by merging scripts from matching platform directories in general-to-specific order. The `all/` directory executes everywhere.
+
+## Key Design Points
+
+1. **Unified resolution** — Lore and writ use identical segment matching
+2. **Multi-layer merge** — Scripts from multiple matching directories run in order
+3. **General-to-specific** — Resolution order: `all/` → OS → OS.Distro
+4. **Accumulation semantics** — Each layer adds to the pipeline (no override)
+5. **Graph optimization** — Package operations (install, remove) deduplicated and batched
+
+## Resolution Order
+
+For a Debian system running Deploy:
+
+```
+all/Deploy/*           → runs first  (universal)
+Linux/Deploy/*         → runs second (OS-level)
+Linux.Debian/Deploy/*  → runs last   (distro-specific)
+```
+
+For each phase (e.g., `install`), scripts from all matching directories execute in order:
+
+```
+all/Deploy/install.star        → plan.install("common-tool")
+Linux/Deploy/install.star      → plan.install("linux-tool")
+Linux.Debian/Deploy/install.star → plan.install("debian-tool")
+```
+
+Result: All three packages queued. The plan builder deduplicates and batches.
+
+## Authoring Warnings
+
+| Risk | Description | Mitigation |
+|------|-------------|------------|
+| **Conflicting writes** | Multiple layers write same file with different content | Last wins; author must ensure override is intentional |
+| **Order dependency** | Specific layer depends on state from general layer | Document dependencies; this is a feature, not a bug |
+| **No undo primitive** | Cannot cancel an action from a general layer | Don't use general layer for that phase if you need different behavior |
+| **Debugging complexity** | Multiple scripts contribute to one phase | Execution trace shows source file for each action |
+
+---
+
+## Part 1: Documentation Updates
+
+### 1.1. RFC Section 9.3 — Package Directory Structure
+
+**File:** `noblefactor/devlore/design/02-devlore-rfc.md`
+
+**Changes:**
+
+1. Add subsection on **Resolution Order** explaining multi-layer merge
+2. Update ABNF comment to note that `all/` is not required (packages may be platform-specific only)
+3. Add table showing resolution examples:
+
+```markdown
+#### 9.3.1. Platform Resolution
+
+Scripts from all matching platform directories execute in general-to-specific order:
+
+| Target System | Resolution Order |
+|---------------|------------------|
+| macOS | `Common/` → `Darwin/` |
+| Ubuntu | `Common/` → `Linux/` → `Linux.Debian/` |
+| Fedora 40 | `Common/` → `Linux/` → `Linux.Fedora/` |
+| Windows 11 | `Common/` → `Windows/` |
+
+**Merge semantics:** Each layer's scripts for a given phase ALL run, in order. Actions accumulate. Package operations (install, remove, upgrade) are deduplicated and batched during plan optimization.
+```
+
+4. Add note about graph optimization
+
+### 1.2. RFC Section 7 — Phase Pipeline
+
+**File:** `noblefactor/devlore/design/02-devlore-rfc.md`
+
+**Changes:**
+
+1. Update to reference multi-layer resolution from Section 9.3
+2. Add note that phases may have multiple contributing scripts
+
+### 1.3. ADR-006 — Phase Pipeline Design
+
+**File:** `noblefactor/devlore/design/adr/006-phase-pipeline.md`
+
+**Changes:**
+
+1. Update phase contract to show three-input API:
+   ```python
+   def install(system, package, plan):
+   ```
+2. Add section on **Multi-Layer Execution**
+3. Update Docker example to show `Linux/` + `Linux.Debian/` split
+
+### 1.4. New ADR — Unified Segment Resolution
+
+**File:** `noblefactor/devlore/design/adr/053-unified-segment-resolution.md`
+
+**Purpose:** Document the decision to unify lore and writ segment matching.
+
+**Sections:**
+- Context: Both tools need platform-specific behavior
+- Decision: Unified resolution algorithm
+- Resolution order: general-to-specific
+- Merge semantics: accumulation, not override
+- Graph optimization: dedup and batch package operations
+- Warnings and authoring guidance
+
+### 1.5. Writ RFC Section 4 — Segment Matching
+
+**File:** `noblefactor/devlore/design/writ/03-writ-rfc.md`
+
+**Changes:**
+
+1. Reference ADR-053 for unified resolution
+2. Note that writ uses same algorithm as lore
+3. Update examples to show multi-layer matching
+
+### 1.6. AUTHORING.md — Package Authoring Guide
+
+**File:** `devlore-registry/AUTHORING.md`
+
+**Changes:**
+
+1. Update Section 3.1 to explain multi-layer structure
+2. Add examples of when to use `all/` vs OS vs OS.Distro
+3. Add warnings section about layer conflicts
+4. Update docker example to show three-tier structure:
+   ```
+   docker/
+   ├── all/
+   │   └── Deploy/
+   │       └── verify.star       # Same verification everywhere
+   ├── Linux/
+   │   └── Deploy/
+   │       ├── provision.star    # Common Linux config
+   │       └── cleanup.star
+   ├── Linux.Debian/
+   │   └── Deploy/
+   │       ├── prepare.star      # apt repo setup
+   │       └── install.star      # apt packages
+   └── Linux.Fedora/
+       └── Deploy/
+           ├── prepare.star      # dnf repo setup
+           └── install.star      # dnf packages
+   ```
+
+---
+
+## Part 2: Implementation Updates
+
+### 2.1. Platform Resolution Module
+
+**File:** `internal/lore/pipeline/resolver.go` (new)
+
+**Purpose:** Resolve platform directories for a package.
+
+```go
+// Resolver finds and orders platform directories for execution.
+type Resolver struct {
+    os     string // runtime.GOOS
+    distro string // detected from /etc/os-release
+}
+
+// Resolve returns ordered list of matching platform directories.
+// Order: all → OS → OS.Distro (general to specific)
+func (r *Resolver) Resolve(packageDir, pipeline string) ([]string, error)
+
+// Example for Linux.Debian + Deploy:
+// Returns: ["all/Deploy", "Linux/Deploy", "Linux.Debian/Deploy"]
+// (only directories that exist)
+```
+
+### 2.2. Phase Collector
+
+**File:** `internal/lore/pipeline/collector.go` (new)
+
+**Purpose:** Collect all phase scripts from resolved directories.
+
+```go
+// PhaseScripts maps phase name to ordered list of scripts.
+type PhaseScripts map[string][]string
+
+// Collect gathers all phase scripts from platform directories.
+func Collect(dirs []string) (PhaseScripts, error)
+
+// Example output:
+// {
+//   "install": ["all/Deploy/install.star", "Linux/Deploy/install.star", "Linux.Debian/Deploy/install.star"],
+//   "verify": ["all/Deploy/verify.star"],
+// }
+```
+
+### 2.3. Executor Updates
+
+**File:** `internal/lore/pipeline/executor.go`
+
+**Changes:**
+
+1. Update `executePhase` to run multiple scripts per phase
+2. Track source file in execution trace
+3. Accumulate plan actions across scripts
+
+```go
+func (e *Executor) executePhase(lifecycle *Lifecycle, phaseName string, scripts []string) PhaseResult {
+    for _, script := range scripts {
+        err := e.runPhaseScript(script, phaseName)
+        if err != nil {
+            // Record which script failed
+            return PhaseResult{Error: fmt.Errorf("%s: %w", script, err)}
+        }
+    }
+}
+```
+
+### 2.4. Lifecycle Struct Updates
+
+**File:** `internal/lore/pipeline/lifecycle.go`
+
+**Changes:**
+
+1. Remove `Phases map[string]string` field — phases discovered from directories
+2. Add `PackageDir` usage for directory-based resolution
+3. Update `GetPhaseScript` → `GetPhaseScripts` returning `[]string`
+
+### 2.5. Plan Builder — Deduplication
+
+**File:** `internal/lore/plan/builder.go` (new or existing)
+
+**Purpose:** Build execution graph with optimization.
+
+```go
+// Builder accumulates plan actions from phase scripts.
+type Builder struct {
+    installs []string
+    removes  []string
+    // ... other action types
+}
+
+// Optimize deduplicates and batches package operations.
+func (b *Builder) Optimize() *Plan {
+    // Deduplicate: plan.install("docker-ce") twice → one install
+    // Batch: multiple plan.install() → single apt install docker-ce pkg2 pkg3
+}
+```
+
+### 2.6. Distro Detection
+
+**File:** `internal/platform/distro.go` (new or existing)
+
+**Purpose:** Detect Linux distribution family.
+
+```go
+// DetectDistro returns the distro family (Debian, Fedora) or empty.
+func DetectDistro() string {
+    // Parse /etc/os-release
+    // Map ID/ID_LIKE to family:
+    //   ubuntu, debian, pop, mint → Debian
+    //   fedora, rhel, centos, rocky, alma, amzn, azurelinux → Fedora
+}
+```
+
+### 2.7. Shared Resolution Module (lore + writ)
+
+**File:** `internal/segment/resolver.go` (new)
+
+**Purpose:** Unified resolution used by both lore and writ.
+
+```go
+// This Go module is shared between lore and writ.
+// Both import from internal/segment.
+
+type Platform struct {
+    OS     string // Darwin, Linux, Windows
+    Distro string // Debian, Fedora, or empty
+}
+
+func (p Platform) MatchingSegments() []string {
+    // Returns: ["all", "Linux", "Linux.Debian"] for Debian
+}
+```
+
+### 2.8. Test Updates
+
+**Files:**
+- `internal/lore/pipeline/resolver_test.go` (new)
+- `internal/lore/pipeline/collector_test.go` (new)
+- `internal/lore/pipeline/pipeline_test.go` (update)
+
+**Test cases:**
+1. Single platform directory (all only)
+2. Two layers (all + Darwin)
+3. Three layers (all + Linux + Linux.Debian)
+4. Missing intermediate layer (all + Linux.Debian, no Linux/)
+5. Phase in some layers but not others
+6. Deduplication of package operations
+
+---
+
+## Part 3: Migration
+
+### 3.1. Existing Packages
+
+The docker package already uses the directory structure. No migration needed for existing packages using the new structure.
+
+Packages using the old `phases:` field in lifecycle.yaml will continue to work until deprecated. Add:
+
+```yaml
+# DEPRECATED: phases field. Use directory structure instead.
+# See: packages/<name>/<platform>/<pipeline>/<phase>.star
+```
+
+### 3.2. Schema Update
+
+**File:** `devlore-cli/schema/lifecycle.json`
+
+1. Remove `phases` from required fields
+2. Add deprecation note in description
+3. Platforms remain in lifecycle.yaml for metadata (supported platforms list)
+
+---
+
+## Implementation Order
+
+| Phase | Task | Effort |
+|-------|------|--------|
+| 1 | Create ADR-053 (unified resolution) | S |
+| 2 | Implement distro detection | S |
+| 3 | Implement resolver module | M |
+| 4 | Implement collector module | M |
+| 5 | Update executor for multi-script phases | M |
+| 6 | Implement plan builder with dedup | M |
+| 7 | Update RFC Section 9.3 | S |
+| 8 | Update ADR-006 | S |
+| 9 | Update writ RFC Section 4 | S |
+| 10 | Update AUTHORING.md | S |
+| 11 | Update lifecycle.go (remove Phases field) | S |
+| 12 | Write tests | M |
+
+**Effort key:** S (small, < 1 hour) · M (medium, 1-4 hours)
+
+---
+
+## Open Questions
+
+1. **Empty directories:** If `Linux/Deploy/` exists but is empty, is that an error or just no-op?
+   - **Proposed:** No-op. Empty directory contributes nothing.
+
+2. **Phase function name:** Must match filename (`install.star` → `def install()`)?
+   - **Proposed:** Yes, enforced at runtime.
+
+3. **Upgrade pipeline phases:** Same as Deploy, or different set?
+   - **Current:** Same phases (prepare, install, provision, verify)
+   - **Proposed:** Keep same. Upgrade is "deploy with existing state."

--- a/internal/bindgen/cobra/README.md
+++ b/internal/bindgen/cobra/README.md
@@ -16,10 +16,9 @@ Extracts Starlark binding metadata from Go source files that use [spf13/cobra](h
 - Function-level scope for command/flag association
 - **Qualified command names** - Uses package directory for prefixes (`container_create`, `config_create`)
 
-### What Doesn't Work
-- **No subcommand hierarchy tree** - We flatten with prefixes, don't build parent-child tree
-- **Limited receiver detection** - Only detects `flags` or `f` variable names
-- **Helper function flags** - Flags added via `addFlags(flags)` helper functions are missed
+### Known Limitations
+
+See [TODO.md Section 7: Bindgen Tool](../../../TODO.md#7-bindgen-tool) for tracked issues and roadmap.
 
 ## Test Results
 
@@ -35,92 +34,7 @@ All 10 "create" commands now captured:
   service_create, volume_create
 ```
 
-## Honest Assessment
-
-### Extractor Issues
-
-| Issue | Severity | Status | Impact | Location |
-|-------|----------|--------|--------|----------|
-| Command name collision | Critical | **FIXED** | Was losing ~20% of commands | `extractor.go:237-253` |
-| Limited receiver detection | Medium | Open | Missing ~60% of flags | `extractor.go:373-384` |
-| Helper function flags missed | Medium | Open | Flags added via `addFlags()` not captured | N/A |
-| No subcommand hierarchy tree | Low | Open | We flatten with prefixes, don't build tree | N/A |
-| Silent unquote failures | Low | Open | Malformed strings silently dropped | `extractor.go:332, 455` |
-
-### Generator Issues
-
-| Issue | Severity | Status | Impact | Location |
-|-------|----------|--------|--------|----------|
-| Command name not split | Critical | Open | `container_run` → should be `container run` | `codegen.go` template |
-| No positional args | Critical | Open | Can't pass image names, container IDs, etc. | `codegen.go` template |
-| Stub template broken | Medium | Open | `title` function undefined | `stubgen.go:9` |
-
-**Bottom line:** Extractor captures all 144 commands but misses ~60% of flags. Generator produces scaffolding with critical bugs. **Not production-ready** — use as development accelerator with manual refinement.
-
-## Known Issues
-
-### FIXED: Command Name Collision
-
-**Status:** Fixed on 2026-01-11
-
-**Solution:** Use package directory as command prefix. Commands in `cli/command/container/` get prefixed with `container_`.
-
-**Location:** `extractor.go:178-200` (`calculatePrefix`) and `extractor.go:237-253` (key generation)
-
-```go
-// Generate qualified key to avoid collisions
-// e.g., "container" + "create" -> "container_create"
-key := currentCmd.Name
-if prefix != "" && prefix != currentCmd.Name {
-    key = prefix + "_" + currentCmd.Name
-}
-```
-
-### Low: No Subcommand Hierarchy Tree
-
-**Problem:** We flatten the command tree using prefixes rather than building a true hierarchy.
-
-**Impact:** Minor - the prefixed names work well for binding generation. A true tree would only be needed for generating CLI help text or command groupings.
-
-**Not blocking for current use case.**
-
-### Medium: Limited Receiver Detection
-
-**Problem:** `isFlagReceiver()` only matches `flags` or `f` as variable names.
-
-**Location:** `extractor.go:329-340`
-
-```go
-case *ast.Ident:
-    return v.Name == "flags" || v.Name == "f"  // Misses "fs", "flagSet", etc.
-```
-
-**Fix:** Be more permissive or track actual variable assignments.
-
-### Low: Dead Parameter
-
-**Problem:** `fset` parameter passed to `extractFromFunction` but never used.
-
-**Location:** `extractor.go:168`
-
-```go
-func (e *Extractor) extractFromFunction(fn *ast.FuncDecl, fset *token.FileSet) {
-    // fset is never used
-```
-
-**Fix:** Remove parameter or use it for position information in error messages.
-
-### Low: Silent Unquote Failures
-
-**Problem:** `strconv.Unquote` errors are silently ignored.
-
-**Location:** `extractor.go:289, 411`
-
-```go
-s, _ := strconv.Unquote(v.Value)  // Error ignored
-```
-
-**Fix:** Log warnings in verbose mode.
+See [TODO.md Section 7](../../../TODO.md#7-bindgen-tool) for detailed issue tracking.
 
 ## Architecture
 
@@ -169,14 +83,6 @@ cd ~/Workspace/OSS/docker-cli
 ln -sf vendor.mod go.mod
 ln -sf vendor.sum go.sum
 ```
-
-## Next Steps (Priority Order)
-
-1. ~~**Fix command collision**~~ - DONE: Using package directory prefixes
-2. **Improve receiver detection** - Track variable assignments or match more patterns
-3. **Handle helper functions** - Track flags added via helper functions like `addFlags()`
-4. **Add tests** - Unit tests for extraction logic
-5. **Build hierarchy tree** (optional) - Parse `AddCommand()` calls if tree structure needed
 
 ## Files
 
@@ -264,16 +170,6 @@ func (b *CommandBindings) containerRun(...) (starlark.Value, error) {
 | Code size | 634 lines | 4,124 lines |
 | Production ready | Yes | No |
 
-### Why Generated Bindings Are Incomplete
-
-1. **Missing flags (~60%)** — Extractor only recognizes `flags` or `f` receivers. Docker-cli uses `opts.Flags()`, `copts.AddFlags()`, etc.
-
-2. **Broken command invocation** — Generator emits `container_run` as a single arg. Should be `container`, `run` as separate args.
-
-3. **No positional args** — Generator doesn't emit code to handle positional arguments (e.g., image name for `docker run`).
-
-4. **No helper patterns** — Flags added via `addCommonFlags(cmd)` helpers aren't captured.
-
 ### Intended Workflow
 
 The generator is a **development accelerator**, not a production-ready solution:
@@ -295,25 +191,8 @@ The generator is a **development accelerator**, not a production-ready solution:
 - Documents all available commands and their descriptions
 - Identifies which flags exist (even if not all captured)
 
-**What humans must still do:**
-- Fix command invocation (`container_run` → `container run`)
-- Add missing flags (check `docker <cmd> --help`)
-- Add positional argument handling
-- Add return value parsing where useful (e.g., `docker ps --format json`)
-
-### Generator Bugs to Fix
-
-| Bug | Location | Impact |
-|-----|----------|--------|
-| Command name splitting | `codegen.go` template | Commands don't execute |
-| Missing positional args | `codegen.go` template | Can't pass image names, etc. |
-| Stub template broken | `stubgen.go:9` | IDE stubs don't generate |
-
 ### Conclusion
 
 **The extractor works. The generator produces scaffolding. Human refinement is required.**
 
-For now, the practical approach is:
-1. Use generated code as reference (what commands exist, what flags are documented)
-2. Hand-write high-value bindings (as done in `docker.go`)
-3. Use extraction diff to detect new commands/flags on version bumps
+See [TODO.md Section 7](../../../TODO.md#7-bindgen-tool) for known issues and roadmap.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -735,3 +735,166 @@ func TestStatusString(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveOperationPrunesEmptyDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create nested structure: tmpDir/a/b/c/file.txt
+	nested := filepath.Join(tmpDir, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "file.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &RemoveOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Data: map[string]any{
+			"prune_empty_dirs": true,
+			"prune_boundary":   tmpDir,
+		},
+	}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// File should be gone
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected file to be removed")
+	}
+
+	// All empty parent dirs up to boundary should be gone
+	if _, err := os.Stat(filepath.Join(tmpDir, "a")); !os.IsNotExist(err) {
+		t.Error("expected a/ to be pruned")
+	}
+
+	// Boundary dir should still exist
+	if _, err := os.Stat(tmpDir); err != nil {
+		t.Errorf("boundary dir should still exist: %v", err)
+	}
+}
+
+func TestRemoveOperationPruneStopsAtNonEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create nested structure: tmpDir/a/b/file.txt and tmpDir/a/other.txt
+	nested := filepath.Join(tmpDir, "a", "b")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "file.txt")
+	other := filepath.Join(tmpDir, "a", "other.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &RemoveOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Data: map[string]any{
+			"prune_empty_dirs": true,
+			"prune_boundary":   tmpDir,
+		},
+	}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// File and b/ should be gone
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected file to be removed")
+	}
+	if _, err := os.Stat(nested); !os.IsNotExist(err) {
+		t.Error("expected b/ to be pruned")
+	}
+
+	// a/ should still exist (has other.txt)
+	if _, err := os.Stat(filepath.Join(tmpDir, "a")); err != nil {
+		t.Error("expected a/ to remain (not empty)")
+	}
+	// other.txt should still exist
+	if _, err := os.Stat(other); err != nil {
+		t.Error("expected other.txt to remain")
+	}
+}
+
+func TestUnlinkOperationPrunesEmptyDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	nested := filepath.Join(tmpDir, "a", "b")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "link.txt")
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &UnlinkOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Data: map[string]any{
+			"prune_empty_dirs": true,
+			"prune_boundary":   tmpDir,
+		},
+	}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("unlink: %v", err)
+	}
+
+	// Symlink and parent dirs should be gone
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected symlink to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "a")); !os.IsNotExist(err) {
+		t.Error("expected a/ to be pruned")
+	}
+}
+
+func TestRemoveNoPruneWithoutFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	nested := filepath.Join(tmpDir, "a", "b")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "file.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	op := &RemoveOp{}
+	// No prune flags set
+	ctx := &Context{Context: context.Background()}
+	node := &Node{ID: "test", Target: target}
+	state := &PipelineState{Metadata: make(map[string]string)}
+
+	if err := op.Execute(ctx, node, state); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// File should be gone
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected file to be removed")
+	}
+
+	// Parent dirs should remain (no pruning without flag)
+	if _, err := os.Stat(nested); err != nil {
+		t.Error("expected b/ to remain (no prune flag)")
+	}
+}

--- a/internal/engine/ops.go
+++ b/internal/engine/ops.go
@@ -191,6 +191,8 @@ func (o *BackupOp) Execute(ctx *Context, node *Node, state *PipelineState) error
 }
 
 // UnlinkOp removes a symlink at node.Target.
+// If ctx.Data["prune_empty_dirs"] is true and ctx.Data["prune_boundary"] is set,
+// empty parent directories are removed up to the boundary.
 type UnlinkOp struct{}
 
 func (o *UnlinkOp) Name() string { return "unlink" }
@@ -212,10 +214,17 @@ func (o *UnlinkOp) Execute(ctx *Context, node *Node, _ *PipelineState) error {
 		return fmt.Errorf("%s is not a symlink", node.Target)
 	}
 
-	return os.Remove(node.Target)
+	if err := os.Remove(node.Target); err != nil {
+		return err
+	}
+
+	pruneEmptyParents(ctx, node.Target)
+	return nil
 }
 
 // RemoveOp deletes the file at node.Target.
+// If ctx.Data["prune_empty_dirs"] is true and ctx.Data["prune_boundary"] is set,
+// empty parent directories are removed up to the boundary.
 type RemoveOp struct{}
 
 func (o *RemoveOp) Name() string { return "remove" }
@@ -229,7 +238,58 @@ func (o *RemoveOp) Execute(ctx *Context, node *Node, _ *PipelineState) error {
 		return nil // Already gone
 	}
 
-	return os.Remove(node.Target)
+	if err := os.Remove(node.Target); err != nil {
+		return err
+	}
+
+	pruneEmptyParents(ctx, node.Target)
+	return nil
+}
+
+// pruneEmptyParents removes empty parent directories up to the prune boundary.
+// Requires ctx.Data["prune_empty_dirs"] = true and ctx.Data["prune_boundary"] set.
+// Silently stops on any error or non-empty directory.
+func pruneEmptyParents(ctx *Context, path string) {
+	if ctx.Data == nil {
+		return
+	}
+	prune, _ := ctx.Data["prune_empty_dirs"].(bool)
+	if !prune {
+		return
+	}
+	boundary, _ := ctx.Data["prune_boundary"].(string)
+	if boundary == "" {
+		return
+	}
+
+	// Clean paths for consistent comparison
+	boundary = filepath.Clean(boundary)
+	dir := filepath.Dir(path)
+
+	for {
+		// Stop at or above boundary
+		if dir == boundary || !isSubpath(dir, boundary) {
+			return
+		}
+
+		// Try to remove (fails if not empty)
+		if err := os.Remove(dir); err != nil {
+			return // Not empty or permission error
+		}
+
+		// Move up
+		dir = filepath.Dir(dir)
+	}
+}
+
+// isSubpath returns true if path is under parent (not equal to).
+func isSubpath(path, parent string) bool {
+	rel, err := filepath.Rel(parent, path)
+	if err != nil {
+		return false
+	}
+	// Must not start with ".." and must not be "."
+	return rel != "." && !filepath.IsAbs(rel) && (len(rel) < 2 || rel[:2] != "..")
 }
 
 // FileOps returns all built-in file operations for registration.

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -86,14 +86,23 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --conflict value %q: must be stop, backup, overwrite, or skip", conflictFlag)
 	}
 
-	// Resolve source root from config
-	sourceRoot := cli.GetString("writ", "repo", true)
-	if sourceRoot == "" {
-		return fmt.Errorf("no repo configured; set writ.repo in config or use WRIT_REPO env var")
+	// Collect layer sources (base → team → personal, each with System → Home)
+	layerSources, err := CollectLayerSources()
+	if err != nil {
+		return fmt.Errorf("collect layer sources: %w", err)
 	}
-	sourceRoot = expandPath(sourceRoot)
 
-	// Resolve target root (default: $HOME)
+	// Fall back to legacy single-repo mode if no layers configured
+	var sourceRoot string
+	if len(layerSources) == 0 {
+		sourceRoot = cli.GetString("writ", "repo", true)
+		if sourceRoot == "" {
+			return fmt.Errorf("no repo configured; use 'writ repo init' or 'writ repo add' to configure a repository")
+		}
+		sourceRoot = expandPath(sourceRoot)
+	}
+
+	// Resolve target root (default: $HOME) - used for single-repo mode
 	targetRoot := os.Getenv("HOME")
 	if targetRoot == "" {
 		return fmt.Errorf("HOME environment variable not set")
@@ -121,29 +130,56 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if verbose {
-		fmt.Fprintf(os.Stderr, "Source: %s\n", sourceRoot)
-		fmt.Fprintf(os.Stderr, "Target: %s\n", targetRoot)
+		if len(layerSources) > 0 {
+			fmt.Fprintf(os.Stderr, "Layers: %d sources\n", len(layerSources))
+			for _, src := range layerSources {
+				fmt.Fprintf(os.Stderr, "  %s/%s: %s → %s\n", src.Layer, src.TargetName, src.SourceRoot, src.TargetRoot)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Source: %s\n", sourceRoot)
+			fmt.Fprintf(os.Stderr, "Target: %s\n", targetRoot)
+		}
 		fmt.Fprintf(os.Stderr, "Projects: %v\n", args)
 		fmt.Fprintf(os.Stderr, "Segments: %s\n", segs.String())
 	}
 
 	// Build deployment tree
-	deployTree, err := tree.Build(tree.BuildConfig{
-		SourceRoot: sourceRoot,
-		TargetRoot: targetRoot,
-		Projects:   args,
-		Segments:   segs,
-	})
+	var deployTree *tree.BuildResult
+	if len(layerSources) > 0 {
+		// Multi-layer mode
+		deployTree, err = tree.Build(tree.BuildConfig{
+			Sources:    layerSources,
+			TargetRoot: targetRoot,
+			Projects:   args,
+			Segments:   segs,
+		})
+	} else {
+		// Single-repo mode (backwards compatible)
+		deployTree, err = tree.Build(tree.BuildConfig{
+			SourceRoot: sourceRoot,
+			TargetRoot: targetRoot,
+			Projects:   args,
+			Segments:   segs,
+		})
+	}
 	if err != nil {
 		return fmt.Errorf("build tree: %w", err)
 	}
 
-	// Warn about source collisions (same target from different source dirs)
+	// Warn about source collisions (same target from different source dirs or layers)
 	if deployTree.HasCollisions() {
-		fmt.Fprintf(os.Stderr, "Warning: %d source collision(s) resolved by specificity:\n", len(deployTree.Collisions))
-		for _, c := range deployTree.Collisions {
-			fmt.Fprintf(os.Stderr, "  %s: using %s (specificity %d) over %s (specificity %d)\n",
-				c.Target, c.Winner, c.WinnerSpecificity, c.Loser, c.LoserSpecificity)
+		if len(layerSources) > 0 {
+			fmt.Fprintf(os.Stderr, "Warning: %d source collision(s) resolved by layer/specificity:\n", len(deployTree.Collisions))
+			for _, c := range deployTree.Collisions {
+				fmt.Fprintf(os.Stderr, "  %s: using %s [%s] over %s [%s]\n",
+					c.Target, c.Winner, c.WinnerLayer, c.Loser, c.LoserLayer)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: %d source collision(s) resolved by specificity:\n", len(deployTree.Collisions))
+			for _, c := range deployTree.Collisions {
+				fmt.Fprintf(os.Stderr, "  %s: using %s (specificity %d) over %s (specificity %d)\n",
+					c.Target, c.Winner, c.WinnerSpecificity, c.Loser, c.LoserSpecificity)
+			}
 		}
 	}
 
@@ -482,6 +518,14 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		projectSet[p] = true
 	}
 
+	// Determine prune boundary (for removing empty parent directories)
+	var pruneRoot string
+	if deployState != nil {
+		pruneRoot = deployState.TargetRoot
+	} else {
+		pruneRoot = os.Getenv("HOME")
+	}
+
 	// Collect files to remove
 	type removeEntry struct {
 		RelTarget      string
@@ -693,6 +737,9 @@ func runRemove(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "  error removing %s: %v\n", re.RelTarget, err)
 			continue
 		}
+
+		// Prune empty parent directories up to the target root
+		pruneEmptyParentDirs(re.Target, pruneRoot)
 
 		removed++
 		if verbose {
@@ -2608,6 +2655,38 @@ func hasDecryptOp(ops []string) bool {
 		}
 	}
 	return false
+}
+
+// pruneEmptyParentDirs removes empty parent directories up to (but not including) boundary.
+// Stops at non-empty directories or on any error.
+func pruneEmptyParentDirs(target, boundary string) {
+	if boundary == "" {
+		return
+	}
+
+	boundary = filepath.Clean(boundary)
+	dir := filepath.Dir(target)
+
+	for {
+		// Stop at or above boundary
+		if dir == boundary || dir == "/" || dir == "." {
+			return
+		}
+
+		// Check if dir is under boundary
+		rel, err := filepath.Rel(boundary, dir)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			return
+		}
+
+		// Try to remove (fails if not empty)
+		if err := os.Remove(dir); err != nil {
+			return // Not empty or permission error
+		}
+
+		// Move up
+		dir = filepath.Dir(dir)
+	}
 }
 
 // DryRunOutput represents the dry-run output format.

--- a/internal/writ/layer.go
+++ b/internal/writ/layer.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package writ
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/NobleFactor/devlore-cli/internal/writ/tree"
+)
+
+// LayerOrder defines the processing order for repository layers.
+// Layers are processed in this order, with later layers overriding earlier ones.
+var LayerOrder = []string{"base", "team", "personal"}
+
+// TargetSpec defines a source directory within a repo and its deployment target.
+type TargetSpec struct {
+	SourceDir  string // "System" or "Home"
+	TargetRoot string // "/" or "$HOME"
+}
+
+// TargetOrder defines the processing order for targets within each repo.
+// System files are deployed before Home files.
+func TargetOrder() []TargetSpec {
+	home := os.Getenv("HOME")
+	return []TargetSpec{
+		{SourceDir: "System", TargetRoot: "/"},
+		{SourceDir: "Home", TargetRoot: home},
+	}
+}
+
+// CollectLayerSources gathers all configured repository layers and expands them
+// into source/target pairs. Returns sources ordered: base/System, base/Home,
+// team/System, team/Home, personal/System, personal/Home (if configured/exist).
+func CollectLayerSources() ([]tree.LayerSource, error) {
+	var sources []tree.LayerSource
+
+	for i, layer := range LayerOrder {
+		path := getConfiguredRepo(layer)
+		if path == "" {
+			continue
+		}
+		// Expand path
+		path = expandPath(path)
+
+		// Expand each target (System, Home) within this layer
+		for _, spec := range TargetOrder() {
+			sourceDir := filepath.Join(path, spec.SourceDir)
+			if !dirExists(sourceDir) {
+				continue
+			}
+			sources = append(sources, tree.LayerSource{
+				Layer:      layer,
+				Path:       path,
+				Order:      i,
+				SourceRoot: sourceDir,
+				TargetRoot: spec.TargetRoot,
+				TargetName: spec.SourceDir,
+			})
+		}
+	}
+	return sources, nil
+}
+
+// dirExists checks if a directory exists.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/internal/writ/manifest/builder.go
+++ b/internal/writ/manifest/builder.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package manifest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NobleFactor/devlore-cli/internal/engine"
+)
+
+// Builder implements engine.GraphBuilder for packages-manifest files.
+// It translates a packages-manifest into an execution graph that lore
+// can process to install software.
+type Builder struct{}
+
+// NewBuilder creates a new packages-manifest graph builder.
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// BuildGraph loads a packages-manifest file and builds an execution graph.
+// This is the engine.GraphBuilder interface implementation.
+//
+// Entry point 1: Load, validate, and build from file path.
+func (b *Builder) BuildGraph(ctx context.Context, manifestPath string, opts engine.BuildOptions) (*engine.Graph, error) {
+	// Load and validate the manifest
+	manifest, err := Load(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest: %w", err)
+	}
+
+	// Validate against schema
+	if err := Validate(manifestPath); err != nil {
+		return nil, fmt.Errorf("validate manifest: %w", err)
+	}
+
+	return b.BuildGraphFromManifest(ctx, manifest, opts)
+}
+
+// BuildGraphFromManifest builds an execution graph from an already-parsed manifest.
+//
+// Entry point 2: Build from pre-parsed manifest (for callers who already have the data).
+func (b *Builder) BuildGraphFromManifest(ctx context.Context, manifest *PackagesManifest, opts engine.BuildOptions) (*engine.Graph, error) {
+	graph := &engine.Graph{
+		Nodes: make([]*engine.Node, 0, len(manifest.Packages)),
+	}
+
+	for _, pkg := range manifest.Packages {
+		node := b.buildPackageNode(pkg, opts)
+		graph.Nodes = append(graph.Nodes, node)
+	}
+
+	// Add dependency edges between packages if needed
+	// (For now, packages are independent; registry resolution may add deps later)
+
+	return graph, nil
+}
+
+// buildPackageNode creates an engine.Node for a single package entry.
+func (b *Builder) buildPackageNode(pkg PackageEntry, opts engine.BuildOptions) *engine.Node {
+	// Build the lore pipeline operations
+	// The four-phase lore pipeline: prepare → install → provision → verify
+	operations := []string{"prepare", "install", "provision", "verify"}
+
+	node := &engine.Node{
+		ID:         pkg.Name,
+		Operations: operations,
+		Metadata:   make(map[string]string),
+	}
+
+	// Store package name for registry lookup
+	node.Metadata["package"] = pkg.Name
+
+	// Store enabled features
+	if len(pkg.With) > 0 {
+		for i, feature := range pkg.With {
+			node.Metadata[fmt.Sprintf("feature.%d", i)] = feature
+		}
+		node.Metadata["feature_count"] = fmt.Sprintf("%d", len(pkg.With))
+	}
+
+	return node
+}
+
+// Ensure Builder implements engine.GraphBuilder.
+var _ engine.GraphBuilder = (*Builder)(nil)

--- a/internal/writ/manifest/manifest.go
+++ b/internal/writ/manifest/manifest.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// Package manifest provides loading and validation for packages-manifest files.
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/schema"
+)
+
+// PackagesManifest represents the parsed packages-manifest.{yaml,json} file.
+type PackagesManifest struct {
+	// Packages is the list of package entries.
+	Packages []PackageEntry `json:"packages" yaml:"packages"`
+}
+
+// PackageEntry represents a single package in the manifest.
+// It can be either a simple string (package name) or an object with options.
+type PackageEntry struct {
+	// Name is the package name.
+	Name string
+
+	// With is a list of features to enable.
+	With []string
+}
+
+// PackageOptions holds the options for a package (used during parsing).
+type PackageOptions struct {
+	With []string `json:"with" yaml:"with"`
+}
+
+// Load reads and parses a packages-manifest file from the given path.
+// Supports both YAML and JSON formats based on file extension.
+func Load(path string) (*PackagesManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	return Parse(data, path)
+}
+
+// Parse parses packages-manifest content from bytes.
+// The path is used to determine the format (yaml/json).
+func Parse(data []byte, path string) (*PackagesManifest, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+
+	// Parse into intermediate structure for flexible handling
+	var raw struct {
+		Packages []interface{} `json:"packages" yaml:"packages"`
+	}
+
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, fmt.Errorf("invalid JSON: %w", err)
+		}
+	default: // .yaml, .yml, or legacy .manifest
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return nil, fmt.Errorf("invalid YAML: %w", err)
+		}
+	}
+
+	manifest := &PackagesManifest{}
+
+	for i, item := range raw.Packages {
+		entry, err := parsePackageEntry(item)
+		if err != nil {
+			return nil, fmt.Errorf("packages[%d]: %w", i, err)
+		}
+		manifest.Packages = append(manifest.Packages, entry)
+	}
+
+	return manifest, nil
+}
+
+// parsePackageEntry parses a single package entry from the raw interface value.
+// Supports both string format ("gh") and object format ({"neovim": {"with": [...]}}).
+func parsePackageEntry(item interface{}) (PackageEntry, error) {
+	switch v := item.(type) {
+	case string:
+		// Simple string: "gh"
+		if v == "" {
+			return PackageEntry{}, fmt.Errorf("empty package name")
+		}
+		return PackageEntry{Name: v}, nil
+
+	case map[string]interface{}:
+		// Object format: {"neovim": {"with": [...]}}
+		if len(v) != 1 {
+			return PackageEntry{}, fmt.Errorf("expected single-key map, got %d keys", len(v))
+		}
+
+		for name, opts := range v {
+			if name == "" {
+				return PackageEntry{}, fmt.Errorf("empty package name")
+			}
+
+			entry := PackageEntry{Name: name}
+
+			if opts == nil {
+				return entry, nil
+			}
+
+			optsMap, ok := opts.(map[string]interface{})
+			if !ok {
+				return PackageEntry{}, fmt.Errorf("invalid options for %q: expected object", name)
+			}
+
+			// Parse "with" array
+			if withRaw, exists := optsMap["with"]; exists {
+				withArray, ok := withRaw.([]interface{})
+				if !ok {
+					return PackageEntry{}, fmt.Errorf("invalid 'with' for %q: expected array", name)
+				}
+
+				for _, w := range withArray {
+					feature, ok := w.(string)
+					if !ok {
+						return PackageEntry{}, fmt.Errorf("invalid feature in 'with' for %q: expected string", name)
+					}
+					entry.With = append(entry.With, feature)
+				}
+			}
+
+			// Check for unknown keys
+			for key := range optsMap {
+				if key != "with" {
+					return PackageEntry{}, fmt.Errorf("unknown option %q for package %q", key, name)
+				}
+			}
+
+			return entry, nil
+		}
+	}
+
+	return PackageEntry{}, fmt.Errorf("invalid package entry: expected string or object")
+}
+
+// Validate validates a packages-manifest file against the embedded JSON schema.
+// Returns nil if valid, or an error describing the validation failure.
+func Validate(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+
+	return ValidateBytes(data, path)
+}
+
+// ValidateBytes validates packages-manifest content against the embedded JSON schema.
+func ValidateBytes(data []byte, path string) error {
+	// Parse the schema
+	var schemaDoc map[string]interface{}
+	if err := json.Unmarshal(schema.PackagesManifestSchema, &schemaDoc); err != nil {
+		return fmt.Errorf("parse schema: %w", err)
+	}
+
+	// Parse the manifest
+	ext := strings.ToLower(filepath.Ext(path))
+	var doc map[string]interface{}
+
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("invalid JSON: %w", err)
+		}
+	default:
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("invalid YAML: %w", err)
+		}
+	}
+
+	// Basic validation: check required fields
+	if _, exists := doc["packages"]; !exists {
+		return fmt.Errorf("missing required field: packages")
+	}
+
+	// Check packages is an array
+	packages, ok := doc["packages"].([]interface{})
+	if !ok {
+		return fmt.Errorf("'packages' must be an array")
+	}
+
+	// Validate each package entry
+	for i, pkg := range packages {
+		if err := validatePackageEntry(pkg, i); err != nil {
+			return err
+		}
+	}
+
+	// Check for unknown top-level fields
+	for key := range doc {
+		if key != "packages" {
+			return fmt.Errorf("unknown field: %s", key)
+		}
+	}
+
+	return nil
+}
+
+// validatePackageEntry validates a single package entry.
+func validatePackageEntry(pkg interface{}, index int) error {
+	switch v := pkg.(type) {
+	case string:
+		if v == "" {
+			return fmt.Errorf("packages[%d]: empty package name", index)
+		}
+		return nil
+
+	case map[string]interface{}:
+		if len(v) == 0 {
+			return fmt.Errorf("packages[%d]: empty object", index)
+		}
+		if len(v) > 1 {
+			return fmt.Errorf("packages[%d]: expected single-key map (package name), got %d keys", index, len(v))
+		}
+
+		for name, opts := range v {
+			if name == "" {
+				return fmt.Errorf("packages[%d]: empty package name", index)
+			}
+
+			if opts == nil {
+				return nil
+			}
+
+			optsMap, ok := opts.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("packages[%d] (%s): options must be an object", index, name)
+			}
+
+			// Validate "with" if present
+			if withRaw, exists := optsMap["with"]; exists {
+				withArray, ok := withRaw.([]interface{})
+				if !ok {
+					return fmt.Errorf("packages[%d] (%s): 'with' must be an array", index, name)
+				}
+
+				for j, w := range withArray {
+					if _, ok := w.(string); !ok {
+						return fmt.Errorf("packages[%d] (%s): with[%d] must be a string", index, name, j)
+					}
+				}
+			}
+
+			// Check for unknown keys
+			for key := range optsMap {
+				if key != "with" {
+					return fmt.Errorf("packages[%d] (%s): unknown option %q", index, name, key)
+				}
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("packages[%d]: must be a string or object", index)
+	}
+}
+
+// IsManifestFile returns true if the filename is a packages-manifest file.
+func IsManifestFile(filename string) bool {
+	base := filepath.Base(filename)
+	return base == "packages-manifest.yaml" ||
+		base == "packages-manifest.json" ||
+		base == "packages.manifest" // legacy
+}
+
+// PackageNames returns the list of package names from the manifest.
+func (m *PackagesManifest) PackageNames() []string {
+	names := make([]string, len(m.Packages))
+	for i, pkg := range m.Packages {
+		names[i] = pkg.Name
+	}
+	return names
+}
+
+// String returns a human-readable representation of the package entry.
+func (e PackageEntry) String() string {
+	if len(e.With) == 0 {
+		return e.Name
+	}
+	return fmt.Sprintf("%s --with %s", e.Name, strings.Join(e.With, " --with "))
+}

--- a/internal/writ/manifest/manifest_test.go
+++ b/internal/writ/manifest/manifest_test.go
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/internal/engine"
+)
+
+func TestParse_YAML_SimplePackages(t *testing.T) {
+	yaml := `packages:
+  - gh
+  - jq
+  - ripgrep
+`
+	m, err := Parse([]byte(yaml), "packages-manifest.yaml")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(m.Packages) != 3 {
+		t.Fatalf("expected 3 packages, got %d", len(m.Packages))
+	}
+
+	expected := []string{"gh", "jq", "ripgrep"}
+	for i, pkg := range m.Packages {
+		if pkg.Name != expected[i] {
+			t.Errorf("packages[%d]: expected %q, got %q", i, expected[i], pkg.Name)
+		}
+		if len(pkg.With) != 0 {
+			t.Errorf("packages[%d]: expected no features, got %v", i, pkg.With)
+		}
+	}
+}
+
+func TestParse_YAML_PackagesWithFeatures(t *testing.T) {
+	yaml := `packages:
+  - gh
+  - neovim:
+      with: [lsp, treesitter]
+  - docker:
+      with:
+        - rootless
+        - compose
+`
+	m, err := Parse([]byte(yaml), "packages-manifest.yaml")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(m.Packages) != 3 {
+		t.Fatalf("expected 3 packages, got %d", len(m.Packages))
+	}
+
+	// Check gh (simple)
+	if m.Packages[0].Name != "gh" {
+		t.Errorf("packages[0]: expected 'gh', got %q", m.Packages[0].Name)
+	}
+
+	// Check neovim (with features)
+	if m.Packages[1].Name != "neovim" {
+		t.Errorf("packages[1]: expected 'neovim', got %q", m.Packages[1].Name)
+	}
+	if len(m.Packages[1].With) != 2 {
+		t.Errorf("packages[1]: expected 2 features, got %d", len(m.Packages[1].With))
+	}
+	if m.Packages[1].With[0] != "lsp" || m.Packages[1].With[1] != "treesitter" {
+		t.Errorf("packages[1]: unexpected features: %v", m.Packages[1].With)
+	}
+
+	// Check docker (with features)
+	if m.Packages[2].Name != "docker" {
+		t.Errorf("packages[2]: expected 'docker', got %q", m.Packages[2].Name)
+	}
+	if len(m.Packages[2].With) != 2 {
+		t.Errorf("packages[2]: expected 2 features, got %d", len(m.Packages[2].With))
+	}
+}
+
+func TestParse_JSON(t *testing.T) {
+	json := `{
+  "packages": [
+    "gh",
+    "jq",
+    {"neovim": {"with": ["lsp", "treesitter"]}}
+  ]
+}`
+	m, err := Parse([]byte(json), "packages-manifest.json")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(m.Packages) != 3 {
+		t.Fatalf("expected 3 packages, got %d", len(m.Packages))
+	}
+
+	if m.Packages[0].Name != "gh" {
+		t.Errorf("packages[0]: expected 'gh', got %q", m.Packages[0].Name)
+	}
+	if m.Packages[2].Name != "neovim" {
+		t.Errorf("packages[2]: expected 'neovim', got %q", m.Packages[2].Name)
+	}
+	if len(m.Packages[2].With) != 2 {
+		t.Errorf("packages[2]: expected 2 features, got %d", len(m.Packages[2].With))
+	}
+}
+
+func TestParse_EmptyWithOptions(t *testing.T) {
+	yaml := `packages:
+  - neovim:
+`
+	m, err := Parse([]byte(yaml), "packages-manifest.yaml")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(m.Packages) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(m.Packages))
+	}
+
+	if m.Packages[0].Name != "neovim" {
+		t.Errorf("expected 'neovim', got %q", m.Packages[0].Name)
+	}
+	if len(m.Packages[0].With) != 0 {
+		t.Errorf("expected no features, got %v", m.Packages[0].With)
+	}
+}
+
+func TestValidate_Valid(t *testing.T) {
+	yaml := `packages:
+  - gh
+  - neovim:
+      with: [lsp]
+`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err != nil {
+		t.Errorf("expected valid manifest, got error: %v", err)
+	}
+}
+
+func TestValidate_MissingPackages(t *testing.T) {
+	yaml := `something: else`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for missing 'packages' field")
+	}
+}
+
+func TestValidate_PackagesNotArray(t *testing.T) {
+	yaml := `packages: "not an array"`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for 'packages' not being an array")
+	}
+}
+
+func TestValidate_EmptyPackageName(t *testing.T) {
+	yaml := `packages:
+  - ""
+`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for empty package name")
+	}
+}
+
+func TestValidate_MultipleKeysInPackage(t *testing.T) {
+	yaml := `packages:
+  - neovim:
+      with: [lsp]
+    docker:
+      with: [rootless]
+`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for multiple keys in package object")
+	}
+}
+
+func TestValidate_UnknownOption(t *testing.T) {
+	yaml := `packages:
+  - neovim:
+      with: [lsp]
+      from: brew
+`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for unknown option 'from'")
+	}
+}
+
+func TestValidate_UnknownTopLevelField(t *testing.T) {
+	yaml := `packages:
+  - gh
+extra: field
+`
+	err := ValidateBytes([]byte(yaml), "packages-manifest.yaml")
+	if err == nil {
+		t.Error("expected error for unknown top-level field")
+	}
+}
+
+func TestIsManifestFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected bool
+	}{
+		{"packages-manifest.yaml", true},
+		{"packages-manifest.json", true},
+		{"packages.manifest", true},
+		{"packages.yaml", false},
+		{"manifest.yaml", false},
+		{".packages-manifest.yaml", false},
+		{"dir/packages-manifest.yaml", true},
+	}
+
+	for _, tc := range tests {
+		got := IsManifestFile(tc.filename)
+		if got != tc.expected {
+			t.Errorf("IsManifestFile(%q): expected %v, got %v", tc.filename, tc.expected, got)
+		}
+	}
+}
+
+func TestLoad_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "packages-manifest.yaml")
+
+	content := `packages:
+  - gh
+  - neovim:
+      with: [lsp]
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	m, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(m.Packages) != 2 {
+		t.Errorf("expected 2 packages, got %d", len(m.Packages))
+	}
+}
+
+func TestPackageEntry_String(t *testing.T) {
+	tests := []struct {
+		entry    PackageEntry
+		expected string
+	}{
+		{PackageEntry{Name: "gh"}, "gh"},
+		{PackageEntry{Name: "neovim", With: []string{"lsp"}}, "neovim --with lsp"},
+		{PackageEntry{Name: "docker", With: []string{"rootless", "compose"}}, "docker --with rootless --with compose"},
+	}
+
+	for _, tc := range tests {
+		got := tc.entry.String()
+		if got != tc.expected {
+			t.Errorf("String(): expected %q, got %q", tc.expected, got)
+		}
+	}
+}
+
+func TestPackagesManifest_PackageNames(t *testing.T) {
+	m := &PackagesManifest{
+		Packages: []PackageEntry{
+			{Name: "gh"},
+			{Name: "neovim", With: []string{"lsp"}},
+			{Name: "docker"},
+		},
+	}
+
+	names := m.PackageNames()
+	expected := []string{"gh", "neovim", "docker"}
+
+	if len(names) != len(expected) {
+		t.Fatalf("expected %d names, got %d", len(expected), len(names))
+	}
+
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("names[%d]: expected %q, got %q", i, expected[i], name)
+		}
+	}
+}
+
+// ============================================================================
+// Builder Tests
+// ============================================================================
+
+func TestBuilder_BuildGraphFromManifest(t *testing.T) {
+	builder := NewBuilder()
+	manifest := &PackagesManifest{
+		Packages: []PackageEntry{
+			{Name: "gh"},
+			{Name: "neovim", With: []string{"lsp", "treesitter"}},
+			{Name: "docker", With: []string{"rootless"}},
+		},
+	}
+
+	graph, err := builder.BuildGraphFromManifest(nil, manifest, defaultBuildOpts())
+	if err != nil {
+		t.Fatalf("BuildGraphFromManifest failed: %v", err)
+	}
+
+	if len(graph.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(graph.Nodes))
+	}
+
+	// Check first node (simple package)
+	if graph.Nodes[0].ID != "gh" {
+		t.Errorf("nodes[0].ID: expected 'gh', got %q", graph.Nodes[0].ID)
+	}
+	if graph.Nodes[0].Metadata["package"] != "gh" {
+		t.Errorf("nodes[0].Metadata['package']: expected 'gh', got %q", graph.Nodes[0].Metadata["package"])
+	}
+
+	// Check second node (with features)
+	if graph.Nodes[1].ID != "neovim" {
+		t.Errorf("nodes[1].ID: expected 'neovim', got %q", graph.Nodes[1].ID)
+	}
+	if graph.Nodes[1].Metadata["feature_count"] != "2" {
+		t.Errorf("nodes[1].Metadata['feature_count']: expected '2', got %q", graph.Nodes[1].Metadata["feature_count"])
+	}
+	if graph.Nodes[1].Metadata["feature.0"] != "lsp" {
+		t.Errorf("nodes[1].Metadata['feature.0']: expected 'lsp', got %q", graph.Nodes[1].Metadata["feature.0"])
+	}
+
+	// Check operations (four-phase pipeline)
+	expectedOps := []string{"prepare", "install", "provision", "verify"}
+	for i, node := range graph.Nodes {
+		if len(node.Operations) != 4 {
+			t.Errorf("nodes[%d].Operations: expected 4 ops, got %d", i, len(node.Operations))
+		}
+		for j, op := range node.Operations {
+			if op != expectedOps[j] {
+				t.Errorf("nodes[%d].Operations[%d]: expected %q, got %q", i, j, expectedOps[j], op)
+			}
+		}
+	}
+}
+
+func TestBuilder_BuildGraph_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "packages-manifest.yaml")
+
+	content := `packages:
+  - gh
+  - neovim:
+      with: [lsp]
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	builder := NewBuilder()
+	graph, err := builder.BuildGraph(nil, path, defaultBuildOpts())
+	if err != nil {
+		t.Fatalf("BuildGraph failed: %v", err)
+	}
+
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(graph.Nodes))
+	}
+
+	if graph.Nodes[0].ID != "gh" {
+		t.Errorf("nodes[0].ID: expected 'gh', got %q", graph.Nodes[0].ID)
+	}
+	if graph.Nodes[1].ID != "neovim" {
+		t.Errorf("nodes[1].ID: expected 'neovim', got %q", graph.Nodes[1].ID)
+	}
+}
+
+func TestBuilder_BuildGraph_InvalidManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "packages-manifest.yaml")
+
+	// Missing 'packages' field
+	content := `invalid: content`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	builder := NewBuilder()
+	_, err := builder.BuildGraph(nil, path, defaultBuildOpts())
+	if err == nil {
+		t.Error("expected error for invalid manifest")
+	}
+}
+
+func defaultBuildOpts() engine.BuildOptions {
+	return engine.BuildOptions{
+		DryRun:   false,
+		Features: nil,
+		Data:     make(map[string]any),
+	}
+}

--- a/internal/writ/receipt/receipt.go
+++ b/internal/writ/receipt/receipt.go
@@ -77,6 +77,7 @@ type WritContext struct {
 	TargetRoot string            `json:"target_root" yaml:"target_root"`
 	Projects   []string          `json:"projects" yaml:"projects"`
 	Segments   map[string]string `json:"segments" yaml:"segments"`
+	Layers     []string          `json:"layers,omitempty" yaml:"layers,omitempty"`
 }
 
 // Node represents a single operation in the execution graph.
@@ -101,6 +102,9 @@ type Node struct {
 
 	// Project this file belongs to.
 	Project string `json:"project,omitempty" yaml:"project,omitempty"`
+
+	// Layer is the repository layer this file came from (base, team, personal).
+	Layer string `json:"layer,omitempty" yaml:"layer,omitempty"`
 
 	// SourceChecksum is the SHA256 of the source file at deploy time.
 	SourceChecksum string `json:"source_checksum,omitempty" yaml:"source_checksum,omitempty"`
@@ -170,6 +174,7 @@ func (r *Receipt) AddNode(node *engine.Node, alreadyDeployed bool) {
 		Source:    node.Source,
 		Target:    node.Target,
 		Project:   node.Project,
+		Layer:     node.Metadata["layer"],
 	}
 
 	if alreadyDeployed {
@@ -192,6 +197,7 @@ func (r *Receipt) AddNodeWithChecksums(node *engine.Node, alreadyDeployed bool, 
 		Source:         node.Source,
 		Target:         node.Target,
 		Project:        node.Project,
+		Layer:          node.Metadata["layer"],
 		SourceChecksum: sourceChecksum,
 		TargetChecksum: targetChecksum,
 	}

--- a/internal/writ/state/state.go
+++ b/internal/writ/state/state.go
@@ -30,10 +30,15 @@ type State struct {
 	LastUpdated time.Time `json:"last_updated" yaml:"last_updated"`
 
 	// SourceRoot is the dotfiles repository path.
+	// For multi-layer deployments, this is the first layer's path.
 	SourceRoot string `json:"source_root" yaml:"source_root"`
 
 	// TargetRoot is the deployment target (e.g., $HOME).
 	TargetRoot string `json:"target_root" yaml:"target_root"`
+
+	// Layers lists the repository layers used in the deployment.
+	// Empty for single-repo deployments.
+	Layers []string `json:"layers,omitempty" yaml:"layers,omitempty"`
 
 	// Files maps relative target paths to their deployment info.
 	Files map[string]*FileEntry `json:"files" yaml:"files"`
@@ -49,6 +54,10 @@ type FileEntry struct {
 
 	// Project this file belongs to.
 	Project string `json:"project" yaml:"project"`
+
+	// Layer is the repository layer this file came from (base, team, personal).
+	// Empty for single-repo deployments.
+	Layer string `json:"layer,omitempty" yaml:"layer,omitempty"`
 
 	// Operations performed: link, expand, copy, decrypt.
 	Operations []string `json:"operations" yaml:"operations"`

--- a/internal/writ/tree/builder.go
+++ b/internal/writ/tree/builder.go
@@ -4,12 +4,14 @@
 package tree
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/NobleFactor/devlore-cli/internal/engine"
+	"github.com/NobleFactor/devlore-cli/internal/writ/manifest"
 	"github.com/NobleFactor/devlore-cli/internal/writ/segment"
 )
 
@@ -194,6 +196,13 @@ func walkDirectory(match segment.MatchResult, targetRoot string) ([]*engine.Node
 
 		if ops.HasDelegate() {
 			node.DelegateTo = "lore"
+
+			// Validate packages-manifest files
+			if manifest.IsManifestFile(d.Name()) {
+				if err := manifest.Validate(path); err != nil {
+					return fmt.Errorf("invalid %s: %w", relPath, err)
+				}
+			}
 		}
 
 		nodes = append(nodes, node)

--- a/internal/writ/tree/builder.go
+++ b/internal/writ/tree/builder.go
@@ -15,16 +15,29 @@ import (
 	"github.com/NobleFactor/devlore-cli/internal/writ/segment"
 )
 
+// LayerSource represents a repository layer with its path and precedence order.
+type LayerSource struct {
+	Layer      string // "base", "team", or "personal"
+	Path       string // Repo root path
+	Order      int    // 0=base, 1=team, 2=personal (for precedence sorting)
+	SourceRoot string // Full path to source directory (e.g., /path/to/repo/Home)
+	TargetRoot string // Target root (e.g., $HOME or /)
+	TargetName string // "System" or "Home"
+}
+
 // BuildResult contains the built execution graph and build-time metadata.
 type BuildResult struct {
 	// Graph is the execution graph ready for the engine.
 	Graph *engine.Graph
 
-	// SourceRoot is the source root directory.
+	// SourceRoot is the source root directory (for single-source mode).
 	SourceRoot string
 
 	// TargetRoot is the target root directory.
 	TargetRoot string
+
+	// Sources are the layer sources processed (for multi-source mode).
+	Sources []LayerSource
 
 	// Projects included in this build.
 	Projects []string
@@ -34,6 +47,9 @@ type BuildResult struct {
 
 	// Collisions are files where a more specific source overrode a less specific one.
 	Collisions []Collision
+
+	// NodeLayers tracks which layer each node came from (node.ID → layer name).
+	NodeLayers map[string]string
 }
 
 // Collision records when a more specific file overrides a less specific one.
@@ -41,26 +57,38 @@ type Collision struct {
 	// Target is the relative target path that had a collision.
 	Target string
 
-	// Winner is the source that won (more specific).
+	// Winner is the source that won (more specific or higher layer).
 	Winner string
 
 	// WinnerSpecificity is the number of suffixes on the winning directory.
 	WinnerSpecificity int
 
-	// Loser is the source that was overridden (less specific).
+	// WinnerLayer is the layer of the winner (empty for single-source mode).
+	WinnerLayer string
+
+	// Loser is the source that was overridden (less specific or lower layer).
 	Loser string
 
 	// LoserSpecificity is the number of suffixes on the losing directory.
 	LoserSpecificity int
+
+	// LoserLayer is the layer of the loser (empty for single-source mode).
+	LoserLayer string
 }
 
 // BuildConfig holds configuration for building a deployment graph.
 type BuildConfig struct {
-	// SourceRoot is the source directory (e.g., ~/dotfiles/Home/Configs).
+	// SourceRoot is the source directory for single-source mode.
+	// Deprecated: Use Sources for multi-layer support.
 	SourceRoot string
 
 	// TargetRoot is the target directory (e.g., $HOME).
+	// Used as default when Sources is empty.
 	TargetRoot string
+
+	// Sources are the layer sources for multi-source mode.
+	// If empty, falls back to single-source mode using SourceRoot/TargetRoot.
+	Sources []LayerSource
 
 	// Projects to include (e.g., ["all", "noblefactor"]).
 	Projects []string
@@ -69,8 +97,28 @@ type BuildConfig struct {
 	Segments segment.Segments
 }
 
+// nodeEntry tracks a node with its layer and specificity for collision detection.
+type nodeEntry struct {
+	node        *engine.Node
+	specificity int
+	layerOrder  int    // 0=base, 1=team, 2=personal
+	layer       string // "base", "team", "personal", or "" for single-source mode
+}
+
 // Build creates an execution graph from the given configuration.
+// Supports both single-source mode (SourceRoot) and multi-source mode (Sources).
 func Build(cfg BuildConfig) (*BuildResult, error) {
+	// Multi-source mode: process all layer sources
+	if len(cfg.Sources) > 0 {
+		return buildMultiSource(cfg)
+	}
+
+	// Single-source mode: backwards compatible
+	return buildSingleSource(cfg)
+}
+
+// buildSingleSource builds from a single source root (backwards compatible).
+func buildSingleSource(cfg BuildConfig) (*BuildResult, error) {
 	matches, err := segment.MatchDirectories(cfg.SourceRoot, cfg.Projects, cfg.Segments)
 	if err != nil {
 		return nil, err
@@ -82,13 +130,9 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 		TargetRoot:  cfg.TargetRoot,
 		Projects:    cfg.Projects,
 		MatchedDirs: matches,
+		NodeLayers:  make(map[string]string),
 	}
 
-	// Collect nodes, tracking by target path for collision detection
-	type nodeEntry struct {
-		node        *engine.Node
-		specificity int
-	}
 	nodesByTarget := make(map[string]nodeEntry)
 
 	for _, match := range matches {
@@ -133,6 +177,112 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 					LoserSpecificity:  existing.specificity,
 				})
 				nodesByTarget[node.ID] = nodeEntry{node: node, specificity: specificity}
+			}
+		}
+	}
+
+	// Convert map to sorted slice
+	for _, entry := range nodesByTarget {
+		result.Graph.Nodes = append(result.Graph.Nodes, entry.node)
+	}
+	sort.Slice(result.Graph.Nodes, func(i, j int) bool {
+		return result.Graph.Nodes[i].ID < result.Graph.Nodes[j].ID
+	})
+
+	return result, nil
+}
+
+// buildMultiSource builds from multiple layer sources with precedence.
+// Layers are processed in order (base → team → personal).
+// Higher-order layers override lower-order layers for the same target.
+func buildMultiSource(cfg BuildConfig) (*BuildResult, error) {
+	result := &BuildResult{
+		Graph:      &engine.Graph{},
+		Sources:    cfg.Sources,
+		TargetRoot: cfg.TargetRoot,
+		Projects:   cfg.Projects,
+		NodeLayers: make(map[string]string),
+	}
+
+	// Set SourceRoot to first source for backwards compatibility
+	if len(cfg.Sources) > 0 {
+		result.SourceRoot = cfg.Sources[0].SourceRoot
+	}
+
+	nodesByTarget := make(map[string]nodeEntry)
+
+	// Process sources in order (base → team → personal)
+	for _, source := range cfg.Sources {
+		matches, err := segment.MatchDirectories(source.SourceRoot, cfg.Projects, cfg.Segments)
+		if err != nil {
+			return nil, fmt.Errorf("layer %s: %w", source.Layer, err)
+		}
+
+		result.MatchedDirs = append(result.MatchedDirs, matches...)
+
+		for _, match := range matches {
+			nodes, err := walkDirectory(match, source.TargetRoot)
+			if err != nil {
+				return nil, fmt.Errorf("layer %s: %w", source.Layer, err)
+			}
+
+			specificity := len(match.Suffixes)
+			for _, node := range nodes {
+				// Store layer in node metadata
+				node.Metadata["layer"] = source.Layer
+
+				existing, exists := nodesByTarget[node.ID]
+				if !exists {
+					nodesByTarget[node.ID] = nodeEntry{
+						node:        node,
+						specificity: specificity,
+						layerOrder:  source.Order,
+						layer:       source.Layer,
+					}
+					result.NodeLayers[node.ID] = source.Layer
+					continue
+				}
+
+				// Collision resolution: layer takes precedence, then specificity
+				newWins := false
+				if source.Order > existing.layerOrder {
+					// Higher layer always wins (personal > team > base)
+					newWins = true
+				} else if source.Order == existing.layerOrder {
+					// Same layer: specificity wins, or last if equal
+					if specificity >= existing.specificity {
+						newWins = true
+					}
+				}
+
+				if newWins {
+					result.Collisions = append(result.Collisions, Collision{
+						Target:            node.ID,
+						Winner:            node.Source,
+						WinnerSpecificity: specificity,
+						WinnerLayer:       source.Layer,
+						Loser:             existing.node.Source,
+						LoserSpecificity:  existing.specificity,
+						LoserLayer:        existing.layer,
+					})
+					nodesByTarget[node.ID] = nodeEntry{
+						node:        node,
+						specificity: specificity,
+						layerOrder:  source.Order,
+						layer:       source.Layer,
+					}
+					result.NodeLayers[node.ID] = source.Layer
+				} else {
+					result.Collisions = append(result.Collisions, Collision{
+						Target:            node.ID,
+						Winner:            existing.node.Source,
+						WinnerSpecificity: existing.specificity,
+						WinnerLayer:       existing.layer,
+						Loser:             node.Source,
+						LoserSpecificity:  specificity,
+						LoserLayer:        source.Layer,
+					})
+				}
 			}
 		}
 	}

--- a/internal/writ/tree/node.go
+++ b/internal/writ/tree/node.go
@@ -9,8 +9,12 @@ import (
 )
 
 // DelegateFiles are filenames that should be delegated to lore.
+// packages-manifest.{yaml,json} is the canonical format.
+// packages.manifest is supported for backward compatibility.
 var DelegateFiles = []string{
-	"packages.manifest",
+	"packages-manifest.yaml",
+	"packages-manifest.json",
+	"packages.manifest", // legacy
 }
 
 // ProcessingPipeline determines operations from a filename.

--- a/internal/writ/tree/tree_test.go
+++ b/internal/writ/tree/tree_test.go
@@ -253,3 +253,285 @@ func TestOperationHelpers(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildMultiSource(t *testing.T) {
+	// Create base and personal layer directories
+	baseDir := t.TempDir()
+	personalDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create project in base layer
+	if err := os.MkdirAll(filepath.Join(baseDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "all", ".bashrc"), []byte("base bashrc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create project in personal layer with different file
+	if err := os.MkdirAll(filepath.Join(personalDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(personalDir, "all", ".zshrc"), []byte("personal zshrc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	segs := segment.Segments{
+		{Name: "OS", Value: "Darwin"},
+	}
+
+	sources := []LayerSource{
+		{Layer: "base", Path: baseDir, Order: 0, SourceRoot: baseDir, TargetRoot: targetDir},
+		{Layer: "personal", Path: personalDir, Order: 2, SourceRoot: personalDir, TargetRoot: targetDir},
+	}
+
+	result, err := Build(BuildConfig{
+		Sources:  sources,
+		Projects: []string{"all"},
+		Segments: segs,
+	})
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 2 nodes (one from each layer)
+	if len(result.Graph.Nodes) != 2 {
+		t.Errorf("got %d nodes, want 2", len(result.Graph.Nodes))
+		for _, n := range result.Graph.Nodes {
+			t.Logf("  node: %s layer=%s", n.ID, n.Metadata["layer"])
+		}
+	}
+
+	// Verify layer metadata is set
+	for _, n := range result.Graph.Nodes {
+		layer := n.Metadata["layer"]
+		if layer == "" {
+			t.Errorf("node %s missing layer metadata", n.ID)
+		}
+		// Verify NodeLayers map
+		if result.NodeLayers[n.ID] != layer {
+			t.Errorf("NodeLayers[%s] = %s, want %s", n.ID, result.NodeLayers[n.ID], layer)
+		}
+	}
+
+	// No collisions (different files)
+	if len(result.Collisions) != 0 {
+		t.Errorf("got %d collisions, want 0", len(result.Collisions))
+	}
+}
+
+func TestBuildMultiSourceLayerPrecedence(t *testing.T) {
+	// Create base and personal layer directories
+	baseDir := t.TempDir()
+	personalDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create same file in both layers
+	if err := os.MkdirAll(filepath.Join(baseDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "all", ".bashrc"), []byte("base bashrc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(personalDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(personalDir, "all", ".bashrc"), []byte("personal bashrc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	segs := segment.Segments{
+		{Name: "OS", Value: "Darwin"},
+	}
+
+	sources := []LayerSource{
+		{Layer: "base", Path: baseDir, Order: 0, SourceRoot: baseDir, TargetRoot: targetDir},
+		{Layer: "personal", Path: personalDir, Order: 2, SourceRoot: personalDir, TargetRoot: targetDir},
+	}
+
+	result, err := Build(BuildConfig{
+		Sources:  sources,
+		Projects: []string{"all"},
+		Segments: segs,
+	})
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 1 node (collision resolved)
+	if len(result.Graph.Nodes) != 1 {
+		t.Errorf("got %d nodes, want 1", len(result.Graph.Nodes))
+	}
+
+	// Should have 1 collision
+	if len(result.Collisions) != 1 {
+		t.Errorf("got %d collisions, want 1", len(result.Collisions))
+	}
+
+	// Personal layer should win
+	if len(result.Graph.Nodes) > 0 {
+		node := result.Graph.Nodes[0]
+		if node.Metadata["layer"] != "personal" {
+			t.Errorf("winner layer = %s, want personal", node.Metadata["layer"])
+		}
+		if !strings.Contains(node.Source, personalDir) {
+			t.Errorf("winner source should be from personal layer, got %s", node.Source)
+		}
+	}
+
+	// Verify collision details
+	if len(result.Collisions) > 0 {
+		c := result.Collisions[0]
+		if c.WinnerLayer != "personal" {
+			t.Errorf("collision winner layer = %s, want personal", c.WinnerLayer)
+		}
+		if c.LoserLayer != "base" {
+			t.Errorf("collision loser layer = %s, want base", c.LoserLayer)
+		}
+	}
+}
+
+func TestBuildMultiSourceSpecificityWithinLayer(t *testing.T) {
+	// Create single layer with different specificities
+	layerDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create all (specificity 0) and all.Darwin (specificity 1)
+	if err := os.MkdirAll(filepath.Join(layerDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(layerDir, "all.Darwin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same file in both
+	if err := os.WriteFile(filepath.Join(layerDir, "all", ".bashrc"), []byte("generic"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(layerDir, "all.Darwin", ".bashrc"), []byte("darwin"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	segs := segment.Segments{
+		{Name: "OS", Value: "Darwin"},
+	}
+
+	sources := []LayerSource{
+		{Layer: "personal", Path: layerDir, Order: 2, SourceRoot: layerDir, TargetRoot: targetDir},
+	}
+
+	result, err := Build(BuildConfig{
+		Sources:  sources,
+		Projects: []string{"all"},
+		Segments: segs,
+	})
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 1 node (collision resolved)
+	if len(result.Graph.Nodes) != 1 {
+		t.Errorf("got %d nodes, want 1", len(result.Graph.Nodes))
+	}
+
+	// More specific (all.Darwin) should win
+	if len(result.Graph.Nodes) > 0 {
+		node := result.Graph.Nodes[0]
+		if !strings.Contains(node.Source, "all.Darwin") {
+			t.Errorf("winner should be from all.Darwin, got %s", node.Source)
+		}
+	}
+
+	// Verify collision details
+	if len(result.Collisions) != 1 {
+		t.Errorf("got %d collisions, want 1", len(result.Collisions))
+	} else {
+		c := result.Collisions[0]
+		if c.WinnerSpecificity != 1 {
+			t.Errorf("winner specificity = %d, want 1", c.WinnerSpecificity)
+		}
+		if c.LoserSpecificity != 0 {
+			t.Errorf("loser specificity = %d, want 0", c.LoserSpecificity)
+		}
+	}
+}
+
+func TestBuildMultiSourceLayerBeatsSpecificity(t *testing.T) {
+	// Layer precedence should beat specificity
+	baseDir := t.TempDir()
+	personalDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Base layer with high specificity (all.Darwin)
+	if err := os.MkdirAll(filepath.Join(baseDir, "all.Darwin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "all.Darwin", ".bashrc"), []byte("base darwin"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Personal layer with low specificity (all)
+	if err := os.MkdirAll(filepath.Join(personalDir, "all"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(personalDir, "all", ".bashrc"), []byte("personal generic"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	segs := segment.Segments{
+		{Name: "OS", Value: "Darwin"},
+	}
+
+	sources := []LayerSource{
+		{Layer: "base", Path: baseDir, Order: 0, SourceRoot: baseDir, TargetRoot: targetDir},
+		{Layer: "personal", Path: personalDir, Order: 2, SourceRoot: personalDir, TargetRoot: targetDir},
+	}
+
+	result, err := Build(BuildConfig{
+		Sources:  sources,
+		Projects: []string{"all"},
+		Segments: segs,
+	})
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 1 node
+	if len(result.Graph.Nodes) != 1 {
+		t.Errorf("got %d nodes, want 1", len(result.Graph.Nodes))
+	}
+
+	// Personal layer should win despite lower specificity
+	if len(result.Graph.Nodes) > 0 {
+		node := result.Graph.Nodes[0]
+		if node.Metadata["layer"] != "personal" {
+			t.Errorf("winner layer = %s, want personal (layer beats specificity)", node.Metadata["layer"])
+		}
+	}
+
+	// Verify collision
+	if len(result.Collisions) != 1 {
+		t.Errorf("got %d collisions, want 1", len(result.Collisions))
+	} else {
+		c := result.Collisions[0]
+		// Personal wins with specificity 0
+		if c.WinnerSpecificity != 0 {
+			t.Errorf("winner specificity = %d, want 0 (personal/all)", c.WinnerSpecificity)
+		}
+		// Base loses with specificity 1
+		if c.LoserSpecificity != 1 {
+			t.Errorf("loser specificity = %d, want 1 (base/all.Darwin)", c.LoserSpecificity)
+		}
+		if c.WinnerLayer != "personal" {
+			t.Errorf("winner layer = %s, want personal", c.WinnerLayer)
+		}
+		if c.LoserLayer != "base" {
+			t.Errorf("loser layer = %s, want base", c.LoserLayer)
+		}
+	}
+}

--- a/packaging/macports/Portfile.template
+++ b/packaging/macports/Portfile.template
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/NobleFactor/devlore-cli {{VERSION}} v
+go.offline_build    no
+revision            0
+
+homepage            https://devlore.noblefactor.com
+
+description         DevLore CLI - writ and lore tools
+
+long_description    DevLore CLI provides the writ and lore tools for \
+                    documentation generation and management.
+
+categories          devel
+installs_libs       no
+license             Apache-2
+maintainers         {noblefactor.com:support @NobleFactor} \
+                    openmaintainer
+
+checksums           rmd160  {{RMD160}} \
+                    sha256  {{SHA256}} \
+                    size    {{SIZE}}
+
+build.env-append    CGO_ENABLED=0
+
+build {
+    system -W ${worksrcpath} "go build -ldflags '-s -w -X github.com/NobleFactor/devlore-cli/internal/cli.Version=${version}' -o ${worksrcpath}/writ ./cmd/writ"
+    system -W ${worksrcpath} "go build -ldflags '-s -w -X github.com/NobleFactor/devlore-cli/internal/cli.Version=${version}' -o ${worksrcpath}/lore ./cmd/lore"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/writ ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/lore ${destroot}${prefix}/bin/
+}

--- a/packaging/macports/generate-portfile.sh
+++ b/packaging/macports/generate-portfile.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Noble Factor. All rights reserved.
+
+# generate-portfile.sh - Generate MacPorts Portfile from template
+# Called by GoReleaser as a post hook
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: generate-portfile.sh <version>" >&2
+    exit 1
+fi
+
+# Remove 'v' prefix if present
+VERSION="${VERSION#v}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/Portfile.template"
+OUTPUT="${SCRIPT_DIR}/../../dist/Portfile"
+
+TARBALL_URL="https://github.com/NobleFactor/devlore-cli/archive/v${VERSION}.tar.gz"
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+echo "Downloading source tarball for checksums..."
+curl -sSL "$TARBALL_URL" -o "$TMPFILE"
+
+# Calculate checksums
+SHA256=$(shasum -a 256 "$TMPFILE" | cut -d' ' -f1)
+RMD160=$(openssl dgst -rmd160 "$TMPFILE" 2>/dev/null | awk '{print $NF}')
+SIZE=$(stat -f%z "$TMPFILE" 2>/dev/null || stat -c%s "$TMPFILE" 2>/dev/null)
+
+echo "  SHA256: $SHA256"
+echo "  RMD160: $RMD160"
+echo "  SIZE:   $SIZE"
+
+# Generate Portfile from template
+mkdir -p "$(dirname "$OUTPUT")"
+sed -e "s/{{VERSION}}/$VERSION/g" \
+    -e "s/{{SHA256}}/$SHA256/g" \
+    -e "s/{{RMD160}}/$RMD160/g" \
+    -e "s/{{SIZE}}/$SIZE/g" \
+    "$TEMPLATE" > "$OUTPUT"
+
+echo "Generated: $OUTPUT"

--- a/schema/packages-manifest.json
+++ b/schema/packages-manifest.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://noblefactor.com/schemas/packages-manifest.json",
+  "title": "Packages Manifest",
+  "description": "Declares software dependencies for a writ project. Writ delegates to lore for installation.",
+  "type": "object",
+  "properties": {
+    "packages": {
+      "type": "array",
+      "description": "List of packages to install via lore",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Package name (simple form)",
+            "minLength": 1,
+            "examples": ["gh", "jq", "ripgrep"]
+          },
+          {
+            "type": "object",
+            "description": "Package with options (single-key map where key is package name)",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {
+              "type": "object",
+              "description": "Package options",
+              "properties": {
+                "with": {
+                  "type": "array",
+                  "description": "Features to enable for this package",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "examples": [["lsp", "treesitter"], ["rootless", "compose"]]
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        ]
+      }
+    }
+  },
+  "required": ["packages"],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "packages": [
+        "gh",
+        "jq",
+        "ripgrep",
+        {"neovim": {"with": ["lsp", "treesitter"]}},
+        {"docker": {"with": ["rootless", "compose"]}}
+      ]
+    }
+  ]
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,6 +17,12 @@ var DevloreSchema []byte
 //go:embed defaults/devlore-config.yaml
 var DevloreDefaultConfig []byte
 
+// PackagesManifestSchema is the JSON schema for packages-manifest.{json,yaml} files.
+// These files declare software dependencies for writ projects.
+//
+//go:embed packages-manifest.json
+var PackagesManifestSchema []byte
+
 // Legacy aliases for backward compatibility.
 // These point to the shared devlore schema and config.
 var (

--- a/wiki/Releasing.md
+++ b/wiki/Releasing.md
@@ -86,6 +86,54 @@ The `release.yaml` workflow handles deployments automatically:
 3. **On push to `main`**: Builds binaries, deploys to website's `main` branch (production)
 4. **On push of `v*` tag**: Creates GitHub Release with binaries
 
+## Release Artifacts
+
+Each release includes binaries and package manager assets for multiple platforms:
+
+### Binaries
+
+| Platform | Architecture | Format |
+|----------|--------------|--------|
+| Darwin (macOS) | amd64, arm64 | `.tar.gz` |
+| Linux | amd64, arm64 | `.tar.gz` |
+| Windows | amd64, arm64 | `.zip` |
+
+### Package Manager Assets
+
+| Platform | Format | File | Publishing |
+|----------|--------|------|------------|
+| macOS | Homebrew formula | `dist/homebrew/...` | Manual (to homebrew-tap repo) |
+| macOS | MacPorts Portfile | `Portfile` | Manual (PR to macports-ports) |
+| Debian/Ubuntu | `.deb` | `devlore-cli_*_amd64.deb` | Manual (to apt repo) |
+| RHEL/Fedora | `.rpm` | `devlore-cli-*.x86_64.rpm` | Manual (to yum repo) |
+| Windows | Winget manifest | `dist/winget/...` | Manual (PR to winget-pkgs) |
+
+All assets are generated but **not auto-published** to package repositories. This allows review before submission.
+
+### MacPorts Portfile Generation
+
+The Portfile is generated from a template during the release:
+
+1. `packaging/macports/Portfile.template` - Template with placeholders
+2. `packaging/macports/generate-portfile.sh` - Substitutes version and checksums
+3. GoReleaser runs the script as a post-hook and includes the result via `extra_files`
+
+To submit to MacPorts after a release:
+
+```bash
+# Fork https://github.com/macports/macports-ports
+# Copy the Portfile to devel/devlore-cli/Portfile
+# Submit PR
+```
+
+### Future Publishing
+
+When ready to auto-publish, enable by removing `skip_upload: true` from:
+- `brews:` in `.goreleaser.yaml` (requires homebrew-tap repo)
+- `winget:` in `.goreleaser.yaml` (requires winget-pkgs PR approval)
+
+For apt/yum repos, consider services like Gemfury or Packagecloud.
+
 ## Version Numbering
 
 - **Draft/testing**: `v0.1.0-draft`


### PR DESCRIPTION
## Summary
- Update platform ABNF to use `Common` (not `all`), `Fedora` (not `RHEL`), add `Unix`
- Update unified-segment-resolution plan examples

## Test plan
- [ ] Verify documentation consistency with devlore-registry AUTHORING.md