### PR TITLE
fix(model): fail immediately in non-interactive mode when no provider configured

### DIFF
--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -255,7 +255,7 @@ func SaveConfig(cfg *Config) error {
 }
 
 // EnsureProvider returns a configured AI provider, prompting the user if needed.
-// If noAI is true, returns nil without prompting.
+// If interactive is false, fails immediately if no provider is configured.
 //
 // Lookup priority:
 //   - CLI flags (passed via cliFlags parameter)
@@ -263,11 +263,8 @@ func SaveConfig(cfg *Config) error {
 //   - Config file: ~/.config/devlore/config.yaml
 //   - API key from native keystore
 //   - Fallback to Ollama if available locally
-//   - Interactive prompt
-func EnsureProvider(ctx context.Context, noAI bool, cliFlags CLIFlags) (Provider, error) {
-	if noAI {
-		return nil, nil
-	}
+//   - Interactive prompt (only if interactive=true)
+func EnsureProvider(ctx context.Context, interactive bool, cliFlags CLIFlags) (Provider, error) {
 
 	// 1. Try loading config (env > config file, API key from env > config > keystore)
 	cfg, err := LoadConfig()
@@ -313,7 +310,10 @@ func EnsureProvider(ctx context.Context, noAI bool, cliFlags CLIFlags) (Provider
 		return ollamaProvider, nil
 	}
 
-	// 4. No provider available - prompt user or fail
+	// 4. No provider available - fail in non-interactive mode, prompt otherwise
+	if !interactive {
+		return nil, fmt.Errorf("no AI provider configured; set DEVLORE_MODEL_PROVIDER and DEVLORE_MODEL_API_KEY, or use --model-provider and --model-api-key flags")
+	}
 	return promptForProvider(ctx)
 }
 

--- a/internal/writ/migrate_cmd.go
+++ b/internal/writ/migrate_cmd.go
@@ -115,7 +115,8 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		Provider: mustGetString(cmd.Root(), "model-provider"),
 	}
 
-	provider, err := model.EnsureProvider(ctx, false, modelFlags)
+	interactive := isInteractive(nonInteractive)
+	provider, err := model.EnsureProvider(ctx, interactive, modelFlags)
 	if err != nil {
 		return fmt.Errorf("model provider required: %w", err)
 	}
@@ -132,7 +133,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		RegClient:  regClient,
 	}
 
-	if isInteractive(nonInteractive) {
+	if interactive {
 		return runMigrateInteractive(opts, layer, useMove, verbose)
 	}
 


### PR DESCRIPTION
## Summary
- Add `interactive` parameter to `EnsureProvider` to distinguish between interactive and non-interactive contexts
- When `interactive=false` and no AI provider is configured (and Ollama isn't available), return an error immediately with a helpful message
- Remove unused `noAI` parameter - there is no `--no-ai` or `--no-model` option

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/model/... ./internal/writ/...` passes
- [x] `writ migrate --dry-run --non-interactive ~/path` without model config fails immediately with clear error
- [x] `writ migrate --dry-run --non-interactive --model-provider=github --model-api-key=... ~/path` works correctly