### PR TITLE
fix: update sync-knowledge workflow for new star commands

### DIFF
--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -52,8 +52,8 @@ jobs:
       - name: Build knowledge base
         working-directory: noblefactor-ops
         run: |
-          ./star devlore build-knowledge \
-            --target all \
+          ./star devlore-registry build knowledge \
+            --domain all \
             --source_path ${{ github.workspace }}/devlore-cli \
             --registry_path ${{ github.workspace }}/devlore-registry
 


### PR DESCRIPTION
## Summary
- Use devlore-registry build knowledge instead of devlore build-knowledge
- Update flag from --target to --domain

## Test plan
- [ ] Merge noblefactor-ops PR first
- [ ] Verify workflow triggers on internal/starlark/** changes