### PR TITLE
ci: add workflow to sync knowledge base to devlore-registry

### DIFF
--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: SSPL-1.0
+# Sync knowledge base to devlore-registry when source code changes.
+# This keeps the LLM context accurate for package generation and migrations.
+name: Sync Knowledge Base
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - 'release/*'
+    paths:
+      # Starlark binding code
+      - 'internal/starlark/**'
+      # Writ migrate code
+      - 'internal/writ/migrate/**'
+
+jobs:
+  sync-knowledge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout devlore-cli
+        uses: actions/checkout@v4
+        with:
+          path: devlore-cli
+
+      - name: Checkout noblefactor-ops
+        uses: actions/checkout@v4
+        with:
+          repository: NobleFactor/noblefactor-ops
+          token: ${{ secrets.NOBLEFACTOR_REPOSITORY_ACCESS }}
+          path: noblefactor-ops
+
+      - name: Checkout devlore-registry
+        uses: actions/checkout@v4
+        with:
+          repository: NobleFactor/devlore-registry
+          token: ${{ secrets.NOBLEFACTOR_REPOSITORY_ACCESS }}
+          ref: ${{ github.ref_name }}
+          path: devlore-registry
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache-dependency-path: noblefactor-ops/go.sum
+
+      - name: Build star tool
+        working-directory: noblefactor-ops
+        run: go build -o star ./cmd/star
+
+      - name: Sync Starlark bindings
+        working-directory: noblefactor-ops
+        run: |
+          ./star devlore refresh-bindings \
+            --cli_path ${{ github.workspace }}/devlore-cli \
+            --registry_path ${{ github.workspace }}/devlore-registry
+
+      # TODO: Implement refresh-writ-knowledge command
+      # - name: Sync writ migrate knowledge
+      #   working-directory: noblefactor-ops
+      #   run: |
+      #     ./star devlore refresh-writ-knowledge \
+      #       --cli_path ${{ github.workspace }}/devlore-cli \
+      #       --registry_path ${{ github.workspace }}/devlore-registry
+
+      - name: Commit and push to devlore-registry
+        working-directory: devlore-registry
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if there are changes
+          if git diff --quiet; then
+            echo "No knowledge changes to commit"
+            exit 0
+          fi
+
+          git add knowledge/
+          git commit -m "chore: sync knowledge from devlore-cli@${{ github.sha }}"
+          git push origin ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- Add GitHub workflow to sync LLM knowledge base when devlore-cli source changes
- Triggers on push to develop/main/release/* when starlark or writ/migrate code changes
- Auto-commits to devlore-registry on matching branch

## Synced knowledge

- [x] Starlark bindings (`internal/starlark/**`)
- [ ] Writ migrate patterns (`internal/writ/migrate/**` - placeholder for future)

## Test plan

- [ ] Verify `NOBLEFACTOR_REPOSITORY_ACCESS` secret exists at org level
- [ ] Merge and confirm workflow runs on next starlark change