### PR TITLE
Add uniform pipeline interface with LorePackage abstraction

### DIFF
--- a/docs/plans/uniform-pipeline-interface.md
+++ b/docs/plans/uniform-pipeline-interface.md
@@ -1,0 +1,164 @@
+# Uniform Pipeline Interface — Design
+
+**Date:** 2026-01-26
+**Status:** Draft
+
+## Summary
+
+Every `LorePackage` provides a uniform pipeline interface. The engine's package-manifest delegate queries packages for pipeline phases and adds them to the execution graph without knowing whether the package is from the lore registry or a native package manager.
+
+## Key Design Points
+
+1. **Uniform interface** — `LorePackage.PhaseActions()` returns executable phases regardless of source
+2. **Polymorphic implementation** — Lore packages return Starlark scripts; native PM packages return PM actions
+3. **Required phases** — Each operation has exactly one required phase; native packages implement only this phase
+4. **Graph-centric execution** — Phases are added to an execution graph, not executed directly
+5. **Optimization opportunity** — Native PM operations can be batched at graph compilation time
+
+## Required Phases
+
+Each pipeline operation has exactly one **required phase** that must be implemented. Native PM packages implement only the required phase; lore packages may implement additional phases.
+
+| Operation | Required Phase | Native PM Action | Optional Phases |
+|-----------|---------------|------------------|-----------------|
+| Deploy | `install` | `pm install` | prepare, provision, verify |
+| Upgrade | `upgrade` | `pm upgrade` | prepare, migrate, verify |
+| Decommission | `uninstall` | `pm remove` | unprovision, cleanup |
+
+The **migrate** phase (Upgrade only) handles version-specific changes:
+- Config file format migrations
+- Data schema updates
+- Service reconfiguration after upgrade
+
+This is distinct from **provision** (Deploy only) which handles first-time setup.
+
+This creates a clean separation:
+- **Native PM packages**: Implement exactly the required phase (the PM does the work)
+- **Lore packages**: May implement any/all phases (Starlark scripts do the work)
+
+```go
+// RequiredPhase returns the required phase for an operation.
+func RequiredPhase(op Operation) string {
+    switch op {
+    case OpDeploy:       return "install"
+    case OpUpgrade:      return "upgrade"
+    case OpDecommission: return "uninstall"
+    }
+}
+```
+
+## Phase Representation
+
+A phase action is either a Starlark script or a native package manager operation:
+
+```go
+// PhaseAction represents an executable phase action.
+type PhaseAction interface {
+    Type() PhaseActionType  // ScriptAction or NativePMAction
+}
+
+// ScriptAction executes a Starlark phase script.
+type ScriptAction struct {
+    Path  string  // Path to .star file
+    Phase string  // Phase name (function to call)
+}
+
+// NativePMAction executes a native package manager operation.
+type NativePMAction struct {
+    Manager   PackageSource  // apt, dnf, brew, winget, etc.
+    Operation PMOperation    // Install, Upgrade, Remove
+    Packages  []string       // Package names
+}
+```
+
+## Pipeline Resolution
+
+### Lore Registry Package
+
+For a lore package on Darwin:
+
+```
+docker/
+├── lifecycle.yaml
+├── Common/Deploy/
+│   └── install.star    → ScriptAction{Path: "Common/Deploy/install.star", Phase: "install"}
+├── Unix/Deploy/
+│   └── install.star    → ScriptAction{Path: "Unix/Deploy/install.star", Phase: "install"}
+└── Darwin/Deploy/
+    └── install.star    → ScriptAction{Path: "Darwin/Deploy/install.star", Phase: "install"}
+```
+
+Result: Three `ScriptAction` items executed in order (general → specific).
+
+### Native PM Package (Synthetic)
+
+For a native package "curl" on Debian:
+
+```
+LorePackage{
+    Name:   "curl",
+    Source: SourceApt,
+}
+```
+
+Pipeline returns only the required phase for each operation:
+
+```
+Deploy.install    → NativePMAction{apt, Install, ["curl"]}
+Upgrade.upgrade   → NativePMAction{apt, Upgrade, ["curl"]}
+Decommission.uninstall → NativePMAction{apt, Remove, ["curl"]}
+```
+
+Other phases (prepare, provision, verify, etc.) return empty for native packages.
+
+## Graph Integration
+
+The engine's delegate builds an execution graph:
+
+```go
+func (d *Delegate) ProcessManifest(manifest *Manifest) error {
+    for _, pkgName := range manifest.Packages {
+        pkg, _ := d.registry.Resolve(pkgName, d.platform)
+
+        for _, phase := range registry.DeployPhaseOrder {
+            actions := pkg.PhaseActions(d.platform, registry.OpDeploy, phase)
+            for _, action := range actions {
+                d.graph.AddNode(action)
+            }
+        }
+    }
+    return nil
+}
+```
+
+The delegate doesn't distinguish between lore and native packages—both provide `PhaseAction` items.
+
+## Graph Optimization (TODO)
+
+Native PM operations can be batched during graph compilation:
+
+```
+Before optimization:
+  NativePMAction{apt, Install, ["curl"]}
+  NativePMAction{apt, Install, ["wget"]}
+  NativePMAction{apt, Install, ["jq"]}
+
+After optimization:
+  NativePMAction{apt, Install, ["curl", "wget", "jq"]}
+```
+
+Constraints:
+- Only batch operations with same manager and operation type
+- Respect dependency ordering (if package B depends on A, A must install first)
+- Lore package phases cannot be batched (Starlark execution is sequential)
+
+**TODO:** Implement graph optimizer that identifies and batches homogeneous native PM operations.
+
+## Implementation Plan
+
+1. Define `PhaseAction` interface and concrete types in `internal/registry/`
+2. Add `PhaseActions(platform, op, phase)` method to `Lifecycle`
+3. Update `LorePackage` to delegate to `Lifecycle.PhaseActions()`
+4. For synthetic lifecycles, return `NativePMAction` for install phase
+5. Update executor to handle both action types
+6. (Future) Implement graph optimizer for batching

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -142,7 +142,13 @@ func New(registry *Registry, opts Options) *Engine {
 // Run executes all nodes in the graph, respecting ordering constraints.
 // Nodes are processed in topological order when edges define dependencies.
 // Returns results for each node.
+//
+// TODO: Add graph optimization pass before execution. Native PM operations
+// (e.g., multiple "install" nodes with the same package manager) should be
+// batched into a single operation to reduce PM invocations. See
+// docs/plans/uniform-pipeline-interface.md for design details.
 func (e *Engine) Run(ctx context.Context, graph *Graph) ([]*Result, error) {
+	// TODO: graph = e.optimize(graph)
 	ordered := e.orderNodes(graph)
 
 	execCtx := &Context{

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -4,11 +4,16 @@
 package lore
 
 import (
+	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/internal/lore/pipeline"
+	"github.com/NobleFactor/devlore-cli/internal/registry"
 )
 
 func newDeployCmd() *cobra.Command {
@@ -27,10 +32,7 @@ Packages can be specified directly or via manifest files (prefixed with @).`,
   lore deploy @team.manifest
   lore deploy @base.manifest @team.manifest neovim --with lsp`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("deploy: not yet implemented")
-			return nil
-		},
+		RunE: runDeploy,
 	}
 
 	cmd.Flags().Bool("known-only", false, "Skip LOW CONFIDENCE items")
@@ -40,6 +42,70 @@ Packages can be specified directly or via manifest files (prefixed with @).`,
 	cmd.Flags().Int("parallel", 1, "Install n packages concurrently")
 
 	return cmd
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Get flags
+	features, _ := cmd.Flags().GetStringArray("with")
+	dryRun := viper.GetBool("lore.dry-run")
+	verbose := viper.GetBool("lore.verbose")
+
+	// Create registry client
+	regClient, err := registry.NewDefault()
+	if err != nil {
+		return fmt.Errorf("creating registry client: %w", err)
+	}
+
+	// Create executor config
+	cfg := pipeline.ExecutorConfig{
+		Features: features,
+		DryRun:   dryRun,
+		Verbose:  verbose,
+		Output:   os.Stdout,
+	}
+
+	executor := pipeline.NewExecutor(cfg)
+
+	// Detect platform for package resolution
+	platform := pipeline.DetectPlatform()
+
+	// Process each package argument
+	var lastErr error
+	for _, arg := range args {
+		// TODO: Handle @manifest syntax
+		if len(arg) > 0 && arg[0] == '@' {
+			fmt.Fprintf(os.Stderr, "Manifest files not yet supported: %s\n", arg)
+			continue
+		}
+
+		// Resolve package from registry
+		pkg, err := regClient.Resolve(arg, platform)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving package %q: %v\n", arg, err)
+			lastErr = err
+			continue
+		}
+
+		// Execute the deploy pipeline
+		result, err := executor.ExecutePackage(ctx, pkg, pipeline.OpDeploy)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deploying %q: %v\n", arg, err)
+			lastErr = err
+			continue
+		}
+
+		if !result.Success {
+			fmt.Fprintf(os.Stderr, "Deployment failed for %q\n", arg)
+			lastErr = fmt.Errorf("deployment failed for %s", arg)
+		}
+	}
+
+	return lastErr
 }
 
 func newUpgradeCmd() *cobra.Command {

--- a/internal/lore/pipeline/executor.go
+++ b/internal/lore/pipeline/executor.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"go.starlark.net/starlark"
 
+	"github.com/NobleFactor/devlore-cli/internal/host"
+	"github.com/NobleFactor/devlore-cli/internal/registry"
 	loreStar "github.com/NobleFactor/devlore-cli/internal/starlark"
 )
 
@@ -41,6 +44,20 @@ func (o Operation) String() string {
 	}
 }
 
+// toRegistryOp converts pipeline.Operation to registry.Operation.
+func (o Operation) toRegistryOp() registry.Operation {
+	switch o {
+	case OpDeploy:
+		return registry.OpDeploy
+	case OpUpgrade:
+		return registry.OpUpgrade
+	case OpDecommission:
+		return registry.OpDecommission
+	default:
+		return registry.OpDeploy
+	}
+}
+
 // ExecutorConfig configures the pipeline executor.
 type ExecutorConfig struct {
 	// Features to enable for this execution.
@@ -60,6 +77,9 @@ type ExecutorConfig struct {
 
 	// SinglePhase runs only this phase (empty = all phases).
 	SinglePhase string
+
+	// Platform override (empty = auto-detect).
+	Platform string
 }
 
 // PhaseResult captures the result of executing a single phase.
@@ -71,12 +91,14 @@ type PhaseResult struct {
 	Success   bool
 	Error     error
 	Skipped   bool
+	Scripts   []string // Scripts that were executed for this phase
 }
 
 // ExecutionResult captures the result of a full pipeline execution.
 type ExecutionResult struct {
 	Package   string
 	Operation Operation
+	Platform  string
 	Started   time.Time
 	Completed time.Time
 	Duration  time.Duration
@@ -89,6 +111,7 @@ type ExecutionResult struct {
 type Executor struct {
 	config   ExecutorConfig
 	bindings *loreStar.Bindings
+	platform string // Resolved platform string for registry
 }
 
 // NewExecutor creates a new pipeline executor.
@@ -102,17 +125,60 @@ func NewExecutor(cfg ExecutorConfig) *Executor {
 
 	bindings := loreStar.NewBindings(cfg.Features, cfg.Settings, cfg.Output)
 
+	// Resolve platform
+	platform := cfg.Platform
+	if platform == "" {
+		platform = DetectPlatform()
+	}
+
 	return &Executor{
 		config:   cfg,
 		bindings: bindings,
+		platform: platform,
 	}
 }
 
-// Execute runs the pipeline for a package.
-func (e *Executor) Execute(ctx context.Context, lifecycle *Lifecycle, op Operation) (*ExecutionResult, error) {
+// DetectPlatform converts host.Platform to registry platform string.
+// Examples: "Darwin", "Linux", "Linux.Debian", "Linux.Fedora", "Windows"
+func DetectPlatform() string {
+	p := host.DetectPlatform()
+	switch p.OS {
+	case "darwin":
+		return "Darwin"
+	case "windows":
+		return "Windows"
+	case "linux":
+		// Qualify with distro if available
+		switch strings.ToLower(p.Distro) {
+		case "debian", "ubuntu":
+			return "Linux.Debian"
+		case "fedora", "rhel", "centos", "rocky", "alma":
+			return "Linux.Fedora"
+		default:
+			return "Linux"
+		}
+	default:
+		return "Linux"
+	}
+}
+
+// ExecutePackage runs the pipeline for a LorePackage.
+func (e *Executor) ExecutePackage(ctx context.Context, pkg *registry.LorePackage, op Operation) (*ExecutionResult, error) {
+	lifecycle := pkg.Lifecycle()
+	return e.execute(ctx, lifecycle, pkg.Dir, op)
+}
+
+// Execute runs the pipeline for a package lifecycle.
+// Deprecated: Use ExecutePackage with a LorePackage for proper directory resolution.
+func (e *Executor) Execute(ctx context.Context, lifecycle *registry.Lifecycle, packageDir string, op Operation) (*ExecutionResult, error) {
+	return e.execute(ctx, lifecycle, packageDir, op)
+}
+
+func (e *Executor) execute(ctx context.Context, lifecycle *registry.Lifecycle, packageDir string, op Operation) (*ExecutionResult, error) {
 	result := &ExecutionResult{
 		Package:   lifecycle.Name,
 		Operation: op,
+		Platform:  e.platform,
 		Started:   time.Now(),
 	}
 
@@ -131,7 +197,7 @@ func (e *Executor) Execute(ctx context.Context, lifecycle *Lifecycle, op Operati
 	phases := e.phasesToRun(op)
 
 	if e.config.DryRun {
-		e.printDryRun(lifecycle, phases)
+		e.printDryRun(lifecycle, packageDir, op, phases)
 		result.Success = true
 		result.Completed = time.Now()
 		result.Duration = result.Completed.Sub(result.Started)
@@ -139,6 +205,7 @@ func (e *Executor) Execute(ctx context.Context, lifecycle *Lifecycle, op Operati
 	}
 
 	// Run each phase
+	regOp := op.toRegistryOp()
 	for _, phaseName := range phases {
 		select {
 		case <-ctx.Done():
@@ -149,7 +216,7 @@ func (e *Executor) Execute(ctx context.Context, lifecycle *Lifecycle, op Operati
 		default:
 		}
 
-		phaseResult := e.executePhase(lifecycle, phaseName)
+		phaseResult := e.executePhase(lifecycle, packageDir, regOp, phaseName)
 		result.Phases = append(result.Phases, phaseResult)
 
 		if !phaseResult.Success && !phaseResult.Skipped {
@@ -175,22 +242,27 @@ func (e *Executor) phasesToRun(op Operation) []string {
 
 	switch op {
 	case OpDecommission:
-		return DecommissionPhaseOrder
+		return registry.DecommissionPhaseOrder
+	case OpUpgrade:
+		return registry.UpgradePhaseOrder
 	default:
-		return PhaseOrder
+		return registry.DeployPhaseOrder
 	}
 }
 
-func (e *Executor) executePhase(lifecycle *Lifecycle, phaseName string) PhaseResult {
+func (e *Executor) executePhase(lifecycle *registry.Lifecycle, packageDir string, op registry.Operation, phaseName string) PhaseResult {
 	result := PhaseResult{
 		Name:    phaseName,
 		Started: time.Now(),
 	}
 
-	scriptPath := lifecycle.GetPhaseScript(phaseName)
-	if scriptPath == "" {
+	// Discover all scripts for this phase (chained execution)
+	scripts := lifecycle.DiscoverPhaseScripts(packageDir, e.platform, op, phaseName)
+	result.Scripts = scripts
+
+	if len(scripts) == 0 {
 		if e.config.Verbose {
-			fmt.Fprintf(e.config.Output, "Skipping phase %q (not defined)\n", phaseName)
+			fmt.Fprintf(e.config.Output, "Skipping phase %q (no scripts found)\n", phaseName)
 		}
 		result.Skipped = true
 		result.Success = true
@@ -199,20 +271,25 @@ func (e *Executor) executePhase(lifecycle *Lifecycle, phaseName string) PhaseRes
 		return result
 	}
 
-	e.printPhaseStart(phaseName)
+	e.printPhaseStart(phaseName, scripts)
 
-	err := e.runPhaseScript(scriptPath, phaseName)
+	// Execute scripts in order (general → specific)
+	for _, scriptPath := range scripts {
+		err := e.runPhaseScript(scriptPath, phaseName)
+		if err != nil {
+			result.Error = err
+			result.Success = false
+			result.Completed = time.Now()
+			result.Duration = result.Completed.Sub(result.Started)
+			fmt.Fprintf(e.config.Output, "\n✗ Phase %q failed in %s: %v\n", phaseName, scriptPath, err)
+			return result
+		}
+	}
+
+	result.Success = true
 	result.Completed = time.Now()
 	result.Duration = result.Completed.Sub(result.Started)
-
-	if err != nil {
-		result.Error = err
-		result.Success = false
-		fmt.Fprintf(e.config.Output, "\n✗ Phase %q failed: %v\n", phaseName, err)
-	} else {
-		result.Success = true
-		fmt.Fprintf(e.config.Output, "✓ Phase %q completed\n\n", phaseName)
-	}
+	fmt.Fprintf(e.config.Output, "✓ Phase %q completed\n\n", phaseName)
 
 	return result
 }
@@ -255,12 +332,13 @@ func (e *Executor) runPhaseScript(scriptPath, phaseName string) error {
 	return nil
 }
 
-func (e *Executor) printHeader(lifecycle *Lifecycle, features []string, settings map[string]string) {
+func (e *Executor) printHeader(lifecycle *registry.Lifecycle, features []string, settings map[string]string) {
 	fmt.Fprintln(e.config.Output, "╔════════════════════════════════════════════════════════════════╗")
 	fmt.Fprintf(e.config.Output, "║  Lore Pipeline: %s\n", lifecycle.Name)
 	fmt.Fprintln(e.config.Output, "╚════════════════════════════════════════════════════════════════╝")
 	fmt.Fprintln(e.config.Output)
 	fmt.Fprintf(e.config.Output, "Package:  %s v%s\n", lifecycle.Name, lifecycle.Version)
+	fmt.Fprintf(e.config.Output, "Platform: %s\n", e.platform)
 	fmt.Fprintf(e.config.Output, "Features: %v\n", features)
 	if len(settings) > 0 {
 		fmt.Fprintf(e.config.Output, "Settings: %v\n", settings)
@@ -268,24 +346,32 @@ func (e *Executor) printHeader(lifecycle *Lifecycle, features []string, settings
 	fmt.Fprintln(e.config.Output)
 }
 
-func (e *Executor) printDryRun(lifecycle *Lifecycle, phases []string) {
+func (e *Executor) printDryRun(lifecycle *registry.Lifecycle, packageDir string, op Operation, phases []string) {
+	regOp := op.toRegistryOp()
 	fmt.Fprintln(e.config.Output, "[DRY RUN] Would execute the following phases:")
 	for _, phaseName := range phases {
-		if script, ok := lifecycle.Phases[phaseName]; ok {
-			fmt.Fprintf(e.config.Output, "  - %s: %s\n", phaseName, script)
+		scripts := lifecycle.DiscoverPhaseScripts(packageDir, e.platform, regOp, phaseName)
+		if len(scripts) > 0 {
+			fmt.Fprintf(e.config.Output, "  - %s:\n", phaseName)
+			for _, s := range scripts {
+				fmt.Fprintf(e.config.Output, "      %s\n", s)
+			}
 		} else {
-			fmt.Fprintf(e.config.Output, "  - %s: (not defined, would skip)\n", phaseName)
+			fmt.Fprintf(e.config.Output, "  - %s: (no scripts, would skip)\n", phaseName)
 		}
 	}
 }
 
-func (e *Executor) printPhaseStart(phaseName string) {
+func (e *Executor) printPhaseStart(phaseName string, scripts []string) {
 	fmt.Fprintln(e.config.Output, "────────────────────────────────────────────────────────────────")
 	fmt.Fprintf(e.config.Output, "Phase: %s\n", phaseName)
+	if len(scripts) > 1 {
+		fmt.Fprintf(e.config.Output, "Scripts: %d (chained)\n", len(scripts))
+	}
 	fmt.Fprintln(e.config.Output, "────────────────────────────────────────────────────────────────")
 }
 
-func (e *Executor) printSuccess(lifecycle *Lifecycle) {
+func (e *Executor) printSuccess(lifecycle *registry.Lifecycle) {
 	fmt.Fprintln(e.config.Output, "════════════════════════════════════════════════════════════════")
 	fmt.Fprintf(e.config.Output, "✓ Pipeline completed successfully for %s\n", lifecycle.Name)
 	fmt.Fprintln(e.config.Output, "════════════════════════════════════════════════════════════════")

--- a/internal/lore/pipeline/pipeline_test.go
+++ b/internal/lore/pipeline/pipeline_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/NobleFactor/devlore-cli/internal/registry"
 )
 
 func TestLoadLifecycle(t *testing.T) {
@@ -23,8 +25,8 @@ func TestLoadLifecycle(t *testing.T) {
 version: "1.0.0"
 description: "Test package"
 platforms:
-  - darwin
-  - linux
+  - Darwin
+  - Linux
 features:
   completions:
     description: "Install shell completions"
@@ -37,16 +39,12 @@ settings:
     description: "Shell to configure"
     type: string
     default: zsh
-phases:
-  prepare: prepare.star
-  install: install.star
-  verify: verify.star
 `
 	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	lifecycle, err := LoadLifecycle(pkgDir)
+	lifecycle, err := registry.LoadLifecycle(pkgDir)
 	if err != nil {
 		t.Fatalf("LoadLifecycle failed: %v", err)
 	}
@@ -61,14 +59,11 @@ phases:
 	if len(lifecycle.Platforms) != 2 {
 		t.Errorf("len(Platforms) = %d, want 2", len(lifecycle.Platforms))
 	}
-	if lifecycle.PackageDir != pkgDir {
-		t.Errorf("PackageDir = %q, want %q", lifecycle.PackageDir, pkgDir)
-	}
 }
 
 func TestLifecycleEnabledFeatures(t *testing.T) {
-	lifecycle := &Lifecycle{
-		Features: map[string]Feature{
+	lifecycle := &registry.Lifecycle{
+		Features: map[string]registry.Feature{
 			"completions": {Default: true},
 			"debug":       {Default: false},
 			"telemetry":   {Default: true},
@@ -131,8 +126,8 @@ func TestLifecycleEnabledFeatures(t *testing.T) {
 }
 
 func TestLifecycleResolvedSettings(t *testing.T) {
-	lifecycle := &Lifecycle{
-		Settings: map[string]Setting{
+	lifecycle := &registry.Lifecycle{
+		Settings: map[string]registry.Setting{
 			"shell":  {Default: "zsh"},
 			"editor": {Default: "vim"},
 		},
@@ -153,51 +148,132 @@ func TestLifecycleResolvedSettings(t *testing.T) {
 }
 
 func TestLifecycleHasPhase(t *testing.T) {
-	lifecycle := &Lifecycle{
-		Phases: map[string]string{
-			"prepare": "prepare.star",
-			"install": "install.star",
-		},
+	// Create a temporary package with phase scripts
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "testpkg")
+
+	// Create directory structure: Common/Deploy/prepare.star, Common/Deploy/install.star
+	deployDir := filepath.Join(pkgDir, "Common", "Deploy")
+	if err := os.MkdirAll(deployDir, 0755); err != nil {
+		t.Fatal(err)
 	}
 
-	if !lifecycle.HasPhase("prepare") {
+	if err := os.WriteFile(filepath.Join(deployDir, "prepare.star"), []byte("def prepare(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lifecycle.yaml
+	lifecycleYAML := `name: testpkg
+version: "1.0"
+description: "Test"
+platforms:
+  - Darwin
+  - Linux
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycle, err := registry.LoadLifecycle(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !lifecycle.HasPhase(pkgDir, "Darwin", registry.OpDeploy, "prepare") {
 		t.Error("HasPhase(prepare) = false, want true")
 	}
-	if lifecycle.HasPhase("provision") {
+	if !lifecycle.HasPhase(pkgDir, "Darwin", registry.OpDeploy, "install") {
+		t.Error("HasPhase(install) = false, want true")
+	}
+	if lifecycle.HasPhase(pkgDir, "Darwin", registry.OpDeploy, "provision") {
 		t.Error("HasPhase(provision) = true, want false")
 	}
 }
 
-func TestLifecycleGetPhaseScript(t *testing.T) {
-	lifecycle := &Lifecycle{
-		PackageDir: "/registry/testpkg",
-		Phases: map[string]string{
-			"install": "install.star",
-		},
+func TestLifecycleDiscoverPhaseScripts(t *testing.T) {
+	// Create a temporary package with chained phase scripts
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "testpkg")
+
+	// Create Common/Deploy/install.star
+	commonDeployDir := filepath.Join(pkgDir, "Common", "Deploy")
+	if err := os.MkdirAll(commonDeployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commonDeployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
-	got := lifecycle.GetPhaseScript("install")
-	want := "/registry/testpkg/install.star"
-	if got != want {
-		t.Errorf("GetPhaseScript(install) = %q, want %q", got, want)
+	// Create Unix/Deploy/install.star
+	unixDeployDir := filepath.Join(pkgDir, "Unix", "Deploy")
+	if err := os.MkdirAll(unixDeployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unixDeployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
-	got = lifecycle.GetPhaseScript("provision")
-	if got != "" {
-		t.Errorf("GetPhaseScript(provision) = %q, want empty", got)
+	// Create Darwin/Deploy/install.star
+	darwinDeployDir := filepath.Join(pkgDir, "Darwin", "Deploy")
+	if err := os.MkdirAll(darwinDeployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(darwinDeployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lifecycle.yaml
+	lifecycleYAML := `name: testpkg
+version: "1.0"
+description: "Test"
+platforms:
+  - Darwin
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lifecycle, err := registry.LoadLifecycle(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should discover all three scripts in order: Common → Unix → Darwin
+	scripts := lifecycle.DiscoverPhaseScripts(pkgDir, "Darwin", registry.OpDeploy, "install")
+	if len(scripts) != 3 {
+		t.Errorf("len(scripts) = %d, want 3", len(scripts))
+	}
+
+	// Verify order: Common first, Unix second, Darwin last
+	if len(scripts) >= 1 && filepath.Base(filepath.Dir(filepath.Dir(scripts[0]))) != "Common" {
+		t.Errorf("first script should be from Common, got %s", scripts[0])
+	}
+	if len(scripts) >= 2 && filepath.Base(filepath.Dir(filepath.Dir(scripts[1]))) != "Unix" {
+		t.Errorf("second script should be from Unix, got %s", scripts[1])
+	}
+	if len(scripts) >= 3 && filepath.Base(filepath.Dir(filepath.Dir(scripts[2]))) != "Darwin" {
+		t.Errorf("third script should be from Darwin, got %s", scripts[2])
 	}
 }
 
 func TestLifecycleSupportsPlatform(t *testing.T) {
-	lifecycle := &Lifecycle{
-		Platforms: []string{"darwin", "linux"},
+	lifecycle := &registry.Lifecycle{
+		Platforms: []string{"Darwin", "Linux"},
 	}
 
-	if !lifecycle.SupportsPlatform("darwin") {
-		t.Error("SupportsPlatform(darwin) = false, want true")
+	if !lifecycle.SupportsPlatform("Darwin") {
+		t.Error("SupportsPlatform(Darwin) = false, want true")
 	}
-	if lifecycle.SupportsPlatform("windows") {
-		t.Error("SupportsPlatform(windows) = true, want false")
+	if lifecycle.SupportsPlatform("Windows") {
+		t.Error("SupportsPlatform(Windows) = true, want false")
+	}
+	// Test distro matching
+	lifecycle.Platforms = []string{"Linux"}
+	if !lifecycle.SupportsPlatform("Linux.Debian") {
+		t.Error("SupportsPlatform(Linux.Debian) = false, want true (matches Linux)")
 	}
 }
 
@@ -205,35 +281,43 @@ func TestExecutorDryRun(t *testing.T) {
 	// Create a temporary package
 	tmpDir := t.TempDir()
 	pkgDir := filepath.Join(tmpDir, "dryrunpkg")
-	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+
+	// Create Common/Deploy/prepare.star and Common/Deploy/install.star
+	deployDir := filepath.Join(pkgDir, "Common", "Deploy")
+	if err := os.MkdirAll(deployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deployDir, "prepare.star"), []byte("def prepare(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	lifecycleYAML := `name: dryrunpkg
 version: "1.0"
+description: "Dry run test"
 platforms:
-  - darwin
-  - linux
-phases:
-  prepare: prepare.star
-  install: install.star
+  - Darwin
+  - Linux
 `
 	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	lifecycle, err := LoadLifecycle(pkgDir)
+	lifecycle, err := registry.LoadLifecycle(pkgDir)
 	if err != nil {
 		t.Fatalf("LoadLifecycle failed: %v", err)
 	}
 
 	var buf bytes.Buffer
 	executor := NewExecutor(ExecutorConfig{
-		DryRun: true,
-		Output: &buf,
+		DryRun:   true,
+		Output:   &buf,
+		Platform: "Darwin",
 	})
 
-	result, err := executor.Execute(context.Background(), lifecycle, OpDeploy)
+	result, err := executor.Execute(context.Background(), lifecycle, pkgDir, OpDeploy)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -252,18 +336,19 @@ func TestExecutorWithPhaseScripts(t *testing.T) {
 	// Create a temporary package with real Starlark scripts
 	tmpDir := t.TempDir()
 	pkgDir := filepath.Join(tmpDir, "realpkg")
-	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+
+	// Create Common/Deploy/ directory
+	deployDir := filepath.Join(pkgDir, "Common", "Deploy")
+	if err := os.MkdirAll(deployDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	lifecycleYAML := `name: realpkg
 version: "1.0"
+description: "Real package test"
 platforms:
-  - darwin
-  - linux
-phases:
-  install: install.star
-  verify: verify.star
+  - Darwin
+  - Linux
 `
 	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
 		t.Fatal(err)
@@ -273,7 +358,7 @@ phases:
 	installStar := `def install():
     note("Installing realpkg")
 `
-	if err := os.WriteFile(filepath.Join(pkgDir, "install.star"), []byte(installStar), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deployDir, "install.star"), []byte(installStar), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -281,22 +366,23 @@ phases:
 	verifyStar := `def verify():
     note("Verifying realpkg")
 `
-	if err := os.WriteFile(filepath.Join(pkgDir, "verify.star"), []byte(verifyStar), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deployDir, "verify.star"), []byte(verifyStar), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	lifecycle, err := LoadLifecycle(pkgDir)
+	lifecycle, err := registry.LoadLifecycle(pkgDir)
 	if err != nil {
 		t.Fatalf("LoadLifecycle failed: %v", err)
 	}
 
 	var buf bytes.Buffer
 	executor := NewExecutor(ExecutorConfig{
-		Output:  &buf,
-		Verbose: true,
+		Output:   &buf,
+		Verbose:  true,
+		Platform: "Darwin",
 	})
 
-	result, err := executor.Execute(context.Background(), lifecycle, OpDeploy)
+	result, err := executor.Execute(context.Background(), lifecycle, pkgDir, OpDeploy)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -333,5 +419,33 @@ func TestOperationString(t *testing.T) {
 		if got := tt.op.String(); got != tt.want {
 			t.Errorf("%d.String() = %q, want %q", tt.op, got, tt.want)
 		}
+	}
+}
+
+func TestPlatformResolutionOrder(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     []string
+	}{
+		{"Darwin", []string{"Common", "Unix", "Darwin"}},
+		{"Linux", []string{"Common", "Unix", "Linux"}},
+		{"Linux.Debian", []string{"Common", "Unix", "Linux", "Linux.Debian"}},
+		{"Linux.Fedora", []string{"Common", "Unix", "Linux", "Linux.Fedora"}},
+		{"Windows", []string{"Common", "Windows"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			got := registry.PlatformResolutionOrder(tt.platform)
+			if len(got) != len(tt.want) {
+				t.Errorf("len = %d, want %d; got %v", len(got), len(tt.want), got)
+				return
+			}
+			for i, p := range tt.want {
+				if got[i] != p {
+					t.Errorf("order[%d] = %q, want %q", i, got[i], p)
+				}
+			}
+		})
 	}
 }

--- a/internal/registry/action.go
+++ b/internal/registry/action.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+// action.go defines PhaseAction types for uniform pipeline phases.
+//
+// PhaseAction is the core abstraction: both Starlark scripts (ScriptAction)
+// and native PM operations (NativePMAction) implement this interface.
+// The engine's package-manifest delegate queries LorePackage.PhaseActions()
+// and adds the results to the execution graph.
+//
+// TODO: Implement graph optimization that batches NativePMAction nodes with
+// the same manager and operation. See docs/plans/uniform-pipeline-interface.md.
+
+package registry
+
+// PhaseActionType distinguishes between script and native PM actions.
+type PhaseActionType int
+
+const (
+	// ActionScript is a Starlark phase script.
+	ActionScript PhaseActionType = iota
+	// ActionNativePM is a native package manager operation.
+	ActionNativePM
+)
+
+// PMOperation represents a native package manager operation.
+type PMOperation int
+
+const (
+	// PMInstall installs packages.
+	PMInstall PMOperation = iota
+	// PMRemove removes packages.
+	PMRemove
+	// PMUpdate refreshes the package index.
+	PMUpdate
+	// PMUpgrade upgrades installed packages.
+	PMUpgrade
+)
+
+// String returns the operation name.
+func (op PMOperation) String() string {
+	switch op {
+	case PMInstall:
+		return "install"
+	case PMRemove:
+		return "remove"
+	case PMUpdate:
+		return "update"
+	case PMUpgrade:
+		return "upgrade"
+	default:
+		return "unknown"
+	}
+}
+
+// PhaseAction represents an executable phase action.
+// This provides a uniform interface for both Starlark scripts and native PM operations.
+type PhaseAction interface {
+	// Type returns the action type (script or native PM).
+	Type() PhaseActionType
+
+	// Phase returns the phase name this action belongs to.
+	Phase() string
+}
+
+// ScriptAction executes a Starlark phase script.
+type ScriptAction struct {
+	// Path is the absolute path to the .star file.
+	Path string
+
+	// PhaseName is the phase name (function to call in the script).
+	PhaseName string
+
+	// Platform is the platform directory this script came from.
+	Platform string
+}
+
+// Type returns ActionScript.
+func (a *ScriptAction) Type() PhaseActionType {
+	return ActionScript
+}
+
+// Phase returns the phase name.
+func (a *ScriptAction) Phase() string {
+	return a.PhaseName
+}
+
+// NativePMAction executes a native package manager operation.
+type NativePMAction struct {
+	// Manager identifies which package manager to use.
+	Manager PackageSource
+
+	// Operation is the PM operation (install, remove, update).
+	Operation PMOperation
+
+	// Packages is the list of package names to operate on.
+	Packages []string
+
+	// PhaseName is the phase this action belongs to.
+	PhaseName string
+}
+
+// Type returns ActionNativePM.
+func (a *NativePMAction) Type() PhaseActionType {
+	return ActionNativePM
+}
+
+// Phase returns the phase name.
+func (a *NativePMAction) Phase() string {
+	return a.PhaseName
+}
+
+// Batchable returns true if this action can be batched with others.
+// Native PM install/upgrade/remove operations are batchable; update (index refresh) is not.
+func (a *NativePMAction) Batchable() bool {
+	return a.Operation == PMInstall || a.Operation == PMUpgrade || a.Operation == PMRemove
+}
+
+// CanBatchWith returns true if this action can be batched with another.
+// Actions can be batched if they have the same manager, operation, and phase.
+func (a *NativePMAction) CanBatchWith(other *NativePMAction) bool {
+	return a.Manager == other.Manager &&
+		a.Operation == other.Operation &&
+		a.PhaseName == other.PhaseName
+}
+
+// Merge combines this action with another, returning a new batched action.
+// Returns nil if the actions cannot be batched.
+func (a *NativePMAction) Merge(other *NativePMAction) *NativePMAction {
+	if !a.CanBatchWith(other) {
+		return nil
+	}
+
+	// Combine package lists
+	packages := make([]string, 0, len(a.Packages)+len(other.Packages))
+	packages = append(packages, a.Packages...)
+	packages = append(packages, other.Packages...)
+
+	return &NativePMAction{
+		Manager:   a.Manager,
+		Operation: a.Operation,
+		Packages:  packages,
+		PhaseName: a.PhaseName,
+	}
+}

--- a/internal/registry/action_test.go
+++ b/internal/registry/action_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package registry
+
+import (
+	"testing"
+)
+
+func TestPMOperation_String(t *testing.T) {
+	tests := []struct {
+		op   PMOperation
+		want string
+	}{
+		{PMInstall, "install"},
+		{PMRemove, "remove"},
+		{PMUpdate, "update"},
+		{PMUpgrade, "upgrade"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.op.String(); got != tt.want {
+				t.Errorf("PMOperation.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScriptAction(t *testing.T) {
+	action := &ScriptAction{
+		Path:      "/pkg/Common/Deploy/install.star",
+		PhaseName: "install",
+		Platform:  "Common",
+	}
+
+	if action.Type() != ActionScript {
+		t.Errorf("Type() = %v, want ActionScript", action.Type())
+	}
+	if action.Phase() != "install" {
+		t.Errorf("Phase() = %q, want \"install\"", action.Phase())
+	}
+}
+
+func TestNativePMAction(t *testing.T) {
+	action := &NativePMAction{
+		Manager:   SourceApt,
+		Operation: PMInstall,
+		Packages:  []string{"curl", "wget"},
+		PhaseName: "install",
+	}
+
+	if action.Type() != ActionNativePM {
+		t.Errorf("Type() = %v, want ActionNativePM", action.Type())
+	}
+	if action.Phase() != "install" {
+		t.Errorf("Phase() = %q, want \"install\"", action.Phase())
+	}
+}
+
+func TestNativePMAction_Batchable(t *testing.T) {
+	tests := []struct {
+		op   PMOperation
+		want bool
+	}{
+		{PMInstall, true},
+		{PMRemove, true},
+		{PMUpdate, false},
+		{PMUpgrade, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.op.String(), func(t *testing.T) {
+			action := &NativePMAction{Operation: tt.op}
+			if got := action.Batchable(); got != tt.want {
+				t.Errorf("Batchable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNativePMAction_CanBatchWith(t *testing.T) {
+	base := &NativePMAction{
+		Manager:   SourceApt,
+		Operation: PMInstall,
+		Packages:  []string{"curl"},
+		PhaseName: "install",
+	}
+
+	tests := []struct {
+		name  string
+		other *NativePMAction
+		want  bool
+	}{
+		{
+			name: "same manager and operation",
+			other: &NativePMAction{
+				Manager:   SourceApt,
+				Operation: PMInstall,
+				Packages:  []string{"wget"},
+				PhaseName: "install",
+			},
+			want: true,
+		},
+		{
+			name: "different manager",
+			other: &NativePMAction{
+				Manager:   SourceBrew,
+				Operation: PMInstall,
+				Packages:  []string{"wget"},
+				PhaseName: "install",
+			},
+			want: false,
+		},
+		{
+			name: "different operation",
+			other: &NativePMAction{
+				Manager:   SourceApt,
+				Operation: PMRemove,
+				Packages:  []string{"wget"},
+				PhaseName: "install",
+			},
+			want: false,
+		},
+		{
+			name: "different phase",
+			other: &NativePMAction{
+				Manager:   SourceApt,
+				Operation: PMInstall,
+				Packages:  []string{"wget"},
+				PhaseName: "upgrade",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := base.CanBatchWith(tt.other); got != tt.want {
+				t.Errorf("CanBatchWith() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNativePMAction_Merge(t *testing.T) {
+	a := &NativePMAction{
+		Manager:   SourceApt,
+		Operation: PMInstall,
+		Packages:  []string{"curl", "wget"},
+		PhaseName: "install",
+	}
+
+	b := &NativePMAction{
+		Manager:   SourceApt,
+		Operation: PMInstall,
+		Packages:  []string{"jq", "vim"},
+		PhaseName: "install",
+	}
+
+	merged := a.Merge(b)
+	if merged == nil {
+		t.Fatal("Merge() returned nil")
+	}
+
+	if merged.Manager != SourceApt {
+		t.Errorf("Manager = %v, want SourceApt", merged.Manager)
+	}
+	if merged.Operation != PMInstall {
+		t.Errorf("Operation = %v, want PMInstall", merged.Operation)
+	}
+	if len(merged.Packages) != 4 {
+		t.Errorf("len(Packages) = %d, want 4", len(merged.Packages))
+	}
+
+	expected := []string{"curl", "wget", "jq", "vim"}
+	for i, pkg := range expected {
+		if merged.Packages[i] != pkg {
+			t.Errorf("Packages[%d] = %q, want %q", i, merged.Packages[i], pkg)
+		}
+	}
+
+	// Test incompatible merge returns nil
+	incompatible := &NativePMAction{
+		Manager:   SourceBrew,
+		Operation: PMInstall,
+		Packages:  []string{"htop"},
+		PhaseName: "install",
+	}
+	if result := a.Merge(incompatible); result != nil {
+		t.Errorf("Merge(incompatible) = %v, want nil", result)
+	}
+}
+
+func TestUpgradePhaseOrder_IncludesMigrate(t *testing.T) {
+	// Verify the upgrade phase order includes migrate
+	found := false
+	for _, phase := range UpgradePhaseOrder {
+		if phase == "migrate" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("UpgradePhaseOrder = %v, should include \"migrate\"", UpgradePhaseOrder)
+	}
+
+	// Verify order: prepare, upgrade, migrate, verify
+	expected := []string{"prepare", "upgrade", "migrate", "verify"}
+	if len(UpgradePhaseOrder) != len(expected) {
+		t.Errorf("len(UpgradePhaseOrder) = %d, want %d", len(UpgradePhaseOrder), len(expected))
+	}
+	for i, phase := range expected {
+		if i < len(UpgradePhaseOrder) && UpgradePhaseOrder[i] != phase {
+			t.Errorf("UpgradePhaseOrder[%d] = %q, want %q", i, UpgradePhaseOrder[i], phase)
+		}
+	}
+}

--- a/internal/registry/lifecycle.go
+++ b/internal/registry/lifecycle.go
@@ -1,19 +1,7 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025 Noble Factor. All rights reserved.
 
-// Package pipeline provides the lore four-phase execution pipeline.
-// Phases: prepare → install → provision → verify
-//
-// Phase scripts are discovered from the directory structure:
-//
-//	<package>/<platform>/<operation>/<phase>.star
-//
-// Platform resolution order (most specific first):
-//   - Linux.Debian, Linux.Fedora (distro-specific)
-//   - Linux, Darwin, Windows (OS-level)
-//   - Unix (Darwin + Linux + BSD)
-//   - Common (all platforms)
-package pipeline
+package registry
 
 import (
 	"fmt"
@@ -62,8 +50,24 @@ type Lifecycle struct {
 	// HardwareProvisions defines hardware-specific configuration requirements.
 	HardwareProvisions map[string]HardwareProvision `yaml:"hardware_provisions,omitempty"`
 
-	// PackageDir is the directory containing this lifecycle (set by loader).
-	PackageDir string `yaml:"-"`
+	// synthetic is true for packages from native PMs (not lifecycle.yaml)
+	synthetic bool
+}
+
+// Feature represents a package feature definition.
+type Feature struct {
+	Description string   `yaml:"description"`
+	Default     bool     `yaml:"default"`
+	Platforms   []string `yaml:"platforms,omitempty"`
+}
+
+// Setting represents a package setting definition.
+type Setting struct {
+	Description string   `yaml:"description"`
+	Type        string   `yaml:"type"`
+	Default     string   `yaml:"default"`
+	Values      []string `yaml:"values,omitempty"`
+	Platforms   []string `yaml:"platforms,omitempty"`
 }
 
 // HardwareProvision defines hardware-specific configuration.
@@ -73,28 +77,36 @@ type HardwareProvision struct {
 	BootArg     string `yaml:"boot_arg,omitempty"`
 }
 
-// Feature represents a package feature definition.
-type Feature struct {
-	Description string `yaml:"description"`
-	Default     bool   `yaml:"default"`
-}
-
-// Setting represents a package setting definition.
-type Setting struct {
-	Description string   `yaml:"description"`
-	Type        string   `yaml:"type"`
-	Default     string   `yaml:"default"`
-	Values      []string `yaml:"values,omitempty"`
-}
-
 // DeployPhaseOrder is the standard order of deploy pipeline phases.
 var DeployPhaseOrder = []string{"prepare", "install", "provision", "verify"}
 
 // UpgradePhaseOrder is the order for upgrade operations.
-var UpgradePhaseOrder = []string{"prepare", "install", "verify"}
+// The "migrate" phase handles version-specific migrations (config format changes,
+// data migrations, etc.) that may be needed between versions.
+var UpgradePhaseOrder = []string{"prepare", "upgrade", "migrate", "verify"}
 
 // DecommissionPhaseOrder is the order for decommission operations.
 var DecommissionPhaseOrder = []string{"unprovision", "uninstall", "cleanup"}
+
+// RequiredPhase returns the required phase for an operation.
+// Each operation has exactly one required phase that must be implemented.
+// Native PM packages implement only this phase; lore packages may add others.
+//
+//   - Deploy requires "install"
+//   - Upgrade requires "upgrade"
+//   - Decommission requires "uninstall"
+func RequiredPhase(op Operation) string {
+	switch op {
+	case OpDeploy:
+		return "install"
+	case OpUpgrade:
+		return "upgrade"
+	case OpDecommission:
+		return "uninstall"
+	default:
+		return "install"
+	}
+}
 
 // PhaseOrder returns the phase order for an operation.
 func PhaseOrder(op Operation) []string {
@@ -156,32 +168,7 @@ func LoadLifecycle(packageDir string) (*Lifecycle, error) {
 		return nil, fmt.Errorf("parsing lifecycle.yaml: %w", err)
 	}
 
-	lifecycle.PackageDir = packageDir
 	return &lifecycle, nil
-}
-
-// LoadLifecycleFromRegistry loads a lifecycle from a registry directory.
-func LoadLifecycleFromRegistry(registryDir, packageName string) (*Lifecycle, error) {
-	packageDir := filepath.Join(registryDir, packageName)
-	return LoadLifecycle(packageDir)
-}
-
-// GetPhaseScript returns the path to a single phase script for the given
-// platform and operation. This finds the MOST SPECIFIC script only.
-// For chained execution, use DiscoverPhaseScripts instead.
-//
-// Returns empty string if no script exists for this phase.
-func (l *Lifecycle) GetPhaseScript(platform string, op Operation, phase string) string {
-	// Check platforms from most specific to least specific (reverse order)
-	platforms := PlatformResolutionOrder(platform)
-	for i := len(platforms) - 1; i >= 0; i-- {
-		p := platforms[i]
-		path := filepath.Join(l.PackageDir, p, string(op), phase+".star")
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-	}
-	return ""
 }
 
 // DiscoverPhaseScripts returns all phase scripts for a phase, ordered from
@@ -193,10 +180,14 @@ func (l *Lifecycle) GetPhaseScript(platform string, op Operation, phase string) 
 //	 "Linux/Deploy/install.star", "Linux.Debian/Deploy/install.star"]
 //
 // Only scripts that exist are included.
-func (l *Lifecycle) DiscoverPhaseScripts(platform string, op Operation, phase string) []string {
+func (l *Lifecycle) DiscoverPhaseScripts(packageDir, platform string, op Operation, phase string) []string {
+	if l.synthetic {
+		return nil // Synthetic lifecycles have no scripts
+	}
+
 	var scripts []string
 	for _, p := range PlatformResolutionOrder(platform) {
-		path := filepath.Join(l.PackageDir, p, string(op), phase+".star")
+		path := filepath.Join(packageDir, p, string(op), phase+".star")
 		if _, err := os.Stat(path); err == nil {
 			scripts = append(scripts, path)
 		}
@@ -204,18 +195,40 @@ func (l *Lifecycle) DiscoverPhaseScripts(platform string, op Operation, phase st
 	return scripts
 }
 
+// GetPhaseScript returns the path to a single phase script for the given
+// platform and operation. This finds the MOST SPECIFIC script only.
+// For chained execution, use DiscoverPhaseScripts instead.
+//
+// Returns empty string if no script exists for this phase.
+func (l *Lifecycle) GetPhaseScript(packageDir, platform string, op Operation, phase string) string {
+	if l.synthetic {
+		return ""
+	}
+
+	// Check platforms from most specific to least specific (reverse order)
+	platforms := PlatformResolutionOrder(platform)
+	for i := len(platforms) - 1; i >= 0; i-- {
+		p := platforms[i]
+		path := filepath.Join(packageDir, p, string(op), phase+".star")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
 // HasPhase returns true if at least one phase script exists for this phase
 // on the given platform and operation.
-func (l *Lifecycle) HasPhase(platform string, op Operation, phase string) bool {
-	return len(l.DiscoverPhaseScripts(platform, op, phase)) > 0
+func (l *Lifecycle) HasPhase(packageDir, platform string, op Operation, phase string) bool {
+	return len(l.DiscoverPhaseScripts(packageDir, platform, op, phase)) > 0
 }
 
 // DiscoverAllPhases returns a map of phase name to script paths for all
 // phases in an operation on the given platform.
-func (l *Lifecycle) DiscoverAllPhases(platform string, op Operation) map[string][]string {
+func (l *Lifecycle) DiscoverAllPhases(packageDir, platform string, op Operation) map[string][]string {
 	phases := make(map[string][]string)
 	for _, phase := range PhaseOrder(op) {
-		scripts := l.DiscoverPhaseScripts(platform, op, phase)
+		scripts := l.DiscoverPhaseScripts(packageDir, platform, op, phase)
 		if len(scripts) > 0 {
 			phases[phase] = scripts
 		}
@@ -286,6 +299,15 @@ func (l *Lifecycle) SupportsPlatform(platform string) bool {
 		if p == platform {
 			return true
 		}
+		// Check for distro match (e.g., "Linux" matches "Linux.Debian")
+		if strings.HasPrefix(platform, p+".") {
+			return true
+		}
 	}
 	return false
+}
+
+// IsSynthetic returns true if this lifecycle was synthesized for a native PM package.
+func (l *Lifecycle) IsSynthetic() bool {
+	return l.synthetic
 }

--- a/internal/registry/lifecycle.json
+++ b/internal/registry/lifecycle.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://noblefactor.com/schemas/lifecycle.json",
+  "title": "Lore Package Lifecycle",
+  "description": "Metadata for a lore package. Phase scripts are discovered from the directory structure (see RFC Section 9.3).",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Package name (must match directory name)",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 1,
+      "examples": ["docker", "kubectl", "aws-cli"]
+    },
+    "version": {
+      "type": "string",
+      "description": "Package version or 'latest'",
+      "minLength": 1,
+      "examples": ["latest", "1.2.3", "27.5.1"]
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line description of the package",
+      "minLength": 1
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri",
+      "description": "Official homepage URL"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri",
+      "description": "Source repository URL"
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier",
+      "examples": ["MIT", "Apache-2.0", "GPL-3.0-only"]
+    },
+    "maintainer": {
+      "type": "string",
+      "description": "Package maintainer name or organization"
+    },
+    "aliases": {
+      "type": "array",
+      "description": "Alternative names for AI-assisted search and validation",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "examples": [["docker ce", "docker engine", "container runtime"]]
+    },
+    "platforms": {
+      "type": "array",
+      "description": "Supported platforms (must have matching platform directories)",
+      "items": {
+        "type": "string",
+        "enum": ["Darwin", "Linux", "Windows"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "features": {
+      "type": "object",
+      "description": "Optional features enabled via --with <feature>",
+      "additionalProperties": {
+        "$ref": "#/$defs/feature"
+      }
+    },
+    "settings": {
+      "type": "object",
+      "description": "Configurable settings via --with <setting>=<value>",
+      "additionalProperties": {
+        "$ref": "#/$defs/setting"
+      }
+    },
+    "provides": {
+      "type": "array",
+      "description": "Commands or capabilities this package provides",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "description": "Packages that conflict and must be removed first",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "sources": {
+      "type": "array",
+      "description": "Upstream release artifacts for verification and direct download",
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "verification": {
+      "type": "object",
+      "description": "How to verify successful installation",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Command to run for verification",
+          "examples": ["docker --version", "kubectl version --client"]
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in command output",
+          "examples": ["Docker version \\d+\\.\\d+", "Client Version"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "hardware_provisions": {
+      "type": "object",
+      "description": "Hardware-specific configuration requirements",
+      "additionalProperties": {
+        "$ref": "#/$defs/hardware_provision"
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Tribal knowledge and important notes for maintainers"
+    },
+    "tags": {
+      "type": "array",
+      "description": "Categorization tags for search and filtering",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": ["name", "version", "description", "platforms"],
+  "additionalProperties": false,
+  "$defs": {
+    "feature": {
+      "type": "object",
+      "description": "Feature definition",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What this feature enables"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Whether enabled by default",
+          "default": false
+        },
+        "platforms": {
+          "type": "array",
+          "description": "Platforms where this feature is available (omit for all)",
+          "items": {
+            "type": "string",
+            "enum": ["Darwin", "Linux", "Windows"]
+          }
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    },
+    "setting": {
+      "type": "object",
+      "description": "Setting definition",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What this setting configures"
+        },
+        "type": {
+          "type": "string",
+          "description": "Value type",
+          "enum": ["string", "number", "boolean"],
+          "default": "string"
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value"
+        },
+        "values": {
+          "type": "array",
+          "description": "Allowed values (if enumerated)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "description": "Platforms where this setting applies (omit for all)",
+          "items": {
+            "type": "string",
+            "enum": ["Darwin", "Linux", "Windows"]
+          }
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    },
+    "source": {
+      "type": "object",
+      "description": "Upstream release artifact",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Download URL"
+        },
+        "sha256": {
+          "type": "string",
+          "description": "SHA256 checksum",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["Darwin", "Linux", "Windows"]
+        },
+        "arch": {
+          "type": "string",
+          "enum": ["amd64", "arm64"],
+          "description": "CPU architecture"
+        }
+      },
+      "required": ["url", "sha256", "platform", "arch"],
+      "additionalProperties": false
+    },
+    "hardware_provision": {
+      "type": "object",
+      "description": "Hardware-specific configuration",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Why this hardware needs special handling"
+        },
+        "reference": {
+          "type": "string",
+          "format": "uri",
+          "description": "Documentation reference URL"
+        },
+        "boot_arg": {
+          "type": "string",
+          "description": "Kernel boot argument required"
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/internal/registry/package.go
+++ b/internal/registry/package.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PackageSource indicates where a package was resolved from.
+type PackageSource string
+
+const (
+	SourceLore   PackageSource = "lore"   // Lore registry (full lifecycle)
+	SourceApt    PackageSource = "apt"    // Debian/Ubuntu apt
+	SourceDnf    PackageSource = "dnf"    // Fedora/RHEL dnf
+	SourceBrew   PackageSource = "brew"   // macOS Homebrew
+	SourcePort   PackageSource = "port"   // macOS MacPorts
+	SourceWinget PackageSource = "winget" // Windows winget
+	SourceChoco  PackageSource = "choco"  // Windows Chocolatey
+)
+
+// LorePackage provides a uniform view over any package, whether from
+// the lore registry or a native package manager. Use Lifecycle() to
+// get phase and feature metadata.
+type LorePackage struct {
+	Name        string        // Package name
+	Version     string        // Version (may be "latest" for native PMs)
+	Description string        // One-line description
+	Source      PackageSource // Where this package was resolved from
+	Dir         string        // Package directory (lore packages only)
+
+	// Native package manager name (for non-lore packages)
+	// e.g., "docker.io" for apt, "docker" for brew
+	NativeName string
+
+	// Cached lifecycle (loaded lazily)
+	lifecycle *Lifecycle
+}
+
+// Lifecycle returns the package's lifecycle metadata.
+// For lore packages, this loads from lifecycle.yaml.
+// For native PM packages, this returns a synthetic lifecycle.
+func (p *LorePackage) Lifecycle() *Lifecycle {
+	if p.lifecycle != nil {
+		return p.lifecycle
+	}
+
+	if p.Source == SourceLore && p.Dir != "" {
+		// Load from lifecycle.yaml
+		lc, err := LoadLifecycle(p.Dir)
+		if err == nil {
+			p.lifecycle = lc
+			return p.lifecycle
+		}
+	}
+
+	// Synthetic lifecycle for native PM packages
+	p.lifecycle = &Lifecycle{
+		Name:        p.Name,
+		Version:     p.Version,
+		Description: p.Description,
+		Platforms:   []string{"Darwin", "Linux", "Windows"},
+		synthetic:   true,
+	}
+	return p.lifecycle
+}
+
+// DiscoverPhaseScripts returns all phase scripts for a phase, ordered from
+// most general to most specific for chained execution.
+//
+// For native PM packages, returns empty (the engine handles install directly).
+func (p *LorePackage) DiscoverPhaseScripts(platform string, op Operation, phase string) []string {
+	if p.Source != SourceLore || p.Dir == "" {
+		return nil // Native PM packages don't have scripts
+	}
+	return p.Lifecycle().DiscoverPhaseScripts(p.Dir, platform, op, phase)
+}
+
+// HasPhase returns true if at least one phase script exists for this phase.
+func (p *LorePackage) HasPhase(platform string, op Operation, phase string) bool {
+	return len(p.DiscoverPhaseScripts(platform, op, phase)) > 0
+}
+
+// PhaseActions returns the executable actions for a phase.
+// This provides a uniform interface for both lore and native PM packages.
+//
+// For lore packages: returns ScriptAction items for each discovered script.
+// For native PM packages: returns a NativePMAction for install/uninstall phases.
+func (p *LorePackage) PhaseActions(platform string, op Operation, phase string) []PhaseAction {
+	if p.Source == SourceLore && p.Dir != "" {
+		// Lore package: return script actions
+		scripts := p.DiscoverPhaseScripts(platform, op, phase)
+		actions := make([]PhaseAction, 0, len(scripts))
+		for _, script := range scripts {
+			actions = append(actions, &ScriptAction{
+				Path:      script,
+				PhaseName: phase,
+				Platform:  platformFromPath(script, p.Dir),
+			})
+		}
+		return actions
+	}
+
+	// Native PM package: return native PM action for relevant phases
+	pmOp, ok := phaseToNativePMOp(op, phase)
+	if !ok {
+		return nil // Phase not applicable for native PM
+	}
+
+	pkgName := p.NativeName
+	if pkgName == "" {
+		pkgName = p.Name
+	}
+
+	return []PhaseAction{
+		&NativePMAction{
+			Manager:   p.Source,
+			Operation: pmOp,
+			Packages:  []string{pkgName},
+			PhaseName: phase,
+		},
+	}
+}
+
+// platformFromPath extracts the platform directory name from a script path.
+func platformFromPath(scriptPath, packageDir string) string {
+	rel, err := filepath.Rel(packageDir, scriptPath)
+	if err != nil {
+		return ""
+	}
+	// Path is like "Darwin/Deploy/install.star" - extract first component
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return ""
+}
+
+// phaseToNativePMOp maps operation+phase to native PM operation.
+// Native PM packages only implement the required phase for each operation.
+// Returns false if the phase is not the required phase for the operation.
+func phaseToNativePMOp(op Operation, phase string) (PMOperation, bool) {
+	// Only the required phase maps to a native PM operation
+	if phase != RequiredPhase(op) {
+		return 0, false
+	}
+
+	switch op {
+	case OpDeploy:
+		return PMInstall, true
+	case OpUpgrade:
+		return PMUpgrade, true
+	case OpDecommission:
+		return PMRemove, true
+	default:
+		return PMInstall, true
+	}
+}
+
+// IsNative returns true if this package comes from a native package manager.
+func (p *LorePackage) IsNative() bool {
+	return p.Source != SourceLore
+}
+
+// IsSynthetic returns true if the lifecycle is synthetic (not from lifecycle.yaml).
+func (p *LorePackage) IsSynthetic() bool {
+	return p.Lifecycle().synthetic
+}
+
+// Resolve looks up a package by name in the registry.
+// It checks the lore registry first, then falls back to native package managers.
+func (c *Client) Resolve(name string, platform string) (*LorePackage, error) {
+	// First, check lore registry
+	pkgDir := filepath.Join(c.cacheDir, "packages", name)
+	if dirExists(pkgDir) {
+		lc, err := LoadLifecycle(pkgDir)
+		if err != nil {
+			return nil, err
+		}
+		return &LorePackage{
+			Name:        lc.Name,
+			Version:     lc.Version,
+			Description: lc.Description,
+			Source:      SourceLore,
+			Dir:         pkgDir,
+			lifecycle:   lc,
+		}, nil
+	}
+
+	// Fall back to native package manager based on platform
+	return c.resolveNative(name, platform)
+}
+
+// resolveNative creates a synthetic LorePackage for a native PM package.
+func (c *Client) resolveNative(name string, platform string) (*LorePackage, error) {
+	var source PackageSource
+	switch {
+	case strings.HasPrefix(platform, "Linux.Debian") || platform == "Linux":
+		source = SourceApt
+	case strings.HasPrefix(platform, "Linux.Fedora"):
+		source = SourceDnf
+	case platform == "Darwin":
+		source = SourceBrew
+	case platform == "Windows":
+		source = SourceWinget
+	default:
+		source = SourceApt // Default fallback
+	}
+
+	return &LorePackage{
+		Name:       name,
+		Version:    "latest",
+		Source:     source,
+		NativeName: name, // Same name; could be mapped differently
+	}, nil
+}
+
+// dirExists checks if a directory exists.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/registry/package_test.go
+++ b/internal/registry/package_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRequiredPhase(t *testing.T) {
+	tests := []struct {
+		op   Operation
+		want string
+	}{
+		{OpDeploy, "install"},
+		{OpUpgrade, "upgrade"},
+		{OpDecommission, "uninstall"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.op), func(t *testing.T) {
+			got := RequiredPhase(tt.op)
+			if got != tt.want {
+				t.Errorf("RequiredPhase(%s) = %q, want %q", tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPhaseToNativePMOp(t *testing.T) {
+	tests := []struct {
+		op      Operation
+		phase   string
+		wantPM  PMOperation
+		wantOK  bool
+	}{
+		// Required phases should map
+		{OpDeploy, "install", PMInstall, true},
+		{OpUpgrade, "upgrade", PMUpgrade, true},
+		{OpDecommission, "uninstall", PMRemove, true},
+
+		// Non-required phases should not map
+		{OpDeploy, "prepare", 0, false},
+		{OpDeploy, "provision", 0, false},
+		{OpDeploy, "verify", 0, false},
+		{OpUpgrade, "prepare", 0, false},
+		{OpUpgrade, "migrate", 0, false},
+		{OpDecommission, "unprovision", 0, false},
+		{OpDecommission, "cleanup", 0, false},
+	}
+
+	for _, tt := range tests {
+		name := string(tt.op) + "/" + tt.phase
+		t.Run(name, func(t *testing.T) {
+			gotPM, gotOK := phaseToNativePMOp(tt.op, tt.phase)
+			if gotOK != tt.wantOK {
+				t.Errorf("phaseToNativePMOp(%s, %s) ok = %v, want %v", tt.op, tt.phase, gotOK, tt.wantOK)
+			}
+			if gotOK && gotPM != tt.wantPM {
+				t.Errorf("phaseToNativePMOp(%s, %s) = %v, want %v", tt.op, tt.phase, gotPM, tt.wantPM)
+			}
+		})
+	}
+}
+
+func TestLorePackage_PhaseActions_NativePM(t *testing.T) {
+	// Native PM package should return NativePMAction only for required phases
+	pkg := &LorePackage{
+		Name:       "curl",
+		Version:    "latest",
+		Source:     SourceApt,
+		NativeName: "curl",
+	}
+
+	tests := []struct {
+		op        Operation
+		phase     string
+		wantCount int
+		wantPMOp  PMOperation
+	}{
+		// Required phases return one action
+		{OpDeploy, "install", 1, PMInstall},
+		{OpUpgrade, "upgrade", 1, PMUpgrade},
+		{OpDecommission, "uninstall", 1, PMRemove},
+
+		// Non-required phases return empty
+		{OpDeploy, "prepare", 0, 0},
+		{OpDeploy, "provision", 0, 0},
+		{OpDeploy, "verify", 0, 0},
+		{OpUpgrade, "migrate", 0, 0},
+	}
+
+	for _, tt := range tests {
+		name := string(tt.op) + "/" + tt.phase
+		t.Run(name, func(t *testing.T) {
+			actions := pkg.PhaseActions("Linux.Debian", tt.op, tt.phase)
+
+			if len(actions) != tt.wantCount {
+				t.Errorf("PhaseActions() returned %d actions, want %d", len(actions), tt.wantCount)
+				return
+			}
+
+			if tt.wantCount > 0 {
+				action := actions[0]
+				if action.Type() != ActionNativePM {
+					t.Errorf("action.Type() = %v, want ActionNativePM", action.Type())
+				}
+
+				pmAction, ok := action.(*NativePMAction)
+				if !ok {
+					t.Fatal("action is not *NativePMAction")
+				}
+
+				if pmAction.Manager != SourceApt {
+					t.Errorf("Manager = %v, want SourceApt", pmAction.Manager)
+				}
+				if pmAction.Operation != tt.wantPMOp {
+					t.Errorf("Operation = %v, want %v", pmAction.Operation, tt.wantPMOp)
+				}
+				if len(pmAction.Packages) != 1 || pmAction.Packages[0] != "curl" {
+					t.Errorf("Packages = %v, want [curl]", pmAction.Packages)
+				}
+			}
+		})
+	}
+}
+
+func TestLorePackage_PhaseActions_LorePackage(t *testing.T) {
+	// Create a temporary lore package with scripts
+	tmpDir := t.TempDir()
+	pkgDir := filepath.Join(tmpDir, "testpkg")
+
+	// Create Common/Deploy/install.star
+	commonDeployDir := filepath.Join(pkgDir, "Common", "Deploy")
+	if err := os.MkdirAll(commonDeployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commonDeployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Darwin/Deploy/install.star
+	darwinDeployDir := filepath.Join(pkgDir, "Darwin", "Deploy")
+	if err := os.MkdirAll(darwinDeployDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(darwinDeployDir, "install.star"), []byte("def install(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lifecycle.yaml
+	lifecycleYAML := `name: testpkg
+version: "1.0"
+description: "Test package"
+platforms:
+  - Darwin
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := &LorePackage{
+		Name:    "testpkg",
+		Version: "1.0",
+		Source:  SourceLore,
+		Dir:     pkgDir,
+	}
+
+	// Test install phase returns ScriptActions
+	actions := pkg.PhaseActions("Darwin", OpDeploy, "install")
+
+	// Should have 2 scripts: Common and Darwin (Unix doesn't exist)
+	if len(actions) != 2 {
+		t.Errorf("PhaseActions() returned %d actions, want 2", len(actions))
+	}
+
+	for i, action := range actions {
+		if action.Type() != ActionScript {
+			t.Errorf("action[%d].Type() = %v, want ActionScript", i, action.Type())
+		}
+		scriptAction, ok := action.(*ScriptAction)
+		if !ok {
+			t.Errorf("action[%d] is not *ScriptAction", i)
+			continue
+		}
+		if scriptAction.PhaseName != "install" {
+			t.Errorf("action[%d].PhaseName = %q, want \"install\"", i, scriptAction.PhaseName)
+		}
+	}
+
+	// Test non-existent phase returns empty
+	actions = pkg.PhaseActions("Darwin", OpDeploy, "provision")
+	if len(actions) != 0 {
+		t.Errorf("PhaseActions(provision) returned %d actions, want 0", len(actions))
+	}
+}
+
+func TestLorePackage_IsNative(t *testing.T) {
+	tests := []struct {
+		source PackageSource
+		want   bool
+	}{
+		{SourceLore, false},
+		{SourceApt, true},
+		{SourceDnf, true},
+		{SourceBrew, true},
+		{SourceWinget, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.source), func(t *testing.T) {
+			pkg := &LorePackage{Source: tt.source}
+			if got := pkg.IsNative(); got != tt.want {
+				t.Errorf("IsNative() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/registry/schema.go
+++ b/internal/registry/schema.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025 Noble Factor. All rights reserved.
+
+package registry
+
+import _ "embed"
+
+// LifecycleSchema is the JSON schema for lifecycle.yaml files.
+// These files define lore package metadata. Phase scripts are discovered
+// from the directory structure (see RFC Section 9.3).
+//
+//go:embed lifecycle.json
+var LifecycleSchema []byte

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -23,6 +23,13 @@ var DevloreDefaultConfig []byte
 //go:embed packages-manifest.json
 var PackagesManifestSchema []byte
 
+// LifecycleSchema is provided by internal/registry for backward compatibility.
+// Prefer using registry.LifecycleSchema directly.
+// TODO: Remove this re-export once callers are updated.
+//
+//go:embed lifecycle.json
+var LifecycleSchema []byte
+
 // Legacy aliases for backward compatibility.
 // These point to the shared devlore schema and config.
 var (


### PR DESCRIPTION
## Summary
- Add PhaseAction interface for uniform pipeline phases (ScriptAction, NativePMAction)
- Add LorePackage abstraction providing uniform view over lore and native PM packages
- Add RequiredPhase concept: Deploy→install, Upgrade→upgrade, Decommission→uninstall
- Move lifecycle.go from lore/pipeline to registry package
- Add tests for PhaseAction and LorePackage
- Add design doc: docs/plans/uniform-pipeline-interface.md

## Test plan
- [x] Unit tests pass for action.go and package.go
- [ ] Manual verification of phase discovery