### PR TITLE
Fix SPDX license headers: Apache-2.0 → MIT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Noble Factor. All rights reserved.
 #
 # Release workflow: builds binaries and creates GitHub releases

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Noble Factor. All rights reserved.
 #
 # GoReleaser configuration for devlore-cli

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Noble Factor. All rights reserved.
 
 module github.com/NobleFactor/devlore-cli

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Noble Factor. All rights reserved.
 #
 # DevLore CLI Installer

--- a/packaging/macports/generate-portfile.sh
+++ b/packaging/macports/generate-portfile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Noble Factor. All rights reserved.
 
 # generate-portfile.sh - Generate MacPorts Portfile from template


### PR DESCRIPTION
## Summary
Fix incorrect Apache-2.0 license headers to MIT for build/distribution files.

- Build/distribution files use MIT
- Source code uses SSPL-1.0