### PR TITLE
Fix sync-install-script to create PRs instead of pushing directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   # Sync install script to website (keep website as distribution point for script only)
+  # Creates a PR instead of pushing directly to respect branch protection rules
   sync-install-script:
     needs: build-and-release
     runs-on: ubuntu-latest
@@ -147,14 +148,33 @@ jobs:
 
           git checkout "$TARGET_BRANCH" || git checkout -b "$TARGET_BRANCH"
 
+          # Check if there are changes
           git add public/install.sh
           if git diff --cached --quiet; then
             echo "No changes to install script"
             exit 0
           fi
 
+          # Create a PR branch instead of pushing directly (respects branch protection)
+          PR_BRANCH="sync-install-script-${{ github.sha }}"
+          git checkout -b "$PR_BRANCH"
+
           git commit -m "Update install script
 
           Source: ${{ github.repository }}@${{ github.sha }}
           Ref: ${{ github.ref }}"
-          git push origin "$TARGET_BRANCH"
+          git push origin "$PR_BRANCH"
+
+          # Create PR using gh CLI
+          # Per https://cli.github.com/manual/gh_pr_create
+          gh pr create \
+            --repo NobleFactor/devlore.noblefactor.com \
+            --base "$TARGET_BRANCH" \
+            --head "$PR_BRANCH" \
+            --title "Update install script from devlore-cli" \
+            --body "Automated sync of install.sh from devlore-cli.
+
+          Source: ${{ github.repository }}@${{ github.sha }}
+          Ref: ${{ github.ref }}"
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DEPLOY_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -199,8 +199,15 @@ main() {
     info "Fetching release info..."
     local release_json
     release_json=$(get_release_by_tag "$VERSION")
-    if [[ -z "$release_json" ]] || echo "$release_json" | grep -q '"message"[[:space:]]*:[[:space:]]*"Not Found"'; then
-        error "Release $VERSION not found. Check the version exists and GITHUB_TOKEN has correct permissions."
+    # Check for any API error - GitHub API returns "message" field on errors
+    # Per https://docs.github.com/en/rest/releases/releases
+    if [[ -z "$release_json" ]]; then
+        error "Empty response from GitHub API. Check GITHUB_TOKEN is set and valid."
+    fi
+    if echo "$release_json" | grep -q '"message"'; then
+        local api_error
+        api_error=$(echo "$release_json" | grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+        error "GitHub API error: $api_error\nCheck GITHUB_TOKEN has Contents read permission."
     fi
 
     # Determine archive extension


### PR DESCRIPTION
## Summary
- Fix sync-install-script workflow to create PRs instead of pushing directly (respects branch protection)
- Improve install.sh error handling to show actual API error messages

## Test plan
- [ ] Verify workflow creates PR on next release
- [ ] Verify install.sh shows proper error messages on auth failures