### PR TITLE
Add phase discovery from directory structure with chaining

### DIFF
--- a/internal/lore/pipeline/executor.go
+++ b/internal/lore/pipeline/executor.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"go.starlark.net/starlark"
+
+	loreStar "github.com/NobleFactor/devlore-cli/internal/starlark"
+)
+
+// Operation represents the type of pipeline operation.
+type Operation int
+
+const (
+	// OpDeploy runs the standard deploy pipeline: prepare → install → provision → verify
+	OpDeploy Operation = iota
+	// OpUpgrade runs the upgrade pipeline (same as deploy with version context)
+	OpUpgrade
+	// OpDecommission runs the reverse pipeline: unprovision → uninstall → cleanup
+	OpDecommission
+)
+
+// String returns the operation name.
+func (o Operation) String() string {
+	switch o {
+	case OpDeploy:
+		return "deploy"
+	case OpUpgrade:
+		return "upgrade"
+	case OpDecommission:
+		return "decommission"
+	default:
+		return "unknown"
+	}
+}
+
+// ExecutorConfig configures the pipeline executor.
+type ExecutorConfig struct {
+	// Features to enable for this execution.
+	Features []string
+
+	// Settings to pass to phase scripts.
+	Settings map[string]string
+
+	// DryRun shows what would happen without executing.
+	DryRun bool
+
+	// Verbose enables detailed output.
+	Verbose bool
+
+	// Output is where execution output is written.
+	Output io.Writer
+
+	// SinglePhase runs only this phase (empty = all phases).
+	SinglePhase string
+}
+
+// PhaseResult captures the result of executing a single phase.
+type PhaseResult struct {
+	Name      string
+	Started   time.Time
+	Completed time.Time
+	Duration  time.Duration
+	Success   bool
+	Error     error
+	Skipped   bool
+}
+
+// ExecutionResult captures the result of a full pipeline execution.
+type ExecutionResult struct {
+	Package   string
+	Operation Operation
+	Started   time.Time
+	Completed time.Time
+	Duration  time.Duration
+	Success   bool
+	Phases    []PhaseResult
+	Error     error
+}
+
+// Executor runs lore pipeline phases.
+type Executor struct {
+	config   ExecutorConfig
+	bindings *loreStar.Bindings
+}
+
+// NewExecutor creates a new pipeline executor.
+func NewExecutor(cfg ExecutorConfig) *Executor {
+	if cfg.Output == nil {
+		cfg.Output = os.Stdout
+	}
+	if cfg.Settings == nil {
+		cfg.Settings = make(map[string]string)
+	}
+
+	bindings := loreStar.NewBindings(cfg.Features, cfg.Settings, cfg.Output)
+
+	return &Executor{
+		config:   cfg,
+		bindings: bindings,
+	}
+}
+
+// Execute runs the pipeline for a package.
+func (e *Executor) Execute(ctx context.Context, lifecycle *Lifecycle, op Operation) (*ExecutionResult, error) {
+	result := &ExecutionResult{
+		Package:   lifecycle.Name,
+		Operation: op,
+		Started:   time.Now(),
+	}
+
+	// Resolve features and settings
+	features := lifecycle.EnabledFeatures(e.config.Features)
+	settings := lifecycle.ResolvedSettings(e.config.Settings)
+
+	// Update bindings with resolved values
+	e.bindings.UpdateFeatures(features)
+	e.bindings.UpdateSettings(settings)
+
+	// Print header
+	e.printHeader(lifecycle, features, settings)
+
+	// Determine phases to run
+	phases := e.phasesToRun(op)
+
+	if e.config.DryRun {
+		e.printDryRun(lifecycle, phases)
+		result.Success = true
+		result.Completed = time.Now()
+		result.Duration = result.Completed.Sub(result.Started)
+		return result, nil
+	}
+
+	// Run each phase
+	for _, phaseName := range phases {
+		select {
+		case <-ctx.Done():
+			result.Error = ctx.Err()
+			result.Completed = time.Now()
+			result.Duration = result.Completed.Sub(result.Started)
+			return result, ctx.Err()
+		default:
+		}
+
+		phaseResult := e.executePhase(lifecycle, phaseName)
+		result.Phases = append(result.Phases, phaseResult)
+
+		if !phaseResult.Success && !phaseResult.Skipped {
+			result.Error = phaseResult.Error
+			result.Completed = time.Now()
+			result.Duration = result.Completed.Sub(result.Started)
+			return result, phaseResult.Error
+		}
+	}
+
+	result.Success = true
+	result.Completed = time.Now()
+	result.Duration = result.Completed.Sub(result.Started)
+
+	e.printSuccess(lifecycle)
+	return result, nil
+}
+
+func (e *Executor) phasesToRun(op Operation) []string {
+	if e.config.SinglePhase != "" {
+		return []string{e.config.SinglePhase}
+	}
+
+	switch op {
+	case OpDecommission:
+		return DecommissionPhaseOrder
+	default:
+		return PhaseOrder
+	}
+}
+
+func (e *Executor) executePhase(lifecycle *Lifecycle, phaseName string) PhaseResult {
+	result := PhaseResult{
+		Name:    phaseName,
+		Started: time.Now(),
+	}
+
+	scriptPath := lifecycle.GetPhaseScript(phaseName)
+	if scriptPath == "" {
+		if e.config.Verbose {
+			fmt.Fprintf(e.config.Output, "Skipping phase %q (not defined)\n", phaseName)
+		}
+		result.Skipped = true
+		result.Success = true
+		result.Completed = time.Now()
+		result.Duration = result.Completed.Sub(result.Started)
+		return result
+	}
+
+	e.printPhaseStart(phaseName)
+
+	err := e.runPhaseScript(scriptPath, phaseName)
+	result.Completed = time.Now()
+	result.Duration = result.Completed.Sub(result.Started)
+
+	if err != nil {
+		result.Error = err
+		result.Success = false
+		fmt.Fprintf(e.config.Output, "\n✗ Phase %q failed: %v\n", phaseName, err)
+	} else {
+		result.Success = true
+		fmt.Fprintf(e.config.Output, "✓ Phase %q completed\n\n", phaseName)
+	}
+
+	return result
+}
+
+func (e *Executor) runPhaseScript(scriptPath, phaseName string) error {
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return fmt.Errorf("reading script: %w", err)
+	}
+
+	thread := &starlark.Thread{
+		Name: phaseName,
+		Print: func(_ *starlark.Thread, msg string) {
+			fmt.Fprintf(e.config.Output, "  [print] %s\n", msg)
+		},
+	}
+
+	// Execute the script
+	globals, err := starlark.ExecFile(thread, scriptPath, data, e.bindings.Globals())
+	if err != nil {
+		return fmt.Errorf("executing script: %w", err)
+	}
+
+	// Call the phase function
+	fn, ok := globals[phaseName]
+	if !ok {
+		return fmt.Errorf("function %q not found in script", phaseName)
+	}
+
+	callable, ok := fn.(starlark.Callable)
+	if !ok {
+		return fmt.Errorf("%q is not callable", phaseName)
+	}
+
+	_, err = starlark.Call(thread, callable, nil, nil)
+	if err != nil {
+		return fmt.Errorf("calling %s(): %w", phaseName, err)
+	}
+
+	return nil
+}
+
+func (e *Executor) printHeader(lifecycle *Lifecycle, features []string, settings map[string]string) {
+	fmt.Fprintln(e.config.Output, "╔════════════════════════════════════════════════════════════════╗")
+	fmt.Fprintf(e.config.Output, "║  Lore Pipeline: %s\n", lifecycle.Name)
+	fmt.Fprintln(e.config.Output, "╚════════════════════════════════════════════════════════════════╝")
+	fmt.Fprintln(e.config.Output)
+	fmt.Fprintf(e.config.Output, "Package:  %s v%s\n", lifecycle.Name, lifecycle.Version)
+	fmt.Fprintf(e.config.Output, "Features: %v\n", features)
+	if len(settings) > 0 {
+		fmt.Fprintf(e.config.Output, "Settings: %v\n", settings)
+	}
+	fmt.Fprintln(e.config.Output)
+}
+
+func (e *Executor) printDryRun(lifecycle *Lifecycle, phases []string) {
+	fmt.Fprintln(e.config.Output, "[DRY RUN] Would execute the following phases:")
+	for _, phaseName := range phases {
+		if script, ok := lifecycle.Phases[phaseName]; ok {
+			fmt.Fprintf(e.config.Output, "  - %s: %s\n", phaseName, script)
+		} else {
+			fmt.Fprintf(e.config.Output, "  - %s: (not defined, would skip)\n", phaseName)
+		}
+	}
+}
+
+func (e *Executor) printPhaseStart(phaseName string) {
+	fmt.Fprintln(e.config.Output, "────────────────────────────────────────────────────────────────")
+	fmt.Fprintf(e.config.Output, "Phase: %s\n", phaseName)
+	fmt.Fprintln(e.config.Output, "────────────────────────────────────────────────────────────────")
+}
+
+func (e *Executor) printSuccess(lifecycle *Lifecycle) {
+	fmt.Fprintln(e.config.Output, "════════════════════════════════════════════════════════════════")
+	fmt.Fprintf(e.config.Output, "✓ Pipeline completed successfully for %s\n", lifecycle.Name)
+	fmt.Fprintln(e.config.Output, "════════════════════════════════════════════════════════════════")
+}

