### PR TITLE
feat(execution): add plan.gather() for parallel execution, simplify Edge

### DIFF
--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -14,6 +14,16 @@ on:
       - 'internal/starlark/**'
       # Writ migrate code
       - 'internal/writ/migrate/**'
+  pull_request:
+    branches:
+      - develop
+      - main
+      - 'release/*'
+    paths:
+      # Starlark binding code
+      - 'internal/starlark/**'
+      # Writ migrate code
+      - 'internal/writ/migrate/**'
 
 jobs:
   sync-knowledge:
@@ -57,7 +67,22 @@ jobs:
             --source_path ${{ github.workspace }}/devlore-cli \
             --registry_path ${{ github.workspace }}/devlore-registry
 
-      - name: Commit and push to devlore-registry
+      - name: Validate knowledge (PR only)
+        if: github.event_name == 'pull_request'
+        working-directory: devlore-registry
+        run: |
+          # On PRs, just validate - don't push
+          if git diff --quiet; then
+            echo "No knowledge changes detected"
+          else
+            echo "Knowledge changes detected:"
+            git diff --stat
+            echo ""
+            echo "These changes will be pushed when the PR is merged."
+          fi
+
+      - name: Commit and push to devlore-registry (push only)
+        if: github.event_name == 'push'
         working-directory: devlore-registry
         run: |
           git config user.name "github-actions[bot]"

--- a/docs/package-hierarchy.md
+++ b/docs/package-hierarchy.md
@@ -165,12 +165,12 @@ Core execution graph primitives and executor shared by writ and lore.
 - `BackupOp` - Move file to timestamped backup
 - `CopyOp` - Write content to target
 - `DecryptOp` - Decrypt content using SOPS
-- `ExpandOp` - Process content as Go template
-- `FileWriteOp` - Write inline content to target
+- `RenderOp` - Process content as Go template
+- `WriteOp` - Write inline content to target
 - `LinkOp` - Create symlink
 - `MkdirOp` - Create directory
 - `RemoveOp` - Delete file
-- `RenameOp` - Move file (git mv when possible)
+- `MoveOp` - Move file (git mv when possible)
 - `UnlinkOp` - Remove symlink
 - `ValidateOp` - Check precondition
 - `ShellOp` - Execute shell command

