### PR TITLE
chore: use GitHub App token for cross-repo automation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,21 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: NobleFactor
+          repositories: noblefactor-ops
+
       - name: Clone noblefactor-ops
         uses: actions/checkout@v4
         with:
           repository: NobleFactor/noblefactor-ops
           path: noblefactor-ops
-          token: ${{ secrets.NOBLEFACTOR_AUTOMATION }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -12,6 +12,15 @@ jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: NobleFactor
+          repositories: devlore.noblefactor.com
+
       - name: Checkout CLI repo
         uses: actions/checkout@v4
 
@@ -33,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: NobleFactor/devlore.noblefactor.com
-          token: ${{ secrets.NOBLEFACTOR_AUTOMATION }}
+          token: ${{ steps.app-token.outputs.token }}
           path: site
 
       - name: Update site content
@@ -46,7 +55,7 @@ jobs:
       - name: Create and merge PR on site repo
         working-directory: site
         env:
-          GH_TOKEN: ${{ secrets.NOBLEFACTOR_AUTOMATION }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="cli-docs/update-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,6 +119,15 @@ jobs:
     needs: build-and-release
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: NobleFactor
+          repositories: devlore.noblefactor.com
+
       - name: Checkout devlore-cli
         uses: actions/checkout@v4
 
@@ -126,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: NobleFactor/devlore.noblefactor.com
-          token: ${{ secrets.NOBLEFACTOR_CONTENT_ACCESS }}
+          token: ${{ steps.app-token.outputs.token }}
           path: website
 
       - name: Sync install script to website
@@ -177,4 +186,4 @@ jobs:
           Source: ${{ github.repository }}@${{ github.sha }}
           Ref: ${{ github.ref }}"
         env:
-          GH_TOKEN: ${{ secrets.NOBLEFACTOR_CONTENT_ACCESS }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -29,6 +29,15 @@ jobs:
   sync-knowledge:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: NobleFactor
+          repositories: noblefactor-ops,devlore-registry
+
       - name: Checkout devlore-cli
         uses: actions/checkout@v4
         with:
@@ -38,14 +47,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: NobleFactor/noblefactor-ops
-          token: ${{ secrets.NOBLEFACTOR_AUTOMATION }}
+          token: ${{ steps.app-token.outputs.token }}
           path: noblefactor-ops
 
       - name: Checkout devlore-registry
         uses: actions/checkout@v4
         with:
           repository: NobleFactor/devlore-registry
-          token: ${{ secrets.NOBLEFACTOR_AUTOMATION }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
           path: devlore-registry
 


### PR DESCRIPTION
Replace NOBLEFACTOR_AUTOMATION PAT with GitHub App token in:
- docs-publish.yaml
- sync-knowledge.yaml
- ci.yaml

Uses actions/create-github-app-token to generate scoped tokens from the NobleFactor Automation app.