--- a/internal/lore/pipeline/lifecycle.go
+++ b/internal/lore/pipeline/lifecycle.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// Package pipeline provides the lore four-phase execution pipeline.
+// Phases: prepare → install → provision → verify
+//
+// Phase scripts are discovered from the directory structure:
+//
+//	<package>/<platform>/<operation>/<phase>.star
+//
+// Platform resolution order (most specific first):
+//   - Linux.Debian, Linux.Fedora (distro-specific)
+//   - Linux, Darwin, Windows (OS-level)
+//   - Unix (Darwin + Linux + BSD)
+//   - Common (all platforms)
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Operation represents a pipeline operation type.
+type Operation string
+
+const (
+	OpDeploy       Operation = "Deploy"
+	OpUpgrade      Operation = "Upgrade"
+	OpDecommission Operation = "Decommission"
+)
+
+// Lifecycle represents a lore package's lifecycle manifest.
+// This is loaded from lifecycle.yaml in the package directory.
+// Phase scripts are discovered from the directory structure, not from YAML.
+type Lifecycle struct {
+	Name        string             `yaml:"name"`
+	Version     string             `yaml:"version"`
+	Description string             `yaml:"description"`
+	Homepage    string             `yaml:"homepage,omitempty"`
+	Repository  string             `yaml:"repository,omitempty"`
+	License     string             `yaml:"license,omitempty"`
+	Maintainer  string             `yaml:"maintainer,omitempty"`
+	Aliases     []string           `yaml:"aliases,omitempty"`
+	Platforms   []string           `yaml:"platforms"`
+	Provides    []string           `yaml:"provides,omitempty"`
+	Conflicts   []string           `yaml:"conflicts,omitempty"`
+	Features    map[string]Feature `yaml:"features,omitempty"`
+	Settings    map[string]Setting `yaml:"settings,omitempty"`
+	Tags        []string           `yaml:"tags,omitempty"`
+	Notes       string             `yaml:"notes,omitempty"`
+
+	// Verification defines how to verify the installation.
+	Verification struct {
+		Command string `yaml:"command,omitempty"`
+		Pattern string `yaml:"pattern,omitempty"`
+	} `yaml:"verification,omitempty"`
+
+	// HardwareProvisions defines hardware-specific configuration requirements.
+	HardwareProvisions map[string]HardwareProvision `yaml:"hardware_provisions,omitempty"`
+
+	// PackageDir is the directory containing this lifecycle (set by loader).
+	PackageDir string `yaml:"-"`
+}
+
+// HardwareProvision defines hardware-specific configuration.
+type HardwareProvision struct {
+	Description string `yaml:"description"`
+	Reference   string `yaml:"reference,omitempty"`
+	BootArg     string `yaml:"boot_arg,omitempty"`
+}
+
+// Feature represents a package feature definition.
+type Feature struct {
+	Description string `yaml:"description"`
+	Default     bool   `yaml:"default"`
+}
+
+// Setting represents a package setting definition.
+type Setting struct {
+	Description string   `yaml:"description"`
+	Type        string   `yaml:"type"`
+	Default     string   `yaml:"default"`
+	Values      []string `yaml:"values,omitempty"`
+}
+
+// DeployPhaseOrder is the standard order of deploy pipeline phases.
+var DeployPhaseOrder = []string{"prepare", "install", "provision", "verify"}
+
+// UpgradePhaseOrder is the order for upgrade operations.
+var UpgradePhaseOrder = []string{"prepare", "install", "verify"}
+
+// DecommissionPhaseOrder is the order for decommission operations.
+var DecommissionPhaseOrder = []string{"unprovision", "uninstall", "cleanup"}
+
+// PhaseOrder returns the phase order for an operation.
+func PhaseOrder(op Operation) []string {
+	switch op {
+	case OpDeploy:
+		return DeployPhaseOrder
+	case OpUpgrade:
+		return UpgradePhaseOrder
+	case OpDecommission:
+		return DecommissionPhaseOrder
+	default:
+		return DeployPhaseOrder
+	}
+}
+
+// PlatformResolutionOrder returns the order of platform directories for
+// phase script chaining, from most general to most specific.
+//
+// Scripts are executed in this order, allowing specific platforms to
+// build upon general setup. Each script that exists is executed.
+//
+// Examples:
+//   - "Linux.Debian" → ["Common", "Unix", "Linux", "Linux.Debian"]
+//   - "Darwin" → ["Common", "Unix", "Darwin"]
+//   - "Windows" → ["Common", "Windows"]
+func PlatformResolutionOrder(platform string) []string {
+	var order []string
+
+	// Common is always first (base setup for all platforms)
+	order = append(order, "Common")
+
+	// Unix covers Darwin, Linux, and BSD
+	if platform == "Darwin" || strings.HasPrefix(platform, "Linux") {
+		order = append(order, "Unix")
+	}
+
+	// OS-level platform
+	if strings.HasPrefix(platform, "Linux.") {
+		// For distro-qualified Linux, add base Linux before the distro
+		order = append(order, "Linux")
+	}
+
+	// The specific platform last (most specific)
+	order = append(order, platform)
+
+	return order
+}
+
+// LoadLifecycle loads a lifecycle manifest from a package directory.
+func LoadLifecycle(packageDir string) (*Lifecycle, error) {
+	path := filepath.Join(packageDir, "lifecycle.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading lifecycle.yaml: %w", err)
+	}
+
+	var lifecycle Lifecycle
+	if err := yaml.Unmarshal(data, &lifecycle); err != nil {
+		return nil, fmt.Errorf("parsing lifecycle.yaml: %w", err)
+	}
+
+	lifecycle.PackageDir = packageDir
+	return &lifecycle, nil
+}
+
+// LoadLifecycleFromRegistry loads a lifecycle from a registry directory.
+func LoadLifecycleFromRegistry(registryDir, packageName string) (*Lifecycle, error) {
+	packageDir := filepath.Join(registryDir, packageName)
+	return LoadLifecycle(packageDir)
+}
+
+// GetPhaseScript returns the path to a single phase script for the given
+// platform and operation. This finds the MOST SPECIFIC script only.
+// For chained execution, use DiscoverPhaseScripts instead.
+//
+// Returns empty string if no script exists for this phase.
+func (l *Lifecycle) GetPhaseScript(platform string, op Operation, phase string) string {
+	// Check platforms from most specific to least specific (reverse order)
+	platforms := PlatformResolutionOrder(platform)
+	for i := len(platforms) - 1; i >= 0; i-- {
+		p := platforms[i]
+		path := filepath.Join(l.PackageDir, p, string(op), phase+".star")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// DiscoverPhaseScripts returns all phase scripts for a phase, ordered from
+// most general to most specific for chained execution.
+//
+// Example for platform="Linux.Debian", op=OpDeploy, phase="install":
+//
+//	["Common/Deploy/install.star", "Unix/Deploy/install.star",
+//	 "Linux/Deploy/install.star", "Linux.Debian/Deploy/install.star"]
+//
+// Only scripts that exist are included.
+func (l *Lifecycle) DiscoverPhaseScripts(platform string, op Operation, phase string) []string {
+	var scripts []string
+	for _, p := range PlatformResolutionOrder(platform) {
+		path := filepath.Join(l.PackageDir, p, string(op), phase+".star")
+		if _, err := os.Stat(path); err == nil {
+			scripts = append(scripts, path)
+		}
+	}
+	return scripts
+}
+
+// HasPhase returns true if at least one phase script exists for this phase
+// on the given platform and operation.
+func (l *Lifecycle) HasPhase(platform string, op Operation, phase string) bool {
+	return len(l.DiscoverPhaseScripts(platform, op, phase)) > 0
+}
+
+// DiscoverAllPhases returns a map of phase name to script paths for all
+// phases in an operation on the given platform.
+func (l *Lifecycle) DiscoverAllPhases(platform string, op Operation) map[string][]string {
+	phases := make(map[string][]string)
+	for _, phase := range PhaseOrder(op) {
+		scripts := l.DiscoverPhaseScripts(platform, op, phase)
+		if len(scripts) > 0 {
+			phases[phase] = scripts
+		}
+	}
+	return phases
+}
+
+// EnabledFeatures returns the list of enabled features given explicit enables
+// and the default settings.
+func (l *Lifecycle) EnabledFeatures(explicit []string) []string {
+	// Build a set of explicitly mentioned features (positive or negative)
+	explicitSet := make(map[string]bool)
+	for _, f := range explicit {
+		if len(f) > 0 && f[0] == '-' {
+			// Negative feature: -completions means disable
+			explicitSet[f[1:]] = false
+		} else {
+			explicitSet[f] = true
+		}
+	}
+
+	// Start with explicit enables
+	var result []string
+	for _, f := range explicit {
+		if len(f) > 0 && f[0] != '-' {
+			result = append(result, f)
+		}
+	}
+
+	// Add defaults that weren't explicitly disabled
+	for name, feat := range l.Features {
+		if feat.Default {
+			if enabled, mentioned := explicitSet[name]; !mentioned {
+				// Default is on and not mentioned: enable
+				result = append(result, name)
+			} else if !enabled {
+				// Explicitly disabled: don't add
+				continue
+			}
+		}
+	}
+
+	return result
+}
+
+// ResolvedSettings returns settings with defaults filled in.
+func (l *Lifecycle) ResolvedSettings(explicit map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	// First, apply defaults
+	for name, setting := range l.Settings {
+		if setting.Default != "" {
+			result[name] = setting.Default
+		}
+	}
+
+	// Then, apply explicit overrides
+	for k, v := range explicit {
+		result[k] = v
+	}
+
+	return result
+}
+
+// SupportsPlatform returns true if the lifecycle supports the given platform.
+func (l *Lifecycle) SupportsPlatform(platform string) bool {
+	for _, p := range l.Platforms {
+		if p == platform {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/lore/pipeline/pipeline_test.go
+++ b/internal/lore/pipeline/pipeline_test.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadLifecycle(t *testing.T) {
+	// Create a temporary directory with a lifecycle.yaml
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "testpkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycleYAML := `name: testpkg
+version: "1.0.0"
+description: "Test package"
+platforms:
+  - darwin
+  - linux
+features:
+  completions:
+    description: "Install shell completions"
+    default: true
+  debug:
+    description: "Enable debug mode"
+    default: false
+settings:
+  shell:
+    description: "Shell to configure"
+    type: string
+    default: zsh
+phases:
+  prepare: prepare.star
+  install: install.star
+  verify: verify.star
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycle, err := LoadLifecycle(pkgDir)
+	if err != nil {
+		t.Fatalf("LoadLifecycle failed: %v", err)
+	}
+
+	// Verify basic fields
+	if lifecycle.Name != "testpkg" {
+		t.Errorf("Name = %q, want %q", lifecycle.Name, "testpkg")
+	}
+	if lifecycle.Version != "1.0.0" {
+		t.Errorf("Version = %q, want %q", lifecycle.Version, "1.0.0")
+	}
+	if len(lifecycle.Platforms) != 2 {
+		t.Errorf("len(Platforms) = %d, want 2", len(lifecycle.Platforms))
+	}
+	if lifecycle.PackageDir != pkgDir {
+		t.Errorf("PackageDir = %q, want %q", lifecycle.PackageDir, pkgDir)
+	}
+}
+
+func TestLifecycleEnabledFeatures(t *testing.T) {
+	lifecycle := &Lifecycle{
+		Features: map[string]Feature{
+			"completions": {Default: true},
+			"debug":       {Default: false},
+			"telemetry":   {Default: true},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		explicit []string
+		want     []string
+	}{
+		{
+			name:     "no explicit",
+			explicit: nil,
+			want:     []string{"completions", "telemetry"},
+		},
+		{
+			name:     "explicit enable non-default",
+			explicit: []string{"debug"},
+			want:     []string{"debug", "completions", "telemetry"},
+		},
+		{
+			name:     "explicit disable default",
+			explicit: []string{"-completions"},
+			want:     []string{"telemetry"},
+		},
+		{
+			name:     "mixed",
+			explicit: []string{"debug", "-telemetry"},
+			want:     []string{"debug", "completions"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lifecycle.EnabledFeatures(tt.explicit)
+			gotSet := make(map[string]bool)
+			for _, f := range got {
+				gotSet[f] = true
+			}
+			wantSet := make(map[string]bool)
+			for _, f := range tt.want {
+				wantSet[f] = true
+			}
+
+			// Check all wanted features are present
+			for f := range wantSet {
+				if !gotSet[f] {
+					t.Errorf("missing feature %q", f)
+				}
+			}
+			// Check no extra features
+			for f := range gotSet {
+				if !wantSet[f] {
+					t.Errorf("unexpected feature %q", f)
+				}
+			}
+		})
+	}
+}
+
+func TestLifecycleResolvedSettings(t *testing.T) {
+	lifecycle := &Lifecycle{
+		Settings: map[string]Setting{
+			"shell":  {Default: "zsh"},
+			"editor": {Default: "vim"},
+		},
+	}
+
+	explicit := map[string]string{
+		"editor": "nvim",
+	}
+
+	got := lifecycle.ResolvedSettings(explicit)
+
+	if got["shell"] != "zsh" {
+		t.Errorf("shell = %q, want %q", got["shell"], "zsh")
+	}
+	if got["editor"] != "nvim" {
+		t.Errorf("editor = %q, want %q", got["editor"], "nvim")
+	}
+}
+
+func TestLifecycleHasPhase(t *testing.T) {
+	lifecycle := &Lifecycle{
+		Phases: map[string]string{
+			"prepare": "prepare.star",
+			"install": "install.star",
+		},
+	}
+
+	if !lifecycle.HasPhase("prepare") {
+		t.Error("HasPhase(prepare) = false, want true")
+	}
+	if lifecycle.HasPhase("provision") {
+		t.Error("HasPhase(provision) = true, want false")
+	}
+}
+
+func TestLifecycleGetPhaseScript(t *testing.T) {
+	lifecycle := &Lifecycle{
+		PackageDir: "/registry/testpkg",
+		Phases: map[string]string{
+			"install": "install.star",
+		},
+	}
+
+	got := lifecycle.GetPhaseScript("install")
+	want := "/registry/testpkg/install.star"
+	if got != want {
+		t.Errorf("GetPhaseScript(install) = %q, want %q", got, want)
+	}
+
+	got = lifecycle.GetPhaseScript("provision")
+	if got != "" {
+		t.Errorf("GetPhaseScript(provision) = %q, want empty", got)
+	}
+}
+
+func TestLifecycleSupportsPlatform(t *testing.T) {
+	lifecycle := &Lifecycle{
+		Platforms: []string{"darwin", "linux"},
+	}
+
+	if !lifecycle.SupportsPlatform("darwin") {
+		t.Error("SupportsPlatform(darwin) = false, want true")
+	}
+	if lifecycle.SupportsPlatform("windows") {
+		t.Error("SupportsPlatform(windows) = true, want false")
+	}
+}
+
+func TestExecutorDryRun(t *testing.T) {
+	// Create a temporary package
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "dryrunpkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycleYAML := `name: dryrunpkg
+version: "1.0"
+platforms:
+  - darwin
+  - linux
+phases:
+  prepare: prepare.star
+  install: install.star
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycle, err := LoadLifecycle(pkgDir)
+	if err != nil {
+		t.Fatalf("LoadLifecycle failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	executor := NewExecutor(ExecutorConfig{
+		DryRun: true,
+		Output: &buf,
+	})
+
+	result, err := executor.Execute(context.Background(), lifecycle, OpDeploy)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("result.Success = false, want true")
+	}
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("[DRY RUN]")) {
+		t.Error("output should contain [DRY RUN]")
+	}
+}
+
+func TestExecutorWithPhaseScripts(t *testing.T) {
+	// Create a temporary package with real Starlark scripts
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "realpkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycleYAML := `name: realpkg
+version: "1.0"
+platforms:
+  - darwin
+  - linux
+phases:
+  install: install.star
+  verify: verify.star
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create install.star
+	installStar := `def install():
+    note("Installing realpkg")
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "install.star"), []byte(installStar), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create verify.star
+	verifyStar := `def verify():
+    note("Verifying realpkg")
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "verify.star"), []byte(verifyStar), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycle, err := LoadLifecycle(pkgDir)
+	if err != nil {
+		t.Fatalf("LoadLifecycle failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	executor := NewExecutor(ExecutorConfig{
+		Output:  &buf,
+		Verbose: true,
+	})
+
+	result, err := executor.Execute(context.Background(), lifecycle, OpDeploy)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("result.Success = false, want true; error = %v", result.Error)
+	}
+
+	// Should have run install and verify (prepare and provision skipped)
+	if len(result.Phases) != 4 {
+		t.Errorf("len(result.Phases) = %d, want 4", len(result.Phases))
+	}
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("Installing realpkg")) {
+		t.Error("output should contain 'Installing realpkg'")
+	}
+	if !bytes.Contains([]byte(output), []byte("Verifying realpkg")) {
+		t.Error("output should contain 'Verifying realpkg'")
+	}
+}
+
+func TestOperationString(t *testing.T) {
+	tests := []struct {
+		op   Operation
+		want string
+	}{
+		{OpDeploy, "deploy"},
+		{OpUpgrade, "upgrade"},
+		{OpDecommission, "decommission"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.op.String(); got != tt.want {
+			t.Errorf("%d.String() = %q, want %q", tt.op, got, tt.want)
+		}
+	}
+}

--- a/schema/lifecycle.json
+++ b/schema/lifecycle.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://noblefactor.com/schemas/lifecycle.json",
+  "title": "Lore Package Lifecycle",
+  "description": "Metadata for a lore package. Phase scripts are discovered from the directory structure (see RFC Section 9.3).",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Package name (must match directory name)",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 1,
+      "examples": ["docker", "kubectl", "aws-cli"]
+    },
+    "version": {
+      "type": "string",
+      "description": "Package version or 'latest'",
+      "minLength": 1,
+      "examples": ["latest", "1.2.3", "27.5.1"]
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line description of the package",
+      "minLength": 1
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri",
+      "description": "Official homepage URL"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri",
+      "description": "Source repository URL"
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier",
+      "examples": ["MIT", "Apache-2.0", "GPL-3.0-only"]
+    },
+    "maintainer": {
+      "type": "string",
+      "description": "Package maintainer name or organization"
+    },
+    "aliases": {
+      "type": "array",
+      "description": "Alternative names for AI-assisted search and validation",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "examples": [["docker ce", "docker engine", "container runtime"]]
+    },
+    "platforms": {
+      "type": "array",
+      "description": "Supported platforms (must have matching platform directories)",
+      "items": {
+        "type": "string",
+        "enum": ["Darwin", "Linux", "Windows"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "features": {
+      "type": "object",
+      "description": "Optional features enabled via --with <feature>",
+      "additionalProperties": {
+        "$ref": "#/$defs/feature"
+      }
+    },
+    "settings": {
+      "type": "object",
+      "description": "Configurable settings via --with <setting>=<value>",
+      "additionalProperties": {
+        "$ref": "#/$defs/setting"
+      }
+    },
+    "provides": {
+      "type": "array",
+      "description": "Commands or capabilities this package provides",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "description": "Packages that conflict and must be removed first",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "sources": {
+      "type": "array",
+      "description": "Upstream release artifacts for verification and direct download",
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "verification": {
+      "type": "object",
+      "description": "How to verify successful installation",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Command to run for verification",
+          "examples": ["docker --version", "kubectl version --client"]
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in command output",
+          "examples": ["Docker version \\d+\\.\\d+", "Client Version"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "hardware_provisions": {
+      "type": "object",
+      "description": "Hardware-specific configuration requirements",
+      "additionalProperties": {
+        "$ref": "#/$defs/hardware_provision"
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Tribal knowledge and important notes for maintainers"
+    },
+    "tags": {
+      "type": "array",
+      "description": "Categorization tags for search and filtering",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": ["name", "version", "description", "platforms"],
+  "additionalProperties": false,
+  "$defs": {
+    "feature": {
+      "type": "object",
+      "description": "Feature definition",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What this feature enables"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Whether enabled by default",
+          "default": false
+        },
+        "platforms": {
+          "type": "array",
+          "description": "Platforms where this feature is available (omit for all)",
+          "items": {
+            "type": "string",
+            "enum": ["Darwin", "Linux", "Windows"]
+          }
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    },
+    "setting": {
+      "type": "object",
+      "description": "Setting definition",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What this setting configures"
+        },
+        "type": {
+          "type": "string",
+          "description": "Value type",
+          "enum": ["string", "number", "boolean"],
+          "default": "string"
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value"
+        },
+        "values": {
+          "type": "array",
+          "description": "Allowed values (if enumerated)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "description": "Platforms where this setting applies (omit for all)",
+          "items": {
+            "type": "string",
+            "enum": ["Darwin", "Linux", "Windows"]
+          }
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    },
+    "source": {
+      "type": "object",
+      "description": "Upstream release artifact",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Download URL"
+        },
+        "sha256": {
+          "type": "string",
+          "description": "SHA256 checksum",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["Darwin", "Linux", "Windows"]
+        },
+        "arch": {
+          "type": "string",
+          "enum": ["amd64", "arm64"],
+          "description": "CPU architecture"
+        }
+      },
+      "required": ["url", "sha256", "platform", "arch"],
+      "additionalProperties": false
+    },
+    "hardware_provision": {
+      "type": "object",
+      "description": "Hardware-specific configuration",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Why this hardware needs special handling"
+        },
+        "reference": {
+          "type": "string",
+          "format": "uri",
+          "description": "Documentation reference URL"
+        },
+        "boot_arg": {
+          "type": "string",
+          "description": "Kernel boot argument required"
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Remove `Phases` field from Lifecycle struct — phases discovered from directories
- Add `PlatformResolutionOrder()` for general→specific chaining (Common→Unix→Linux→Linux.Debian)
- Add `DiscoverPhaseScripts()` for chained execution of multiple platform scripts
- Add `lifecycle.json` schema embedded in schema package
- Update Lifecycle struct with all fields from schema (aliases, provides, conflicts, etc.)

## Chaining behavior
Scripts execute from most general to most specific:
```
Common/Deploy/install.star → Unix/Deploy/install.star → Linux/Deploy/install.star → Linux.Debian/Deploy/install.star
```

## Test plan
- [ ] Verify phase discovery finds scripts in platform directories
- [ ] Verify chaining order is correct for each platform