--- a/internal/cli/receipts_test.go
+++ b/internal/cli/receipts_test.go
@@ -15,6 +15,14 @@ import (
 
 // createTestGraph creates a minimal test graph for receipt testing.
 func createTestGraph() *execution.Graph {
+	node := &execution.Node{
+		ID:         ".bashrc",
+		Operations: []string{"link"},
+		Status:     execution.StatusCompleted,
+	}
+	node.SetSlotImmediate("source", "/home/user/env/.bashrc")
+	node.SetSlotImmediate("path", "/home/user/.bashrc")
+
 	return &execution.Graph{
 		Version:   "5",
 		Tool:      "test",
@@ -24,15 +32,7 @@ func createTestGraph() *execution.Graph {
 			OS:   "darwin",
 			Arch: "arm64",
 		},
-		Nodes: []*execution.Node{
-			{
-				ID:         ".bashrc",
-				Operations: []string{"link"},
-				Status:     execution.StatusCompleted,
-				Source:     "/home/user/env/.bashrc",
-				Target:     "/home/user/.bashrc",
-			},
-		},
+		Nodes: []*execution.Node{node},
 	}
 }
 

--- a/internal/e2e/migrate_test.go
+++ b/internal/e2e/migrate_test.go
@@ -226,9 +226,9 @@ func evaluateMigrateCorrectness(analysis *migrate.MigrationAnalysis, graph *exec
 	actualRenames := make(map[string]string)
 	if graph != nil {
 		for _, node := range graph.Nodes {
-			// Extract relative paths from source/target
-			source := filepath.Base(node.Source)
-			target := filepath.Base(node.Target)
+			// Extract relative paths from source/target slots
+			source := filepath.Base(node.GetSlot("source"))
+			target := filepath.Base(node.GetSlot("target"))
 			actualRenames[source] = target
 		}
 	}

--- a/internal/execution/builder.go
+++ b/internal/execution/builder.go
@@ -65,12 +65,11 @@ func ExpandDelegates(ctx context.Context, graph *Graph, builder SubgraphBuilder,
 		// Append subgraph edges
 		expandedEdges = append(expandedEdges, sub.Edges...)
 
-		// Add delegation edges: delegate node → each subgraph node
+		// Add edges: delegate node → each subgraph node
 		for _, subNode := range sub.Nodes {
 			expandedEdges = append(expandedEdges, Edge{
-				From:     node.ID,
-				To:       subNode.ID,
-				Relation: "delegates",
+				From: node.ID,
+				To:   subNode.ID,
 			})
 		}
 	}

--- a/internal/execution/builder.go
+++ b/internal/execution/builder.go
@@ -54,7 +54,7 @@ func ExpandDelegates(ctx context.Context, graph *Graph, builder SubgraphBuilder,
 		}
 
 		// Build subgraph from the manifest file
-		sub, err := builder.BuildSubgraph(ctx, node.Source, opts)
+		sub, err := builder.BuildSubgraph(ctx, node.GetSlot("source"), opts)
 		if err != nil {
 			return err
 		}

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -20,6 +20,18 @@ func runGraph(ctx context.Context, e *GraphExecutor, g *Graph) ([]*Result, error
 	return e.RunNodes(ctx, executables, g.Edges)
 }
 
+// testNode creates a node with source and path slots for testing.
+func testNode(id string, ops []string, source, path string) *Node {
+	node := &Node{ID: id, Operations: ops}
+	if source != "" {
+		node.SetSlotImmediate("source", source)
+	}
+	if path != "" {
+		node.SetSlotImmediate("path", path)
+	}
+	return node
+}
+
 func TestRegistryRegisterAndGet(t *testing.T) {
 	reg := NewOperationRegistry()
 	reg.Register(&LinkOp{})
@@ -46,8 +58,8 @@ func TestRegistryNames(t *testing.T) {
 	}
 
 	names := reg.Names()
-	if len(names) != 11 {
-		t.Errorf("expected 11 operations, got %d", len(names))
+	if len(names) != 10 {
+		t.Errorf("expected 10 operations, got %d", len(names))
 	}
 }
 
@@ -62,7 +74,9 @@ func TestLinkOperation(t *testing.T) {
 
 	op := &LinkOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Source: source, Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("link: %v", err)
@@ -91,7 +105,9 @@ func TestLinkOperationIdempotent(t *testing.T) {
 
 	op := &LinkOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Source: source, Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("idempotent link: %v", err)
@@ -104,7 +120,8 @@ func TestCopyOperation(t *testing.T) {
 
 	op := &CopyOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 	inputContent := []byte("file content")
 
 	checksum, err := op.Write(ctx, node, inputContent)
@@ -134,7 +151,8 @@ func TestCopyOperationCreatesParentDirs(t *testing.T) {
 
 	op := &CopyOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 	inputContent := []byte("nested content")
 
 	if _, err := op.Write(ctx, node, inputContent); err != nil {
@@ -150,13 +168,14 @@ func TestCopyOperationCreatesParentDirs(t *testing.T) {
 	}
 }
 
-func TestExpandOperation(t *testing.T) {
-	op := &ExpandOp{}
+func TestRenderOperation(t *testing.T) {
+	op := &RenderOp{}
 	ctx := &Context{
 		Context: context.Background(),
 		Data:    map[string]any{"Username": "testuser", "Shell": "/bin/zsh"},
 	}
-	node := &Node{ID: ".bashrc", Source: "/environment/all/.bashrc", Project: "all"}
+	node := &Node{ID: ".bashrc", Project: "all"}
+	node.SetSlotImmediate("source", "/environment/all/.bashrc")
 	inputContent := []byte("# Shell: {{.Shell}}\n# User: {{.Username}}\n# Project: {{.Project}}")
 
 	result, err := op.Transform(ctx, node, inputContent)
@@ -225,7 +244,8 @@ func TestUnlinkOperation(t *testing.T) {
 
 	op := &UnlinkOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("unlink: %v", err)
@@ -245,7 +265,8 @@ func TestRemoveOperation(t *testing.T) {
 
 	op := &RemoveOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
@@ -256,21 +277,19 @@ func TestRemoveOperation(t *testing.T) {
 	}
 }
 
-func TestFileWriteOperation(t *testing.T) {
+func TestWriteOperation(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "output.txt")
 	content := "hello world"
 
-	op := &FileWriteOp{}
+	op := &WriteOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{
-		ID:       "test",
-		Target:   target,
-		Metadata: map[string]string{"content": content},
-	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
+	node.SetSlotImmediate("content", content)
 
 	if err := op.Execute(ctx, node); err != nil {
-		t.Fatalf("file-write: %v", err)
+		t.Fatalf("write: %v", err)
 	}
 
 	data, err := os.ReadFile(target)
@@ -282,21 +301,19 @@ func TestFileWriteOperation(t *testing.T) {
 	}
 }
 
-func TestFileWriteCreatesParentDirs(t *testing.T) {
+func TestWriteCreatesParentDirs(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "a", "b", "c", "output.txt")
 	content := "nested content"
 
-	op := &FileWriteOp{}
+	op := &WriteOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{
-		ID:       "test",
-		Target:   target,
-		Metadata: map[string]string{"content": content},
-	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
+	node.SetSlotImmediate("content", content)
 
 	if err := op.Execute(ctx, node); err != nil {
-		t.Fatalf("file-write: %v", err)
+		t.Fatalf("write: %v", err)
 	}
 
 	data, err := os.ReadFile(target)
@@ -308,14 +325,11 @@ func TestFileWriteCreatesParentDirs(t *testing.T) {
 	}
 }
 
-func TestFileWriteRequiresContent(t *testing.T) {
-	op := &FileWriteOp{}
+func TestWriteRequiresContent(t *testing.T) {
+	op := &WriteOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{
-		ID:       "test",
-		Target:   "/tmp/test.txt",
-		Metadata: map[string]string{},
-	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", "/tmp/test.txt")
 
 	err := op.Execute(ctx, node)
 	if err == nil {
@@ -326,20 +340,18 @@ func TestFileWriteRequiresContent(t *testing.T) {
 	}
 }
 
-func TestFileWriteDryRun(t *testing.T) {
+func TestWriteDryRun(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "should-not-exist.txt")
 
-	op := &FileWriteOp{}
+	op := &WriteOp{}
 	ctx := &Context{Context: context.Background(), DryRun: true}
-	node := &Node{
-		ID:       "test",
-		Target:   target,
-		Metadata: map[string]string{"content": "test"},
-	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
+	node.SetSlotImmediate("content", "test")
 
 	if err := op.Execute(ctx, node); err != nil {
-		t.Fatalf("file-write dry-run: %v", err)
+		t.Fatalf("write dry-run: %v", err)
 	}
 
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -361,7 +373,7 @@ func TestEngineRunLinkPipeline(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: ".bashrc", Operations: []string{"link"}, Source: source, Target: target},
+			testNode(".bashrc", []string{"link"}, source, target),
 		},
 	}
 
@@ -383,7 +395,7 @@ func TestEngineRunLinkPipeline(t *testing.T) {
 	}
 }
 
-func TestEngineRunExpandCopyPipeline(t *testing.T) {
+func TestEngineRunRenderCopyPipeline(t *testing.T) {
 	tmpDir := t.TempDir()
 	source := filepath.Join(tmpDir, "template.txt")
 	target := filepath.Join(tmpDir, "output.txt")
@@ -393,7 +405,7 @@ func TestEngineRunExpandCopyPipeline(t *testing.T) {
 	}
 
 	reg := NewOperationRegistry()
-	reg.Register(&ExpandOp{})
+	reg.Register(&RenderOp{})
 	reg.Register(&CopyOp{})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{
@@ -401,7 +413,7 @@ func TestEngineRunExpandCopyPipeline(t *testing.T) {
 	})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: ".greeting", Operations: []string{"expand", "copy"}, Source: source, Target: target},
+			testNode(".greeting", []string{"render", "copy"}, source, target),
 		},
 	}
 
@@ -427,7 +439,7 @@ func TestEngineRunExpandCopyPipeline(t *testing.T) {
 	}
 }
 
-func TestEngineRunDecryptExpandCopyPipeline(t *testing.T) {
+func TestEngineRunDecryptRenderCopyPipeline(t *testing.T) {
 	tmpDir := t.TempDir()
 	source := filepath.Join(tmpDir, "secret.txt.sops")
 	target := filepath.Join(tmpDir, "secret.txt")
@@ -443,7 +455,7 @@ func TestEngineRunDecryptExpandCopyPipeline(t *testing.T) {
 
 	reg := NewOperationRegistry()
 	reg.Register(&DecryptOp{})
-	reg.Register(&ExpandOp{})
+	reg.Register(&RenderOp{})
 	reg.Register(&CopyOp{})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{
@@ -454,7 +466,7 @@ func TestEngineRunDecryptExpandCopyPipeline(t *testing.T) {
 	})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: ".secret", Operations: []string{"decrypt", "expand", "copy"}, Source: source, Target: target},
+			testNode(".secret", []string{"decrypt", "render", "copy"}, source, target),
 		},
 	}
 
@@ -494,8 +506,8 @@ func TestEngineRunMultipleNodes(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "tgt1.txt", Operations: []string{"link"}, Source: source1, Target: target1},
-			{ID: "sub/tgt2.txt", Operations: []string{"link"}, Source: source2, Target: target2},
+			testNode("tgt1.txt", []string{"link"}, source1, target1),
+			testNode("sub/tgt2.txt", []string{"link"}, source2, target2),
 		},
 	}
 
@@ -554,9 +566,9 @@ func TestEngineTopologicalSort(t *testing.T) {
 	// B depends on A, C depends on B
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "c", Operations: []string{"link"}, Source: srcC, Target: filepath.Join(tmpDir, "out_c")},
-			{ID: "a", Operations: []string{"link"}, Source: srcA, Target: filepath.Join(tmpDir, "out_a")},
-			{ID: "b", Operations: []string{"link"}, Source: srcB, Target: filepath.Join(tmpDir, "out_b")},
+			testNode("c", []string{"link"}, srcC, filepath.Join(tmpDir, "out_c")),
+			testNode("a", []string{"link"}, srcA, filepath.Join(tmpDir, "out_a")),
+			testNode("b", []string{"link"}, srcB, filepath.Join(tmpDir, "out_b")),
 		},
 		Edges: []Edge{
 			{From: "a", To: "b", Relation: "orders"},
@@ -595,7 +607,7 @@ func TestEngineDryRun(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{DryRun: true})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: ".bashrc", Operations: []string{"link"}, Source: source, Target: target},
+			testNode(".bashrc", []string{"link"}, source, target),
 		},
 	}
 
@@ -624,7 +636,7 @@ func TestPreflightNoConflict(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+			testNode("test", []string{"link"}, source, target),
 		},
 	}
 
@@ -650,7 +662,7 @@ func TestPreflightConflictRegularFile(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+			testNode("test", []string{"link"}, source, target),
 		},
 	}
 
@@ -676,7 +688,7 @@ func TestPreflightAlreadyDeployed(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "test", Operations: []string{"link"}, Source: source, Target: target},
+			testNode("test", []string{"link"}, source, target),
 		},
 	}
 
@@ -709,8 +721,8 @@ func TestPreflightPackagesManifest(t *testing.T) {
 
 func TestFileOpsCount(t *testing.T) {
 	ops := FileOps()
-	if len(ops) != 11 {
-		t.Errorf("expected 11 file ops, got %d", len(ops))
+	if len(ops) != 10 {
+		t.Errorf("expected 10 file ops, got %d", len(ops))
 	}
 
 	names := make(map[string]bool)
@@ -720,7 +732,8 @@ func TestFileOpsCount(t *testing.T) {
 
 	// NOTE: No "delegate" operation - writ and lore share the same execution.
 	// Package operations (install, configure, verify) are NOT YET IMPLEMENTED.
-	expected := []string{"link", "copy", "expand", "decrypt", "backup", "unlink", "remove", "mkdir", "file-write", "validate", "rename"}
+	// mkdir removed - all file operations implicitly create directories.
+	expected := []string{"link", "copy", "render", "decrypt", "backup", "unlink", "remove", "write", "validate", "move"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected operation %q in FileOps()", name)
@@ -737,7 +750,8 @@ func TestBackupOperation(t *testing.T) {
 
 	op := &BackupOp{}
 	ctx := &Context{Context: context.Background(), Data: map[string]any{}}
-	node := &Node{ID: "test", Target: target, Metadata: make(map[string]string)}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("backup: %v", err)
@@ -748,10 +762,10 @@ func TestBackupOperation(t *testing.T) {
 		t.Error("expected original file to be moved")
 	}
 
-	// Backup path should be recorded in node metadata
-	backupPath := node.Metadata["backup_path"]
+	// Backup path should be recorded in node annotations
+	backupPath := node.Annotations["backup_path"]
 	if backupPath == "" {
-		t.Fatal("expected backup_path in node metadata")
+		t.Fatal("expected backup_path in node annotations")
 	}
 
 	// Backup should exist with original content
@@ -770,7 +784,8 @@ func TestCopyOperationWithMode(t *testing.T) {
 
 	op := &CopyOp{}
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target, Mode: 0755}
+	node := &Node{ID: "test", Mode: 0755}
+	node.SetSlotImmediate("path", target)
 	inputContent := []byte("#!/bin/sh\necho hello")
 
 	if _, err := op.Write(ctx, node, inputContent); err != nil {
@@ -825,7 +840,8 @@ func TestRemoveOperationPrunesEmptyDirs(t *testing.T) {
 			"prune_boundary":   tmpDir,
 		},
 	}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
@@ -871,7 +887,8 @@ func TestRemoveOperationPruneStopsAtNonEmpty(t *testing.T) {
 			"prune_boundary":   tmpDir,
 		},
 	}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
@@ -918,7 +935,8 @@ func TestUnlinkOperationPrunesEmptyDirs(t *testing.T) {
 			"prune_boundary":   tmpDir,
 		},
 	}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("unlink: %v", err)
@@ -947,7 +965,8 @@ func TestRemoveNoPruneWithoutFlag(t *testing.T) {
 	op := &RemoveOp{}
 	// No prune flags set
 	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Target: target}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("path", target)
 
 	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -571,8 +571,8 @@ func TestEngineTopologicalSort(t *testing.T) {
 			testNode("b", []string{"link"}, srcB, filepath.Join(tmpDir, "out_b")),
 		},
 		Edges: []Edge{
-			{From: "a", To: "b", Relation: "orders"},
-			{From: "b", To: "c", Relation: "orders"},
+			{From: "a", To: "b"},
+			{From: "b", To: "c"},
 		},
 	}
 

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -190,14 +190,15 @@ func (e *GraphExecutor) executeExecutable(ctx *Context, node Executable) *Result
 	var sourceChecksum, targetChecksum string
 
 	// Pre-read source content if pipeline needs it
-	if node.GetSource() != "" && e.needsContent(node) {
+	source := node.GetSlot("source")
+	if source != "" && e.needsContent(node) {
 		var err error
-		content, err = os.ReadFile(node.GetSource())
+		content, err = os.ReadFile(source)
 		if err != nil {
 			return &Result{
 				NodeID: node.GetID(),
 				Status: ResultFailed,
-				Error:  fmt.Errorf("read source %s: %w", node.GetSource(), err),
+				Error:  fmt.Errorf("read source %s: %w", source, err),
 			}
 		}
 		sourceChecksum = ChecksumBytes(content)
@@ -397,8 +398,8 @@ func (e *GraphExecutor) sortNodesByDepth(nodes []*Node) []*Node {
 
 	for i := 0; i < len(sorted)-1; i++ {
 		for j := i + 1; j < len(sorted); j++ {
-			depthI := pathDepth(sorted[i].Target)
-			depthJ := pathDepth(sorted[j].Target)
+			depthI := pathDepth(sorted[i].GetSlot("path"))
+			depthJ := pathDepth(sorted[j].GetSlot("path"))
 			if depthI > depthJ {
 				sorted[i], sorted[j] = sorted[j], sorted[i]
 			}
@@ -415,8 +416,8 @@ func (e *GraphExecutor) sortByDepth(nodes []Executable) []Executable {
 
 	for i := 0; i < len(sorted)-1; i++ {
 		for j := i + 1; j < len(sorted); j++ {
-			depthI := pathDepth(sorted[i].GetTarget())
-			depthJ := pathDepth(sorted[j].GetTarget())
+			depthI := pathDepth(sorted[i].GetSlot("path"))
+			depthJ := pathDepth(sorted[j].GetSlot("path"))
 			if depthI > depthJ {
 				sorted[i], sorted[j] = sorted[j], sorted[i]
 			}

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -148,11 +148,10 @@ type Node struct {
 	// Timestamp is when this operation completed.
 	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 
-	// Source is the absolute path to the source file.
-	Source string `json:"source,omitempty" yaml:"source,omitempty"`
-
-	// Target is the absolute path to the target file.
-	Target string `json:"target,omitempty" yaml:"target,omitempty"`
+	// Slots holds input values for this node. Each slot can be:
+	// - Immediate: value known at analysis time
+	// - Promise: reference to another node's output (creates edge)
+	Slots map[string]SlotValue `json:"slots,omitempty" yaml:"slots,omitempty"`
 
 	// Project this node belongs to.
 	Project string `json:"project,omitempty" yaml:"project,omitempty"`
@@ -174,9 +173,35 @@ type Node struct {
 
 	// Annotations holds extensible metadata (serialized to receipts).
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
 
-	// Metadata holds operation-specific data (not serialized).
-	Metadata map[string]string `json:"-" yaml:"-"`
+// GetSlot returns the resolved value of a slot.
+// If the slot is a promise, returns empty string (must be resolved by executor).
+func (n *Node) GetSlot(name string) string {
+	if n.Slots != nil {
+		if sv, ok := n.Slots[name]; ok {
+			if sv.IsImmediate() {
+				return sv.Immediate
+			}
+		}
+	}
+	return ""
+}
+
+// SetSlotImmediate sets a slot to an immediate value.
+func (n *Node) SetSlotImmediate(name, value string) {
+	if n.Slots == nil {
+		n.Slots = make(map[string]SlotValue)
+	}
+	n.Slots[name] = SlotValue{Immediate: value}
+}
+
+// SetSlotPromise sets a slot to a promise (reference to another node).
+func (n *Node) SetSlotPromise(name, nodeRef, slot string) {
+	if n.Slots == nil {
+		n.Slots = make(map[string]SlotValue)
+	}
+	n.Slots[name] = SlotValue{NodeRef: nodeRef, Slot: slot}
 }
 
 // GetID returns the node's unique identifier.
@@ -185,26 +210,40 @@ func (n *Node) GetID() string { return n.ID }
 // GetOperations returns the list of operations to perform.
 func (n *Node) GetOperations() []string { return n.Operations }
 
-// GetSource returns the source path.
-func (n *Node) GetSource() string { return n.Source }
-
-// GetTarget returns the target path.
-func (n *Node) GetTarget() string { return n.Target }
-
 // GetProject returns the project name.
 func (n *Node) GetProject() string { return n.Project }
 
 // GetMode returns the file mode.
 func (n *Node) GetMode() os.FileMode { return n.Mode }
 
-// GetMetadata returns operation-specific metadata.
-func (n *Node) GetMetadata() map[string]string { return n.Metadata }
-
 // Edge represents a dependency relationship between two nodes.
 type Edge struct {
 	From     string `json:"from" yaml:"from"`
 	To       string `json:"to" yaml:"to"`
 	Relation string `json:"relation" yaml:"relation"`
+}
+
+// SlotValue represents a value that fills a slot in a node.
+// Either Immediate is set (direct value) or NodeRef is set (promise from upstream node).
+type SlotValue struct {
+	// Immediate is the direct value (string, used when known at analysis time).
+	Immediate string `json:"immediate,omitempty" yaml:"immediate,omitempty"`
+
+	// NodeRef is the ID of the node that produces this value (promise).
+	NodeRef string `json:"node_ref,omitempty" yaml:"node_ref,omitempty"`
+
+	// Slot is which output slot of the referenced node (empty = default output).
+	Slot string `json:"slot,omitempty" yaml:"slot,omitempty"`
+}
+
+// IsPromise returns true if this slot value is a promise (reference to another node).
+func (s SlotValue) IsPromise() bool {
+	return s.NodeRef != ""
+}
+
+// IsImmediate returns true if this slot value is an immediate value.
+func (s SlotValue) IsImmediate() bool {
+	return s.NodeRef == "" && s.Immediate != ""
 }
 
 // Graph represents an execution graph containing nodes and edges.
@@ -255,11 +294,9 @@ type Graph struct {
 type Executable interface {
 	GetID() string
 	GetOperations() []string
-	GetSource() string
-	GetTarget() string
+	GetSlot(name string) string
 	GetProject() string
 	GetMode() os.FileMode
-	GetMetadata() map[string]string
 }
 
 // Ensure Node implements Executable.
@@ -423,7 +460,7 @@ func (g *Graph) ComputeSummary() {
 			case "link":
 				g.Summary.TotalFiles++
 				g.Summary.Links++
-			case "expand":
+			case "render":
 				g.Summary.TotalFiles++
 				g.Summary.Templates++
 			case "decrypt":

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -217,10 +217,10 @@ func (n *Node) GetProject() string { return n.Project }
 func (n *Node) GetMode() os.FileMode { return n.Mode }
 
 // Edge represents a dependency relationship between two nodes.
+// From must complete before To can begin execution.
 type Edge struct {
-	From     string `json:"from" yaml:"from"`
-	To       string `json:"to" yaml:"to"`
-	Relation string `json:"relation" yaml:"relation"`
+	From string `json:"from" yaml:"from"`
+	To   string `json:"to" yaml:"to"`
 }
 
 // SlotValue represents a value that fills a slot in a node.

--- a/internal/execution/ops.go
+++ b/internal/execution/ops.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// LinkOp creates a symlink from node.Target pointing to node.Source.
+// LinkOp creates a symlink from node's "path" slot pointing to "source" slot.
 type LinkOp struct{}
 
 func (o *LinkOp) Name() string         { return "link" }
@@ -23,8 +23,8 @@ func (o *LinkOp) Execute(ctx *Context, node Executable) error {
 		return nil
 	}
 
-	target := node.GetTarget()
-	source := node.GetSource()
+	target := node.GetSlot("path")
+	source := node.GetSlot("source")
 
 	// Idempotent: check if symlink already points correctly
 	if info, err := os.Lstat(target); err == nil {
@@ -47,7 +47,7 @@ func (o *LinkOp) Execute(ctx *Context, node Executable) error {
 	return os.Symlink(source, target)
 }
 
-// CopyOp writes content to node.Target and returns the target checksum.
+// CopyOp writes content to node's "path" slot and returns the target checksum.
 type CopyOp struct{}
 
 func (o *CopyOp) Name() string         { return "copy" }
@@ -58,7 +58,7 @@ func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, e
 		return ChecksumBytes(content), nil
 	}
 
-	target := node.GetTarget()
+	target := node.GetSlot("path")
 
 	// Remove existing file/symlink if present
 	if _, err := os.Lstat(target); err == nil {
@@ -83,14 +83,14 @@ func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, e
 	return ChecksumBytes(content), nil
 }
 
-// ExpandOp processes content as a Go text/template with ctx.Data as
-// the template data. Returns the expanded content.
-type ExpandOp struct{}
+// RenderOp processes content as a Go text/template with ctx.Data as
+// the template data. Returns the rendered content.
+type RenderOp struct{}
 
-func (o *ExpandOp) Name() string         { return "expand" }
-func (o *ExpandOp) Category() OpCategory { return OpTransform }
+func (o *RenderOp) Name() string         { return "render" }
+func (o *RenderOp) Category() OpCategory { return OpTransform }
 
-func (o *ExpandOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
+func (o *RenderOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
 	tmpl, err := template.New(node.GetID()).Parse(string(content))
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
@@ -102,8 +102,8 @@ func (o *ExpandOp) Transform(ctx *Context, node Executable, content []byte) ([]b
 		data[k] = v
 	}
 	// Add node-specific data
-	data["Source"] = node.GetSource()
-	data["Target"] = node.GetTarget()
+	data["Source"] = node.GetSlot("source")
+	data["Target"] = node.GetSlot("path")
 	data["Project"] = node.GetProject()
 
 	var buf bytes.Buffer
@@ -138,7 +138,7 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 
 	// Try new signature first (includes source path for format detection)
 	if decrypt, ok := decryptor.(func(string, []byte) ([]byte, error)); ok {
-		return decrypt(node.GetSource(), content)
+		return decrypt(node.GetSlot("source"), content)
 	}
 	if decrypt, ok := decryptor.(func([]byte) ([]byte, error)); ok {
 		// Fall back to legacy signature
@@ -155,8 +155,8 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 //
 // The Package Graph Builder is NOT YET IMPLEMENTED.
 
-// BackupOp moves the existing file at node.Target to a timestamped backup.
-// The backup path is stored in node.Metadata["backup_path"] after execution.
+// BackupOp moves the existing file at node's "path" slot to a timestamped backup.
+// The backup path is stored in node.Annotations["backup_path"] after execution.
 type BackupOp struct{}
 
 func (o *BackupOp) Name() string         { return "backup" }
@@ -174,7 +174,7 @@ func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 		}
 	}
 
-	target := node.GetTarget()
+	target := node.GetSlot("path")
 	timestamp := time.Now().Format("20060102-150405")
 	backupPath := target + suffix + "." + timestamp
 
@@ -182,15 +182,17 @@ func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 		return fmt.Errorf("backup %s → %s: %w", target, backupPath, err)
 	}
 
-	// Store backup path in node metadata for receipt generation
-	metadata := node.GetMetadata()
-	if metadata != nil {
-		metadata["backup_path"] = backupPath
+	// Store backup path in node annotations for receipt generation
+	if n, ok := node.(*Node); ok && n.Annotations == nil {
+		n.Annotations = make(map[string]string)
+	}
+	if n, ok := node.(*Node); ok {
+		n.Annotations["backup_path"] = backupPath
 	}
 	return nil
 }
 
-// UnlinkOp removes a symlink at node.Target.
+// UnlinkOp removes a symlink at node's "path" slot.
 // If ctx.Data["prune_empty_dirs"] is true and ctx.Data["prune_boundary"] is set,
 // empty parent directories are removed up to the boundary.
 type UnlinkOp struct{}
@@ -203,7 +205,7 @@ func (o *UnlinkOp) Execute(ctx *Context, node Executable) error {
 		return nil
 	}
 
-	target := node.GetTarget()
+	target := node.GetSlot("path")
 
 	info, err := os.Lstat(target)
 	if os.IsNotExist(err) {
@@ -225,7 +227,7 @@ func (o *UnlinkOp) Execute(ctx *Context, node Executable) error {
 	return nil
 }
 
-// RemoveOp deletes the file at node.Target.
+// RemoveOp deletes the file at node.GetSlot("path").
 // If ctx.Data["prune_empty_dirs"] is true and ctx.Data["prune_boundary"] is set,
 // empty parent directories are removed up to the boundary.
 type RemoveOp struct{}
@@ -238,7 +240,7 @@ func (o *RemoveOp) Execute(ctx *Context, node Executable) error {
 		return nil
 	}
 
-	target := node.GetTarget()
+	target := node.GetSlot("path")
 
 	if _, err := os.Lstat(target); os.IsNotExist(err) {
 		return nil // Already gone
@@ -298,57 +300,24 @@ func isSubpath(path, parent string) bool {
 	return rel != "." && !filepath.IsAbs(rel) && (len(rel) < 2 || rel[:2] != "..")
 }
 
-// MkdirOp creates a directory at node.Target.
-type MkdirOp struct{}
-
-func (o *MkdirOp) Name() string         { return "mkdir" }
-func (o *MkdirOp) Category() OpCategory { return OpDirect }
-
-func (o *MkdirOp) Execute(ctx *Context, node Executable) error {
-	if ctx.DryRun {
-		return nil
-	}
-
-	target := node.GetTarget()
-
-	// Idempotent: check if directory already exists
-	if info, err := os.Stat(target); err == nil {
-		if info.IsDir() {
-			return nil // Already exists
-		}
-		return fmt.Errorf("%s exists but is not a directory", target)
-	}
-
-	mode := node.GetMode()
-	if mode == 0 {
-		mode = 0755
-	}
-
-	return os.Mkdir(target, mode)
-}
-
-// FileWriteOp writes content from node.Metadata["content"] to node.Target.
+// WriteOp writes content from node's "content" slot to node's "path" slot.
 // Used by plan.file.write() for writing inline content directly.
-type FileWriteOp struct{}
+type WriteOp struct{}
 
-func (o *FileWriteOp) Name() string         { return "file-write" }
-func (o *FileWriteOp) Category() OpCategory { return OpDirect }
+func (o *WriteOp) Name() string         { return "write" }
+func (o *WriteOp) Category() OpCategory { return OpDirect }
 
-func (o *FileWriteOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	content := ""
-	if metadata != nil {
-		content = metadata["content"]
-	}
+func (o *WriteOp) Execute(ctx *Context, node Executable) error {
+	content := node.GetSlot("content")
 	if content == "" {
-		return fmt.Errorf("file-write: no content specified in node metadata")
+		return fmt.Errorf("write: no content specified in node slots")
 	}
 
 	if ctx.DryRun {
 		return nil
 	}
 
-	target := node.GetTarget()
+	target := node.GetSlot("path")
 
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
@@ -364,20 +333,16 @@ func (o *FileWriteOp) Execute(ctx *Context, node Executable) error {
 }
 
 // ValidateOp checks a precondition and fails with a message if unmet.
-// The check function is retrieved from ctx.Data["validators"][node.Metadata["check"]].
+// The check function is retrieved from ctx.Data["validators"][node.GetSlot("check")].
 type ValidateOp struct{}
 
 func (o *ValidateOp) Name() string         { return "validate" }
 func (o *ValidateOp) Category() OpCategory { return OpDirect }
 
 func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	checkName := ""
-	if metadata != nil {
-		checkName = metadata["check"]
-	}
+	checkName := node.GetSlot("check")
 	if checkName == "" {
-		return fmt.Errorf("validate: no check specified in node metadata")
+		return fmt.Errorf("validate: no check specified in node slots")
 	}
 
 	validators, ok := ctx.Data["validators"].(map[string]func() error)
@@ -391,10 +356,7 @@ func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
 	}
 
 	if err := validator(); err != nil {
-		message := ""
-		if metadata != nil {
-			message = metadata["message"]
-		}
+		message := node.GetSlot("message")
 		if message != "" {
 			return fmt.Errorf("%s: %w", message, err)
 		}
@@ -404,20 +366,20 @@ func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
 	return nil
 }
 
-// RenameOp moves a file or directory from node.Source to node.Target using
+// MoveOp moves a file or directory from node's "source" slot to "path" slot using
 // git mv when inside a git repository, falling back to os.Rename otherwise.
-type RenameOp struct{}
+type MoveOp struct{}
 
-func (o *RenameOp) Name() string         { return "rename" }
-func (o *RenameOp) Category() OpCategory { return OpDirect }
+func (o *MoveOp) Name() string         { return "move" }
+func (o *MoveOp) Category() OpCategory { return OpDirect }
 
-func (o *RenameOp) Execute(ctx *Context, node Executable) error {
+func (o *MoveOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
 		return nil
 	}
 
-	source := node.GetSource()
-	target := node.GetTarget()
+	source := node.GetSlot("source")
+	target := node.GetSlot("path")
 
 	// Check if source exists
 	if _, err := os.Stat(source); err != nil {
@@ -445,20 +407,19 @@ func (o *RenameOp) Execute(ctx *Context, node Executable) error {
 //
 // Transform operations (content in → content out):
 //   - decrypt: decrypts encrypted content via ctx.Data["decryptor"]
-//   - expand: expands Go text/template content with ctx.Data
+//   - render: renders Go text/template content with ctx.Data
 //
 // Writer operations (content in → checksum out):
-//   - copy: writes content to node.Target
+//   - copy: writes content to node's "path" slot
 //
 // Direct operations (no content flow):
-//   - link: creates symlink from node.Target → node.Source
-//   - mkdir: creates directory at node.Target
-//   - file-write: writes node.Metadata["content"] to node.Target
-//   - backup: moves node.Target to timestamped backup
-//   - unlink: removes symlink at node.Target
-//   - remove: deletes file at node.Target
+//   - link: creates symlink from "path" → "source" slots
+//   - write: writes "content" slot to "path" slot
+//   - backup: moves "path" slot to timestamped backup
+//   - unlink: removes symlink at "path" slot
+//   - remove: deletes file at "path" slot
 //   - validate: checks precondition from ctx.Data["validators"]
-//   - rename: moves node.Source → node.Target (git mv when possible)
+//   - move: moves "source" → "path" slots (git mv when possible)
 //
 // NOTE: Package operations (package-install, package-upgrade, package-remove,
 // package-update) are provided by ops_package.go.
@@ -466,15 +427,14 @@ func FileOps() []Operation {
 	return []Operation{
 		&LinkOp{},
 		&CopyOp{},
-		&ExpandOp{},
+		&RenderOp{},
 		&DecryptOp{},
 		&BackupOp{},
 		&UnlinkOp{},
 		&RemoveOp{},
-		&MkdirOp{},
-		&FileWriteOp{},
+		&WriteOp{},
 		&ValidateOp{},
-		&RenameOp{},
+		&MoveOp{},
 	}
 }
 

--- a/internal/execution/ops_package.go
+++ b/internal/execution/ops_package.go
@@ -18,11 +18,11 @@ import (
 // These four operations work on ALL platforms. The package manager is determined
 // at execution time by host.PackageManager().
 //
-// On Darwin, the optional node.Metadata["manager"] can override the auto-detected
+// On Darwin, the optional node "manager" slot can override the auto-detected
 // package manager ("brew" or "port"). This supports the brew:pkg and port:pkg
 // prefix syntax in plan.install().
 //
-// Package names are read from node.Metadata["packages"] (comma-separated).
+// Package names are read from node's "packages" slot (comma-separated).
 
 // PackageInstallOp installs packages using the platform's package manager.
 type PackageInstallOp struct{}
@@ -31,19 +31,18 @@ func (o *PackageInstallOp) Name() string         { return "package-install" }
 func (o *PackageInstallOp) Category() OpCategory { return OpDirect }
 
 func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	packages := parsePackages(metadata["packages"])
+	packages := parsePackages(node.GetSlot("packages"))
 	if len(packages) == 0 {
 		return fmt.Errorf("package-install: no packages specified")
 	}
 
-	pm := resolvePMForInstall(metadata["manager"])
+	pm := resolvePMForInstall(node.GetSlot("manager"))
 	if pm == nil {
 		return fmt.Errorf("package-install: no package manager available")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := metadata["cask"] == "true"
+	isCask := node.GetSlot("cask") == "true"
 
 	if ctx.DryRun {
 		if isCask {
@@ -78,20 +77,19 @@ func (o *PackageUpgradeOp) Name() string         { return "package-upgrade" }
 func (o *PackageUpgradeOp) Category() OpCategory { return OpDirect }
 
 func (o *PackageUpgradeOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	packages := parsePackages(metadata["packages"])
+	packages := parsePackages(node.GetSlot("packages"))
 	if len(packages) == 0 {
 		return fmt.Errorf("package-upgrade: no packages specified")
 	}
 
 	// Use InstalledBy to determine which PM to upgrade with
-	pm := resolvePMForUpgrade(metadata["manager"], packages)
+	pm := resolvePMForUpgrade(node.GetSlot("manager"), packages)
 	if pm == nil {
 		return fmt.Errorf("package-upgrade: no package manager available")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := metadata["cask"] == "true"
+	isCask := node.GetSlot("cask") == "true"
 
 	if ctx.DryRun {
 		if isCask {
@@ -128,18 +126,18 @@ func (o *PackageRemoveOp) Name() string         { return "package-remove" }
 func (o *PackageRemoveOp) Category() OpCategory { return OpDirect }
 
 func (o *PackageRemoveOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	packages := parsePackages(metadata["packages"])
+	packages := parsePackages(node.GetSlot("packages"))
 	if len(packages) == 0 {
 		return fmt.Errorf("package-remove: no packages specified")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := metadata["cask"] == "true"
+	isCask := node.GetSlot("cask") == "true"
+	manager := node.GetSlot("manager")
 
 	for _, pkg := range packages {
 		// Use InstalledBy to determine which PM to remove with
-		pm, otherPMs := resolvePMForRemove(metadata["manager"], pkg)
+		pm, otherPMs := resolvePMForRemove(manager, pkg)
 		if pm == nil {
 			return fmt.Errorf("package-remove: no package manager available")
 		}
@@ -187,9 +185,8 @@ func (o *PackageUpdateOp) Name() string         { return "package-update" }
 func (o *PackageUpdateOp) Category() OpCategory { return OpDirect }
 
 func (o *PackageUpdateOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
 	// Update uses preferred PM (not InstalledBy - we're updating the index, not a package)
-	pm := resolvePMForInstall(metadata["manager"])
+	pm := resolvePMForInstall(node.GetSlot("manager"))
 	if pm == nil {
 		return fmt.Errorf("package-update: no package manager available")
 	}
@@ -356,15 +353,14 @@ func runBrewCaskRemove(pkg string) host.Result {
 // Shell Operations
 // =============================================================================
 
-// ShellOp executes a shell command from node.Metadata["command"].
+// ShellOp executes a shell command from node's "command" slot.
 type ShellOp struct{}
 
 func (o *ShellOp) Name() string         { return "shell" }
 func (o *ShellOp) Category() OpCategory { return OpDirect }
 
 func (o *ShellOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	command := metadata["command"]
+	command := node.GetSlot("command")
 	if command == "" {
 		return fmt.Errorf("shell: no command specified")
 	}
@@ -381,15 +377,14 @@ func (o *ShellOp) Execute(ctx *Context, node Executable) error {
 	return cmd.Run()
 }
 
-// PowerShellOp executes a PowerShell command from node.Metadata["command"] (Windows).
+// PowerShellOp executes a PowerShell command from node's "command" slot (Windows).
 type PowerShellOp struct{}
 
 func (o *PowerShellOp) Name() string         { return "powershell" }
 func (o *PowerShellOp) Category() OpCategory { return OpDirect }
 
 func (o *PowerShellOp) Execute(ctx *Context, node Executable) error {
-	metadata := node.GetMetadata()
-	command := metadata["command"]
+	command := node.GetSlot("command")
 	if command == "" {
 		return fmt.Errorf("powershell: no command specified")
 	}

--- a/internal/execution/ops_service.go
+++ b/internal/execution/ops_service.go
@@ -12,10 +12,10 @@ import (
 // Service Manager Operations
 // =============================================================================
 //
-// These operations manage system services. The appropriate operation is selected
-// based on the detected platform during graph building (internal/starlark/platform).
-//
-// Each operation reads the service name from node.Metadata["service"].
+// Platform-specific service operations. The platform bindings (darwin.go,
+// linux.go, windows.go) create nodes with the appropriate operation name
+// (e.g., launchd-start, systemd-start, winservice-start). No runtime
+// platform detection is needed - the binding layer handles platform selection.
 
 // =============================================================================
 // launchd (macOS)
@@ -28,7 +28,7 @@ func (o *LaunchdStartOp) Name() string         { return "launchd-start" }
 func (o *LaunchdStartOp) Category() OpCategory { return OpDirect }
 
 func (o *LaunchdStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("launchd-start: no service specified")
 	}
@@ -52,7 +52,7 @@ func (o *LaunchdStopOp) Name() string         { return "launchd-stop" }
 func (o *LaunchdStopOp) Category() OpCategory { return OpDirect }
 
 func (o *LaunchdStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("launchd-stop: no service specified")
 	}
@@ -76,7 +76,7 @@ func (o *LaunchdRestartOp) Name() string         { return "launchd-restart" }
 func (o *LaunchdRestartOp) Category() OpCategory { return OpDirect }
 
 func (o *LaunchdRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("launchd-restart: no service specified")
 	}
@@ -101,7 +101,7 @@ func (o *LaunchdEnableOp) Name() string         { return "launchd-enable" }
 func (o *LaunchdEnableOp) Category() OpCategory { return OpDirect }
 
 func (o *LaunchdEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("launchd-enable: no service specified")
 	}
@@ -125,7 +125,7 @@ func (o *LaunchdDisableOp) Name() string         { return "launchd-disable" }
 func (o *LaunchdDisableOp) Category() OpCategory { return OpDirect }
 
 func (o *LaunchdDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("launchd-disable: no service specified")
 	}
@@ -153,7 +153,7 @@ func (o *SystemdStartOp) Name() string         { return "systemd-start" }
 func (o *SystemdStartOp) Category() OpCategory { return OpDirect }
 
 func (o *SystemdStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("systemd-start: no service specified")
 	}
@@ -177,7 +177,7 @@ func (o *SystemdStopOp) Name() string         { return "systemd-stop" }
 func (o *SystemdStopOp) Category() OpCategory { return OpDirect }
 
 func (o *SystemdStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("systemd-stop: no service specified")
 	}
@@ -201,7 +201,7 @@ func (o *SystemdRestartOp) Name() string         { return "systemd-restart" }
 func (o *SystemdRestartOp) Category() OpCategory { return OpDirect }
 
 func (o *SystemdRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("systemd-restart: no service specified")
 	}
@@ -225,7 +225,7 @@ func (o *SystemdEnableOp) Name() string         { return "systemd-enable" }
 func (o *SystemdEnableOp) Category() OpCategory { return OpDirect }
 
 func (o *SystemdEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("systemd-enable: no service specified")
 	}
@@ -249,7 +249,7 @@ func (o *SystemdDisableOp) Name() string         { return "systemd-disable" }
 func (o *SystemdDisableOp) Category() OpCategory { return OpDirect }
 
 func (o *SystemdDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("systemd-disable: no service specified")
 	}
@@ -277,7 +277,7 @@ func (o *WinServiceStartOp) Name() string         { return "winservice-start" }
 func (o *WinServiceStartOp) Category() OpCategory { return OpDirect }
 
 func (o *WinServiceStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("winservice-start: no service specified")
 	}
@@ -301,7 +301,7 @@ func (o *WinServiceStopOp) Name() string         { return "winservice-stop" }
 func (o *WinServiceStopOp) Category() OpCategory { return OpDirect }
 
 func (o *WinServiceStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("winservice-stop: no service specified")
 	}
@@ -325,7 +325,7 @@ func (o *WinServiceRestartOp) Name() string         { return "winservice-restart
 func (o *WinServiceRestartOp) Category() OpCategory { return OpDirect }
 
 func (o *WinServiceRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("winservice-restart: no service specified")
 	}
@@ -357,7 +357,7 @@ func (o *WinServiceEnableOp) Name() string         { return "winservice-enable" 
 func (o *WinServiceEnableOp) Category() OpCategory { return OpDirect }
 
 func (o *WinServiceEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("winservice-enable: no service specified")
 	}
@@ -381,7 +381,7 @@ func (o *WinServiceDisableOp) Name() string         { return "winservice-disable
 func (o *WinServiceDisableOp) Category() OpCategory { return OpDirect }
 
 func (o *WinServiceDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetMetadata()["service"]
+	service := node.GetSlot("name")
 	if service == "" {
 		return fmt.Errorf("winservice-disable: no service specified")
 	}

--- a/internal/execution/plan.go
+++ b/internal/execution/plan.go
@@ -219,21 +219,19 @@ func (p *Plan) DependsOn(from, to *Node) {
 	defer p.mu.Unlock()
 
 	p.graph.Edges = append(p.graph.Edges, Edge{
-		From:     from.ID,
-		To:       to.ID,
-		Relation: "depends_on",
+		From: from.ID,
+		To:   to.ID,
 	})
 }
 
-// Orders adds an ordering constraint without implying dependency.
+// Orders adds an ordering constraint between nodes.
 func (p *Plan) Orders(from, to *Node) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	p.graph.Edges = append(p.graph.Edges, Edge{
-		From:     from.ID,
-		To:       to.ID,
-		Relation: "orders",
+		From: from.ID,
+		To:   to.ID,
 	})
 }
 

--- a/internal/execution/plan.go
+++ b/internal/execution/plan.go
@@ -61,40 +61,40 @@ func itoa(i int) string {
 }
 
 // Mkdir adds a directory creation operation.
-func (p *Plan) Mkdir(target string) *Node {
+func (p *Plan) Mkdir(path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
 		ID:         p.nextID("mkdir"),
 		Operations: []string{"mkdir"},
-		Target:     target,
 		Project:    p.project,
 		Mode:       0755,
 	}
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // Link adds a symlink creation operation.
-func (p *Plan) Link(source, target string) *Node {
+func (p *Plan) Link(source, path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
 		ID:         p.nextID("link"),
 		Operations: []string{"link"},
-		Source:     source,
-		Target:     target,
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // Copy adds a file copy operation. Transforms (decrypt, expand) can be
 // prepended to the pipeline.
-func (p *Plan) Copy(source, target string, transforms ...string) *Node {
+func (p *Plan) Copy(source, path string, transforms ...string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -102,17 +102,17 @@ func (p *Plan) Copy(source, target string, transforms ...string) *Node {
 	node := &Node{
 		ID:         p.nextID("copy"),
 		Operations: ops,
-		Source:     source,
-		Target:     target,
 		Project:    p.project,
 		Mode:       0644,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // CopyWithMode adds a file copy operation with explicit permissions.
-func (p *Plan) CopyWithMode(source, target string, mode os.FileMode, transforms ...string) *Node {
+func (p *Plan) CopyWithMode(source, path string, mode os.FileMode, transforms ...string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -120,56 +120,56 @@ func (p *Plan) CopyWithMode(source, target string, mode os.FileMode, transforms 
 	node := &Node{
 		ID:         p.nextID("copy"),
 		Operations: ops,
-		Source:     source,
-		Target:     target,
 		Project:    p.project,
 		Mode:       mode,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // Remove adds a file/directory removal operation.
-func (p *Plan) Remove(target string) *Node {
+func (p *Plan) Remove(path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
 		ID:         p.nextID("remove"),
 		Operations: []string{"remove"},
-		Target:     target,
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // Unlink adds a symlink removal operation.
-func (p *Plan) Unlink(target string) *Node {
+func (p *Plan) Unlink(path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
 		ID:         p.nextID("unlink"),
 		Operations: []string{"unlink"},
-		Target:     target,
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
 // Backup adds a backup operation for an existing file.
-func (p *Plan) Backup(target string) *Node {
+func (p *Plan) Backup(path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
 		ID:         p.nextID("backup"),
 		Operations: []string{"backup"},
-		Target:     target,
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -183,27 +183,25 @@ func (p *Plan) Validate(check, message string) *Node {
 		ID:         p.nextID("validate"),
 		Operations: []string{"validate"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"check":   check,
-			"message": message,
-		},
 	}
+	node.SetSlotImmediate("check", check)
+	node.SetSlotImmediate("message", message)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
 
-// Rename adds a file/directory rename operation (git mv when possible).
-func (p *Plan) Rename(source, target string) *Node {
+// Rename adds a file/directory move operation (git mv when possible).
+func (p *Plan) Rename(source, path string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("rename"),
-		Operations: []string{"rename"},
-		Source:     source,
-		Target:     target,
+		ID:         p.nextID("move"),
+		Operations: []string{"move"},
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }

--- a/internal/execution/preflight.go
+++ b/internal/execution/preflight.go
@@ -71,9 +71,9 @@ func Preflight(graph *Graph) *PreflightResult {
 }
 
 // nodeWritesToTarget returns true if the node's operations produce a file at
-// node.Target (link, copy, or any pipeline ending in copy).
+// node's "path" slot (link, copy, or any pipeline ending in copy).
 func nodeWritesToTarget(node *Node) bool {
-	if node.Target == "" {
+	if node.GetSlot("path") == "" {
 		return false
 	}
 	for _, op := range node.Operations {
@@ -87,11 +87,12 @@ func nodeWritesToTarget(node *Node) bool {
 
 // detectConflict checks if a target path has a conflict.
 func detectConflict(node *Node) Conflict {
-	if node.Target == "" {
+	path := node.GetSlot("path")
+	if path == "" {
 		return Conflict{Node: node, Type: ConflictNone}
 	}
 
-	info, err := os.Lstat(node.Target)
+	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
 		return Conflict{Node: node, Type: ConflictNone}
 	}
@@ -107,12 +108,12 @@ func detectConflict(node *Node) Conflict {
 		return Conflict{
 			Node:    node,
 			Type:    ConflictDirectory,
-			Message: fmt.Sprintf("directory exists at %s", node.Target),
+			Message: fmt.Sprintf("directory exists at %s", path),
 		}
 	}
 
 	if info.Mode()&os.ModeSymlink != 0 {
-		linkTarget, err := os.Readlink(node.Target)
+		linkTarget, err := os.Readlink(path)
 		if err != nil {
 			return Conflict{
 				Node:    node,
@@ -121,7 +122,8 @@ func detectConflict(node *Node) Conflict {
 			}
 		}
 
-		if linkTarget == node.Source {
+		source := node.GetSlot("source")
+		if linkTarget == source {
 			return Conflict{
 				Node:         node,
 				Type:         ConflictOurSymlink,
@@ -141,6 +143,6 @@ func detectConflict(node *Node) Conflict {
 	return Conflict{
 		Node:    node,
 		Type:    ConflictRegularFile,
-		Message: fmt.Sprintf("file exists at %s (%d bytes)", node.Target, info.Size()),
+		Message: fmt.Sprintf("file exists at %s (%d bytes)", path, info.Size()),
 	}
 }

--- a/internal/execution/stateview.go
+++ b/internal/execution/stateview.go
@@ -97,7 +97,7 @@ func (e *FileEntry) IsCopied() bool {
 		return false
 	}
 	for _, op := range last.Operations {
-		if op == "expand" || op == "decrypt" || op == "copy" {
+		if op == "render" || op == "decrypt" || op == "copy" {
 			return true
 		}
 	}
@@ -503,7 +503,7 @@ func (b *StateViewBuilder) addFileRecord(view *StateView, node *Node, record His
 	if !ok {
 		entry = &FileEntry{
 			Target:  relTarget,
-			Source:  node.Source,
+			Source:  node.GetSlot("source"),
 			Project: node.Project,
 			Layer:   node.Layer,
 			History: make([]HistoryRecord, 0),
@@ -511,8 +511,8 @@ func (b *StateViewBuilder) addFileRecord(view *StateView, node *Node, record His
 		view.Files.Entries[relTarget] = entry
 	} else {
 		// Update source/project/layer from latest record
-		if node.Source != "" {
-			entry.Source = node.Source
+		if source := node.GetSlot("source"); source != "" {
+			entry.Source = source
 		}
 		if node.Project != "" {
 			entry.Project = node.Project

--- a/internal/execution/stateview_test.go
+++ b/internal/execution/stateview_test.go
@@ -70,7 +70,7 @@ func TestFileEntryLastOperation(t *testing.T) {
 			Target: ".bashrc",
 			History: []HistoryRecord{
 				{Receipt: "old.yaml", Operations: []string{"link"}},
-				{Receipt: "new.yaml", Operations: []string{"expand", "copy"}},
+				{Receipt: "new.yaml", Operations: []string{"render", "copy"}},
 			},
 		}
 		last := e.LastOperation()
@@ -93,10 +93,10 @@ func TestFileEntryIsCopied(t *testing.T) {
 		{"no history", nil, false},
 		{"link only", []string{"link"}, false},
 		{"copy operation", []string{"copy"}, true},
-		{"expand operation", []string{"expand"}, true},
+		{"render operation", []string{"render"}, true},
 		{"decrypt operation", []string{"decrypt"}, true},
-		{"expand+copy", []string{"expand", "copy"}, true},
-		{"decrypt+expand+copy", []string{"decrypt", "expand", "copy"}, true},
+		{"render+copy", []string{"render", "copy"}, true},
+		{"decrypt+render+copy", []string{"decrypt", "render", "copy"}, true},
 	}
 
 	for _, tt := range tests {
@@ -124,7 +124,7 @@ func TestFileEntryIsLinked(t *testing.T) {
 		{"no history", nil, false},
 		{"link only", []string{"link"}, true},
 		{"copy operation", []string{"copy"}, false},
-		{"expand+copy", []string{"expand", "copy"}, false},
+		{"render+copy", []string{"render", "copy"}, false},
 		{"link with extra ops", []string{"link", "something"}, false},
 	}
 
@@ -195,7 +195,7 @@ func TestFileTreeCopiedLinkedFiles(t *testing.T) {
 			},
 			".gitconfig": {
 				Target:  ".gitconfig",
-				History: []HistoryRecord{{Operations: []string{"expand", "copy"}}},
+				History: []HistoryRecord{{Operations: []string{"render", "copy"}}},
 			},
 			".ssh/config": {
 				Target:  ".ssh/config",
@@ -317,7 +317,7 @@ func TestStateViewSummary(t *testing.T) {
 				},
 				".gitconfig": {
 					Target:  ".gitconfig",
-					History: []HistoryRecord{{Operations: []string{"expand", "copy"}}},
+					History: []HistoryRecord{{Operations: []string{"render", "copy"}}},
 				},
 			},
 		},
@@ -340,20 +340,26 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 	now := time.Now()
 	earlier := now.Add(-time.Hour)
 
+	// Helper to create nodes with source slot
+	makeNode := func(id string, ops []string, source, project, layer string) *Node {
+		n := &Node{
+			ID:         id,
+			Operations: ops,
+			Project:    project,
+			Layer:      layer,
+			Status:     StatusCompleted,
+		}
+		n.SetSlotImmediate("source", source)
+		return n
+	}
+
 	graphs := []*Graph{
 		{
 			Tool:      "writ",
 			Timestamp: earlier,
 			Context:   GraphContext{TargetRoot: "/home/user"},
 			Nodes: []*Node{
-				{
-					ID:         ".bashrc",
-					Operations: []string{"link"},
-					Source:     "/repo/.bashrc",
-					Project:    "shell",
-					Layer:      "base",
-					Status:     StatusCompleted,
-				},
+				makeNode(".bashrc", []string{"link"}, "/repo/.bashrc", "shell", "base"),
 			},
 		},
 		{
@@ -361,21 +367,8 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 			Timestamp: now,
 			Context:   GraphContext{TargetRoot: "/home/user"},
 			Nodes: []*Node{
-				{
-					ID:         ".bashrc",
-					Operations: []string{"expand", "copy"},
-					Source:     "/repo/.bashrc",
-					Project:    "shell",
-					Layer:      "personal",
-					Status:     StatusCompleted,
-				},
-				{
-					ID:         ".gitconfig",
-					Operations: []string{"link"},
-					Source:     "/repo/.gitconfig",
-					Project:    "git",
-					Status:     StatusCompleted,
-				},
+				makeNode(".bashrc", []string{"render", "copy"}, "/repo/.bashrc", "shell", "personal"),
+				makeNode(".gitconfig", []string{"link"}, "/repo/.gitconfig", "git", ""),
 			},
 		},
 	}
@@ -400,7 +393,7 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 	if len(bashrc.History) != 2 {
 		t.Errorf("expected 2 history records for .bashrc, got %d", len(bashrc.History))
 	}
-	// Latest record should be personal layer with expand+copy
+	// Latest record should be personal layer with render+copy
 	if bashrc.Layer != "personal" {
 		t.Errorf("expected layer 'personal', got %q", bashrc.Layer)
 	}
@@ -701,8 +694,8 @@ func TestIsPackageNode(t *testing.T) {
 	}{
 		{[]string{"link"}, false},
 		{[]string{"copy"}, false},
-		{[]string{"expand", "copy"}, false},
-		{[]string{"decrypt", "expand", "copy"}, false},
+		{[]string{"render", "copy"}, false},
+		{[]string{"decrypt", "render", "copy"}, false},
 		{[]string{"install"}, true},
 		{[]string{"prepare"}, true},
 		{[]string{"verify"}, true},

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -265,11 +265,9 @@ func addNativePMNodes(graph *execution.Graph, pkg *lorepackage.Release, action *
 		ID:         fmt.Sprintf("%s-%s-%s", opName, pkg.Name, action.PhaseName),
 		Operations: []string{opName},
 		Project:    pkg.Name,
-		Metadata: map[string]string{
-			"packages": strings.Join(action.Packages, ","),
-			"phase":    action.PhaseName,
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(action.Packages, ","))
+	node.SetSlotImmediate("phase", action.PhaseName)
 
 	graph.Nodes = append(graph.Nodes, node)
 	return nil

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -51,9 +51,9 @@ func TestBuild_WithNativePMPackage(t *testing.T) {
 	for _, node := range result.Graph.Nodes {
 		if len(node.Operations) > 0 && node.Operations[0] == "package-install" {
 			found = true
-			// Verify metadata
-			if node.Metadata["packages"] != "curl" {
-				t.Errorf("expected packages 'curl', got %q", node.Metadata["packages"])
+			// Verify slot values
+			if node.GetSlot("packages") != "curl" {
+				t.Errorf("expected packages 'curl', got %q", node.GetSlot("packages"))
 			}
 			break
 		}
@@ -187,16 +187,13 @@ func TestEngineRunsPackageInstallOperations(t *testing.T) {
 	eng := execution.NewGraphExecutor(reg, execution.ExecutorOptions{DryRun: true})
 
 	// Create a graph with a namespaced package-install node
+	node := &execution.Node{
+		ID:         "package-install-testpkg",
+		Operations: []string{"package-install"},
+	}
+	node.SetSlotImmediate("packages", "testpkg")
 	graph := &execution.Graph{
-		Nodes: []*execution.Node{
-			{
-				ID:         "package-install-testpkg",
-				Operations: []string{"package-install"},
-				Metadata: map[string]string{
-					"packages": "testpkg",
-				},
-			},
-		},
+		Nodes: []*execution.Node{node},
 	}
 
 	results, err := runGraph(context.Background(), eng, graph)
@@ -229,19 +226,16 @@ func TestEngineRunsNamespacedPackageOps(t *testing.T) {
 
 	for _, opName := range ops {
 		t.Run(opName, func(t *testing.T) {
-			metadata := map[string]string{}
+			node := &execution.Node{
+				ID:         "test-" + opName,
+				Operations: []string{opName},
+			}
 			if opName != "package-update" {
-				metadata["packages"] = "testpkg"
+				node.SetSlotImmediate("packages", "testpkg")
 			}
 
 			graph := &execution.Graph{
-				Nodes: []*execution.Node{
-					{
-						ID:         "test-" + opName,
-						Operations: []string{opName},
-						Metadata:   metadata,
-					},
-				},
+				Nodes: []*execution.Node{node},
 			}
 
 			results, err := runGraph(context.Background(), eng, graph)
@@ -285,14 +279,14 @@ func TestNativePMNodeMetadata(t *testing.T) {
 		t.Fatal("no package-install node found")
 	}
 
-	// Verify required metadata
-	if installNode.Metadata["packages"] == "" {
-		t.Error("expected packages metadata to be set")
+	// Verify required slots
+	if installNode.GetSlot("packages") == "" {
+		t.Error("expected packages slot to be set")
 	}
-	if installNode.Metadata["phase"] == "" {
-		t.Error("expected phase metadata to be set")
+	if installNode.GetSlot("phase") == "" {
+		t.Error("expected phase slot to be set")
 	}
-	// Note: manager is NOT set in metadata for namespaced operations
+	// Note: manager is NOT set for namespaced operations
 	// The PM is determined at execution time by host.PackageManager()
 }
 

--- a/internal/manifest/builder.go
+++ b/internal/manifest/builder.go
@@ -67,18 +67,17 @@ func (b *Builder) buildPackageNode(pkg PackageEntry, opts execution.BuildOptions
 	node := &execution.Node{
 		ID:         pkg.Name,
 		Operations: operations,
-		Metadata:   make(map[string]string),
 	}
 
 	// Store package name for registry lookup
-	node.Metadata["package"] = pkg.Name
+	node.SetSlotImmediate("package", pkg.Name)
 
 	// Store enabled features
 	if len(pkg.With) > 0 {
 		for i, feature := range pkg.With {
-			node.Metadata[fmt.Sprintf("feature.%d", i)] = feature
+			node.SetSlotImmediate(fmt.Sprintf("feature.%d", i), feature)
 		}
-		node.Metadata["feature_count"] = fmt.Sprintf("%d", len(pkg.With))
+		node.SetSlotImmediate("feature_count", fmt.Sprintf("%d", len(pkg.With)))
 	}
 
 	return node

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -318,19 +318,19 @@ func TestBuilder_BuildGraphFromManifest(t *testing.T) {
 	if graph.Nodes[0].ID != "gh" {
 		t.Errorf("nodes[0].ID: expected 'gh', got %q", graph.Nodes[0].ID)
 	}
-	if graph.Nodes[0].Metadata["package"] != "gh" {
-		t.Errorf("nodes[0].Metadata['package']: expected 'gh', got %q", graph.Nodes[0].Metadata["package"])
+	if graph.Nodes[0].GetSlot("package") != "gh" {
+		t.Errorf("nodes[0] slot 'package': expected 'gh', got %q", graph.Nodes[0].GetSlot("package"))
 	}
 
 	// Check second node (with features)
 	if graph.Nodes[1].ID != "neovim" {
 		t.Errorf("nodes[1].ID: expected 'neovim', got %q", graph.Nodes[1].ID)
 	}
-	if graph.Nodes[1].Metadata["feature_count"] != "2" {
-		t.Errorf("nodes[1].Metadata['feature_count']: expected '2', got %q", graph.Nodes[1].Metadata["feature_count"])
+	if graph.Nodes[1].GetSlot("feature_count") != "2" {
+		t.Errorf("nodes[1] slot 'feature_count': expected '2', got %q", graph.Nodes[1].GetSlot("feature_count"))
 	}
-	if graph.Nodes[1].Metadata["feature.0"] != "lsp" {
-		t.Errorf("nodes[1].Metadata['feature.0']: expected 'lsp', got %q", graph.Nodes[1].Metadata["feature.0"])
+	if graph.Nodes[1].GetSlot("feature.0") != "lsp" {
+		t.Errorf("nodes[1] slot 'feature.0': expected 'lsp', got %q", graph.Nodes[1].GetSlot("feature.0"))
 	}
 
 	// Check operations (four-phase pipeline)

--- a/internal/starlark/bindings.go
+++ b/internal/starlark/bindings.go
@@ -188,17 +188,13 @@ func (b *Bindings) packageSetting(thread *starlark.Thread, fn *starlark.Builtin,
 // =============================================================================
 
 func (b *Bindings) fsStruct() *starlarkstruct.Struct {
+	// NOTE: fs.* contains ONLY read-only operations.
+	// Mutating operations must use plan.file.* which adds to the execution graph.
+	// This follows the Bazel model: Starlark plans, engine executes.
 	return starlarkstruct.FromStringDict(starlark.String("fs"), starlark.StringDict{
 		"exists":   starlark.NewBuiltin("fs.exists", b.fsExists),
 		"is_dir":   starlark.NewBuiltin("fs.is_dir", b.fsIsDir),
 		"read":     starlark.NewBuiltin("fs.read", b.fsRead),
-		"write":    starlark.NewBuiltin("fs.write", b.fsWrite),
-		"mkdir":    starlark.NewBuiltin("fs.mkdir", b.fsMkdir),
-		"remove":   starlark.NewBuiltin("fs.remove", b.fsRemove),
-		"copy":     starlark.NewBuiltin("fs.copy", b.fsCopy),
-		"move":     starlark.NewBuiltin("fs.move", b.fsMove),
-		"chmod":    starlark.NewBuiltin("fs.chmod", b.fsChmod),
-		"symlink":  starlark.NewBuiltin("fs.symlink", b.fsSymlink),
 		"which":    starlark.NewBuiltin("fs.which", b.fsWhich),
 		"home":     starlark.NewBuiltin("fs.home", b.fsHome),
 		"join":     starlark.NewBuiltin("fs.join", b.fsJoin),
@@ -241,105 +237,6 @@ func (b *Bindings) fsRead(thread *starlark.Thread, fn *starlark.Builtin, args st
 		return starlark.String(""), nil
 	}
 	return starlark.String(data), nil
-}
-
-func (b *Bindings) fsWrite(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path, content string
-	var mode = 0o644
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &path, "content", &content, "mode?", &mode); err != nil {
-		return nil, err
-	}
-	path = b.host.ExpandPath(path)
-
-	_, _ = fmt.Fprintf(b.output, "  [fs] Writing %s\n", path)
-	err := os.WriteFile(path, []byte(content), os.FileMode(mode))
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsMkdir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path string
-	var parents = true
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &path, "parents?", &parents); err != nil {
-		return nil, err
-	}
-	path = b.host.ExpandPath(path)
-
-	var err error
-	if parents {
-		err = os.MkdirAll(path, 0o755)
-	} else {
-		err = os.Mkdir(path, 0o755)
-	}
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsRemove(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path string
-	var recursive bool
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &path, "recursive?", &recursive); err != nil {
-		return nil, err
-	}
-	path = b.host.ExpandPath(path)
-
-	var err error
-	if recursive {
-		err = os.RemoveAll(path)
-	} else {
-		err = os.Remove(path)
-	}
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsCopy(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var src, dest string
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &dest); err != nil {
-		return nil, err
-	}
-	src = b.host.ExpandPath(src)
-	dest = b.host.ExpandPath(dest)
-
-	input, err := os.ReadFile(src)
-	if err != nil {
-		return starlark.False, nil
-	}
-	err = os.WriteFile(dest, input, 0o644)
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsMove(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var src, dest string
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &dest); err != nil {
-		return nil, err
-	}
-	src = b.host.ExpandPath(src)
-	dest = b.host.ExpandPath(dest)
-
-	err := os.Rename(src, dest)
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsChmod(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path string
-	var mode int
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &path, "mode", &mode); err != nil {
-		return nil, err
-	}
-	path = b.host.ExpandPath(path)
-
-	err := os.Chmod(path, os.FileMode(mode))
-	return starlark.Bool(err == nil), nil
-}
-
-func (b *Bindings) fsSymlink(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var src, dest string
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &dest); err != nil {
-		return nil, err
-	}
-	src = b.host.ExpandPath(src)
-	dest = b.host.ExpandPath(dest)
-
-	err := os.Symlink(src, dest)
-	return starlark.Bool(err == nil), nil
 }
 
 func (b *Bindings) fsWhich(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/starlark/interfaces.go
+++ b/internal/starlark/interfaces.go
@@ -127,6 +127,12 @@ type PlanBindings interface {
 	// Graph returns the underlying execution graph being built.
 	Graph() *execution.Graph
 
+	// Host returns the host abstraction for path expansion, etc.
+	Host() host.Host
+
+	// Project returns the project name for grouping nodes.
+	Project() string
+
 	// Package operations - use platform's auto-detected package manager.
 	// On Darwin, supports brew:pkg and port:pkg prefixes for manager override.
 
@@ -152,9 +158,6 @@ type PlanBindings interface {
 
 	// Copy adds a file copy node.
 	Copy(source, target string) *execution.Node
-
-	// Mkdir adds a directory creation node.
-	Mkdir(target string) *execution.Node
 
 	// Write adds a file write node (write content directly to target).
 	Write(target, content string) *execution.Node

--- a/internal/starlark/output.go
+++ b/internal/starlark/output.go
@@ -91,23 +91,29 @@ func (o *Output) FillSlot(consumer *execution.Node, slotName string) {
 	// Set the slot to reference this output's node
 	consumer.SetSlotPromise(slotName, o.node.ID, o.slot)
 
-	// Create edge: consumer depends_on producer
+	// Create edge: producer must complete before consumer
 	o.graph.Edges = append(o.graph.Edges, execution.Edge{
-		From:     o.node.ID, // producer
-		To:       consumer.ID,
-		Relation: "depends_on",
+		From: o.node.ID,
+		To:   consumer.ID,
 	})
 }
 
 // FillSlot fills a slot in a node from a Starlark value.
 //
-// Any slot accepts either:
+// Any slot accepts:
 //   - A promise (Output): creates an edge, value flows at runtime
+//   - A gather (Gather): creates edges from all members (parallel execution)
 //   - An immediate value: stored directly, known at analysis time
 func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, value starlark.Value) error {
 	// Promise: create edge, value flows at runtime
 	if output, ok := value.(*Output); ok {
 		output.FillSlot(node, slotName)
+		return nil
+	}
+
+	// Gather: create edges from all members (parallel execution)
+	if gather, ok := value.(*Gather); ok {
+		gather.FillSlot(node, slotName)
 		return nil
 	}
 
@@ -157,4 +163,64 @@ func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, val
 // Path returns a path from the node's slots.
 func (o *Output) Path() string {
 	return o.node.GetSlot("path")
+}
+
+// Gather represents a collection of outputs that can run in parallel.
+// When used as a slot input, it creates edges from ALL members to the consumer,
+// enabling parallel execution of the gathered nodes.
+//
+// Usage in Starlark:
+//
+//	a = plan.file.copy(src1, dst1)
+//	b = plan.file.copy(src2, dst2)
+//	c = plan.file.copy(src3, dst3)
+//	group = plan.gather(a, b, c)
+//	d = plan.whatever(group)  # d waits for a, b, c (which run in parallel)
+type Gather struct {
+	outputs []*Output
+	graph   *execution.Graph
+}
+
+// NewGather creates a new Gather from multiple outputs.
+func NewGather(graph *execution.Graph, outputs ...*Output) *Gather {
+	return &Gather{
+		outputs: outputs,
+		graph:   graph,
+	}
+}
+
+// Starlark Value interface
+func (g *Gather) String() string {
+	ids := make([]string, len(g.outputs))
+	for i, o := range g.outputs {
+		ids[i] = o.node.ID
+	}
+	return fmt.Sprintf("Gather(%v)", ids)
+}
+func (g *Gather) Type() string          { return "Gather" }
+func (g *Gather) Freeze()               {}
+func (g *Gather) Truth() starlark.Bool  { return len(g.outputs) > 0 }
+func (g *Gather) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Gather") }
+
+// Outputs returns the gathered outputs.
+func (g *Gather) Outputs() []*Output {
+	return g.outputs
+}
+
+// FillSlot fills a slot in the consumer node with all gathered promises,
+// creating edges from each member. This enables parallel execution.
+func (g *Gather) FillSlot(consumer *execution.Node, slotName string) {
+	for i, output := range g.outputs {
+		// Set slot reference for each output
+		subSlot := fmt.Sprintf("%s[%d]", slotName, i)
+		consumer.SetSlotPromise(subSlot, output.node.ID, output.slot)
+
+		// Create edge: producer must complete before consumer
+		g.graph.Edges = append(g.graph.Edges, execution.Edge{
+			From: output.node.ID,
+			To:   consumer.ID,
+		})
+	}
+	// Store count for runtime
+	consumer.SetSlotImmediate(slotName+".len", fmt.Sprintf("%d", len(g.outputs)))
 }

--- a/internal/starlark/output.go
+++ b/internal/starlark/output.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+)
+
+// Output represents a promise - a handle to a node's output that can flow
+// through the graph to fill slots in other nodes.
+//
+// When passed to a plan function's slot, it creates an edge in the graph.
+// The same promise can flow to multiple slots (fan-out).
+type Output struct {
+	// node is the action that produces this output
+	node *execution.Node
+
+	// graph is the execution graph (for creating edges)
+	graph *execution.Graph
+
+	// slot identifies which output of the node this represents (empty = default)
+	slot string
+}
+
+// NewOutput creates a new Output (promise) representing a node's output.
+func NewOutput(node *execution.Node, graph *execution.Graph, slot string) *Output {
+	return &Output{
+		node:  node,
+		graph: graph,
+		slot:  slot,
+	}
+}
+
+// Starlark Value interface
+func (o *Output) String() string        { return fmt.Sprintf("Output(%s)", o.node.ID) }
+func (o *Output) Type() string          { return "Output" }
+func (o *Output) Freeze()               {}
+func (o *Output) Truth() starlark.Bool  { return true }
+func (o *Output) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Output") }
+
+// Starlark HasAttrs interface
+func (o *Output) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "node_id":
+		return starlark.String(o.node.ID), nil
+	case "slot":
+		return starlark.String(o.slot), nil
+	default:
+		// Get the value from the node's slots
+		if value := o.node.GetSlot(name); value != "" {
+			return starlark.String(value), nil
+		}
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("Output has no attribute %q", name))
+	}
+}
+
+func (o *Output) AttrNames() []string {
+	names := []string{"node_id", "slot"}
+	// Add slot names from the node
+	if o.node.Slots != nil {
+		for name := range o.node.Slots {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// Node returns the execution node that produces this output.
+func (o *Output) Node() *execution.Node {
+	return o.node
+}
+
+// Graph returns the execution graph.
+func (o *Output) Graph() *execution.Graph {
+	return o.graph
+}
+
+// Slot returns which output slot this represents.
+func (o *Output) Slot() string {
+	return o.slot
+}
+
+// FillSlot fills a slot in the consumer node with this promise, creating an edge.
+// This is called when a promise is passed to a plan function.
+func (o *Output) FillSlot(consumer *execution.Node, slotName string) {
+	// Set the slot to reference this output's node
+	consumer.SetSlotPromise(slotName, o.node.ID, o.slot)
+
+	// Create edge: consumer depends_on producer
+	o.graph.Edges = append(o.graph.Edges, execution.Edge{
+		From:     o.node.ID, // producer
+		To:       consumer.ID,
+		Relation: "depends_on",
+	})
+}
+
+// FillSlot fills a slot in a node from a Starlark value.
+//
+// Any slot accepts either:
+//   - A promise (Output): creates an edge, value flows at runtime
+//   - An immediate value: stored directly, known at analysis time
+func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, value starlark.Value) error {
+	// Promise: create edge, value flows at runtime
+	if output, ok := value.(*Output); ok {
+		output.FillSlot(node, slotName)
+		return nil
+	}
+
+	// Immediate: store directly
+	if str, ok := starlark.AsString(value); ok {
+		node.SetSlotImmediate(slotName, str)
+		return nil
+	}
+
+	// List: recurse for each element
+	if list, ok := value.(*starlark.List); ok {
+		iter := list.Iterate()
+		defer iter.Done()
+		var v starlark.Value
+		i := 0
+		for iter.Next(&v) {
+			subSlot := fmt.Sprintf("%s[%d]", slotName, i)
+			if err := FillSlot(node, graph, subSlot, v); err != nil {
+				return fmt.Errorf("list element %d: %w", i, err)
+			}
+			i++
+		}
+		node.SetSlotImmediate(slotName+".len", fmt.Sprintf("%d", i))
+		return nil
+	}
+
+	// Other immediate types
+	switch v := value.(type) {
+	case starlark.Int:
+		i, _ := v.Int64()
+		node.SetSlotImmediate(slotName, fmt.Sprintf("%d", i))
+		return nil
+	case starlark.Bool:
+		node.SetSlotImmediate(slotName, fmt.Sprintf("%t", v))
+		return nil
+	case starlark.Float:
+		node.SetSlotImmediate(slotName, fmt.Sprintf("%f", v))
+		return nil
+	case starlark.NoneType:
+		return nil
+	}
+
+	return fmt.Errorf("unsupported value type %s for slot %q", value.Type(), slotName)
+}
+
+
+// Path returns a path from the node's slots.
+func (o *Output) Path() string {
+	return o.node.GetSlot("path")
+}

--- a/internal/starlark/plan.go
+++ b/internal/starlark/plan.go
@@ -263,9 +263,8 @@ func (p *planBindings) Shell(command string) *execution.Node {
 // DependsOn creates a dependency edge between nodes.
 func (p *planBindings) DependsOn(from, to *execution.Node) {
 	p.graph.Edges = append(p.graph.Edges, execution.Edge{
-		From:     to.ID,
-		To:       from.ID,
-		Relation: "depends_on",
+		From: to.ID,
+		To:   from.ID,
 	})
 }
 

--- a/internal/starlark/plan.go
+++ b/internal/starlark/plan.go
@@ -52,16 +52,24 @@ func (p *planBindings) Graph() *execution.Graph {
 	return p.graph
 }
 
+// Host returns the host abstraction.
+func (p *planBindings) Host() host.Host {
+	return p.host
+}
+
+// Project returns the project name for grouping nodes.
+func (p *planBindings) Project() string {
+	return p.project
+}
+
 // PackageInstall adds a package installation node.
 func (p *planBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-install", packages...),
 		Operations: []string{"package-install"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -72,10 +80,8 @@ func (p *planBindings) PackageUpgrade(packages ...string) *execution.Node {
 		ID:         generateNodeID("package-upgrade", packages...),
 		Operations: []string{"package-upgrade"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -86,10 +92,8 @@ func (p *planBindings) PackageRemove(packages ...string) *execution.Node {
 		ID:         generateNodeID("package-remove", packages...),
 		Operations: []string{"package-remove"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -100,7 +104,6 @@ func (p *planBindings) PackageUpdate() *execution.Node {
 		ID:         generateNodeID("package-update"),
 		Operations: []string{"package-update"},
 		Project:    p.project,
-		Metadata:   map[string]string{},
 	}
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
@@ -110,11 +113,11 @@ func (p *planBindings) PackageUpdate() *execution.Node {
 func (p *planBindings) Configure(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("configure"),
-		Operations: []string{"expand", "copy"},
-		Source:     source,
-		Target:     p.host.ExpandPath(target),
+		Operations: []string{"render", "copy"},
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -124,10 +127,10 @@ func (p *planBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("link"),
 		Operations: []string{"link"},
-		Source:     source,
-		Target:     p.host.ExpandPath(target),
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -137,22 +140,10 @@ func (p *planBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("copy"),
 		Operations: []string{"copy"},
-		Source:     source,
-		Target:     p.host.ExpandPath(target),
 		Project:    p.project,
 	}
-	p.graph.Nodes = append(p.graph.Nodes, node)
-	return node
-}
-
-// Mkdir adds a directory creation node.
-func (p *planBindings) Mkdir(target string) *execution.Node {
-	node := &execution.Node{
-		ID:         generateNodeID("mkdir"),
-		Operations: []string{"mkdir"},
-		Target:     p.host.ExpandPath(target),
-		Project:    p.project,
-	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -161,13 +152,11 @@ func (p *planBindings) Mkdir(target string) *execution.Node {
 func (p *planBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("write"),
-		Operations: []string{"file-write"},
-		Target:     p.host.ExpandPath(target),
+		Operations: []string{"write"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"content": content,
-		},
 	}
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
+	node.SetSlotImmediate("content", content)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -176,10 +165,10 @@ func (p *planBindings) Write(target, content string) *execution.Node {
 func (p *planBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("remove"),
-		Operations: []string{"file-remove"},
-		Target:     p.host.ExpandPath(target),
+		Operations: []string{"remove"},
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -189,10 +178,10 @@ func (p *planBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("download"),
 		Operations: []string{"download"},
-		Source:     url,
-		Target:     p.host.ExpandPath(target),
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("url", url)
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -202,10 +191,10 @@ func (p *planBindings) ArchiveExtract(archive, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("archive-extract"),
 		Operations: []string{"archive-extract"},
-		Source:     p.host.ExpandPath(archive),
-		Target:     p.host.ExpandPath(target),
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("source", p.host.ExpandPath(archive))
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -215,10 +204,10 @@ func (p *planBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-clone"),
 		Operations: []string{"git-clone"},
-		Source:     url,
-		Target:     p.host.ExpandPath(target),
 		Project:    p.project,
 	}
+	node.SetSlotImmediate("url", url)
+	node.SetSlotImmediate("path", p.host.ExpandPath(target))
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -229,10 +218,8 @@ func (p *planBindings) GitCheckout(ref string) *execution.Node {
 		ID:         generateNodeID("git-checkout"),
 		Operations: []string{"git-checkout"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"ref": ref,
-		},
 	}
+	node.SetSlotImmediate("ref", ref)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -252,13 +239,11 @@ func (p *planBindings) GitPull() *execution.Node {
 func (p *planBindings) Service(name string, action ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("service", name, action.String()),
-		Operations: []string{"service-" + action.String()},
+		Operations: []string{"service"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"service": name,
-			"action":  action.String(),
-		},
 	}
+	node.SetSlotImmediate("name", name)
+	node.SetSlotImmediate("action", action.String())
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -269,10 +254,8 @@ func (p *planBindings) Shell(command string) *execution.Node {
 		ID:         generateNodeID("shell"),
 		Operations: []string{"shell"},
 		Project:    p.project,
-		Metadata: map[string]string{
-			"command": command,
-		},
 	}
+	node.SetSlotImmediate("command", command)
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return node
 }
@@ -295,10 +278,11 @@ type StarlarkPlanBindings struct {
 	PlanBindings
 }
 
-// ToStarlark converts the plan bindings to a Starlark struct.
+// ToStarlark converts the plan bindings to a Starlark value.
 // Exposed to phase scripts as the third argument.
 //
-// Starlark API uses nested structs:
+// All namespaces use the Attr receiver pattern for consistency and
+// static analysis support. Starlark API:
 //
 //	plan.package.install("pkg1", "pkg2", ...)  # Install packages
 //	plan.package.upgrade("pkg1", ...)          # Upgrade packages
@@ -307,292 +291,42 @@ type StarlarkPlanBindings struct {
 //	plan.file.configure(source, target)        # Configure file (template + copy)
 //	plan.file.link(source, target)             # Create symlink
 //	plan.file.copy(source, target)             # Copy file
-//	plan.file.mkdir(target)                    # Create directory
 //	plan.file.write(target, content)           # Write content to file
+//	plan.file.remove(target)                   # Remove file/directory
+//	plan.archive.extract(archive, prefix)      # Extract archive
+//	plan.git.clone(url, path)                  # Clone repository
+//	plan.git.checkout(repo, ref)               # Checkout ref
+//	plan.git.pull(repo)                        # Pull changes
+//	plan.source(path)                          # Declare source file
+//	plan.literal(content)                      # Inline content
+//	plan.download(url)                         # Download file
 //	plan.service(name, action)                 # Manage service
 //	plan.shell(command)                        # Run shell command
-//	plan.depends_on(from, to)                  # Create dependency
+//	plan.depends_on(consumer, producer)        # Create dependency
 func (s *StarlarkPlanBindings) ToStarlark() starlark.Value {
-	// Package operations namespace: plan.package.*
-	packageOps := starlarkstruct.FromStringDict(starlark.String("package"), starlark.StringDict{
-		"install": starlark.NewBuiltin("plan.package.install", s.packageInstallBuiltin),
-		"upgrade": starlark.NewBuiltin("plan.package.upgrade", s.packageUpgradeBuiltin),
-		"remove":  starlark.NewBuiltin("plan.package.remove", s.packageRemoveBuiltin),
-		"update":  starlark.NewBuiltin("plan.package.update", s.packageUpdateBuiltin),
-	})
-
-	// File operations namespace: plan.file.*
-	fileOps := starlarkstruct.FromStringDict(starlark.String("file"), starlark.StringDict{
-		"configure": starlark.NewBuiltin("plan.file.configure", s.configureBuiltin),
-		"link":      starlark.NewBuiltin("plan.file.link", s.linkBuiltin),
-		"copy":      starlark.NewBuiltin("plan.file.copy", s.copyBuiltin),
-		"mkdir":     starlark.NewBuiltin("plan.file.mkdir", s.mkdirBuiltin),
-		"write":     starlark.NewBuiltin("plan.file.write", s.writeBuiltin),
-		"remove":    starlark.NewBuiltin("plan.file.remove", s.removeBuiltin),
-	})
-
-	// Archive operations namespace: plan.archive.*
-	archiveOps := starlarkstruct.FromStringDict(starlark.String("archive"), starlark.StringDict{
-		"extract": starlark.NewBuiltin("plan.archive.extract", s.archiveExtractBuiltin),
-	})
-
-	// Git operations namespace: plan.git.*
-	gitOps := starlarkstruct.FromStringDict(starlark.String("git"), starlark.StringDict{
-		"clone":    starlark.NewBuiltin("plan.git.clone", s.gitCloneBuiltin),
-		"checkout": starlark.NewBuiltin("plan.git.checkout", s.gitCheckoutBuiltin),
-		"pull":     starlark.NewBuiltin("plan.git.pull", s.gitPullBuiltin),
-	})
-
-	return starlarkstruct.FromStringDict(starlark.String("plan"), starlark.StringDict{
-		"package":    packageOps,
-		"file":       fileOps,
-		"archive":    archiveOps,
-		"git":        gitOps,
-		"download":   starlark.NewBuiltin("plan.download", s.downloadBuiltin),
-		"service":    starlark.NewBuiltin("plan.service", s.serviceBuiltin),
-		"shell":      starlark.NewBuiltin("plan.shell", s.shellBuiltin),
-		"depends_on": starlark.NewBuiltin("plan.depends_on", s.dependsOnBuiltin),
-	})
+	return NewPlanRoot(s.Graph(), s.Host(), s.Project())
 }
 
-func (s *StarlarkPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	packages := make([]string, len(args))
-	for i, arg := range args {
-		str, ok := starlark.AsString(arg)
-		if !ok {
-			return nil, fmt.Errorf("install: argument %d is not a string", i)
+// extractNodeID extracts the node ID from an argument that may be Output or struct.
+func extractNodeID(arg starlark.Value, position string) (string, error) {
+	// Check if it's an Output
+	if output, ok := arg.(*Output); ok {
+		return output.node.ID, nil
+	}
+
+	// Check if it's a struct with an id attribute
+	if st, ok := arg.(*starlarkstruct.Struct); ok {
+		idVal, err := st.Attr("id")
+		if err != nil {
+			return "", fmt.Errorf("%s argument has no id", position)
 		}
-		packages[i] = str
-	}
-	if len(packages) == 0 {
-		return nil, fmt.Errorf("install: at least one package required")
-	}
-	node := s.PackageInstall(packages...)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	packages := make([]string, len(args))
-	for i, arg := range args {
-		str, ok := starlark.AsString(arg)
+		idStr, ok := starlark.AsString(idVal)
 		if !ok {
-			return nil, fmt.Errorf("upgrade: argument %d is not a string", i)
+			return "", fmt.Errorf("%s argument id is not a string", position)
 		}
-		packages[i] = str
+		return idStr, nil
 	}
-	if len(packages) == 0 {
-		return nil, fmt.Errorf("upgrade: at least one package required")
-	}
-	node := s.PackageUpgrade(packages...)
-	return nodeToStarlark(node), nil
+
+	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
 }
 
-func (s *StarlarkPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	packages := make([]string, len(args))
-	for i, arg := range args {
-		str, ok := starlark.AsString(arg)
-		if !ok {
-			return nil, fmt.Errorf("remove: argument %d is not a string", i)
-		}
-		packages[i] = str
-	}
-	if len(packages) == 0 {
-		return nil, fmt.Errorf("remove: at least one package required")
-	}
-	node := s.PackageRemove(packages...)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	node := s.PackageUpdate()
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Configure(source, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Link(source, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Copy(source, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) mkdirBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target string
-	if err := starlark.UnpackArgs("mkdir", args, kwargs, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Mkdir(target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target, content string
-	if err := starlark.UnpackArgs("write", args, kwargs, "target", &target, "content", &content); err != nil {
-		return nil, err
-	}
-	node := s.Write(target, content)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) removeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target string
-	if err := starlark.UnpackArgs("remove", args, kwargs, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Remove(target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) downloadBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var url, target string
-	if err := starlark.UnpackArgs("download", args, kwargs, "url", &url, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.Download(url, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) archiveExtractBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var archive, target string
-	if err := starlark.UnpackArgs("extract", args, kwargs, "archive", &archive, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.ArchiveExtract(archive, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) gitCloneBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var url, target string
-	if err := starlark.UnpackArgs("clone", args, kwargs, "url", &url, "target", &target); err != nil {
-		return nil, err
-	}
-	node := s.GitClone(url, target)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) gitCheckoutBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var ref string
-	if err := starlark.UnpackArgs("checkout", args, kwargs, "ref", &ref); err != nil {
-		return nil, err
-	}
-	node := s.GitCheckout(ref)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) gitPullBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	node := s.GitPull()
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var name, action string
-	if err := starlark.UnpackArgs("service", args, kwargs, "name", &name, "action", &action); err != nil {
-		return nil, err
-	}
-
-	var serviceAction ServiceAction
-	switch action {
-	case "start":
-		serviceAction = ServiceStart
-	case "stop":
-		serviceAction = ServiceStop
-	case "restart":
-		serviceAction = ServiceRestart
-	case "enable":
-		serviceAction = ServiceEnable
-	case "disable":
-		serviceAction = ServiceDisable
-	default:
-		return nil, fmt.Errorf("service: unknown action %q", action)
-	}
-
-	node := s.Service(name, serviceAction)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var command string
-	if err := starlark.UnpackArgs("shell", args, kwargs, "command", &command); err != nil {
-		return nil, err
-	}
-	node := s.Shell(command)
-	return nodeToStarlark(node), nil
-}
-
-func (s *StarlarkPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
-	}
-
-	fromStruct, ok := args[0].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: first argument must be a node")
-	}
-	toStruct, ok := args[1].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: second argument must be a node")
-	}
-
-	fromID, err := fromStruct.Attr("id")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: first argument has no id")
-	}
-	toID, err := toStruct.Attr("id")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: second argument has no id")
-	}
-
-	fromIDStr, _ := starlark.AsString(fromID)
-	toIDStr, _ := starlark.AsString(toID)
-
-	// Create edge in the graph
-	graph := s.Graph()
-	graph.Edges = append(graph.Edges, execution.Edge{
-		From:     toIDStr,
-		To:       fromIDStr,
-		Relation: "depends_on",
-	})
-
-	return starlark.None, nil
-}
-
-// nodeToStarlark converts a execution.Node to a Starlark struct.
-func nodeToStarlark(node *execution.Node) starlark.Value {
-	ops := make([]starlark.Value, len(node.Operations))
-	for i, op := range node.Operations {
-		ops[i] = starlark.String(op)
-	}
-
-	metadata := starlark.NewDict(len(node.Metadata))
-	for k, v := range node.Metadata {
-		_ = metadata.SetKey(starlark.String(k), starlark.String(v))
-	}
-
-	return starlarkstruct.FromStringDict(starlark.String("node"), starlark.StringDict{
-		"id":         starlark.String(node.ID),
-		"operations": starlark.NewList(ops),
-		"source":     starlark.String(node.Source),
-		"target":     starlark.String(node.Target),
-		"project":    starlark.String(node.Project),
-		"metadata":   metadata,
-	})
-}

--- a/internal/starlark/plan_archive.go
+++ b/internal/starlark/plan_archive.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// ArchivePlan implements plan.archive.* bindings using the slot-based model.
+type ArchivePlan struct {
+	graph   *execution.Graph
+	host    host.Host
+	project string
+}
+
+// NewArchivePlan creates a new ArchivePlan for the given graph and host.
+func NewArchivePlan(graph *execution.Graph, h host.Host, project string) *ArchivePlan {
+	return &ArchivePlan{
+		graph:   graph,
+		host:    h,
+		project: project,
+	}
+}
+
+// Starlark Value interface
+func (a *ArchivePlan) String() string        { return "plan.archive" }
+func (a *ArchivePlan) Type() string          { return "plan.archive" }
+func (a *ArchivePlan) Freeze()               {}
+func (a *ArchivePlan) Truth() starlark.Bool  { return true }
+func (a *ArchivePlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: plan.archive") }
+
+// Starlark HasAttrs interface
+func (a *ArchivePlan) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "extract":
+		return starlark.NewBuiltin("plan.archive.extract", a.extract), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan.archive has no attribute %q", name))
+	}
+}
+
+func (a *ArchivePlan) AttrNames() []string {
+	return []string{"extract"}
+}
+
+// extract extracts an archive to a target directory.
+// Usage: plan.archive.extract(archive, prefix)
+//
+// Slots:
+//   - archive: Archive file to extract (promise or immediate)
+//   - prefix: Directory to extract into (promise or immediate)
+//
+// Returns: Promise of the extracted directory
+func (a *ArchivePlan) extract(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var archive, prefix starlark.Value
+	if err := starlark.UnpackArgs("extract", args, kwargs, "archive", &archive, "prefix", &prefix); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("archive-extract"),
+		Operations: []string{"archive-extract"},
+		Project:    a.project,
+	}
+
+	if err := FillSlot(node, a.graph, "archive", archive); err != nil {
+		return nil, fmt.Errorf("extract: archive: %w", err)
+	}
+	if err := FillSlot(node, a.graph, "prefix", prefix); err != nil {
+		return nil, fmt.Errorf("extract: prefix: %w", err)
+	}
+
+	a.graph.Nodes = append(a.graph.Nodes, node)
+	return NewOutput(node, a.graph, ""), nil
+}

--- a/internal/starlark/plan_file.go
+++ b/internal/starlark/plan_file.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// FilePlan implements plan.file.* bindings using the slot-based model.
+// Each method adds a node to the execution graph.
+//
+// Slots can be filled with either:
+// - Immediate values (strings known at analysis time)
+// - Promises (Output handles that create edges)
+type FilePlan struct {
+	graph   *execution.Graph
+	host    host.Host
+	project string
+}
+
+// NewFilePlan creates a new FilePlan for the given graph and host.
+func NewFilePlan(graph *execution.Graph, h host.Host, project string) *FilePlan {
+	return &FilePlan{
+		graph:   graph,
+		host:    h,
+		project: project,
+	}
+}
+
+// Starlark Value interface
+func (f *FilePlan) String() string        { return "plan.file" }
+func (f *FilePlan) Type() string          { return "plan.file" }
+func (f *FilePlan) Freeze()               {}
+func (f *FilePlan) Truth() starlark.Bool  { return true }
+func (f *FilePlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: plan.file") }
+
+// Starlark HasAttrs interface
+func (f *FilePlan) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "configure":
+		return starlark.NewBuiltin("plan.file.configure", f.configure), nil
+	case "link":
+		return starlark.NewBuiltin("plan.file.link", f.link), nil
+	case "copy":
+		return starlark.NewBuiltin("plan.file.copy", f.copy), nil
+	case "write":
+		return starlark.NewBuiltin("plan.file.write", f.write), nil
+	case "remove":
+		return starlark.NewBuiltin("plan.file.remove", f.remove), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan.file has no attribute %q", name))
+	}
+}
+
+func (f *FilePlan) AttrNames() []string {
+	return []string{"configure", "copy", "link", "remove", "write"}
+}
+
+// configure adds a configuration file node (template expansion + copy).
+// Usage: plan.file.configure(source, path)
+//
+// Slots:
+//   - source: Input file/content (promise or immediate)
+//   - path: Destination path (promise or immediate)
+//
+// Returns: Promise of the configured file
+func (f *FilePlan) configure(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("configure"),
+		Operations: []string{"render", "copy"},
+		Project:    f.project,
+	}
+
+	if err := FillSlot(node, f.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("configure: source: %w", err)
+	}
+	if err := FillSlot(node, f.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("configure: path: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return NewOutput(node, f.graph, ""), nil
+}
+
+// link adds a symlink creation node.
+// Usage: plan.file.link(source, path)
+//
+// Slots:
+//   - source: File to link to (promise or immediate)
+//   - path: Where to create the symlink (promise or immediate)
+//
+// Returns: Promise of the symlink
+func (f *FilePlan) link(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("link"),
+		Operations: []string{"link"},
+		Project:    f.project,
+	}
+
+	if err := FillSlot(node, f.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("link: source: %w", err)
+	}
+	if err := FillSlot(node, f.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("link: path: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return NewOutput(node, f.graph, ""), nil
+}
+
+// copy adds a file copy node.
+// Usage: plan.file.copy(source, path)
+//
+// Slots:
+//   - source: File to copy (promise or immediate)
+//   - path: Destination path (promise or immediate)
+//
+// Returns: Promise of the copied file
+func (f *FilePlan) copy(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("copy"),
+		Operations: []string{"copy"},
+		Project:    f.project,
+	}
+
+	if err := FillSlot(node, f.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("copy: source: %w", err)
+	}
+	if err := FillSlot(node, f.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("copy: path: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return NewOutput(node, f.graph, ""), nil
+}
+
+// write adds a file write node.
+// Usage: plan.file.write(content, path)
+//
+// Slots:
+//   - content: Content to write (promise or immediate)
+//   - path: Destination path (promise or immediate)
+//
+// Returns: Promise of the written file
+func (f *FilePlan) write(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var content, path starlark.Value
+	if err := starlark.UnpackArgs("write", args, kwargs, "content", &content, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("write"),
+		Operations: []string{"write"},
+		Project:    f.project,
+	}
+
+	if err := FillSlot(node, f.graph, "content", content); err != nil {
+		return nil, fmt.Errorf("write: content: %w", err)
+	}
+	if err := FillSlot(node, f.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("write: path: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return NewOutput(node, f.graph, ""), nil
+}
+
+// remove adds a file/directory removal node.
+// Usage: plan.file.remove(path)
+//
+// Slots:
+//   - path: Path to remove (promise or immediate)
+//
+// Returns: None (removal produces no output)
+func (f *FilePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path starlark.Value
+	if err := starlark.UnpackArgs("remove", args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("remove"),
+		Operations: []string{"remove"},
+		Project:    f.project,
+	}
+
+	if err := FillSlot(node, f.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("remove: path: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return starlark.None, nil
+}

--- a/internal/starlark/plan_git.go
+++ b/internal/starlark/plan_git.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// GitPlan implements plan.git.* bindings using the slot-based model.
+type GitPlan struct {
+	graph   *execution.Graph
+	host    host.Host
+	project string
+}
+
+// NewGitPlan creates a new GitPlan for the given graph and host.
+func NewGitPlan(graph *execution.Graph, h host.Host, project string) *GitPlan {
+	return &GitPlan{
+		graph:   graph,
+		host:    h,
+		project: project,
+	}
+}
+
+// Starlark Value interface
+func (g *GitPlan) String() string        { return "plan.git" }
+func (g *GitPlan) Type() string          { return "plan.git" }
+func (g *GitPlan) Freeze()               {}
+func (g *GitPlan) Truth() starlark.Bool  { return true }
+func (g *GitPlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: plan.git") }
+
+// Starlark HasAttrs interface
+func (g *GitPlan) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "clone":
+		return starlark.NewBuiltin("plan.git.clone", g.clone), nil
+	case "checkout":
+		return starlark.NewBuiltin("plan.git.checkout", g.checkout), nil
+	case "pull":
+		return starlark.NewBuiltin("plan.git.pull", g.pull), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan.git has no attribute %q", name))
+	}
+}
+
+func (g *GitPlan) AttrNames() []string {
+	return []string{"checkout", "clone", "pull"}
+}
+
+// clone clones a git repository.
+// Usage: plan.git.clone(url, path)
+//
+// Slots:
+//   - url: Repository URL to clone (promise or immediate)
+//   - path: Local path to clone into (promise or immediate)
+//
+// Returns: Promise of the cloned repository
+func (g *GitPlan) clone(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var url, path starlark.Value
+	if err := starlark.UnpackArgs("clone", args, kwargs, "url", &url, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("git-clone"),
+		Operations: []string{"git-clone"},
+		Project:    g.project,
+	}
+
+	if err := FillSlot(node, g.graph, "url", url); err != nil {
+		return nil, fmt.Errorf("clone: url: %w", err)
+	}
+	if err := FillSlot(node, g.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("clone: path: %w", err)
+	}
+
+	g.graph.Nodes = append(g.graph.Nodes, node)
+	return NewOutput(node, g.graph, ""), nil
+}
+
+// checkout checks out a git ref in a repository.
+// Usage: plan.git.checkout(repo, ref)
+//
+// Slots:
+//   - repo: Repository to checkout in (promise from clone)
+//   - ref: Branch, tag, or commit to checkout (promise or immediate)
+//
+// Returns: Promise of the checked out repository
+func (g *GitPlan) checkout(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var repo, ref starlark.Value
+	if err := starlark.UnpackArgs("checkout", args, kwargs, "repo", &repo, "ref", &ref); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("git-checkout"),
+		Operations: []string{"git-checkout"},
+		Project:    g.project,
+	}
+
+	if err := FillSlot(node, g.graph, "repo", repo); err != nil {
+		return nil, fmt.Errorf("checkout: repo: %w", err)
+	}
+	if err := FillSlot(node, g.graph, "ref", ref); err != nil {
+		return nil, fmt.Errorf("checkout: ref: %w", err)
+	}
+
+	g.graph.Nodes = append(g.graph.Nodes, node)
+	return NewOutput(node, g.graph, ""), nil
+}
+
+// pull pulls latest changes in a repository.
+// Usage: plan.git.pull(repo)
+//
+// Slots:
+//   - repo: Repository to pull in (promise from clone)
+//
+// Returns: Promise of the updated repository
+func (g *GitPlan) pull(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var repo starlark.Value
+	if err := starlark.UnpackArgs("pull", args, kwargs, "repo", &repo); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("git-pull"),
+		Operations: []string{"git-pull"},
+		Project:    g.project,
+	}
+
+	if err := FillSlot(node, g.graph, "repo", repo); err != nil {
+		return nil, fmt.Errorf("pull: repo: %w", err)
+	}
+
+	g.graph.Nodes = append(g.graph.Nodes, node)
+	return NewOutput(node, g.graph, ""), nil
+}

--- a/internal/starlark/plan_package.go
+++ b/internal/starlark/plan_package.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// PackagePlan implements plan.package.* bindings using the slot-based model.
+// Each method adds a node to the execution graph.
+type PackagePlan struct {
+	graph   *execution.Graph
+	host    host.Host
+	project string
+}
+
+// NewPackagePlan creates a new PackagePlan for the given graph and host.
+func NewPackagePlan(graph *execution.Graph, h host.Host, project string) *PackagePlan {
+	return &PackagePlan{
+		graph:   graph,
+		host:    h,
+		project: project,
+	}
+}
+
+// Starlark Value interface
+func (p *PackagePlan) String() string        { return "plan.package" }
+func (p *PackagePlan) Type() string          { return "plan.package" }
+func (p *PackagePlan) Freeze()               {}
+func (p *PackagePlan) Truth() starlark.Bool  { return true }
+func (p *PackagePlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: plan.package") }
+
+// Starlark HasAttrs interface
+func (p *PackagePlan) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "install":
+		return starlark.NewBuiltin("plan.package.install", p.install), nil
+	case "upgrade":
+		return starlark.NewBuiltin("plan.package.upgrade", p.upgrade), nil
+	case "remove":
+		return starlark.NewBuiltin("plan.package.remove", p.remove), nil
+	case "update":
+		return starlark.NewBuiltin("plan.package.update", p.update), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan.package has no attribute %q", name))
+	}
+}
+
+func (p *PackagePlan) AttrNames() []string {
+	return []string{"install", "remove", "update", "upgrade"}
+}
+
+// install adds a package installation node.
+// Usage: plan.package.install("pkg1", "pkg2", ...)
+//
+// Slots: packages (list of package names, immediate strings)
+// Returns: Promise of installed packages
+func (p *PackagePlan) install(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	packages, err := argsToStrings("install", args)
+	if err != nil {
+		return nil, err
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("install: at least one package required")
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("package-install", packages...),
+		Operations: []string{"package-install"},
+		Project:    p.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// upgrade adds a package upgrade node.
+// Usage: plan.package.upgrade("pkg1", "pkg2", ...)
+//
+// Slots: packages (list of package names, immediate strings)
+// Returns: Promise of upgraded packages
+func (p *PackagePlan) upgrade(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	packages, err := argsToStrings("upgrade", args)
+	if err != nil {
+		return nil, err
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("upgrade: at least one package required")
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("package-upgrade", packages...),
+		Operations: []string{"package-upgrade"},
+		Project:    p.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// remove adds a package removal node.
+// Usage: plan.package.remove("pkg1", "pkg2", ...)
+//
+// Slots: packages (list of package names, immediate strings)
+// Returns: None (removal produces no output)
+func (p *PackagePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	packages, err := argsToStrings("remove", args)
+	if err != nil {
+		return nil, err
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("remove: at least one package required")
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("package-remove", packages...),
+		Operations: []string{"package-remove"},
+		Project:    p.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	// Remove produces no output
+	return starlark.None, nil
+}
+
+// update adds a package index update node.
+// Usage: plan.package.update()
+//
+// Slots: (none)
+// Returns: Promise of updated package index
+func (p *PackagePlan) update(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	if len(args) > 0 {
+		return nil, fmt.Errorf("update: takes no arguments")
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("package-update"),
+		Operations: []string{"package-update"},
+		Project:    p.project,
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// argsToStrings converts Starlark args to a string slice.
+func argsToStrings(funcName string, args starlark.Tuple) ([]string, error) {
+	result := make([]string, len(args))
+	for i, arg := range args {
+		str, ok := starlark.AsString(arg)
+		if !ok {
+			return nil, fmt.Errorf("%s: argument %d is not a string", funcName, i)
+		}
+		result[i] = str
+	}
+	return result, nil
+}

--- a/internal/starlark/plan_root.go
+++ b/internal/starlark/plan_root.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// PlanRoot implements the top-level plan namespace using the slot-based model.
+// It provides access to sub-namespaces (package, file, archive, git) and
+// top-level bindings (source, literal, download, service, shell, depends_on).
+type PlanRoot struct {
+	graph   *execution.Graph
+	host    host.Host
+	project string
+
+	// Sub-namespaces (cached)
+	packagePlan *PackagePlan
+	filePlan    *FilePlan
+	archivePlan *ArchivePlan
+	gitPlan     *GitPlan
+}
+
+// NewPlanRoot creates a new PlanRoot for the given graph and host.
+func NewPlanRoot(graph *execution.Graph, h host.Host, project string) *PlanRoot {
+	return &PlanRoot{
+		graph:       graph,
+		host:        h,
+		project:     project,
+		packagePlan: NewPackagePlan(graph, h, project),
+		filePlan:    NewFilePlan(graph, h, project),
+		archivePlan: NewArchivePlan(graph, h, project),
+		gitPlan:     NewGitPlan(graph, h, project),
+	}
+}
+
+// Starlark Value interface
+func (p *PlanRoot) String() string        { return "plan" }
+func (p *PlanRoot) Type() string          { return "plan" }
+func (p *PlanRoot) Freeze()               {}
+func (p *PlanRoot) Truth() starlark.Bool  { return true }
+func (p *PlanRoot) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: plan") }
+
+// Starlark HasAttrs interface
+func (p *PlanRoot) Attr(name string) (starlark.Value, error) {
+	switch name {
+	// Sub-namespaces
+	case "package":
+		return p.packagePlan, nil
+	case "file":
+		return p.filePlan, nil
+	case "archive":
+		return p.archivePlan, nil
+	case "git":
+		return p.gitPlan, nil
+	// Top-level bindings
+	case "source":
+		return starlark.NewBuiltin("plan.source", p.source), nil
+	case "literal":
+		return starlark.NewBuiltin("plan.literal", p.literal), nil
+	case "download":
+		return starlark.NewBuiltin("plan.download", p.download), nil
+	case "service":
+		return starlark.NewBuiltin("plan.service", p.service), nil
+	case "shell":
+		return starlark.NewBuiltin("plan.shell", p.shell), nil
+	case "depends_on":
+		return starlark.NewBuiltin("plan.depends_on", p.dependsOn), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan has no attribute %q", name))
+	}
+}
+
+func (p *PlanRoot) AttrNames() []string {
+	return []string{
+		"archive", "depends_on", "download", "file", "git",
+		"literal", "package", "service", "shell", "source",
+	}
+}
+
+// source creates a source file artifact.
+// Usage: plan.source(path)
+//
+// Slots:
+//   - path: Path to existing source file (immediate only)
+//
+// Returns: Promise of the source file
+func (p *PlanRoot) source(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path starlark.Value
+	if err := starlark.UnpackArgs("source", args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("source"),
+		Operations: []string{"source"},
+		Project:    p.project,
+	}
+
+	if err := FillSlot(node, p.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("source: path: %w", err)
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// literal creates a literal content artifact.
+// Usage: plan.literal(content)
+//
+// Slots:
+//   - content: Inline content (promise or immediate)
+//
+// Returns: Promise of the content
+func (p *PlanRoot) literal(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var content starlark.Value
+	if err := starlark.UnpackArgs("literal", args, kwargs, "content", &content); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("literal"),
+		Operations: []string{"literal"},
+		Project:    p.project,
+	}
+
+	if err := FillSlot(node, p.graph, "content", content); err != nil {
+		return nil, fmt.Errorf("literal: content: %w", err)
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// download downloads a file from a URL.
+// Usage: plan.download(url)
+//
+// Slots:
+//   - url: URL to download from (promise or immediate)
+//
+// Returns: Promise of the downloaded file
+func (p *PlanRoot) download(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var url starlark.Value
+	if err := starlark.UnpackArgs("download", args, kwargs, "url", &url); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("download"),
+		Operations: []string{"download"},
+		Project:    p.project,
+	}
+
+	if err := FillSlot(node, p.graph, "url", url); err != nil {
+		return nil, fmt.Errorf("download: url: %w", err)
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// service manages a system service.
+// Usage: plan.service(name, action)
+//
+// Slots:
+//   - name: Service name (promise or immediate)
+//   - action: Action to perform: start, stop, restart, enable, disable (immediate)
+//
+// Returns: Promise of the service operation
+func (p *PlanRoot) service(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name, action starlark.Value
+	if err := starlark.UnpackArgs("service", args, kwargs, "name", &name, "action", &action); err != nil {
+		return nil, err
+	}
+
+	// Validate action is a known value
+	actionStr, ok := starlark.AsString(action)
+	if !ok {
+		return nil, fmt.Errorf("service: action must be a string, got %s", action.Type())
+	}
+	switch actionStr {
+	case "start", "stop", "restart", "enable", "disable":
+		// Valid
+	default:
+		return nil, fmt.Errorf("service: unknown action %q", actionStr)
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("service"),
+		Operations: []string{"service-" + actionStr},
+		Project:    p.project,
+	}
+
+	if err := FillSlot(node, p.graph, "name", name); err != nil {
+		return nil, fmt.Errorf("service: name: %w", err)
+	}
+	if err := FillSlot(node, p.graph, "action", action); err != nil {
+		return nil, fmt.Errorf("service: action: %w", err)
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// shell runs a shell command.
+// Usage: plan.shell(command)
+//
+// Slots:
+//   - command: Command to execute (promise or immediate)
+//
+// Returns: Promise of the command result
+func (p *PlanRoot) shell(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var command starlark.Value
+	if err := starlark.UnpackArgs("shell", args, kwargs, "command", &command); err != nil {
+		return nil, err
+	}
+
+	node := &execution.Node{
+		ID:         generateNodeID("shell"),
+		Operations: []string{"shell"},
+		Project:    p.project,
+	}
+
+	if err := FillSlot(node, p.graph, "command", command); err != nil {
+		return nil, fmt.Errorf("shell: command: %w", err)
+	}
+
+	p.graph.Nodes = append(p.graph.Nodes, node)
+	return NewOutput(node, p.graph, ""), nil
+}
+
+// dependsOn creates an explicit dependency between two nodes.
+// Usage: plan.depends_on(consumer, producer)
+//
+// This is a graph-wiring primitive for explicit ordering when there's no
+// data flow between nodes. The consumer will not execute until the producer
+// completes.
+//
+// Arguments:
+//   - consumer: Node that depends on the producer (Output)
+//   - producer: Node that must complete first (Output)
+//
+// Returns: None
+func (p *PlanRoot) dependsOn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
+	}
+
+	// Extract node ID from first argument (consumer - depends ON the second)
+	consumerID, err := extractNodeID(args[0], "first")
+	if err != nil {
+		return nil, fmt.Errorf("depends_on: %w", err)
+	}
+
+	// Extract node ID from second argument (producer - depended upon)
+	producerID, err := extractNodeID(args[1], "second")
+	if err != nil {
+		return nil, fmt.Errorf("depends_on: %w", err)
+	}
+
+	// Create edge in the graph: consumer depends_on producer
+	p.graph.Edges = append(p.graph.Edges, execution.Edge{
+		From:     producerID,
+		To:       consumerID,
+		Relation: "depends_on",
+	})
+
+	return starlark.None, nil
+}

--- a/internal/starlark/plan_root.go
+++ b/internal/starlark/plan_root.go
@@ -70,8 +70,8 @@ func (p *PlanRoot) Attr(name string) (starlark.Value, error) {
 		return starlark.NewBuiltin("plan.service", p.service), nil
 	case "shell":
 		return starlark.NewBuiltin("plan.shell", p.shell), nil
-	case "depends_on":
-		return starlark.NewBuiltin("plan.depends_on", p.dependsOn), nil
+	case "gather":
+		return starlark.NewBuiltin("plan.gather", p.gather), nil
 	default:
 		return nil, starlark.NoSuchAttrError(fmt.Sprintf("plan has no attribute %q", name))
 	}
@@ -79,7 +79,7 @@ func (p *PlanRoot) Attr(name string) (starlark.Value, error) {
 
 func (p *PlanRoot) AttrNames() []string {
 	return []string{
-		"archive", "depends_on", "download", "file", "git",
+		"archive", "download", "file", "gather", "git",
 		"literal", "package", "service", "shell", "source",
 	}
 }
@@ -235,41 +235,38 @@ func (p *PlanRoot) shell(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 	return NewOutput(node, p.graph, ""), nil
 }
 
-// dependsOn creates an explicit dependency between two nodes.
-// Usage: plan.depends_on(consumer, producer)
+// gather creates a handle for parallel execution of multiple nodes.
+// Usage: plan.gather(promise1, promise2, ...)
 //
-// This is a graph-wiring primitive for explicit ordering when there's no
-// data flow between nodes. The consumer will not execute until the producer
-// completes.
+// This collects multiple promises into a single handle. When the handle is
+// passed to another operation, it creates edges from ALL gathered nodes to
+// the consumer, enabling parallel execution.
 //
 // Arguments:
-//   - consumer: Node that depends on the producer (Output)
-//   - producer: Node that must complete first (Output)
+//   - promises: Two or more Output values to gather
 //
-// Returns: None
-func (p *PlanRoot) dependsOn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
+// Returns: Gather handle that can be passed to other operations
+//
+// Example:
+//
+//	a = plan.file.copy(src1, dst1)
+//	b = plan.file.copy(src2, dst2)
+//	c = plan.file.copy(src3, dst3)
+//	group = plan.gather(a, b, c)
+//	d = plan.whatever(group)  # d waits for a, b, c (which run in parallel)
+func (p *PlanRoot) gather(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("gather: expected at least 2 arguments, got %d", len(args))
 	}
 
-	// Extract node ID from first argument (consumer - depends ON the second)
-	consumerID, err := extractNodeID(args[0], "first")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
+	outputs := make([]*Output, 0, len(args))
+	for i, arg := range args {
+		output, ok := arg.(*Output)
+		if !ok {
+			return nil, fmt.Errorf("gather: argument %d must be an Output, got %s", i+1, arg.Type())
+		}
+		outputs = append(outputs, output)
 	}
 
-	// Extract node ID from second argument (producer - depended upon)
-	producerID, err := extractNodeID(args[1], "second")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	// Create edge in the graph: consumer depends_on producer
-	p.graph.Edges = append(p.graph.Edges, execution.Edge{
-		From:     producerID,
-		To:       consumerID,
-		Relation: "depends_on",
-	})
-
-	return starlark.None, nil
+	return NewGather(p.graph, outputs...), nil
 }

--- a/internal/starlark/platform/common.go
+++ b/internal/starlark/platform/common.go
@@ -66,6 +66,16 @@ func (b *basePlanBindings) Graph() *execution.Graph {
 	return b.graph
 }
 
+// Host returns the host abstraction.
+func (b *basePlanBindings) Host() host.Host {
+	return b.host
+}
+
+// Project returns the project name for grouping nodes.
+func (b *basePlanBindings) Project() string {
+	return b.project
+}
+
 // newBasePlanBindings creates a new base plan bindings.
 func newBasePlanBindings(graph *execution.Graph, h host.Host, project string) *basePlanBindings {
 	return &basePlanBindings{
@@ -79,10 +89,10 @@ func newBasePlanBindings(graph *execution.Graph, h host.Host, project string) *b
 func (b *basePlanBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("remove"),
-		Operations: []string{"file-remove"},
-		Target:     b.host.ExpandPath(target),
+		Operations: []string{"remove"},
 		Project:    b.project,
 	}
+	node.SetSlotImmediate("path", b.host.ExpandPath(target))
 	b.graph.Nodes = append(b.graph.Nodes, node)
 	return node
 }
@@ -92,10 +102,10 @@ func (b *basePlanBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("download"),
 		Operations: []string{"download"},
-		Source:     url,
-		Target:     b.host.ExpandPath(target),
 		Project:    b.project,
 	}
+	node.SetSlotImmediate("url", url)
+	node.SetSlotImmediate("path", b.host.ExpandPath(target))
 	b.graph.Nodes = append(b.graph.Nodes, node)
 	return node
 }
@@ -105,10 +115,10 @@ func (b *basePlanBindings) ArchiveExtract(archive, target string) *execution.Nod
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("archive-extract"),
 		Operations: []string{"archive-extract"},
-		Source:     b.host.ExpandPath(archive),
-		Target:     b.host.ExpandPath(target),
 		Project:    b.project,
 	}
+	node.SetSlotImmediate("source", b.host.ExpandPath(archive))
+	node.SetSlotImmediate("path", b.host.ExpandPath(target))
 	b.graph.Nodes = append(b.graph.Nodes, node)
 	return node
 }
@@ -118,10 +128,10 @@ func (b *basePlanBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-clone"),
 		Operations: []string{"git-clone"},
-		Source:     url,
-		Target:     b.host.ExpandPath(target),
 		Project:    b.project,
 	}
+	node.SetSlotImmediate("url", url)
+	node.SetSlotImmediate("path", b.host.ExpandPath(target))
 	b.graph.Nodes = append(b.graph.Nodes, node)
 	return node
 }
@@ -132,10 +142,8 @@ func (b *basePlanBindings) GitCheckout(ref string) *execution.Node {
 		ID:         baseGenerateNodeID("git-checkout"),
 		Operations: []string{"git-checkout"},
 		Project:    b.project,
-		Metadata: map[string]string{
-			"ref": ref,
-		},
 	}
+	node.SetSlotImmediate("ref", ref)
 	b.graph.Nodes = append(b.graph.Nodes, node)
 	return node
 }

--- a/internal/starlark/platform/darwin.go
+++ b/internal/starlark/platform/darwin.go
@@ -30,7 +30,7 @@ func darwinGenerateNodeID(prefix string, components ...string) string {
 	return fmt.Sprintf("%s-%d", prefix, id)
 }
 
-// DarwinPlanBindings provides macOS-specific plan bindings.
+// DarwinPlanBindings provides macOS-specific plan bindings using the slot-based model.
 // Uses Homebrew for package management and launchd for services.
 type DarwinPlanBindings struct {
 	*basePlanBindings
@@ -53,87 +53,7 @@ func (d *DarwinPlanBindings) PackageManagerName() string {
 	return d.host.PackageManager().Name()
 }
 
-// PackageInstall adds a package installation node using the platform's package manager.
-// Supports brew:, cask:, and port: prefixes to override auto-detection.
-func (d *DarwinPlanBindings) PackageInstall(packages ...string) *execution.Node {
-	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
-		Operations: []string{"package-install"},
-		Project:    d.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(cleanPkgs, ","),
-		},
-	}
-	if manager != "" {
-		node.Metadata["manager"] = manager
-	}
-	if isCask {
-		node.Metadata["cask"] = "true"
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// PackageUpgrade adds a package upgrade node using the platform's package manager.
-// Supports brew:, cask:, and port: prefixes to override auto-detection.
-func (d *DarwinPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
-	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
-		Operations: []string{"package-upgrade"},
-		Project:    d.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(cleanPkgs, ","),
-		},
-	}
-	if manager != "" {
-		node.Metadata["manager"] = manager
-	}
-	if isCask {
-		node.Metadata["cask"] = "true"
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// PackageRemove adds a package removal node using the platform's package manager.
-// Supports brew:, cask:, and port: prefixes to override auto-detection.
-func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
-	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
-		Operations: []string{"package-remove"},
-		Project:    d.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(cleanPkgs, ","),
-		},
-	}
-	if manager != "" {
-		node.Metadata["manager"] = manager
-	}
-	if isCask {
-		node.Metadata["cask"] = "true"
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// PackageUpdate adds a package index update node using the platform's package manager.
-func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("package-update"),
-		Operations: []string{"package-update"},
-		Project:    d.project,
-		Metadata:   map[string]string{},
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
 // parsePackagesWithPrefix extracts manager override from brew:, cask:, or port: prefixes.
-// Returns clean package names, the manager override, and whether cask mode is enabled.
-// For cask: prefix, manager is set to "brew" and isCask is true.
 func parsePackagesWithPrefix(packages []string) (cleanPkgs []string, manager string, isCask bool) {
 	cleanPkgs = make([]string, len(packages))
 	for i, p := range packages {
@@ -141,7 +61,7 @@ func parsePackagesWithPrefix(packages []string) (cleanPkgs []string, manager str
 		cleanPkgs[i] = pkg
 		if prefix != "" {
 			if prefix == "cask" {
-				manager = "brew" // Cask requires Homebrew
+				manager = "brew"
 				isCask = true
 			} else {
 				manager = prefix
@@ -151,114 +71,8 @@ func parsePackagesWithPrefix(packages []string) (cleanPkgs []string, manager str
 	return cleanPkgs, manager, isCask
 }
 
-// Configure adds a configuration file node.
-func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("configure"),
-		Operations: []string{"expand", "copy"},
-		Source:     source,
-		Target:     d.host.ExpandPath(target),
-		Project:    d.project,
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Link adds a symlink creation node.
-func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("link"),
-		Operations: []string{"link"},
-		Source:     source,
-		Target:     d.host.ExpandPath(target),
-		Project:    d.project,
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Copy adds a file copy node.
-func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("copy"),
-		Operations: []string{"copy"},
-		Source:     source,
-		Target:     d.host.ExpandPath(target),
-		Project:    d.project,
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Mkdir adds a directory creation node.
-func (d *DarwinPlanBindings) Mkdir(target string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("mkdir"),
-		Operations: []string{"mkdir"},
-		Target:     d.host.ExpandPath(target),
-		Project:    d.project,
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Write adds a file write node (write content directly to target).
-func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("write"),
-		Operations: []string{"file-write"},
-		Target:     d.host.ExpandPath(target),
-		Project:    d.project,
-		Metadata: map[string]string{
-			"content": content,
-		},
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Service adds a launchd service management node.
-func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("launchd", name, action.String()),
-		Operations: []string{"launchd-" + action.String()},
-		Project:    d.project,
-		Metadata: map[string]string{
-			"service": name,
-			"action":  action.String(),
-		},
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// Shell adds a shell command execution node.
-func (d *DarwinPlanBindings) Shell(command string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("shell"),
-		Operations: []string{"shell"},
-		Project:    d.project,
-		Metadata: map[string]string{
-			"command": command,
-		},
-	}
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
-}
-
-// DependsOn creates a dependency edge between nodes.
-func (d *DarwinPlanBindings) DependsOn(from, to *execution.Node) {
-	d.graph.Edges = append(d.graph.Edges, execution.Edge{
-		From:     to.ID,
-		To:       from.ID,
-		Relation: "depends_on",
-	})
-}
-
 // ToStarlark converts the plan bindings to a Starlark struct.
-// Uses nested structs: plan.package.install(), plan.file.copy(), etc.
 func (d *DarwinPlanBindings) ToStarlark() starlark.Value {
-	// Package operations namespace: plan.package.*
 	packageOps := starlarkstruct.FromStringDict(starlark.String("package"), starlark.StringDict{
 		"install": starlark.NewBuiltin("install", d.packageInstallBuiltin),
 		"remove":  starlark.NewBuiltin("remove", d.packageRemoveBuiltin),
@@ -266,20 +80,16 @@ func (d *DarwinPlanBindings) ToStarlark() starlark.Value {
 		"upgrade": starlark.NewBuiltin("upgrade", d.packageUpgradeBuiltin),
 	})
 
-	// File operations namespace: plan.file.*
 	fileOps := starlarkstruct.FromStringDict(starlark.String("file"), starlark.StringDict{
 		"configure": starlark.NewBuiltin("configure", d.configureBuiltin),
 		"copy":      starlark.NewBuiltin("copy", d.copyBuiltin),
 		"link":      starlark.NewBuiltin("link", d.linkBuiltin),
-		"mkdir":     starlark.NewBuiltin("mkdir", d.mkdirBuiltin),
 		"write":     starlark.NewBuiltin("write", d.writeBuiltin),
 	})
 
 	return starlarkstruct.FromStringDict(starlark.String("plan"), starlark.StringDict{
-		// Namespaces
-		"file":    fileOps,
-		"package": packageOps,
-		// Global functions (at root of plan)
+		"file":       fileOps,
+		"package":    packageOps,
 		"depends_on": starlark.NewBuiltin("depends_on", d.dependsOnBuiltin),
 		"service":    starlark.NewBuiltin("service", d.serviceBuiltin),
 		"shell":      starlark.NewBuiltin("shell", d.shellBuiltin),
@@ -298,8 +108,23 @@ func (d *DarwinPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starla
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("install: at least one package required")
 	}
-	node := d.PackageInstall(packages...)
-	return nodeToStarlark(node), nil
+
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
+		Operations: []string{"package-install"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -314,8 +139,23 @@ func (d *DarwinPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starla
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("upgrade: at least one package required")
 	}
-	node := d.PackageUpgrade(packages...)
-	return nodeToStarlark(node), nil
+
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
+		Operations: []string{"package-upgrade"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -330,93 +170,180 @@ func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlar
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("remove: at least one package required")
 	}
-	node := d.PackageRemove(packages...)
-	return nodeToStarlark(node), nil
+
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
+		Operations: []string{"package-remove"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return starlark.None, nil
 }
 
 func (d *DarwinPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	node := d.PackageUpdate()
-	return nodeToStarlark(node), nil
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-update"),
+		Operations: []string{"package-update"},
+		Project:    d.project,
+	}
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "target", &target); err != nil {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "path", &path); err != nil {
 		return nil, err
 	}
-	node := d.Configure(source, target)
-	return nodeToStarlark(node), nil
+
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("configure"),
+		Operations: []string{"render", "copy"},
+		Project:    d.project,
+	}
+
+	if err := loreStar.FillSlot(node, d.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("configure: source: %w", err)
+	}
+	if err := loreStar.FillSlot(node, d.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("configure: path: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "target", &target); err != nil {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "path", &path); err != nil {
 		return nil, err
 	}
-	node := d.Link(source, target)
-	return nodeToStarlark(node), nil
+
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("link"),
+		Operations: []string{"link"},
+		Project:    d.project,
+	}
+
+	if err := loreStar.FillSlot(node, d.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("link: source: %w", err)
+	}
+	if err := loreStar.FillSlot(node, d.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("link: path: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "target", &target); err != nil {
+	var source, path starlark.Value
+	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "path", &path); err != nil {
 		return nil, err
 	}
-	node := d.Copy(source, target)
-	return nodeToStarlark(node), nil
-}
 
-func (d *DarwinPlanBindings) mkdirBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target string
-	if err := starlark.UnpackArgs("mkdir", args, kwargs, "target", &target); err != nil {
-		return nil, err
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("copy"),
+		Operations: []string{"copy"},
+		Project:    d.project,
 	}
-	node := d.Mkdir(target)
-	return nodeToStarlark(node), nil
+
+	if err := loreStar.FillSlot(node, d.graph, "source", source); err != nil {
+		return nil, fmt.Errorf("copy: source: %w", err)
+	}
+	if err := loreStar.FillSlot(node, d.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("copy: path: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target, content string
-	if err := starlark.UnpackArgs("write", args, kwargs, "target", &target, "content", &content); err != nil {
+	var content, path starlark.Value
+	if err := starlark.UnpackArgs("write", args, kwargs, "content", &content, "path", &path); err != nil {
 		return nil, err
 	}
-	node := d.Write(target, content)
-	return nodeToStarlark(node), nil
+
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("write"),
+		Operations: []string{"write"},
+		Project:    d.project,
+	}
+
+	if err := loreStar.FillSlot(node, d.graph, "content", content); err != nil {
+		return nil, fmt.Errorf("write: content: %w", err)
+	}
+	if err := loreStar.FillSlot(node, d.graph, "path", path); err != nil {
+		return nil, fmt.Errorf("write: path: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var name, action string
+	var name, action starlark.Value
 	if err := starlark.UnpackArgs("service", args, kwargs, "name", &name, "action", &action); err != nil {
 		return nil, err
 	}
 
-	var serviceAction loreStar.ServiceAction
-	switch action {
-	case "start":
-		serviceAction = loreStar.ServiceStart
-	case "stop":
-		serviceAction = loreStar.ServiceStop
-	case "restart":
-		serviceAction = loreStar.ServiceRestart
-	case "enable":
-		serviceAction = loreStar.ServiceEnable
-	case "disable":
-		serviceAction = loreStar.ServiceDisable
+	// Validate action
+	actionStr, ok := starlark.AsString(action)
+	if !ok {
+		return nil, fmt.Errorf("service: action must be a string, got %s", action.Type())
+	}
+	switch actionStr {
+	case "start", "stop", "restart", "enable", "disable":
+		// Valid
 	default:
-		return nil, fmt.Errorf("service: unknown action %q", action)
+		return nil, fmt.Errorf("service: unknown action %q", actionStr)
 	}
 
-	node := d.Service(name, serviceAction)
-	return nodeToStarlark(node), nil
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("launchd"),
+		Operations: []string{"launchd-" + actionStr},
+		Project:    d.project,
+	}
+
+	if err := loreStar.FillSlot(node, d.graph, "name", name); err != nil {
+		return nil, fmt.Errorf("service: name: %w", err)
+	}
+	if err := loreStar.FillSlot(node, d.graph, "action", action); err != nil {
+		return nil, fmt.Errorf("service: action: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var command string
+	var command starlark.Value
 	if err := starlark.UnpackArgs("shell", args, kwargs, "command", &command); err != nil {
 		return nil, err
 	}
-	node := d.Shell(command)
-	return nodeToStarlark(node), nil
+
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("shell"),
+		Operations: []string{"shell"},
+		Project:    d.project,
+	}
+
+	if err := loreStar.FillSlot(node, d.graph, "command", command); err != nil {
+		return nil, fmt.Errorf("shell: command: %w", err)
+	}
+
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -424,26 +351,15 @@ func (d *DarwinPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Bu
 		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
 	}
 
-	fromStruct, ok := args[0].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: first argument must be a node")
-	}
-	toStruct, ok := args[1].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: second argument must be a node")
+	fromIDStr, err := extractNodeID(args[0], "first")
+	if err != nil {
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
 
-	fromID, err := fromStruct.Attr("id")
+	toIDStr, err := extractNodeID(args[1], "second")
 	if err != nil {
-		return nil, fmt.Errorf("depends_on: first argument has no id")
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
-	toID, err := toStruct.Attr("id")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: second argument has no id")
-	}
-
-	fromIDStr, _ := starlark.AsString(fromID)
-	toIDStr, _ := starlark.AsString(toID)
 
 	d.graph.Edges = append(d.graph.Edges, execution.Edge{
 		From:     toIDStr,
@@ -454,24 +370,168 @@ func (d *DarwinPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Bu
 	return starlark.None, nil
 }
 
-// nodeToStarlark converts an execution.Node to a Starlark struct.
-func nodeToStarlark(node *execution.Node) starlark.Value {
-	ops := make([]starlark.Value, len(node.Operations))
-	for i, op := range node.Operations {
-		ops[i] = starlark.String(op)
+func extractNodeID(arg starlark.Value, position string) (string, error) {
+	if output, ok := arg.(*loreStar.Output); ok {
+		return output.Node().ID, nil
 	}
 
-	metadata := starlark.NewDict(len(node.Metadata))
-	for k, v := range node.Metadata {
-		_ = metadata.SetKey(starlark.String(k), starlark.String(v))
+	if st, ok := arg.(*starlarkstruct.Struct); ok {
+		idVal, err := st.Attr("id")
+		if err != nil {
+			return "", fmt.Errorf("%s argument has no id", position)
+		}
+		idStr, ok := starlark.AsString(idVal)
+		if !ok {
+			return "", fmt.Errorf("%s argument id is not a string", position)
+		}
+		return idStr, nil
 	}
 
-	return starlarkstruct.FromStringDict(starlark.String("node"), starlark.StringDict{
-		"id":         starlark.String(node.ID),
-		"operations": starlark.NewList(ops),
-		"source":     starlark.String(node.Source),
-		"target":     starlark.String(node.Target),
-		"project":    starlark.String(node.Project),
-		"metadata":   metadata,
+	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
+}
+
+// Legacy Go API methods - still use old fields for backward compatibility
+// These are used by internal Go code, not Starlark scripts
+
+func (d *DarwinPlanBindings) PackageInstall(packages ...string) *execution.Node {
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
+		Operations: []string{"package-install"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
+		Operations: []string{"package-upgrade"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
+	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
+		Operations: []string{"package-remove"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
+	if manager != "" {
+		node.SetSlotImmediate("manager", manager)
+	}
+	if isCask {
+		node.SetSlotImmediate("cask", "true")
+	}
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("package-update"),
+		Operations: []string{"package-update"},
+		Project:    d.project,
+	}
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("configure"),
+		Operations: []string{"render", "copy"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", d.host.ExpandPath(target))
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("link"),
+		Operations: []string{"link"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", d.host.ExpandPath(target))
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("copy"),
+		Operations: []string{"copy"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", d.host.ExpandPath(target))
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("write"),
+		Operations: []string{"write"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("content", content)
+	node.SetSlotImmediate("path", d.host.ExpandPath(target))
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("launchd", name, action.String()),
+		Operations: []string{"launchd-" + action.String()},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("name", name)
+	node.SetSlotImmediate("action", action.String())
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) Shell(command string) *execution.Node {
+	node := &execution.Node{
+		ID:         darwinGenerateNodeID("shell"),
+		Operations: []string{"shell"},
+		Project:    d.project,
+	}
+	node.SetSlotImmediate("command", command)
+	d.graph.Nodes = append(d.graph.Nodes, node)
+	return node
+}
+
+func (d *DarwinPlanBindings) DependsOn(from, to *execution.Node) {
+	d.graph.Edges = append(d.graph.Edges, execution.Edge{
+		From:     to.ID,
+		To:       from.ID,
+		Relation: "depends_on",
 	})
 }

--- a/internal/starlark/platform/darwin.go
+++ b/internal/starlark/platform/darwin.go
@@ -88,11 +88,11 @@ func (d *DarwinPlanBindings) ToStarlark() starlark.Value {
 	})
 
 	return starlarkstruct.FromStringDict(starlark.String("plan"), starlark.StringDict{
-		"file":       fileOps,
-		"package":    packageOps,
-		"depends_on": starlark.NewBuiltin("depends_on", d.dependsOnBuiltin),
-		"service":    starlark.NewBuiltin("service", d.serviceBuiltin),
-		"shell":      starlark.NewBuiltin("shell", d.shellBuiltin),
+		"file":    fileOps,
+		"package": packageOps,
+		"gather":  starlark.NewBuiltin("gather", d.gatherBuiltin),
+		"service": starlark.NewBuiltin("service", d.serviceBuiltin),
+		"shell":   starlark.NewBuiltin("shell", d.shellBuiltin),
 	})
 }
 
@@ -346,48 +346,21 @@ func (d *DarwinPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builti
 	return loreStar.NewOutput(node, d.graph, ""), nil
 }
 
-func (d *DarwinPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
+func (d *DarwinPlanBindings) gatherBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("gather: expected at least 2 arguments, got %d", len(args))
 	}
 
-	fromIDStr, err := extractNodeID(args[0], "first")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	toIDStr, err := extractNodeID(args[1], "second")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	d.graph.Edges = append(d.graph.Edges, execution.Edge{
-		From:     toIDStr,
-		To:       fromIDStr,
-		Relation: "depends_on",
-	})
-
-	return starlark.None, nil
-}
-
-func extractNodeID(arg starlark.Value, position string) (string, error) {
-	if output, ok := arg.(*loreStar.Output); ok {
-		return output.Node().ID, nil
-	}
-
-	if st, ok := arg.(*starlarkstruct.Struct); ok {
-		idVal, err := st.Attr("id")
-		if err != nil {
-			return "", fmt.Errorf("%s argument has no id", position)
-		}
-		idStr, ok := starlark.AsString(idVal)
+	outputs := make([]*loreStar.Output, 0, len(args))
+	for i, arg := range args {
+		output, ok := arg.(*loreStar.Output)
 		if !ok {
-			return "", fmt.Errorf("%s argument id is not a string", position)
+			return nil, fmt.Errorf("gather: argument %d must be an Output, got %s", i+1, arg.Type())
 		}
-		return idStr, nil
+		outputs = append(outputs, output)
 	}
 
-	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
+	return loreStar.NewGather(d.graph, outputs...), nil
 }
 
 // Legacy Go API methods - still use old fields for backward compatibility
@@ -530,8 +503,7 @@ func (d *DarwinPlanBindings) Shell(command string) *execution.Node {
 
 func (d *DarwinPlanBindings) DependsOn(from, to *execution.Node) {
 	d.graph.Edges = append(d.graph.Edges, execution.Edge{
-		From:     to.ID,
-		To:       from.ID,
-		Relation: "depends_on",
+		From: to.ID,
+		To:   from.ID,
 	})
 }

--- a/internal/starlark/platform/linux.go
+++ b/internal/starlark/platform/linux.go
@@ -221,9 +221,8 @@ func (l *LinuxPlanBindings) Shell(command string) *execution.Node {
 // DependsOn creates a dependency edge between nodes.
 func (l *LinuxPlanBindings) DependsOn(from, to *execution.Node) {
 	l.graph.Edges = append(l.graph.Edges, execution.Edge{
-		From:     to.ID,
-		To:       from.ID,
-		Relation: "depends_on",
+		From: to.ID,
+		To:   from.ID,
 	})
 }
 
@@ -253,9 +252,9 @@ func (l *LinuxPlanBindings) ToStarlark() starlark.Value {
 		"file":    fileOps,
 		"package": packageOps,
 		// Global functions (at root of plan)
-		"depends_on": starlark.NewBuiltin("depends_on", l.dependsOnBuiltin),
-		"service":    starlark.NewBuiltin("service", l.serviceBuiltin),
-		"shell":      starlark.NewBuiltin("shell", l.shellBuiltin),
+		"gather":  starlark.NewBuiltin("gather", l.gatherBuiltin),
+		"service": starlark.NewBuiltin("service", l.serviceBuiltin),
+		"shell":   starlark.NewBuiltin("shell", l.shellBuiltin),
 		// Linux-specific: expose distro info at top level
 		"distro": starlark.String(l.distro),
 	})
@@ -421,52 +420,19 @@ func (l *LinuxPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 	return loreStar.NewOutput(node, l.graph, command, loreStar.OutputCommand), nil
 }
 
-func (l *LinuxPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
+func (l *LinuxPlanBindings) gatherBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("gather: expected at least 2 arguments, got %d", len(args))
 	}
 
-	// Extract node ID from first argument (consumer - depends ON the second)
-	fromIDStr, err := linuxExtractNodeID(args[0], "first")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	// Extract node ID from second argument (producer - depended upon)
-	toIDStr, err := linuxExtractNodeID(args[1], "second")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	// Create edge in the graph: consumer depends_on producer
-	l.graph.Edges = append(l.graph.Edges, execution.Edge{
-		From:     toIDStr,
-		To:       fromIDStr,
-		Relation: "depends_on",
-	})
-
-	return starlark.None, nil
-}
-
-// linuxExtractNodeID extracts the node ID from an argument that may be Output or struct.
-func linuxExtractNodeID(arg starlark.Value, position string) (string, error) {
-	// Check if it's an Output
-	if output, ok := arg.(*loreStar.Output); ok {
-		return output.Node().ID, nil
-	}
-
-	// Check if it's a struct with an id attribute
-	if st, ok := arg.(*starlarkstruct.Struct); ok {
-		idVal, err := st.Attr("id")
-		if err != nil {
-			return "", fmt.Errorf("%s argument has no id", position)
-		}
-		idStr, ok := starlark.AsString(idVal)
+	outputs := make([]*loreStar.Output, 0, len(args))
+	for i, arg := range args {
+		output, ok := arg.(*loreStar.Output)
 		if !ok {
-			return "", fmt.Errorf("%s argument id is not a string", position)
+			return nil, fmt.Errorf("gather: argument %d must be an Output, got %s", i+1, arg.Type())
 		}
-		return idStr, nil
+		outputs = append(outputs, output)
 	}
 
-	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
+	return loreStar.NewGather(l.graph, outputs...), nil
 }

--- a/internal/starlark/platform/linux.go
+++ b/internal/starlark/platform/linux.go
@@ -100,10 +100,8 @@ func (l *LinuxPlanBindings) PackageInstall(packages ...string) *execution.Node {
 		ID:         linuxGenerateNodeID("package-install", packages...),
 		Operations: []string{"package-install"},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -114,10 +112,8 @@ func (l *LinuxPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 		ID:         linuxGenerateNodeID("package-upgrade", packages...),
 		Operations: []string{"package-upgrade"},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -128,10 +124,8 @@ func (l *LinuxPlanBindings) PackageRemove(packages ...string) *execution.Node {
 		ID:         linuxGenerateNodeID("package-remove", packages...),
 		Operations: []string{"package-remove"},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -142,7 +136,6 @@ func (l *LinuxPlanBindings) PackageUpdate() *execution.Node {
 		ID:         linuxGenerateNodeID("package-update"),
 		Operations: []string{"package-update"},
 		Project:    l.project,
-		Metadata:   map[string]string{},
 	}
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
@@ -152,11 +145,11 @@ func (l *LinuxPlanBindings) PackageUpdate() *execution.Node {
 func (l *LinuxPlanBindings) Configure(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("configure"),
-		Operations: []string{"expand", "copy"},
-		Source:     source,
-		Target:     l.host.ExpandPath(target),
+		Operations: []string{"render", "copy"},
 		Project:    l.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", l.host.ExpandPath(target))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -166,10 +159,10 @@ func (l *LinuxPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("link"),
 		Operations: []string{"link"},
-		Source:     source,
-		Target:     l.host.ExpandPath(target),
 		Project:    l.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", l.host.ExpandPath(target))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -179,22 +172,10 @@ func (l *LinuxPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("copy"),
 		Operations: []string{"copy"},
-		Source:     source,
-		Target:     l.host.ExpandPath(target),
 		Project:    l.project,
 	}
-	l.graph.Nodes = append(l.graph.Nodes, node)
-	return node
-}
-
-// Mkdir adds a directory creation node.
-func (l *LinuxPlanBindings) Mkdir(target string) *execution.Node {
-	node := &execution.Node{
-		ID:         linuxGenerateNodeID("mkdir"),
-		Operations: []string{"mkdir"},
-		Target:     l.host.ExpandPath(target),
-		Project:    l.project,
-	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", l.host.ExpandPath(target))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -203,13 +184,11 @@ func (l *LinuxPlanBindings) Mkdir(target string) *execution.Node {
 func (l *LinuxPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("write"),
-		Operations: []string{"file-write"},
-		Target:     l.host.ExpandPath(target),
+		Operations: []string{"write"},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"content": content,
-		},
 	}
+	node.SetSlotImmediate("content", content)
+	node.SetSlotImmediate("path", l.host.ExpandPath(target))
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -220,11 +199,9 @@ func (l *LinuxPlanBindings) Service(name string, action loreStar.ServiceAction) 
 		ID:         linuxGenerateNodeID("systemd", name, action.String()),
 		Operations: []string{"systemd-" + action.String()},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"service": name,
-			"action":  action.String(),
-		},
 	}
+	node.SetSlotImmediate("name", name)
+	node.SetSlotImmediate("action", action.String())
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -235,10 +212,8 @@ func (l *LinuxPlanBindings) Shell(command string) *execution.Node {
 		ID:         linuxGenerateNodeID("shell"),
 		Operations: []string{"shell"},
 		Project:    l.project,
-		Metadata: map[string]string{
-			"command": command,
-		},
 	}
+	node.SetSlotImmediate("command", command)
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
@@ -270,7 +245,6 @@ func (l *LinuxPlanBindings) ToStarlark() starlark.Value {
 		"configure": starlark.NewBuiltin("configure", l.configureBuiltin),
 		"copy":      starlark.NewBuiltin("copy", l.copyBuiltin),
 		"link":      starlark.NewBuiltin("link", l.linkBuiltin),
-		"mkdir":     starlark.NewBuiltin("mkdir", l.mkdirBuiltin),
 		"write":     starlark.NewBuiltin("write", l.writeBuiltin),
 	})
 
@@ -300,7 +274,8 @@ func (l *LinuxPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starlar
 		return nil, fmt.Errorf("install: at least one package required")
 	}
 	node := l.PackageInstall(packages...)
-	return linuxNodeToStarlark(node), nil
+	packagesStr := strings.Join(packages, ",")
+	return loreStar.NewOutput(node, l.graph, packagesStr, loreStar.OutputPackage), nil
 }
 
 func (l *LinuxPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -316,7 +291,8 @@ func (l *LinuxPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starlar
 		return nil, fmt.Errorf("upgrade: at least one package required")
 	}
 	node := l.PackageUpgrade(packages...)
-	return linuxNodeToStarlark(node), nil
+	packagesStr := strings.Join(packages, ",")
+	return loreStar.NewOutput(node, l.graph, packagesStr, loreStar.OutputPackage), nil
 }
 
 func (l *LinuxPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -331,58 +307,83 @@ func (l *LinuxPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlark
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("remove: at least one package required")
 	}
-	node := l.PackageRemove(packages...)
-	return linuxNodeToStarlark(node), nil
+	_ = l.PackageRemove(packages...)
+	// Remove produces no output
+	return starlark.None, nil
 }
 
 func (l *LinuxPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	node := l.PackageUpdate()
-	return linuxNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, l.graph, "<index>", loreStar.OutputPackage), nil
 }
 
 func (l *LinuxPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("configure", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := l.Configure(source, target)
-	return linuxNodeToStarlark(node), nil
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("configure: input: %w", err)
+	}
+	node := l.Configure(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path"), loreStar.OutputFile), nil
 }
 
 func (l *LinuxPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("link", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := l.Link(source, target)
-	return linuxNodeToStarlark(node), nil
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("link: input: %w", err)
+	}
+	node := l.Link(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path"), loreStar.OutputSymlink), nil
 }
 
 func (l *LinuxPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("copy", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := l.Copy(source, target)
-	return linuxNodeToStarlark(node), nil
-}
-
-func (l *LinuxPlanBindings) mkdirBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target string
-	if err := starlark.UnpackArgs("mkdir", args, kwargs, "target", &target); err != nil {
-		return nil, err
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("copy: input: %w", err)
 	}
-	node := l.Mkdir(target)
-	return linuxNodeToStarlark(node), nil
+	node := l.Copy(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path"), loreStar.OutputFile), nil
 }
 
 func (l *LinuxPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target, content string
-	if err := starlark.UnpackArgs("write", args, kwargs, "target", &target, "content", &content); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("write", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := l.Write(target, content)
-	return linuxNodeToStarlark(node), nil
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("write: input: %w", err)
+	}
+	// Create write node directly - content comes from input artifact via edge
+	expandedOut := l.host.ExpandPath(out)
+	node := &execution.Node{
+		ID:         linuxGenerateNodeID("write"),
+		Operations: []string{"write"},
+		Project:    l.project,
+	}
+	node.SetSlotImmediate("source", input.Path())
+	node.SetSlotImmediate("path", expandedOut)
+	l.graph.Nodes = append(l.graph.Nodes, node)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, l.graph, expandedOut, loreStar.OutputFile), nil
 }
 
 func (l *LinuxPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -408,7 +409,7 @@ func (l *LinuxPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Built
 	}
 
 	node := l.Service(name, serviceAction)
-	return linuxNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, l.graph, name, loreStar.OutputService), nil
 }
 
 func (l *LinuxPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -417,7 +418,7 @@ func (l *LinuxPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 		return nil, err
 	}
 	node := l.Shell(command)
-	return linuxNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, l.graph, command, loreStar.OutputCommand), nil
 }
 
 func (l *LinuxPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -425,27 +426,19 @@ func (l *LinuxPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Bui
 		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
 	}
 
-	fromStruct, ok := args[0].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: first argument must be a node")
-	}
-	toStruct, ok := args[1].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: second argument must be a node")
-	}
-
-	fromID, err := fromStruct.Attr("id")
+	// Extract node ID from first argument (consumer - depends ON the second)
+	fromIDStr, err := linuxExtractNodeID(args[0], "first")
 	if err != nil {
-		return nil, fmt.Errorf("depends_on: first argument has no id")
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
-	toID, err := toStruct.Attr("id")
+
+	// Extract node ID from second argument (producer - depended upon)
+	toIDStr, err := linuxExtractNodeID(args[1], "second")
 	if err != nil {
-		return nil, fmt.Errorf("depends_on: second argument has no id")
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
 
-	fromIDStr, _ := starlark.AsString(fromID)
-	toIDStr, _ := starlark.AsString(toID)
-
+	// Create edge in the graph: consumer depends_on producer
 	l.graph.Edges = append(l.graph.Edges, execution.Edge{
 		From:     toIDStr,
 		To:       fromIDStr,
@@ -455,24 +448,25 @@ func (l *LinuxPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Bui
 	return starlark.None, nil
 }
 
-// linuxNodeToStarlark converts an execution.Node to a Starlark struct.
-func linuxNodeToStarlark(node *execution.Node) starlark.Value {
-	ops := make([]starlark.Value, len(node.Operations))
-	for i, op := range node.Operations {
-		ops[i] = starlark.String(op)
+// linuxExtractNodeID extracts the node ID from an argument that may be Output or struct.
+func linuxExtractNodeID(arg starlark.Value, position string) (string, error) {
+	// Check if it's an Output
+	if output, ok := arg.(*loreStar.Output); ok {
+		return output.Node().ID, nil
 	}
 
-	metadata := starlark.NewDict(len(node.Metadata))
-	for k, v := range node.Metadata {
-		_ = metadata.SetKey(starlark.String(k), starlark.String(v))
+	// Check if it's a struct with an id attribute
+	if st, ok := arg.(*starlarkstruct.Struct); ok {
+		idVal, err := st.Attr("id")
+		if err != nil {
+			return "", fmt.Errorf("%s argument has no id", position)
+		}
+		idStr, ok := starlark.AsString(idVal)
+		if !ok {
+			return "", fmt.Errorf("%s argument id is not a string", position)
+		}
+		return idStr, nil
 	}
 
-	return starlarkstruct.FromStringDict(starlark.String("node"), starlark.StringDict{
-		"id":         starlark.String(node.ID),
-		"operations": starlark.NewList(ops),
-		"source":     starlark.String(node.Source),
-		"target":     starlark.String(node.Target),
-		"project":    starlark.String(node.Project),
-		"metadata":   metadata,
-	})
+	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
 }

--- a/internal/starlark/platform/windows.go
+++ b/internal/starlark/platform/windows.go
@@ -180,9 +180,8 @@ func (w *WindowsPlanBindings) Shell(command string) *execution.Node {
 // DependsOn creates a dependency edge between nodes.
 func (w *WindowsPlanBindings) DependsOn(from, to *execution.Node) {
 	w.graph.Edges = append(w.graph.Edges, execution.Edge{
-		From:     to.ID,
-		To:       from.ID,
-		Relation: "depends_on",
+		From: to.ID,
+		To:   from.ID,
 	})
 }
 
@@ -210,9 +209,9 @@ func (w *WindowsPlanBindings) ToStarlark() starlark.Value {
 		"file":    fileOps,
 		"package": packageOps,
 		// Global functions (at root of plan)
-		"depends_on": starlark.NewBuiltin("depends_on", w.dependsOnBuiltin),
-		"service":    starlark.NewBuiltin("service", w.serviceBuiltin),
-		"shell":      starlark.NewBuiltin("shell", w.shellBuiltin),
+		"gather":  starlark.NewBuiltin("gather", w.gatherBuiltin),
+		"service": starlark.NewBuiltin("service", w.serviceBuiltin),
+		"shell":   starlark.NewBuiltin("shell", w.shellBuiltin),
 	})
 }
 
@@ -383,52 +382,19 @@ func (w *WindowsPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Built
 	return loreStar.NewOutput(node, w.graph, command, loreStar.OutputCommand), nil
 }
 
-func (w *WindowsPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
+func (w *WindowsPlanBindings) gatherBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("gather: expected at least 2 arguments, got %d", len(args))
 	}
 
-	// Extract node ID from first argument (consumer - depends ON the second)
-	fromIDStr, err := windowsExtractNodeID(args[0], "first")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	// Extract node ID from second argument (producer - depended upon)
-	toIDStr, err := windowsExtractNodeID(args[1], "second")
-	if err != nil {
-		return nil, fmt.Errorf("depends_on: %w", err)
-	}
-
-	// Create edge in the graph: consumer depends_on producer
-	w.graph.Edges = append(w.graph.Edges, execution.Edge{
-		From:     toIDStr,
-		To:       fromIDStr,
-		Relation: "depends_on",
-	})
-
-	return starlark.None, nil
-}
-
-// windowsExtractNodeID extracts the node ID from an argument that may be Output or struct.
-func windowsExtractNodeID(arg starlark.Value, position string) (string, error) {
-	// Check if it's an Output
-	if output, ok := arg.(*loreStar.Output); ok {
-		return output.Node().ID, nil
-	}
-
-	// Check if it's a struct with an id attribute
-	if st, ok := arg.(*starlarkstruct.Struct); ok {
-		idVal, err := st.Attr("id")
-		if err != nil {
-			return "", fmt.Errorf("%s argument has no id", position)
-		}
-		idStr, ok := starlark.AsString(idVal)
+	outputs := make([]*loreStar.Output, 0, len(args))
+	for i, arg := range args {
+		output, ok := arg.(*loreStar.Output)
 		if !ok {
-			return "", fmt.Errorf("%s argument id is not a string", position)
+			return nil, fmt.Errorf("gather: argument %d must be an Output, got %s", i+1, arg.Type())
 		}
-		return idStr, nil
+		outputs = append(outputs, output)
 	}
 
-	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
+	return loreStar.NewGather(w.graph, outputs...), nil
 }

--- a/internal/starlark/platform/windows.go
+++ b/internal/starlark/platform/windows.go
@@ -58,10 +58,8 @@ func (w *WindowsPlanBindings) PackageInstall(packages ...string) *execution.Node
 		ID:         windowsGenerateNodeID("package-install", packages...),
 		Operations: []string{"package-install"},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -72,10 +70,8 @@ func (w *WindowsPlanBindings) PackageUpgrade(packages ...string) *execution.Node
 		ID:         windowsGenerateNodeID("package-upgrade", packages...),
 		Operations: []string{"package-upgrade"},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -86,10 +82,8 @@ func (w *WindowsPlanBindings) PackageRemove(packages ...string) *execution.Node 
 		ID:         windowsGenerateNodeID("package-remove", packages...),
 		Operations: []string{"package-remove"},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"packages": strings.Join(packages, ","),
-		},
 	}
+	node.SetSlotImmediate("packages", strings.Join(packages, ","))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -100,7 +94,6 @@ func (w *WindowsPlanBindings) PackageUpdate() *execution.Node {
 		ID:         windowsGenerateNodeID("package-update"),
 		Operations: []string{"package-update"},
 		Project:    w.project,
-		Metadata:   map[string]string{},
 	}
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
@@ -110,11 +103,11 @@ func (w *WindowsPlanBindings) PackageUpdate() *execution.Node {
 func (w *WindowsPlanBindings) Configure(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("configure"),
-		Operations: []string{"expand", "copy"},
-		Source:     source,
-		Target:     w.host.ExpandPath(target),
+		Operations: []string{"render", "copy"},
 		Project:    w.project,
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", w.host.ExpandPath(target))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -124,13 +117,11 @@ func (w *WindowsPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("link"),
 		Operations: []string{"link"},
-		Source:     source,
-		Target:     w.host.ExpandPath(target),
 		Project:    w.project,
-		Metadata: map[string]string{
-			"requires_admin": "true",
-		},
 	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", w.host.ExpandPath(target))
+	node.SetSlotImmediate("requires_admin", "true")
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -140,22 +131,10 @@ func (w *WindowsPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("copy"),
 		Operations: []string{"copy"},
-		Source:     source,
-		Target:     w.host.ExpandPath(target),
 		Project:    w.project,
 	}
-	w.graph.Nodes = append(w.graph.Nodes, node)
-	return node
-}
-
-// Mkdir adds a directory creation node.
-func (w *WindowsPlanBindings) Mkdir(target string) *execution.Node {
-	node := &execution.Node{
-		ID:         windowsGenerateNodeID("mkdir"),
-		Operations: []string{"mkdir"},
-		Target:     w.host.ExpandPath(target),
-		Project:    w.project,
-	}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", w.host.ExpandPath(target))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -164,13 +143,11 @@ func (w *WindowsPlanBindings) Mkdir(target string) *execution.Node {
 func (w *WindowsPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("write"),
-		Operations: []string{"file-write"},
-		Target:     w.host.ExpandPath(target),
+		Operations: []string{"write"},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"content": content,
-		},
 	}
+	node.SetSlotImmediate("content", content)
+	node.SetSlotImmediate("path", w.host.ExpandPath(target))
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -181,11 +158,9 @@ func (w *WindowsPlanBindings) Service(name string, action loreStar.ServiceAction
 		ID:         windowsGenerateNodeID("winservice", name, action.String()),
 		Operations: []string{"winservice-" + action.String()},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"service": name,
-			"action":  action.String(),
-		},
 	}
+	node.SetSlotImmediate("name", name)
+	node.SetSlotImmediate("action", action.String())
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -196,10 +171,8 @@ func (w *WindowsPlanBindings) Shell(command string) *execution.Node {
 		ID:         windowsGenerateNodeID("shell"),
 		Operations: []string{"powershell"},
 		Project:    w.project,
-		Metadata: map[string]string{
-			"command": command,
-		},
 	}
+	node.SetSlotImmediate("command", command)
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
@@ -229,7 +202,6 @@ func (w *WindowsPlanBindings) ToStarlark() starlark.Value {
 		"configure": starlark.NewBuiltin("configure", w.configureBuiltin),
 		"copy":      starlark.NewBuiltin("copy", w.copyBuiltin),
 		"link":      starlark.NewBuiltin("link", w.linkBuiltin),
-		"mkdir":     starlark.NewBuiltin("mkdir", w.mkdirBuiltin),
 		"write":     starlark.NewBuiltin("write", w.writeBuiltin),
 	})
 
@@ -257,7 +229,8 @@ func (w *WindowsPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starl
 		return nil, fmt.Errorf("install: at least one package required")
 	}
 	node := w.PackageInstall(packages...)
-	return windowsNodeToStarlark(node), nil
+	packagesStr := strings.Join(packages, ",")
+	return loreStar.NewOutput(node, w.graph, packagesStr, loreStar.OutputPackage), nil
 }
 
 func (w *WindowsPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -273,7 +246,8 @@ func (w *WindowsPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starl
 		return nil, fmt.Errorf("upgrade: at least one package required")
 	}
 	node := w.PackageUpgrade(packages...)
-	return windowsNodeToStarlark(node), nil
+	packagesStr := strings.Join(packages, ",")
+	return loreStar.NewOutput(node, w.graph, packagesStr, loreStar.OutputPackage), nil
 }
 
 func (w *WindowsPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -288,58 +262,90 @@ func (w *WindowsPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starla
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("remove: at least one package required")
 	}
-	node := w.PackageRemove(packages...)
-	return windowsNodeToStarlark(node), nil
+	_ = w.PackageRemove(packages...)
+	// Remove produces no output
+	return starlark.None, nil
 }
 
 func (w *WindowsPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	node := w.PackageUpdate()
-	return windowsNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, w.graph, "<index>", loreStar.OutputPackage), nil
 }
 
 func (w *WindowsPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("configure", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("configure", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := w.Configure(source, target)
-	return windowsNodeToStarlark(node), nil
+
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("configure: input: %w", err)
+	}
+
+	node := w.Configure(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, w.graph, node.GetSlot("path"), loreStar.OutputFile), nil
 }
 
 func (w *WindowsPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("link", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("link", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := w.Link(source, target)
-	return windowsNodeToStarlark(node), nil
+
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("link: input: %w", err)
+	}
+
+	node := w.Link(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, w.graph, node.GetSlot("path"), loreStar.OutputSymlink), nil
 }
 
 func (w *WindowsPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var source, target string
-	if err := starlark.UnpackArgs("copy", args, kwargs, "source", &source, "target", &target); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("copy", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := w.Copy(source, target)
-	return windowsNodeToStarlark(node), nil
-}
 
-func (w *WindowsPlanBindings) mkdirBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target string
-	if err := starlark.UnpackArgs("mkdir", args, kwargs, "target", &target); err != nil {
-		return nil, err
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("copy: input: %w", err)
 	}
-	node := w.Mkdir(target)
-	return windowsNodeToStarlark(node), nil
+
+	node := w.Copy(input.Path(), out)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, w.graph, node.GetSlot("path"), loreStar.OutputFile), nil
 }
 
 func (w *WindowsPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var target, content string
-	if err := starlark.UnpackArgs("write", args, kwargs, "target", &target, "content", &content); err != nil {
+	var inputArg starlark.Value
+	var out string
+	if err := starlark.UnpackArgs("write", args, kwargs, "input", &inputArg, "out", &out); err != nil {
 		return nil, err
 	}
-	node := w.Write(target, content)
-	return windowsNodeToStarlark(node), nil
+
+	input, err := loreStar.ResolveInput(inputArg)
+	if err != nil {
+		return nil, fmt.Errorf("write: input: %w", err)
+	}
+
+	expandedOut := w.host.ExpandPath(out)
+	node := &execution.Node{
+		ID:         windowsGenerateNodeID("write"),
+		Operations: []string{"write"},
+		Project:    w.project,
+	}
+	node.SetSlotImmediate("source", input.Path())
+	node.SetSlotImmediate("path", expandedOut)
+	w.graph.Nodes = append(w.graph.Nodes, node)
+	input.DependOn(node)
+	return loreStar.NewOutput(node, w.graph, expandedOut, loreStar.OutputFile), nil
 }
 
 func (w *WindowsPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -365,7 +371,7 @@ func (w *WindowsPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Bui
 	}
 
 	node := w.Service(name, serviceAction)
-	return windowsNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, w.graph, name, loreStar.OutputService), nil
 }
 
 func (w *WindowsPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -374,7 +380,7 @@ func (w *WindowsPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Built
 		return nil, err
 	}
 	node := w.Shell(command)
-	return windowsNodeToStarlark(node), nil
+	return loreStar.NewOutput(node, w.graph, command, loreStar.OutputCommand), nil
 }
 
 func (w *WindowsPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
@@ -382,27 +388,19 @@ func (w *WindowsPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.B
 		return nil, fmt.Errorf("depends_on: expected 2 arguments, got %d", len(args))
 	}
 
-	fromStruct, ok := args[0].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: first argument must be a node")
-	}
-	toStruct, ok := args[1].(*starlarkstruct.Struct)
-	if !ok {
-		return nil, fmt.Errorf("depends_on: second argument must be a node")
-	}
-
-	fromID, err := fromStruct.Attr("id")
+	// Extract node ID from first argument (consumer - depends ON the second)
+	fromIDStr, err := windowsExtractNodeID(args[0], "first")
 	if err != nil {
-		return nil, fmt.Errorf("depends_on: first argument has no id")
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
-	toID, err := toStruct.Attr("id")
+
+	// Extract node ID from second argument (producer - depended upon)
+	toIDStr, err := windowsExtractNodeID(args[1], "second")
 	if err != nil {
-		return nil, fmt.Errorf("depends_on: second argument has no id")
+		return nil, fmt.Errorf("depends_on: %w", err)
 	}
 
-	fromIDStr, _ := starlark.AsString(fromID)
-	toIDStr, _ := starlark.AsString(toID)
-
+	// Create edge in the graph: consumer depends_on producer
 	w.graph.Edges = append(w.graph.Edges, execution.Edge{
 		From:     toIDStr,
 		To:       fromIDStr,
@@ -412,24 +410,25 @@ func (w *WindowsPlanBindings) dependsOnBuiltin(_ *starlark.Thread, _ *starlark.B
 	return starlark.None, nil
 }
 
-// windowsNodeToStarlark converts an execution.Node to a Starlark struct.
-func windowsNodeToStarlark(node *execution.Node) starlark.Value {
-	ops := make([]starlark.Value, len(node.Operations))
-	for i, op := range node.Operations {
-		ops[i] = starlark.String(op)
+// windowsExtractNodeID extracts the node ID from an argument that may be Output or struct.
+func windowsExtractNodeID(arg starlark.Value, position string) (string, error) {
+	// Check if it's an Output
+	if output, ok := arg.(*loreStar.Output); ok {
+		return output.Node().ID, nil
 	}
 
-	metadata := starlark.NewDict(len(node.Metadata))
-	for k, v := range node.Metadata {
-		_ = metadata.SetKey(starlark.String(k), starlark.String(v))
+	// Check if it's a struct with an id attribute
+	if st, ok := arg.(*starlarkstruct.Struct); ok {
+		idVal, err := st.Attr("id")
+		if err != nil {
+			return "", fmt.Errorf("%s argument has no id", position)
+		}
+		idStr, ok := starlark.AsString(idVal)
+		if !ok {
+			return "", fmt.Errorf("%s argument id is not a string", position)
+		}
+		return idStr, nil
 	}
 
-	return starlarkstruct.FromStringDict(starlark.String("node"), starlark.StringDict{
-		"id":         starlark.String(node.ID),
-		"operations": starlark.NewList(ops),
-		"source":     starlark.String(node.Source),
-		"target":     starlark.String(node.Target),
-		"project":    starlark.String(node.Project),
-		"metadata":   metadata,
-	})
+	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
 }

--- a/internal/starlark/system.go
+++ b/internal/starlark/system.go
@@ -4,12 +4,7 @@
 package starlark
 
 import (
-	"os"
-	"os/exec"
-	"strings"
-
 	"go.starlark.net/starlark"
-	"go.starlark.net/starlarkstruct"
 
 	"github.com/NobleFactor/devlore-cli/internal/host"
 )
@@ -44,167 +39,29 @@ func (s *systemBindings) Service() ServiceQueries {
 }
 
 // ToStarlark converts the system bindings to a Starlark value.
+// Exposed to phase scripts as the fourth argument.
+//
+// All namespaces use the Attr receiver pattern for consistency and
+// static analysis support. Starlark API:
+//
+//	system.platform                        # Platform info struct
+//	system.package.installed(name)         # Check if package installed
+//	system.package.version(name)           # Get package version
+//	system.package.manager()               # Get package manager name
+//	system.service.exists(name)            # Check if service exists
+//	system.service.running(name)           # Check if service is running
+//	system.service.enabled(name)           # Check if service is enabled
+//	system.git.installed()                 # Check if git is installed
+//	system.git.version()                   # Get git version
+//	system.git.repo_root()                 # Get current repo root
+//	system.git.current_branch()            # Get current branch
+//	system.git.is_clean()                  # Check if working dir is clean
+//	system.file.exists(path)               # Check if path exists
+//	system.file.is_dir(path)               # Check if path is a directory
+//	system.file.which(name)                # Find executable in PATH
+//	system.file.home()                     # Get user's home directory
 func (s *systemBindings) ToStarlark() starlark.Value {
-	return starlarkstruct.FromStringDict(starlark.String("system"), starlark.StringDict{
-		"platform": s.platformStruct(),
-		"package":  s.packageStruct(),
-		"service":  s.serviceStruct(),
-		"git":      s.gitStruct(),
-		"fs":       s.fsStruct(),
-	})
-}
-
-// platformStruct returns the platform information as a Starlark struct.
-func (s *systemBindings) platformStruct() starlark.Value {
-	p := s.host.Platform()
-	return starlarkstruct.FromStringDict(starlark.String("platform"), starlark.StringDict{
-		"os":       starlark.String(p.OS),
-		"arch":     starlark.String(p.Arch),
-		"distro":   starlark.String(p.Distro),
-		"version":  starlark.String(p.Version),
-		"hostname": starlark.String(p.Hostname),
-	})
-}
-
-// packageStruct returns package queries as a Starlark struct.
-func (s *systemBindings) packageStruct() starlark.Value {
-	pm := s.host.PackageManager()
-	return starlarkstruct.FromStringDict(starlark.String("package"), starlark.StringDict{
-		"installed": starlark.NewBuiltin("system.package.installed", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("installed", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			return starlark.Bool(pm.Installed(name)), nil
-		}),
-		"version": starlark.NewBuiltin("system.package.version", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("version", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			return starlark.String(pm.Version(name)), nil
-		}),
-		"manager": starlark.NewBuiltin("system.package.manager", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			return starlark.String(pm.Name()), nil
-		}),
-	})
-}
-
-// serviceStruct returns service queries as a Starlark struct.
-func (s *systemBindings) serviceStruct() starlark.Value {
-	sm := s.host.ServiceManager()
-	return starlarkstruct.FromStringDict(starlark.String("service"), starlark.StringDict{
-		"exists": starlark.NewBuiltin("system.service.exists", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("exists", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			return starlark.Bool(sm.Exists(name)), nil
-		}),
-		"running": starlark.NewBuiltin("system.service.running", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("running", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			return starlark.Bool(sm.Status(name) == "running"), nil
-		}),
-		"enabled": starlark.NewBuiltin("system.service.enabled", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("enabled", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			// Check if status contains "enabled" - implementation depends on service manager
-			status := sm.Status(name)
-			return starlark.Bool(status == "enabled" || status == "running"), nil
-		}),
-	})
-}
-
-// gitStruct returns git queries as a Starlark struct.
-func (s *systemBindings) gitStruct() starlark.Value {
-	return starlarkstruct.FromStringDict(starlark.String("git"), starlark.StringDict{
-		"installed": starlark.NewBuiltin("system.git.installed", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			_, err := exec.LookPath("git")
-			return starlark.Bool(err == nil), nil
-		}),
-		"version": starlark.NewBuiltin("system.git.version", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			cmd := exec.Command("git", "--version")
-			output, err := cmd.Output()
-			if err != nil {
-				return starlark.String(""), nil
-			}
-			parts := strings.Fields(string(output))
-			if len(parts) >= 3 {
-				return starlark.String(parts[2]), nil
-			}
-			return starlark.String(strings.TrimSpace(string(output))), nil
-		}),
-		"repo_root": starlark.NewBuiltin("system.git.repo_root", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-			output, err := cmd.Output()
-			if err != nil {
-				return starlark.String(""), nil
-			}
-			return starlark.String(strings.TrimSpace(string(output))), nil
-		}),
-		"current_branch": starlark.NewBuiltin("system.git.current_branch", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-			output, err := cmd.Output()
-			if err != nil {
-				return starlark.String(""), nil
-			}
-			return starlark.String(strings.TrimSpace(string(output))), nil
-		}),
-		"is_clean": starlark.NewBuiltin("system.git.is_clean", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			cmd := exec.Command("git", "status", "--porcelain")
-			output, err := cmd.Output()
-			if err != nil {
-				return starlark.False, nil
-			}
-			return starlark.Bool(len(strings.TrimSpace(string(output))) == 0), nil
-		}),
-	})
-}
-
-// fsStruct returns filesystem queries as a Starlark struct.
-func (s *systemBindings) fsStruct() starlark.Value {
-	return starlarkstruct.FromStringDict(starlark.String("fs"), starlark.StringDict{
-		"exists": starlark.NewBuiltin("system.fs.exists", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var path string
-			if err := starlark.UnpackArgs("exists", args, kwargs, "path", &path); err != nil {
-				return nil, err
-			}
-			path = s.host.ExpandPath(path)
-			_, err := os.Stat(path)
-			return starlark.Bool(err == nil), nil
-		}),
-		"is_dir": starlark.NewBuiltin("system.fs.is_dir", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var path string
-			if err := starlark.UnpackArgs("is_dir", args, kwargs, "path", &path); err != nil {
-				return nil, err
-			}
-			path = s.host.ExpandPath(path)
-			info, err := os.Stat(path)
-			if err != nil {
-				return starlark.False, nil
-			}
-			return starlark.Bool(info.IsDir()), nil
-		}),
-		"which": starlark.NewBuiltin("system.fs.which", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-			var name string
-			if err := starlark.UnpackArgs("which", args, kwargs, "name", &name); err != nil {
-				return nil, err
-			}
-			path, err := exec.LookPath(name)
-			if err != nil {
-				return starlark.String(""), nil
-			}
-			return starlark.String(path), nil
-		}),
-		"home": starlark.NewBuiltin("system.fs.home", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
-			return starlark.String(s.host.HomeDir()), nil
-		}),
-	})
+	return NewSystemRoot(s.host)
 }
 
 // =============================================================================

--- a/internal/starlark/system_file.go
+++ b/internal/starlark/system_file.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// SystemFile implements system.file.* bindings for filesystem queries.
+// These are immediate queries - they execute during analysis, not deferred.
+type SystemFile struct {
+	host host.Host
+}
+
+// NewSystemFile creates a new SystemFile for the given host.
+func NewSystemFile(h host.Host) *SystemFile {
+	return &SystemFile{host: h}
+}
+
+// Starlark Value interface
+func (f *SystemFile) String() string        { return "system.file" }
+func (f *SystemFile) Type() string          { return "system.file" }
+func (f *SystemFile) Freeze()               {}
+func (f *SystemFile) Truth() starlark.Bool  { return true }
+func (f *SystemFile) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: system.file") }
+
+// Starlark HasAttrs interface
+func (f *SystemFile) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "exists":
+		return starlark.NewBuiltin("system.file.exists", f.exists), nil
+	case "is_dir":
+		return starlark.NewBuiltin("system.file.is_dir", f.isDir), nil
+	case "which":
+		return starlark.NewBuiltin("system.file.which", f.which), nil
+	case "home":
+		return starlark.NewBuiltin("system.file.home", f.home), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("system.file has no attribute %q", name))
+	}
+}
+
+func (f *SystemFile) AttrNames() []string {
+	return []string{"exists", "home", "is_dir", "which"}
+}
+
+// exists checks if a path exists.
+// Usage: system.file.exists(path)
+//
+// Arguments:
+//   - path: Path to check (with ~ expansion)
+//
+// Returns: True if path exists
+func (f *SystemFile) exists(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs("exists", args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	path = f.host.ExpandPath(path)
+	_, err := os.Stat(path)
+	return starlark.Bool(err == nil), nil
+}
+
+// isDir checks if a path is a directory.
+// Usage: system.file.is_dir(path)
+//
+// Arguments:
+//   - path: Path to check (with ~ expansion)
+//
+// Returns: True if path exists and is a directory
+func (f *SystemFile) isDir(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs("is_dir", args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	path = f.host.ExpandPath(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return starlark.False, nil
+	}
+	return starlark.Bool(info.IsDir()), nil
+}
+
+// which finds an executable in PATH.
+// Usage: system.file.which(name)
+//
+// Arguments:
+//   - name: Executable name to find
+//
+// Returns: Full path to executable, or empty string if not found
+func (f *SystemFile) which(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("which", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return starlark.String(""), nil
+	}
+	return starlark.String(path), nil
+}
+
+// home returns the user's home directory.
+// Usage: system.file.home()
+//
+// Returns: Path to user's home directory
+func (f *SystemFile) home(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	return starlark.String(f.host.HomeDir()), nil
+}

--- a/internal/starlark/system_git.go
+++ b/internal/starlark/system_git.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// SystemGit implements system.git.* bindings for git queries.
+// These are immediate queries - they execute during analysis, not deferred.
+type SystemGit struct{}
+
+// NewSystemGit creates a new SystemGit.
+func NewSystemGit() *SystemGit {
+	return &SystemGit{}
+}
+
+// Starlark Value interface
+func (g *SystemGit) String() string        { return "system.git" }
+func (g *SystemGit) Type() string          { return "system.git" }
+func (g *SystemGit) Freeze()               {}
+func (g *SystemGit) Truth() starlark.Bool  { return true }
+func (g *SystemGit) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: system.git") }
+
+// Starlark HasAttrs interface
+func (g *SystemGit) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "installed":
+		return starlark.NewBuiltin("system.git.installed", g.installed), nil
+	case "version":
+		return starlark.NewBuiltin("system.git.version", g.version), nil
+	case "repo_root":
+		return starlark.NewBuiltin("system.git.repo_root", g.repoRoot), nil
+	case "current_branch":
+		return starlark.NewBuiltin("system.git.current_branch", g.currentBranch), nil
+	case "is_clean":
+		return starlark.NewBuiltin("system.git.is_clean", g.isClean), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("system.git has no attribute %q", name))
+	}
+}
+
+func (g *SystemGit) AttrNames() []string {
+	return []string{"current_branch", "installed", "is_clean", "repo_root", "version"}
+}
+
+// installed checks if git is installed.
+// Usage: system.git.installed()
+//
+// Returns: True if git is available in PATH
+func (g *SystemGit) installed(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	_, err := exec.LookPath("git")
+	return starlark.Bool(err == nil), nil
+}
+
+// version returns the installed git version.
+// Usage: system.git.version()
+//
+// Returns: Git version string (e.g., "2.43.0"), or empty if not installed
+func (g *SystemGit) version(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	cmd := exec.Command("git", "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return starlark.String(""), nil
+	}
+	parts := strings.Fields(string(output))
+	if len(parts) >= 3 {
+		return starlark.String(parts[2]), nil
+	}
+	return starlark.String(strings.TrimSpace(string(output))), nil
+}
+
+// repoRoot returns the root directory of the current git repository.
+// Usage: system.git.repo_root()
+//
+// Returns: Path to repository root, or empty string if not in a repo
+func (g *SystemGit) repoRoot(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return starlark.String(""), nil
+	}
+	return starlark.String(strings.TrimSpace(string(output))), nil
+}
+
+// currentBranch returns the current git branch name.
+// Usage: system.git.current_branch()
+//
+// Returns: Current branch name, or empty string if not in a repo
+func (g *SystemGit) currentBranch(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return starlark.String(""), nil
+	}
+	return starlark.String(strings.TrimSpace(string(output))), nil
+}
+
+// isClean checks if the working directory has no uncommitted changes.
+// Usage: system.git.is_clean()
+//
+// Returns: True if there are no uncommitted changes
+func (g *SystemGit) isClean(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return starlark.False, nil
+	}
+	return starlark.Bool(len(strings.TrimSpace(string(output))) == 0), nil
+}

--- a/internal/starlark/system_package.go
+++ b/internal/starlark/system_package.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// SystemPackage implements system.package.* bindings for package manager queries.
+// These are immediate queries - they execute during analysis, not deferred.
+type SystemPackage struct {
+	pm host.PackageManager
+}
+
+// NewSystemPackage creates a new SystemPackage for the given package manager.
+func NewSystemPackage(pm host.PackageManager) *SystemPackage {
+	return &SystemPackage{pm: pm}
+}
+
+// Starlark Value interface
+func (p *SystemPackage) String() string        { return "system.package" }
+func (p *SystemPackage) Type() string          { return "system.package" }
+func (p *SystemPackage) Freeze()               {}
+func (p *SystemPackage) Truth() starlark.Bool  { return true }
+func (p *SystemPackage) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: system.package") }
+
+// Starlark HasAttrs interface
+func (p *SystemPackage) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "installed":
+		return starlark.NewBuiltin("system.package.installed", p.installed), nil
+	case "version":
+		return starlark.NewBuiltin("system.package.version", p.version), nil
+	case "manager":
+		return starlark.NewBuiltin("system.package.manager", p.manager), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("system.package has no attribute %q", name))
+	}
+}
+
+func (p *SystemPackage) AttrNames() []string {
+	return []string{"installed", "manager", "version"}
+}
+
+// installed checks if a package is installed.
+// Usage: system.package.installed(name)
+//
+// Arguments:
+//   - name: Package name to check
+//
+// Returns: True if the package is installed
+func (p *SystemPackage) installed(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("installed", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	return starlark.Bool(p.pm.Installed(name)), nil
+}
+
+// version returns the installed version of a package.
+// Usage: system.package.version(name)
+//
+// Arguments:
+//   - name: Package name to check
+//
+// Returns: Version string, or empty if not installed
+func (p *SystemPackage) version(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("version", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	return starlark.String(p.pm.Version(name)), nil
+}
+
+// manager returns the name of the system package manager.
+// Usage: system.package.manager()
+//
+// Returns: Package manager name (e.g., "apt", "brew", "dnf")
+func (p *SystemPackage) manager(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	return starlark.String(p.pm.Name()), nil
+}

--- a/internal/starlark/system_root.go
+++ b/internal/starlark/system_root.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// SystemRoot implements the top-level system namespace using the Attr receiver pattern.
+// It provides access to sub-namespaces (package, service, git, file) and
+// the platform struct.
+//
+// Unlike plan.*, system.* bindings query current system state immediately
+// rather than building an execution graph.
+type SystemRoot struct {
+	host host.Host
+
+	// Sub-namespaces (cached)
+	packageSystem *SystemPackage
+	serviceSystem *SystemService
+	gitSystem     *SystemGit
+	fileSystem    *SystemFile
+
+	// Platform struct (cached)
+	platformValue starlark.Value
+}
+
+// NewSystemRoot creates a new SystemRoot for the given host.
+func NewSystemRoot(h host.Host) *SystemRoot {
+	p := h.Platform()
+	platformValue := starlarkstruct.FromStringDict(starlark.String("platform"), starlark.StringDict{
+		"os":       starlark.String(p.OS),
+		"arch":     starlark.String(p.Arch),
+		"distro":   starlark.String(p.Distro),
+		"version":  starlark.String(p.Version),
+		"hostname": starlark.String(p.Hostname),
+	})
+
+	return &SystemRoot{
+		host:          h,
+		packageSystem: NewSystemPackage(h.PackageManager()),
+		serviceSystem: NewSystemService(h.ServiceManager()),
+		gitSystem:     NewSystemGit(),
+		fileSystem:    NewSystemFile(h),
+		platformValue: platformValue,
+	}
+}
+
+// Starlark Value interface
+func (s *SystemRoot) String() string        { return "system" }
+func (s *SystemRoot) Type() string          { return "system" }
+func (s *SystemRoot) Freeze()               {}
+func (s *SystemRoot) Truth() starlark.Bool  { return true }
+func (s *SystemRoot) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: system") }
+
+// Starlark HasAttrs interface
+func (s *SystemRoot) Attr(name string) (starlark.Value, error) {
+	switch name {
+	// Sub-namespaces
+	case "package":
+		return s.packageSystem, nil
+	case "service":
+		return s.serviceSystem, nil
+	case "git":
+		return s.gitSystem, nil
+	case "file":
+		return s.fileSystem, nil
+	// Platform struct (immediate value, not a namespace)
+	case "platform":
+		return s.platformValue, nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("system has no attribute %q", name))
+	}
+}
+
+func (s *SystemRoot) AttrNames() []string {
+	return []string{"file", "git", "package", "platform", "service"}
+}

--- a/internal/starlark/system_service.go
+++ b/internal/starlark/system_service.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/host"
+)
+
+// SystemService implements system.service.* bindings for service manager queries.
+// These are immediate queries - they execute during analysis, not deferred.
+type SystemService struct {
+	sm host.ServiceManager
+}
+
+// NewSystemService creates a new SystemService for the given service manager.
+func NewSystemService(sm host.ServiceManager) *SystemService {
+	return &SystemService{sm: sm}
+}
+
+// Starlark Value interface
+func (s *SystemService) String() string        { return "system.service" }
+func (s *SystemService) Type() string          { return "system.service" }
+func (s *SystemService) Freeze()               {}
+func (s *SystemService) Truth() starlark.Bool  { return true }
+func (s *SystemService) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: system.service") }
+
+// Starlark HasAttrs interface
+func (s *SystemService) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "exists":
+		return starlark.NewBuiltin("system.service.exists", s.exists), nil
+	case "running":
+		return starlark.NewBuiltin("system.service.running", s.running), nil
+	case "enabled":
+		return starlark.NewBuiltin("system.service.enabled", s.enabled), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("system.service has no attribute %q", name))
+	}
+}
+
+func (s *SystemService) AttrNames() []string {
+	return []string{"enabled", "exists", "running"}
+}
+
+// exists checks if a service exists.
+// Usage: system.service.exists(name)
+//
+// Arguments:
+//   - name: Service name to check
+//
+// Returns: True if the service exists
+func (s *SystemService) exists(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("exists", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	return starlark.Bool(s.sm.Exists(name)), nil
+}
+
+// running checks if a service is running.
+// Usage: system.service.running(name)
+//
+// Arguments:
+//   - name: Service name to check
+//
+// Returns: True if the service is running
+func (s *SystemService) running(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("running", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	return starlark.Bool(s.sm.Status(name) == "running"), nil
+}
+
+// enabled checks if a service is enabled to start on boot.
+// Usage: system.service.enabled(name)
+//
+// Arguments:
+//   - name: Service name to check
+//
+// Returns: True if the service is enabled
+func (s *SystemService) enabled(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs("enabled", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	// Check if status contains "enabled" - implementation depends on service manager
+	status := s.sm.Status(name)
+	return starlark.Bool(status == "enabled" || status == "running"), nil
+}

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -488,10 +488,10 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 	node := &execution.Node{
 		ID:         relTarget,
 		Operations: opStrings,
-		Source:     entry.Source,
-		Target:     target,
 		Project:    entry.Project,
 	}
+	node.SetSlotImmediate("source", entry.Source)
+	node.SetSlotImmediate("path", target)
 
 	if hasDecryptOp(opStrings) {
 		node.Mode = 0600
@@ -695,19 +695,21 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 		}
 
 		var entry reconcile.Entry
+		source := n.GetSlot("source")
+		target := n.GetSlot("path")
 		if checkDrift && n.SourceChecksum != "" {
 			entry = reconcile.Entry{
 				RelTarget:      n.ID,
-				Source:         n.Source,
-				Target:         n.Target,
+				Source:         source,
+				Target:         target,
 				Project:        n.Project,
 				Operations:     n.Operations,
 				SourceChecksum: n.SourceChecksum,
 				TargetChecksum: n.TargetChecksum,
 			}
 			// Check drift
-			currentSourceChecksum := execution.ChecksumFile(n.Source)
-			currentTargetChecksum := execution.ChecksumFile(n.Target)
+			currentSourceChecksum := execution.ChecksumFile(source)
+			currentTargetChecksum := execution.ChecksumFile(target)
 
 			sourceChanged := currentSourceChecksum != "" && currentSourceChecksum != n.SourceChecksum
 			targetChanged := currentTargetChecksum != "" && currentTargetChecksum != n.TargetChecksum
@@ -729,12 +731,12 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 			// Just check if file exists
 			entry = reconcile.Entry{
 				RelTarget:  n.ID,
-				Source:     n.Source,
-				Target:     n.Target,
+				Source:     source,
+				Target:     target,
 				Project:    n.Project,
 				Operations: n.Operations,
 			}
-			if _, err := os.Stat(n.Target); os.IsNotExist(err) {
+			if _, err := os.Stat(target); os.IsNotExist(err) {
 				entry.State = reconcile.StateMissing
 				entry.Message = "file not deployed"
 			} else {

--- a/internal/writ/graph_builder.go
+++ b/internal/writ/graph_builder.go
@@ -63,12 +63,12 @@ func BuildTree(g *execution.Graph, cfg *Config) error {
 			ID:         f.ID,
 			Operations: f.Operations,
 			Status:     execution.StatusPending,
-			Source:     f.Source,
-			Target:     f.Target,
 			Project:    f.Project,
 			Layer:      f.Layer,
 			Mode:       f.Mode,
 		}
+		node.SetSlotImmediate("source", f.Source)
+		node.SetSlotImmediate("path", f.Target)
 		g.Nodes = append(g.Nodes, node)
 	}
 
@@ -220,11 +220,11 @@ func (b *DecommissionGraphBuilder) Build() (*execution.Graph, error) {
 			ID:         relTarget,
 			Operations: []string{op},
 			Status:     execution.StatusPending,
-			Source:     entry.Source,
-			Target:     target,
 			Project:    entry.Project,
 			Layer:      entry.Layer,
 		}
+		node.SetSlotImmediate("source", entry.Source)
+		node.SetSlotImmediate("path", target)
 
 		g.Nodes = append(g.Nodes, node)
 	}

--- a/internal/writ/graph_test.go
+++ b/internal/writ/graph_test.go
@@ -99,9 +99,8 @@ func TestNode(t *testing.T) {
 
 func TestEdge(t *testing.T) {
 	edge := execution.Edge{
-		From:     "nodeA",
-		To:       "nodeB",
-		Relation: "depends-on",
+		From: "nodeA",
+		To:   "nodeB",
 	}
 
 	if edge.From != "nodeA" {
@@ -109,9 +108,6 @@ func TestEdge(t *testing.T) {
 	}
 	if edge.To != "nodeB" {
 		t.Errorf("expected To 'nodeB', got %q", edge.To)
-	}
-	if edge.Relation != "depends-on" {
-		t.Errorf("expected Relation 'depends-on', got %q", edge.Relation)
 	}
 }
 

--- a/internal/writ/graph_test.go
+++ b/internal/writ/graph_test.go
@@ -81,10 +81,10 @@ func TestNode(t *testing.T) {
 		ID:         ".bashrc",
 		Operations: []string{"link"},
 		Status:     execution.StatusPending,
-		Source:     "/home/user/env/all/.bashrc",
-		Target:     "/home/user/.bashrc",
 		Project:    "all",
 	}
+	node.SetSlotImmediate("source", "/home/user/env/all/.bashrc")
+	node.SetSlotImmediate("path", "/home/user/.bashrc")
 
 	if node.ID != ".bashrc" {
 		t.Errorf("expected ID '.bashrc', got %q", node.ID)
@@ -359,7 +359,7 @@ func TestComputeSummary(t *testing.T) {
 		Nodes: []*execution.Node{
 			{ID: "1", Operations: []string{"link"}, Status: execution.StatusCompleted},
 			{ID: "2", Operations: []string{"link"}, Status: execution.StatusCompleted},
-			{ID: "3", Operations: []string{"expand"}, Status: execution.StatusCompleted},
+			{ID: "3", Operations: []string{"render"}, Status: execution.StatusCompleted},
 			{ID: "4", Operations: []string{"decrypt"}, Status: execution.StatusCompleted},
 			{ID: "5", Operations: []string{"copy"}, Status: execution.StatusCompleted},
 			{ID: "6", Status: execution.StatusSkipped},
@@ -407,17 +407,18 @@ func TestNodeAnnotations(t *testing.T) {
 	}
 }
 
-func TestNodeMetadata(t *testing.T) {
+func TestNodeSlots(t *testing.T) {
 	node := &execution.Node{
-		ID:       "install-curl",
-		Metadata: map[string]string{"packages": "curl,wget", "manager": "brew"},
+		ID: "install-curl",
 	}
+	node.SetSlotImmediate("packages", "curl,wget")
+	node.SetSlotImmediate("manager", "brew")
 
-	if node.Metadata["packages"] != "curl,wget" {
-		t.Errorf("expected packages metadata, got %v", node.Metadata)
+	if node.GetSlot("packages") != "curl,wget" {
+		t.Errorf("expected packages slot, got %v", node.GetSlot("packages"))
 	}
-	if node.Metadata["manager"] != "brew" {
-		t.Errorf("expected manager metadata, got %v", node.Metadata)
+	if node.GetSlot("manager") != "brew" {
+		t.Errorf("expected manager slot, got %v", node.GetSlot("manager"))
 	}
 }
 

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -39,7 +39,7 @@ func Execute(w io.Writer, graph *execution.Graph, analysis *MigrationAnalysis) e
 	var renameNodes []*execution.Node
 	for _, node := range graph.Nodes {
 		for _, op := range node.Operations {
-			if op == "rename" {
+			if op == "move" {
 				renameNodes = append(renameNodes, node)
 				break
 			}
@@ -55,20 +55,23 @@ func Execute(w io.Writer, graph *execution.Graph, analysis *MigrationAnalysis) e
 
 	// Verify no target conflicts before starting
 	for _, node := range renameNodes {
-		if exists(node.Target) {
-			return fmt.Errorf("target directory %q already exists; aborting", node.Target)
+		target := node.GetSlot("path")
+		if exists(target) {
+			return fmt.Errorf("target directory %q already exists; aborting", target)
 		}
 	}
 
 	// Perform renames
 	var renames []Rename
 	for _, node := range renameNodes {
-		if err := os.Rename(node.Source, node.Target); err != nil {
-			cli.Error("  %s -> %s", filepath.Base(node.Source), filepath.Base(node.Target))
-			return fmt.Errorf("rename %s -> %s: %w", node.Source, node.Target, err)
+		source := node.GetSlot("source")
+		target := node.GetSlot("path")
+		if err := os.Rename(source, target); err != nil {
+			cli.Error("  %s -> %s", filepath.Base(source), filepath.Base(target))
+			return fmt.Errorf("rename %s -> %s: %w", source, target, err)
 		}
-		cli.Success("  %s -> %s", filepath.Base(node.Source), filepath.Base(node.Target))
-		renames = append(renames, Rename{From: node.Source, To: node.Target})
+		cli.Success("  %s -> %s", filepath.Base(source), filepath.Base(target))
+		renames = append(renames, Rename{From: source, To: target})
 	}
 
 	// Write marker file
@@ -91,8 +94,8 @@ func WriteMigratedMarker(sourceRoot string, graph *execution.Graph, analysis *Mi
 	var renames []Rename
 	for _, node := range graph.Nodes {
 		for _, op := range node.Operations {
-			if op == "rename" {
-				renames = append(renames, Rename{From: node.Source, To: node.Target})
+			if op == "move" {
+				renames = append(renames, Rename{From: node.GetSlot("source"), To: node.GetSlot("path")})
 				break
 			}
 		}

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -91,8 +91,8 @@ func buildMigrationView(graph *execution.Graph, analysis *MigrationAnalysis) *mi
 		nodes = append(nodes, nodeView{
 			ID:         node.ID,
 			Operations: node.Operations,
-			Source:     node.Source,
-			Target:     node.Target,
+			Source:     node.GetSlot("source"),
+			Target:     node.GetSlot("path"),
 			Status:     string(node.Status),
 		})
 	}
@@ -177,7 +177,7 @@ func collectExtraStats(s MigrationStats) []string {
 }
 
 func formatRenames(w io.Writer, graph *execution.Graph, sourceRoot string) {
-	renameNodes := filterNodesByOp(graph, "rename")
+	renameNodes := filterNodesByOp(graph, "move")
 	if len(renameNodes) == 0 {
 		return
 	}
@@ -185,13 +185,14 @@ func formatRenames(w io.Writer, graph *execution.Graph, sourceRoot string) {
 	_, _ = fmt.Fprintf(w, "Directory renames (%d):\n", len(renameNodes))
 	maxLen := 0
 	for _, node := range renameNodes {
-		if len(node.Source) > maxLen {
-			maxLen = len(node.Source)
+		source := node.GetSlot("source")
+		if len(source) > maxLen {
+			maxLen = len(source)
 		}
 	}
 	for _, node := range renameNodes {
-		source := shortenPath(node.Source, sourceRoot)
-		target := shortenPath(node.Target, sourceRoot)
+		source := shortenPath(node.GetSlot("source"), sourceRoot)
+		target := shortenPath(node.GetSlot("path"), sourceRoot)
 		_, _ = fmt.Fprintf(w, "  %-*s  →  %s\n", maxLen-len(sourceRoot), source, target)
 	}
 	_, _ = fmt.Fprintln(w)

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -65,9 +65,8 @@ type nodeView struct {
 
 // edgeView represents a dependency between nodes.
 type edgeView struct {
-	From     string `json:"from" yaml:"from"`
-	To       string `json:"to" yaml:"to"`
-	Relation string `json:"relation" yaml:"relation"`
+	From string `json:"from" yaml:"from"`
+	To   string `json:"to" yaml:"to"`
 }
 
 func formatMigrationYAML(w io.Writer, graph *execution.Graph, analysis *MigrationAnalysis) error {
@@ -101,9 +100,8 @@ func buildMigrationView(graph *execution.Graph, analysis *MigrationAnalysis) *mi
 	var edges []edgeView
 	for _, edge := range graph.Edges {
 		edges = append(edges, edgeView{
-			From:     edge.From,
-			To:       edge.To,
-			Relation: edge.Relation,
+			From: edge.From,
+			To:   edge.To,
 		})
 	}
 

--- a/internal/writ/migrate/migrate_test.go
+++ b/internal/writ/migrate/migrate_test.go
@@ -125,7 +125,7 @@ func TestParseRegistryLLMResponse(t *testing.T) {
 		],
 		"execution_graph": {
 			"nodes": [
-				{"id": "rename-1", "op": "rename", "source": "Home/Configs/all-Darwin", "target": "Home/Configs/all.Darwin", "project": "all"}
+				{"id": "move-1", "op": "move", "source": "Home/Configs/all-Darwin", "target": "Home/Configs/all.Darwin", "project": "all"}
 			],
 			"edges": []
 		}
@@ -160,8 +160,8 @@ func TestParseRegistryLLMResponse(t *testing.T) {
 	if len(result.Graph.Nodes) > 0 {
 		node := result.Graph.Nodes[0]
 		expectedSource := sourceRoot + "/Home/Configs/all-Darwin"
-		if node.Source != expectedSource {
-			t.Errorf("node source = %q, want %q", node.Source, expectedSource)
+		if node.GetSlot("source") != expectedSource {
+			t.Errorf("node source = %q, want %q", node.GetSlot("source"), expectedSource)
 		}
 	}
 }
@@ -237,8 +237,8 @@ func TestFormatMigrationViewJSON(t *testing.T) {
 	// Create a mock graph using registry format
 	graph := buildGraphFromRegistry("/test/root", &registryExecutionGraph{
 		Nodes: []registryNode{
-			{ID: "r1", Op: "rename", Source: "all-Darwin", Target: "all.Darwin"},
-			{ID: "r2", Op: "rename", Source: "all-Unix", Target: "all.Unix"},
+			{ID: "r1", Op: "move", Source: "all-Darwin", Target: "all.Darwin"},
+			{ID: "r2", Op: "move", Source: "all-Unix", Target: "all.Unix"},
 		},
 		Edges: []registryEdge{
 			{From: "r1", To: "r2"},
@@ -302,7 +302,7 @@ func TestFormatMigrationViewYAML(t *testing.T) {
 
 	graph := buildGraphFromRegistry("/test/root", &registryExecutionGraph{
 		Nodes: []registryNode{
-			{ID: "r1", Op: "rename", Source: "pkg-Darwin", Target: "pkg.Darwin"},
+			{ID: "r1", Op: "move", Source: "pkg-Darwin", Target: "pkg.Darwin"},
 		},
 		Edges: []registryEdge{},
 	})
@@ -357,7 +357,7 @@ func TestExecuteWithMockGraph(t *testing.T) {
 
 	graph := buildGraphFromRegistry(tmpDir, &registryExecutionGraph{
 		Nodes: []registryNode{
-			{ID: "r1", Op: "rename", Source: "all-Darwin", Target: "all.Darwin"},
+			{ID: "r1", Op: "move", Source: "all-Darwin", Target: "all.Darwin"},
 		},
 		Edges: []registryEdge{},
 	})
@@ -403,7 +403,7 @@ func TestExecuteConflict(t *testing.T) {
 
 	graph := buildGraphFromRegistry(tmpDir, &registryExecutionGraph{
 		Nodes: []registryNode{
-			{ID: "r1", Op: "rename", Source: "all-Darwin", Target: "all.Darwin"},
+			{ID: "r1", Op: "move", Source: "all-Darwin", Target: "all.Darwin"},
 		},
 		Edges: []registryEdge{},
 	})

--- a/internal/writ/migrate/plan.go
+++ b/internal/writ/migrate/plan.go
@@ -380,7 +380,7 @@ func buildGraphFromRegistry(sourceRoot string, regGraph *registryExecutionGraph)
 
 		var node *execution.Node
 		switch n.Op {
-		case "rename":
+		case "move":
 			node = plan.Rename(source, target)
 		case "mkdir":
 			node = plan.Mkdir(target)

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -344,10 +344,10 @@ func (s *Session) formatGraphForPrompt() string {
 	sb.WriteString("Planned renames:\n")
 	for _, node := range s.graph.Nodes {
 		for _, op := range node.Operations {
-			if op == "rename" {
+			if op == "move" {
 				// Show relative paths for readability
-				source := strings.TrimPrefix(node.Source, s.opts.SourceRoot+"/")
-				target := strings.TrimPrefix(node.Target, s.opts.SourceRoot+"/")
+				source := strings.TrimPrefix(node.GetSlot("source"), s.opts.SourceRoot+"/")
+				target := strings.TrimPrefix(node.GetSlot("path"), s.opts.SourceRoot+"/")
 				sb.WriteString(fmt.Sprintf("  %s -> %s\n", source, target))
 			}
 		}
@@ -414,9 +414,9 @@ func (s *Session) addRenameToGraph(source, target string) {
 
 	// Check if this rename already exists
 	for _, node := range s.graph.Nodes {
-		if node.Source == source {
+		if node.GetSlot("source") == source {
 			// Update existing rename
-			node.Target = target
+			node.SetSlotImmediate("path", target)
 			return
 		}
 	}
@@ -436,7 +436,7 @@ func (s *Session) removeRenameFromGraph(source string) {
 
 	// Find and remove the node
 	for i, node := range s.graph.Nodes {
-		if node.Source == source {
+		if node.GetSlot("source") == source {
 			s.graph.Nodes = append(s.graph.Nodes[:i], s.graph.Nodes[i+1:]...)
 			return
 		}

--- a/internal/writ/reconcile/reconcile_test.go
+++ b/internal/writ/reconcile/reconcile_test.go
@@ -150,7 +150,7 @@ func TestCheckEntry_CopiedFile(t *testing.T) {
 	}
 
 	// Check entry with copy operation
-	entry := checkEntry(sourceFile, targetFile, "config", "testproject", []string{"expand", "copy"})
+	entry := checkEntry(sourceFile, targetFile, "config", "testproject", []string{"render", "copy"})
 
 	if entry.State != StateCopied {
 		t.Errorf("expected StateCopied, got %s (%s)", entry.State.Label(), entry.Message)

--- a/internal/writ/tree/builder.go
+++ b/internal/writ/tree/builder.go
@@ -31,7 +31,7 @@ type FileEntry struct {
 	ID string
 
 	// Operations is the pipeline of operations to perform.
-	// Examples: ["link"], ["decrypt", "expand", "copy"].
+	// Examples: ["link"], ["decrypt", "render", "copy"].
 	Operations []string
 
 	// Source is the absolute path to the source file.
@@ -404,7 +404,7 @@ func (r *BuildResult) TemplateCount() int {
 	count := 0
 	for _, f := range r.Files {
 		for _, op := range f.Operations {
-			if op == "expand" {
+			if op == "render" {
 				count++
 				break
 			}

--- a/internal/writ/tree/node.go
+++ b/internal/writ/tree/node.go
@@ -59,7 +59,7 @@ func ProcessingPipeline(filename string) (targetName string, ops Operations) {
 	// .template is inner (expand after decrypt)
 	if strings.HasSuffix(name, ".template") {
 		name = strings.TrimSuffix(name, ".template")
-		pipeline = append(pipeline, OpExpand)
+		pipeline = append(pipeline, OpRender)
 	}
 
 	// Determine final operation

--- a/internal/writ/tree/operation.go
+++ b/internal/writ/tree/operation.go
@@ -11,8 +11,8 @@ const (
 	// OpLink creates a symlink from target to source.
 	OpLink Operation = iota
 
-	// OpExpand processes a .template file with Go text/template.
-	OpExpand
+	// OpRender processes a .template file with Go text/template.
+	OpRender
 
 	// OpCopy writes content to target (used after expand or decrypt).
 	OpCopy
@@ -36,8 +36,8 @@ func (o Operation) String() string {
 	switch o {
 	case OpLink:
 		return "link"
-	case OpExpand:
-		return "expand"
+	case OpRender:
+		return "render"
 	case OpCopy:
 		return "copy"
 	case OpDecrypt:

--- a/internal/writ/tree/tree_test.go
+++ b/internal/writ/tree/tree_test.go
@@ -19,14 +19,14 @@ func TestProcessingPipeline(t *testing.T) {
 		ops        []Operation
 	}{
 		{"foo", "foo", []Operation{OpLink}},
-		{"foo.template", "foo", []Operation{OpExpand, OpCopy}},
+		{"foo.template", "foo", []Operation{OpRender, OpCopy}},
 		{"foo.age", "foo", []Operation{OpDecrypt, OpCopy}},
 		{"foo.sops", "foo", []Operation{OpDecrypt, OpCopy}},
-		{"foo.template.age", "foo", []Operation{OpDecrypt, OpExpand, OpCopy}},
-		{"foo.template.sops", "foo", []Operation{OpDecrypt, OpExpand, OpCopy}},
+		{"foo.template.age", "foo", []Operation{OpDecrypt, OpRender, OpCopy}},
+		{"foo.template.sops", "foo", []Operation{OpDecrypt, OpRender, OpCopy}},
 		{".bashrc", ".bashrc", []Operation{OpLink}},
-		{".bashrc.template", ".bashrc", []Operation{OpExpand, OpCopy}},
-		{"config.yaml.template.age", "config.yaml", []Operation{OpDecrypt, OpExpand, OpCopy}},
+		{".bashrc.template", ".bashrc", []Operation{OpRender, OpCopy}},
+		{"config.yaml.template.age", "config.yaml", []Operation{OpDecrypt, OpRender, OpCopy}},
 		{"packages.manifest", "packages.manifest", []Operation{OpPackages}},
 	}
 
@@ -238,9 +238,9 @@ func TestOperationHelpers(t *testing.T) {
 		hasPackages bool
 	}{
 		{Operations{OpLink}, false, false},
-		{Operations{OpExpand, OpCopy}, true, false},
+		{Operations{OpRender, OpCopy}, true, false},
 		{Operations{OpDecrypt, OpCopy}, true, false},
-		{Operations{OpDecrypt, OpExpand, OpCopy}, true, false},
+		{Operations{OpDecrypt, OpRender, OpCopy}, true, false},
 		{Operations{OpPackages}, false, true},
 	}
 


### PR DESCRIPTION
## Summary
- Add `plan.gather()` Starlark binding for parallel execution semantics (similar to Python's `asyncio.gather()`)
- Remove `plan.depends_on()` - replaced by gather and automatic slot-based edge creation
- Simplify `Edge` struct by removing unused `Relation` field - executor ignores it and slot references already encode semantics

## Test plan
- [ ] Verify `go test ./...` passes
- [ ] Verify `go build ./...` succeeds
- [ ] Test gather pattern in Starlark scripts