### PR TITLE
ci: update workflow to use build-knowledge command

### DIFF
--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -49,20 +49,13 @@ jobs:
         working-directory: noblefactor-ops
         run: go build -o star ./cmd/star
 
-      - name: Sync Starlark bindings
+      - name: Build knowledge base
         working-directory: noblefactor-ops
         run: |
-          ./star devlore refresh-bindings \
-            --cli_path ${{ github.workspace }}/devlore-cli \
+          ./star devlore build-knowledge \
+            --target all \
+            --source_path ${{ github.workspace }}/devlore-cli \
             --registry_path ${{ github.workspace }}/devlore-registry
-
-      # TODO: Implement refresh-writ-knowledge command
-      # - name: Sync writ migrate knowledge
-      #   working-directory: noblefactor-ops
-      #   run: |
-      #     ./star devlore refresh-writ-knowledge \
-      #       --cli_path ${{ github.workspace }}/devlore-cli \
-      #       --registry_path ${{ github.workspace }}/devlore-registry
 
       - name: Commit and push to devlore-registry
         working-directory: devlore-registry


### PR DESCRIPTION
## Summary

Update sync-knowledge workflow to use the renamed command:
- `star devlore refresh-bindings` → `star devlore build-knowledge --target all`

Depends on: NobleFactor/noblefactor-ops#11