### PR TITLE
Consolidate config types into internal/config package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 docs/cli/
+
+# IDE
+.idea/

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSharedConfigPath(t *testing.T) {
+	// SharedConfigPath should return the same path regardless of which tool calls it
+	path := SharedConfigPath()
+
+	// Verify it's an absolute path
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path, got %q", path)
+	}
+
+	// Verify it's in the devlore directory (shared by both lore and writ)
+	if !strings.Contains(path, "devlore") {
+		t.Errorf("expected path to contain 'devlore', got %q", path)
+	}
+
+	// Verify it ends with config.yaml
+	if filepath.Base(path) != "config.yaml" {
+		t.Errorf("expected path ending in 'config.yaml', got %q", path)
+	}
+}
+
+func TestUnifiedConfig_BothToolsSeeSharedSettings(t *testing.T) {
+	// This test verifies that lore and writ both read from the same config file
+	// and see the same shared settings (model, registry, verbosity)
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Create shared config with settings relevant to both tools
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `
+verbosity: verbose
+dry_run: true
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+registry:
+  url: https://example.com/registry.git
+  branch: develop
+lore:
+  preferences:
+    shell: zsh
+writ:
+  segments:
+    - ROLE
+    - SITE
+  vars:
+    USER_NAME: "Test User"
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	// Load config (simulates what both lore and writ do via cli.loadConfig)
+	config, err := loadConfig(SharedConfigPath())
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+
+	// Verify shared settings are visible
+	// These settings should be the same regardless of whether accessed from lore or writ
+
+	// Check verbosity (shared)
+	verbosity, ok := getNestedValue(config, "verbosity")
+	if !ok {
+		t.Error("expected to find 'verbosity' in config")
+	} else if verbosity != "verbose" {
+		t.Errorf("expected verbosity 'verbose', got %q", verbosity)
+	}
+
+	// Check dry_run (shared)
+	dryRun, ok := getNestedValue(config, "dry_run")
+	if !ok {
+		t.Error("expected to find 'dry_run' in config")
+	} else if dryRun != true {
+		t.Errorf("expected dry_run=true, got %v", dryRun)
+	}
+
+	// Check model settings (shared)
+	provider, ok := getNestedValue(config, "model.provider")
+	if !ok {
+		t.Error("expected to find 'model.provider' in config")
+	} else if provider != "anthropic" {
+		t.Errorf("expected model.provider 'anthropic', got %q", provider)
+	}
+
+	modelName, ok := getNestedValue(config, "model.name")
+	if !ok {
+		t.Error("expected to find 'model.name' in config")
+	} else if modelName != "claude-sonnet-4-20250514" {
+		t.Errorf("expected model.name 'claude-sonnet-4-20250514', got %q", modelName)
+	}
+
+	// Check registry settings (shared)
+	regURL, ok := getNestedValue(config, "registry.url")
+	if !ok {
+		t.Error("expected to find 'registry.url' in config")
+	} else if regURL != "https://example.com/registry.git" {
+		t.Errorf("expected registry.url, got %q", regURL)
+	}
+}
+
+func TestUnifiedConfig_ToolSpecificSettingsVisible(t *testing.T) {
+	// Both tools should be able to read tool-specific settings from the shared config
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `
+lore:
+  preferences:
+    shell: bash
+    editor: vim
+writ:
+  vars:
+    USER_NAME: "Jane Doe"
+    USER_EMAIL: "jane@example.com"
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	config, err := loadConfig(SharedConfigPath())
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+
+	// Both tools can see lore-specific settings
+	loreShell, ok := getNestedValue(config, "lore.preferences.shell")
+	if !ok {
+		t.Error("expected to find 'lore.preferences.shell'")
+	} else if loreShell != "bash" {
+		t.Errorf("expected lore.preferences.shell 'bash', got %q", loreShell)
+	}
+
+	// Both tools can see writ-specific settings
+	writUserName, ok := getNestedValue(config, "writ.vars.USER_NAME")
+	if !ok {
+		t.Error("expected to find 'writ.vars.USER_NAME'")
+	} else if writUserName != "Jane Doe" {
+		t.Errorf("expected writ.vars.USER_NAME 'Jane Doe', got %q", writUserName)
+	}
+}
+
+func TestPrintFlattened_ShowsAllSettings(t *testing.T) {
+	// printFlattened should output all settings from the unified config
+	// This is what 'config list' uses
+
+	config := map[string]interface{}{
+		"verbosity": "verbose",
+		"dry_run":   true,
+		"model": map[string]interface{}{
+			"provider": "anthropic",
+			"name":     "claude-sonnet-4-20250514",
+		},
+		"registry": map[string]interface{}{
+			"url":    "https://example.com/registry.git",
+			"branch": "develop",
+		},
+		"lore": map[string]interface{}{
+			"preferences": map[string]interface{}{
+				"shell": "zsh",
+			},
+		},
+		"writ": map[string]interface{}{
+			"vars": map[string]interface{}{
+				"USER_NAME": "Test User",
+			},
+		},
+	}
+
+	// Capture output
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printFlattened("", config)
+
+	w.Close()
+	os.Stdout = old
+	buf.ReadFrom(r)
+
+	output := buf.String()
+
+	// Verify shared settings are printed
+	expectedKeys := []string{
+		"verbosity=verbose",
+		"dry_run=true",
+		"model.provider=anthropic",
+		"model.name=claude-sonnet-4-20250514",
+		"registry.url=https://example.com/registry.git",
+		"registry.branch=develop",
+		"lore.preferences.shell=zsh",
+		"writ.vars.USER_NAME=Test User",
+	}
+
+	for _, expected := range expectedKeys {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestConfigListOutput_SameForBothTools(t *testing.T) {
+	// The config list command should show identical output for both lore and writ
+	// because they read from the same file
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `
+model:
+  provider: groq
+  name: llama-3.3-70b-versatile
+registry:
+  url: https://example.com/registry.git
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	// Simulate loading config from lore perspective
+	loreConfig, err := loadConfig(SharedConfigPath())
+	if err != nil {
+		t.Fatalf("loadConfig() for lore error: %v", err)
+	}
+
+	// Simulate loading config from writ perspective
+	writConfig, err := loadConfig(SharedConfigPath())
+	if err != nil {
+		t.Fatalf("loadConfig() for writ error: %v", err)
+	}
+
+	// Both should have identical content
+	loreProvider, _ := getNestedValue(loreConfig, "model.provider")
+	writProvider, _ := getNestedValue(writConfig, "model.provider")
+
+	if loreProvider != writProvider {
+		t.Errorf("model.provider differs: lore=%q, writ=%q", loreProvider, writProvider)
+	}
+
+	loreRegistry, _ := getNestedValue(loreConfig, "registry.url")
+	writRegistry, _ := getNestedValue(writConfig, "registry.url")
+
+	if loreRegistry != writRegistry {
+		t.Errorf("registry.url differs: lore=%q, writ=%q", loreRegistry, writRegistry)
+	}
+}
+
+func TestSetNestedValue_WorksForSharedAndToolSpecific(t *testing.T) {
+	config := make(map[string]interface{})
+
+	// Set shared value
+	setNestedValue(config, "model.provider", "anthropic")
+
+	// Set lore-specific value
+	setNestedValue(config, "lore.preferences.shell", "zsh")
+
+	// Set writ-specific value
+	setNestedValue(config, "writ.vars.USER_NAME", "Test User")
+
+	// Verify all values are set correctly
+	provider, ok := getNestedValue(config, "model.provider")
+	if !ok || provider != "anthropic" {
+		t.Errorf("expected model.provider='anthropic', got %v", provider)
+	}
+
+	shell, ok := getNestedValue(config, "lore.preferences.shell")
+	if !ok || shell != "zsh" {
+		t.Errorf("expected lore.preferences.shell='zsh', got %v", shell)
+	}
+
+	userName, ok := getNestedValue(config, "writ.vars.USER_NAME")
+	if !ok || userName != "Test User" {
+		t.Errorf("expected writ.vars.USER_NAME='Test User', got %v", userName)
+	}
+}
+
+func TestDeleteNestedValue_WorksForSharedAndToolSpecific(t *testing.T) {
+	config := map[string]interface{}{
+		"model": map[string]interface{}{
+			"provider": "anthropic",
+			"name":     "claude-sonnet-4-20250514",
+		},
+		"lore": map[string]interface{}{
+			"preferences": map[string]interface{}{
+				"shell": "zsh",
+			},
+		},
+	}
+
+	// Delete shared value
+	if !deleteNestedValue(config, "model.name") {
+		t.Error("expected to delete model.name")
+	}
+
+	_, exists := getNestedValue(config, "model.name")
+	if exists {
+		t.Error("model.name should have been deleted")
+	}
+
+	// model.provider should still exist
+	_, exists = getNestedValue(config, "model.provider")
+	if !exists {
+		t.Error("model.provider should still exist")
+	}
+
+	// Delete tool-specific value
+	if !deleteNestedValue(config, "lore.preferences.shell") {
+		t.Error("expected to delete lore.preferences.shell")
+	}
+
+	_, exists = getNestedValue(config, "lore.preferences.shell")
+	if exists {
+		t.Error("lore.preferences.shell should have been deleted")
+	}
+}
+
+func TestLoadConfig_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	// Create empty config file
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	config, err := loadConfig(SharedConfigPath())
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+
+	// Should return empty map, not nil
+	if config == nil {
+		t.Error("expected non-nil config")
+	}
+
+	if len(config) != 0 {
+		t.Errorf("expected empty config, got %v", config)
+	}
+}
+
+func TestSaveConfig_CreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Directory doesn't exist yet
+	configPath := SharedConfigPath()
+
+	config := map[string]interface{}{
+		"model": map[string]interface{}{
+			"provider": "ollama",
+		},
+	}
+
+	err := saveConfig(configPath, config)
+	if err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config file should have been created")
+	}
+
+	// Verify content
+	loaded, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+
+	provider, ok := getNestedValue(loaded, "model.provider")
+	if !ok || provider != "ollama" {
+		t.Errorf("expected model.provider='ollama', got %v", provider)
+	}
+}
+
+func TestFormatValue_VariousTypes(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected string
+	}{
+		{"hello", "hello"},
+		{42, "42"},
+		{3.14, "3.14"},
+		{true, "true"},
+		{false, "false"},
+		{nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%T(%v)", tt.input, tt.input), func(t *testing.T) {
+			got := formatValue(tt.input)
+			if got != tt.expected {
+				t.Errorf("formatValue(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+// Package config provides centralized configuration for the devlore ecosystem.
+// Both lore and writ consume configuration from this package.
+//
+// Configuration is loaded from ~/.config/devlore/config.yaml with support for:
+//   - Environment variable overrides (DEVLORE_*, LORE_*, WRIT_*)
+//   - CLI flag overrides (applied by callers)
+//   - Native keystore for API keys
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/internal/credentials"
+)
+
+// Verbosity levels for output control.
+const (
+	VerbosityQuiet   = "quiet"   // Errors only
+	VerbosityNormal  = "normal"  // Default output (empty string treated as normal)
+	VerbosityVerbose = "verbose" // Extra output
+)
+
+// Config is the root configuration for the devlore ecosystem.
+// Shared options and resources are at the top level.
+// Tool-specific settings are nested under lore and writ.
+type Config struct {
+	// Shared runtime options
+	Verbosity string `yaml:"verbosity,omitempty" json:"verbosity,omitempty"` // quiet, normal, verbose
+	DryRun    bool   `yaml:"dry_run,omitempty" json:"dry_run,omitempty"`
+
+	// Shared resources
+	Model    ModelConfig    `yaml:"model,omitempty" json:"model,omitempty"`
+	Registry RegistryConfig `yaml:"registry,omitempty" json:"registry,omitempty"`
+
+	// Tool-specific
+	Lore LoreConfig `yaml:"lore,omitempty" json:"lore,omitempty"`
+	Writ WritConfig `yaml:"writ,omitempty" json:"writ,omitempty"`
+}
+
+// Path returns the path to the shared devlore config file.
+// ~/.config/devlore/config.yaml
+func Path() string {
+	return filepath.Join(cli.DevloreConfigHome(), "config.yaml")
+}
+
+// Load reads configuration from the config file and applies environment overrides.
+// API keys are loaded from the native keystore if not in config/env.
+//
+// Precedence (lowest to highest):
+//  1. Config file
+//  2. Environment variables
+//  3. Native keystore (for API key only)
+//  4. CLI flags (applied by caller via ApplyCLIFlags methods)
+func Load() (*Config, error) {
+	cfg := &Config{}
+
+	// Read config file
+	data, err := os.ReadFile(Path())
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	if err == nil {
+		if err := yaml.Unmarshal(data, cfg); err != nil {
+			return nil, fmt.Errorf("parsing config: %w", err)
+		}
+	}
+
+	// Apply environment variable overrides
+	applyEnvOverrides(cfg)
+
+	// Load API key from keystore if not already set
+	if cfg.Model.APIKey == "" && cfg.Model.Provider != "" {
+		cfg.Model.APIKey, _ = credentials.Get(cfg.Model.Provider)
+	}
+
+	return cfg, nil
+}
+
+// Save writes configuration to the config file.
+// API keys are stored in the native keystore, not the config file.
+func Save(cfg *Config) error {
+	// Store API key in keystore (not config file)
+	if cfg.Model.APIKey != "" && cfg.Model.Provider != "" && cfg.Model.Provider != "ollama" {
+		if err := credentials.Set(cfg.Model.Provider, cfg.Model.APIKey); err != nil {
+			cli.Warn("could not store API key in keystore: %v", err)
+		}
+	}
+
+	// Clone config without API key for file storage
+	fileCfg := *cfg
+	fileCfg.Model.APIKey = ""
+
+	path := Path()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	data, err := yaml.Marshal(&fileCfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// applyEnvOverrides applies environment variable overrides to the config.
+// Naming convention: DEVLORE_ + config path with underscores, uppercase.
+// Example: model.provider -> DEVLORE_MODEL_PROVIDER
+func applyEnvOverrides(cfg *Config) {
+	// Shared runtime options
+	if v := os.Getenv("DEVLORE_VERBOSITY"); v != "" {
+		cfg.Verbosity = v
+	}
+	if v := os.Getenv("DEVLORE_DRY_RUN"); v != "" {
+		cfg.DryRun = v == "true" || v == "1"
+	}
+
+	// Model config
+	if v := os.Getenv("DEVLORE_MODEL_PROVIDER"); v != "" {
+		cfg.Model.Provider = v
+	}
+	if v := os.Getenv("DEVLORE_MODEL_NAME"); v != "" {
+		cfg.Model.Name = v
+	}
+	if v := os.Getenv("DEVLORE_MODEL_ENDPOINT"); v != "" {
+		cfg.Model.Endpoint = v
+	}
+	if v := os.Getenv("DEVLORE_MODEL_API_KEY"); v != "" {
+		cfg.Model.APIKey = v
+	}
+
+	// Registry config
+	if v := os.Getenv("DEVLORE_REGISTRY_URL"); v != "" {
+		cfg.Registry.URL = v
+	}
+	if v := os.Getenv("DEVLORE_REGISTRY_BRANCH"); v != "" {
+		cfg.Registry.Branch = v
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	path := Path()
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	// Should end with config.yaml
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path, got %q", path)
+	}
+	if filepath.Base(path) != "config.yaml" {
+		t.Errorf("expected path ending in 'config.yaml', got %q", path)
+	}
+}
+
+func TestLoad_NoFile(t *testing.T) {
+	// Use temp dir to ensure no config file exists
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+
+	// Should return empty config
+	if cfg.Model.Provider != "" {
+		t.Errorf("expected empty provider, got %q", cfg.Model.Provider)
+	}
+	if cfg.Registry.URL != "" {
+		t.Errorf("expected empty registry URL, got %q", cfg.Registry.URL)
+	}
+}
+
+func TestLoad_WithEnvOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Set environment variables
+	t.Setenv("DEVLORE_VERBOSITY", "verbose")
+	t.Setenv("DEVLORE_DRY_RUN", "1")
+	t.Setenv("DEVLORE_MODEL_PROVIDER", "anthropic")
+	t.Setenv("DEVLORE_MODEL_NAME", "claude-sonnet-4-20250514")
+	t.Setenv("DEVLORE_MODEL_API_KEY", "test-api-key")
+	t.Setenv("DEVLORE_MODEL_ENDPOINT", "https://custom-endpoint.example.com")
+	t.Setenv("DEVLORE_REGISTRY_URL", "https://custom-registry.example.com")
+	t.Setenv("DEVLORE_REGISTRY_BRANCH", "main")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Verbosity != "verbose" {
+		t.Errorf("expected verbosity 'verbose', got %q", cfg.Verbosity)
+	}
+	if !cfg.DryRun {
+		t.Error("expected dry_run=true")
+	}
+	if cfg.Model.Provider != "anthropic" {
+		t.Errorf("expected provider 'anthropic', got %q", cfg.Model.Provider)
+	}
+	if cfg.Model.Name != "claude-sonnet-4-20250514" {
+		t.Errorf("expected model 'claude-sonnet-4-20250514', got %q", cfg.Model.Name)
+	}
+	if cfg.Model.APIKey != "test-api-key" {
+		t.Errorf("expected api_key 'test-api-key', got %q", cfg.Model.APIKey)
+	}
+	if cfg.Model.Endpoint != "https://custom-endpoint.example.com" {
+		t.Errorf("expected endpoint 'https://custom-endpoint.example.com', got %q", cfg.Model.Endpoint)
+	}
+	if cfg.Registry.URL != "https://custom-registry.example.com" {
+		t.Errorf("expected registry URL 'https://custom-registry.example.com', got %q", cfg.Registry.URL)
+	}
+	if cfg.Registry.Branch != "main" {
+		t.Errorf("expected registry branch 'main', got %q", cfg.Registry.Branch)
+	}
+}
+
+func TestLoad_FromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Create config file
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `
+verbosity: quiet
+dry_run: true
+model:
+  provider: groq
+  name: llama-3.3-70b-versatile
+registry:
+  url: https://example.com/registry.git
+  branch: main
+writ:
+  segments:
+    - ROLE
+    - SITE
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Verbosity != "quiet" {
+		t.Errorf("expected verbosity 'quiet', got %q", cfg.Verbosity)
+	}
+	if !cfg.DryRun {
+		t.Error("expected dry_run=true")
+	}
+	if cfg.Model.Provider != "groq" {
+		t.Errorf("expected provider 'groq', got %q", cfg.Model.Provider)
+	}
+	if cfg.Model.Name != "llama-3.3-70b-versatile" {
+		t.Errorf("expected model 'llama-3.3-70b-versatile', got %q", cfg.Model.Name)
+	}
+	if cfg.Registry.URL != "https://example.com/registry.git" {
+		t.Errorf("expected registry URL 'https://example.com/registry.git', got %q", cfg.Registry.URL)
+	}
+	if cfg.Registry.Branch != "main" {
+		t.Errorf("expected branch 'main', got %q", cfg.Registry.Branch)
+	}
+	if len(cfg.Writ.Segments) != 2 {
+		t.Errorf("expected 2 writ segments, got %d", len(cfg.Writ.Segments))
+	}
+}
+
+func TestLoad_EnvOverridesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Create config file with one provider
+	configDir := filepath.Join(tmpDir, "devlore")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `
+model:
+  provider: ollama
+  name: llama3.1:8b
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	// Set env to override
+	t.Setenv("DEVLORE_MODEL_PROVIDER", "anthropic")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Env should override file
+	if cfg.Model.Provider != "anthropic" {
+		t.Errorf("expected provider 'anthropic' (from env), got %q", cfg.Model.Provider)
+	}
+	// Name should still come from file
+	if cfg.Model.Name != "llama3.1:8b" {
+		t.Errorf("expected model 'llama3.1:8b' (from file), got %q", cfg.Model.Name)
+	}
+}
+
+func TestSave_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Create initial config
+	cfg := &Config{
+		Verbosity: "verbose",
+		DryRun:    true,
+		Model: ModelConfig{
+			Provider: "groq",
+			Name:     "llama-3.3-70b-versatile",
+		},
+		Registry: RegistryConfig{
+			URL:    "https://example.com/registry.git",
+			Branch: "develop",
+		},
+		Writ: WritConfig{
+			Segments: []string{"ROLE"},
+			Vars:     map[string]string{"ROLE": "desktop"},
+		},
+	}
+
+	// Save
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Load back
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Verify
+	if loaded.Verbosity != cfg.Verbosity {
+		t.Errorf("verbosity mismatch: got %q, want %q", loaded.Verbosity, cfg.Verbosity)
+	}
+	if loaded.DryRun != cfg.DryRun {
+		t.Errorf("dry_run mismatch: got %v, want %v", loaded.DryRun, cfg.DryRun)
+	}
+	if loaded.Model.Provider != cfg.Model.Provider {
+		t.Errorf("provider mismatch: got %q, want %q", loaded.Model.Provider, cfg.Model.Provider)
+	}
+	if loaded.Model.Name != cfg.Model.Name {
+		t.Errorf("model name mismatch: got %q, want %q", loaded.Model.Name, cfg.Model.Name)
+	}
+	if loaded.Registry.URL != cfg.Registry.URL {
+		t.Errorf("registry URL mismatch: got %q, want %q", loaded.Registry.URL, cfg.Registry.URL)
+	}
+	if len(loaded.Writ.Segments) != len(cfg.Writ.Segments) {
+		t.Errorf("writ.segments length mismatch: got %d, want %d", len(loaded.Writ.Segments), len(cfg.Writ.Segments))
+	}
+}
+
+func TestSave_APIKeyNotWrittenToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	cfg := &Config{
+		Model: ModelConfig{
+			Provider: "anthropic",
+			Name:     "claude-sonnet-4-20250514",
+			APIKey:   "secret-api-key",
+		},
+	}
+
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Read raw file content
+	configPath := filepath.Join(tmpDir, "devlore", "config.yaml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading config file: %v", err)
+	}
+
+	// API key should NOT be in the file
+	if string(content) != "" && contains(string(content), "secret-api-key") {
+		t.Error("API key should not be written to config file")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && (s[:len(substr)] == substr || contains(s[1:], substr)))
+}
+
+func TestModelConfig_WithDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ModelConfig
+		expected ModelConfig
+	}{
+		{
+			name:  "empty config gets all defaults",
+			input: ModelConfig{},
+			expected: ModelConfig{
+				Provider: DefaultModelProvider,
+				Name:     DefaultModelName,
+				Endpoint: DefaultModelEndpoint,
+			},
+		},
+		{
+			name: "provider set keeps provider, gets other defaults",
+			input: ModelConfig{
+				Provider: "anthropic",
+			},
+			expected: ModelConfig{
+				Provider: "anthropic",
+				Name:     DefaultModelName,
+				Endpoint: "", // No default endpoint for non-ollama
+			},
+		},
+		{
+			name: "ollama with custom model keeps model",
+			input: ModelConfig{
+				Provider: "ollama",
+				Name:     "codellama:7b",
+			},
+			expected: ModelConfig{
+				Provider: "ollama",
+				Name:     "codellama:7b",
+				Endpoint: DefaultModelEndpoint,
+			},
+		},
+		{
+			name: "fully specified config unchanged",
+			input: ModelConfig{
+				Provider: "openai",
+				Name:     "gpt-4",
+				Endpoint: "https://custom.openai.com",
+				APIKey:   "key",
+			},
+			expected: ModelConfig{
+				Provider: "openai",
+				Name:     "gpt-4",
+				Endpoint: "https://custom.openai.com",
+				APIKey:   "key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.WithDefaults()
+			if got.Provider != tt.expected.Provider {
+				t.Errorf("Provider: got %q, want %q", got.Provider, tt.expected.Provider)
+			}
+			if got.Name != tt.expected.Name {
+				t.Errorf("Name: got %q, want %q", got.Name, tt.expected.Name)
+			}
+			if got.Endpoint != tt.expected.Endpoint {
+				t.Errorf("Endpoint: got %q, want %q", got.Endpoint, tt.expected.Endpoint)
+			}
+			if got.APIKey != tt.expected.APIKey {
+				t.Errorf("APIKey: got %q, want %q", got.APIKey, tt.expected.APIKey)
+			}
+		})
+	}
+}
+
+func TestRegistryConfig_WithDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    RegistryConfig
+		expected RegistryConfig
+	}{
+		{
+			name:  "empty config gets all defaults",
+			input: RegistryConfig{},
+			expected: RegistryConfig{
+				URL:    DefaultRegistryURL,
+				Branch: DefaultRegistryBranch,
+			},
+		},
+		{
+			name: "URL set keeps URL, gets branch default",
+			input: RegistryConfig{
+				URL: "https://custom.example.com/registry.git",
+			},
+			expected: RegistryConfig{
+				URL:    "https://custom.example.com/registry.git",
+				Branch: DefaultRegistryBranch,
+			},
+		},
+		{
+			name: "fully specified config unchanged",
+			input: RegistryConfig{
+				URL:       "https://custom.example.com/registry.git",
+				Branch:    "main",
+				ForceTags: true,
+			},
+			expected: RegistryConfig{
+				URL:       "https://custom.example.com/registry.git",
+				Branch:    "main",
+				ForceTags: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.WithDefaults()
+			if got.URL != tt.expected.URL {
+				t.Errorf("URL: got %q, want %q", got.URL, tt.expected.URL)
+			}
+			if got.Branch != tt.expected.Branch {
+				t.Errorf("Branch: got %q, want %q", got.Branch, tt.expected.Branch)
+			}
+			if got.ForceTags != tt.expected.ForceTags {
+				t.Errorf("ForceTags: got %v, want %v", got.ForceTags, tt.expected.ForceTags)
+			}
+		})
+	}
+}

--- a/internal/config/lore.go
+++ b/internal/config/lore.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package config
+
+// LoreConfig contains lore-specific configuration.
+// Note: verbosity and dry_run are shared options at the Config root level.
+type LoreConfig struct {
+	Preferences Preferences `yaml:"preferences,omitempty" json:"preferences,omitempty"`
+	Sources     Sources     `yaml:"sources,omitempty" json:"sources,omitempty"`
+}
+
+// Preferences controls AI-assisted behavior.
+type Preferences struct {
+	ConsultUserBeforeChanges bool   `yaml:"consult_user_before_changes,omitempty" json:"consult_user_before_changes,omitempty"`
+	ValidateExistingPackages bool   `yaml:"validate_existing_packages,omitempty" json:"validate_existing_packages,omitempty"`
+	SearchInternet           string `yaml:"search_internet,omitempty" json:"search_internet,omitempty"` // always, on-demand, never
+}
+
+// Sources configures documentation sources for AI-assisted features.
+type Sources struct {
+	Corporate      []CorporateSource `yaml:"corporate,omitempty" json:"corporate,omitempty"`
+	TrustedDomains []string          `yaml:"trusted_domains,omitempty" json:"trusted_domains,omitempty"`
+	BlockedDomains []string          `yaml:"blocked_domains,omitempty" json:"blocked_domains,omitempty"`
+}
+
+// CorporateSource represents an organization-specific documentation source.
+type CorporateSource struct {
+	Name string `yaml:"name" json:"name"`
+	URL  string `yaml:"url" json:"url"`
+}

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package config
+
+// Default model settings (Ollama local inference).
+const (
+	DefaultModelProvider = "ollama"
+	DefaultModelName     = "llama3.1:8b"
+	DefaultModelEndpoint = "http://localhost:11434"
+)
+
+// ModelConfig configures the AI/LLM provider.
+// This is shared across lore and writ for AI-assisted features.
+type ModelConfig struct {
+	Provider string `yaml:"provider" json:"provider"` // ollama, anthropic, openai, groq, gemini, github
+	Name     string `yaml:"name" json:"name"`         // Model identifier (e.g., claude-sonnet-4-20250514)
+	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // Custom endpoint URL
+	APIKey   string `yaml:"api_key,omitempty" json:"api_key,omitempty"`   // API key (prefer keystore)
+}
+
+// WithDefaults returns a copy of the config with defaults applied.
+func (c ModelConfig) WithDefaults() ModelConfig {
+	cfg := c
+	if cfg.Provider == "" {
+		cfg.Provider = DefaultModelProvider
+	}
+	if cfg.Name == "" {
+		cfg.Name = DefaultModelName
+	}
+	if cfg.Endpoint == "" && cfg.Provider == "ollama" {
+		cfg.Endpoint = DefaultModelEndpoint
+	}
+	return cfg
+}

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package config
+
+// Default registry settings.
+const (
+	DefaultRegistryURL    = "https://github.com/NobleFactor/devlore-registry.git"
+	DefaultRegistryBranch = "develop" // develop branch has AI assets; main is release-only
+)
+
+// RegistryConfig configures the devlore package registry.
+// This is shared across lore and writ.
+type RegistryConfig struct {
+	// URL is the registry repository URL.
+	// Default: https://github.com/NobleFactor/devlore-registry.git
+	URL string `yaml:"url,omitempty" json:"url,omitempty"`
+
+	// Branch is the git branch to use.
+	// Default: develop (for demo phase; main for releases)
+	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+
+	// ForceTags forces tag resolution even on non-main branches.
+	// When true, "latest" always resolves to the "latest" tag.
+	// Default: false
+	ForceTags bool `yaml:"force_tags,omitempty" json:"force_tags,omitempty"`
+}
+
+// WithDefaults returns a copy of the config with defaults applied.
+func (c RegistryConfig) WithDefaults() RegistryConfig {
+	cfg := c
+	if cfg.URL == "" {
+		cfg.URL = DefaultRegistryURL
+	}
+	if cfg.Branch == "" {
+		cfg.Branch = DefaultRegistryBranch
+	}
+	return cfg
+}

--- a/internal/config/writ.go
+++ b/internal/config/writ.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package config
+
+// WritConfig contains writ-specific configuration.
+// Note: verbosity and dry_run are shared options at the Config root level.
+type WritConfig struct {
+	// Segments are custom segment names beyond built-in OS, DISTRO, ARCH.
+	// Example: ["ROLE", "SITE"]
+	Segments []string `yaml:"segments,omitempty" json:"segments,omitempty"`
+
+	// Vars are template variables and segment value overrides.
+	// Example: {"USER_NAME": "John Doe", "ROLE": "desktop"}
+	Vars map[string]string `yaml:"vars,omitempty" json:"vars,omitempty"`
+}

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -45,6 +45,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/NobleFactor/devlore-cli/internal/config"
 	"github.com/NobleFactor/devlore-cli/internal/model"
 )
 
@@ -112,9 +113,9 @@ func CreateProvider(cfg ProviderConfig) (model.Provider, error) {
 		}
 	}
 
-	return model.NewProvider(model.Config{
+	return model.NewProvider(config.ModelConfig{
 		Provider: cfg.Provider,
-		Model:    cfg.Model,
+		Name:     cfg.Model,
 		Endpoint: cfg.Endpoint,
 		APIKey:   apiKey,
 	})

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -78,7 +78,7 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 	regClient := cfg.RegistryClient
 	if regClient == nil {
 		var err error
-		regClient, err = lorepackage.NewDefault()
+		regClient, err = lorepackage.NewRegistry()
 		if err != nil {
 			return nil, fmt.Errorf("creating registry client: %w", err)
 		}

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/internal/config"
 	"github.com/NobleFactor/devlore-cli/internal/execution"
 	"github.com/NobleFactor/devlore-cli/internal/lore/onboard"
 	"github.com/NobleFactor/devlore-cli/internal/lorepackage"
@@ -141,7 +142,7 @@ type packageRequest struct {
 
 // resolvePackages resolves all packages and reports their confidence.
 func resolvePackages(cfg *loreDeployConfig) ([]resolvedPackage, error) {
-	regClient, err := lorepackage.NewDefault()
+	regClient, err := lorepackage.NewRegistry()
 	if err != nil {
 		return nil, fmt.Errorf("creating registry client: %w", err)
 	}
@@ -513,7 +514,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	limit, _ := cmd.Flags().GetInt("limit")
 
 	// Create registry client
-	regClient, err := lorepackage.NewDefault()
+	regClient, err := lorepackage.NewRegistry()
 	if err != nil {
 		return fmt.Errorf("creating registry client: %w", err)
 	}
@@ -613,14 +614,14 @@ func newUpdateCmd() *cobra.Command {
 func newOnboardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "onboard --from <source>",
-		Short: "Parse wiki or script and generate packages.manifest and config",
+		Short: "Parse wiki or script and generate packages-manifest.yaml and config",
 		Long: `Parse an onboarding wiki page or setup script and generate both a
-packages.manifest file and a config/ directory with configuration files.
+packages-manifest.yaml file and a config/ directory with configuration files.
 
 Lore uses AI to extract installation steps, map them to known registry packages,
 and flag org-specific items for human review.
 
-After onboarding, use 'lore deploy @packages.manifest' to install software,
+After onboarding, use 'lore deploy @packages-manifest.yaml' to install software,
 then 'writ adopt --from-receipt' to bring the generated config into your
 environment repository.`,
 		Example: `  lore onboard --from https://wiki.acme.com/backend-setup
@@ -628,7 +629,7 @@ environment repository.`,
 
   # Full workflow:
   lore onboard --from https://wiki.acme.com/setup
-  lore deploy @packages.manifest
+  lore deploy @packages-manifest.yaml
   writ adopt --from-receipt`,
 		RunE: runOnboard,
 	}
@@ -664,9 +665,9 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("AI provider required; configure with 'lore config model'")
 	}
 
-	provider, err := model.NewProvider(model.Config{
+	provider, err := model.NewProvider(config.ModelConfig{
 		Provider: providerName,
-		Model:    viper.GetString("lore.model.model"),
+		Name:     viper.GetString("lore.model.model"),
 		Endpoint: viper.GetString("lore.model.endpoint"),
 		APIKey:   viper.GetString("lore.model.api_key"),
 	})
@@ -675,7 +676,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get registry
-	reg, err := lorepackage.NewWithConfig()
+	reg, err := lorepackage.NewRegistry()
 	if err != nil {
 		return fmt.Errorf("creating registry: %w", err)
 	}
@@ -736,7 +737,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write manifest
-	manifestPath := outputDir + "/packages.manifest"
+	manifestPath := outputDir + "/packages-manifest.yaml"
 	if err := os.WriteFile(manifestPath, []byte(result.Manifest), 0644); err != nil {
 		return fmt.Errorf("writing manifest: %w", err)
 	}
@@ -745,7 +746,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	cli.Note("")
 	cli.Note("Next steps:")
 	cli.Note("  1. Review the generated manifest")
-	cli.Note("  2. lore deploy @packages.manifest")
+	cli.Note("  2. lore deploy @packages-manifest.yaml")
 
 	return nil
 }

--- a/internal/lorepackage/registry.go
+++ b/internal/lorepackage/registry.go
@@ -14,8 +14,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/internal/config"
 )
 
 // Registry provides access to a devlore registry.
@@ -26,45 +27,27 @@ type Registry struct {
 	forceTags bool     // Force tag resolution even on non-main branches
 }
 
-// RegistryConfig holds optional configuration for registry access.
-// These values can be set in ~/.config/devlore/config.yaml under lore.registry.
-//
-// Example config:
-//
-//	lore:
-//	  registry:
-//	    url: https://github.com/MyOrg/my-registry.git
-//	    branch: main
-//	    force_tags: true
-type RegistryConfig struct {
-	// URL overrides the default registry URL.
-	// Default: https://github.com/NobleFactor/devlore-registry.git
-	URL string `yaml:"url" mapstructure:"url"`
-
-	// Branch overrides the default branch.
-	// Default: develop (for demo phase; main for releases)
-	Branch string `yaml:"branch" mapstructure:"branch"`
-
-	// ForceTags forces tag resolution even on non-main branches.
-	// When true, "latest" always resolves to the "latest" tag.
-	// Default: false
-	ForceTags bool `yaml:"force_tags" mapstructure:"force_tags"`
-}
-
-// LoadRegistryConfig loads registry configuration from viper.
-// Reads from lore.registry.* keys in the config file.
-func LoadRegistryConfig() RegistryConfig {
-	return RegistryConfig{
-		URL:       viper.GetString("lore.registry.url"),
-		Branch:    viper.GetString("lore.registry.branch"),
-		ForceTags: viper.GetBool("lore.registry.force_tags"),
+// NewRegistry creates a registry using configuration from ~/.config/devlore/config.yaml.
+// Empty config values use defaults. To override, update your config file.
+func NewRegistry() (*Registry, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
 	}
-}
 
-// NewWithConfig creates a registry using configuration from viper.
-// This is the preferred way to create a registry in lore commands.
-func NewWithConfig() (*Registry, error) {
-	return NewFromConfig(LoadRegistryConfig())
+	cacheDir, err := defaultCacheDir()
+	if err != nil {
+		return nil, err
+	}
+
+	regCfg := cfg.Registry.WithDefaults()
+
+	return &Registry{
+		name:      "central",
+		provider:  NewGitProvider(regCfg.URL, regCfg.Branch),
+		cacheDir:  filepath.Join(cacheDir, "central"),
+		forceTags: regCfg.ForceTags,
+	}, nil
 }
 
 // Provider abstracts the transport mechanism for registry access.
@@ -106,58 +89,6 @@ func New(name string, provider Provider, cacheDir string) *Registry {
 		provider: provider,
 		cacheDir: cacheDir,
 	}
-}
-
-// Default registry settings.
-const (
-	DefaultRegistryURL    = "https://github.com/NobleFactor/devlore-registry.git"
-	DefaultRegistryBranch = "develop" // develop branch has AI assets; main is release-only
-)
-
-// NewDefault creates a registry with default settings for the central registry.
-// Uses the develop branch during demo phase (AI assets and latest packages).
-//
-// To customize registry settings, use NewFromConfig with values from
-// ~/.config/devlore/config.yaml:
-//
-//	lore:
-//	  registry:
-//	    url: https://github.com/MyOrg/my-registry.git
-//	    branch: main
-//	    force_tags: true
-func NewDefault() (*Registry, error) {
-	return NewFromConfig(RegistryConfig{})
-}
-
-// NewFromConfig creates a registry with the given configuration.
-// Empty config values use defaults.
-func NewFromConfig(cfg RegistryConfig) (*Registry, error) {
-	cacheDir, err := defaultCacheDir()
-	if err != nil {
-		return nil, err
-	}
-
-	// Apply defaults
-	url := cfg.URL
-	if url == "" {
-		url = DefaultRegistryURL
-	}
-
-	branch := cfg.Branch
-	if branch == "" {
-		branch = DefaultRegistryBranch
-	}
-
-	provider := NewGitProvider(url, branch)
-
-	reg := &Registry{
-		name:      "central",
-		provider:  provider,
-		cacheDir:  filepath.Join(cacheDir, "central"),
-		forceTags: cfg.ForceTags,
-	}
-
-	return reg, nil
 }
 
 // ForceTags returns whether tag resolution is forced (even on non-main branches).

--- a/internal/lorepackage/registry_test.go
+++ b/internal/lorepackage/registry_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 )
 
-func TestNewDefault(t *testing.T) {
-	registry, err := NewDefault()
+func TestNewRegistry(t *testing.T) {
+	registry, err := NewRegistry()
 	if err != nil {
-		t.Fatalf("NewDefault() error: %v", err)
+		t.Fatalf("NewRegistry() error: %v", err)
 	}
 
 	if registry.name != "central" {
@@ -158,59 +158,6 @@ func TestKnowledgeIndex_SchemaByPurpose(t *testing.T) {
 				t.Errorf("SchemaByPurpose(%q) = %q, want %q", tt.purpose, got, tt.expected)
 			}
 		})
-	}
-}
-
-func TestRegistryConfig_Defaults(t *testing.T) {
-	cfg := RegistryConfig{}
-
-	registry, err := NewFromConfig(cfg)
-	if err != nil {
-		t.Fatalf("NewFromConfig() error: %v", err)
-	}
-
-	// Check defaults applied
-	if registry.Branch() != DefaultRegistryBranch {
-		t.Errorf("Branch() = %q, want %q", registry.Branch(), DefaultRegistryBranch)
-	}
-
-	gp, ok := registry.provider.(*GitProvider)
-	if !ok {
-		t.Fatal("expected GitProvider")
-	}
-
-	if gp.RepoURL() != DefaultRegistryURL {
-		t.Errorf("RepoURL() = %q, want %q", gp.RepoURL(), DefaultRegistryURL)
-	}
-}
-
-func TestRegistryConfig_Custom(t *testing.T) {
-	cfg := RegistryConfig{
-		URL:       "https://github.com/MyOrg/my-registry.git",
-		Branch:    "main",
-		ForceTags: true,
-	}
-
-	registry, err := NewFromConfig(cfg)
-	if err != nil {
-		t.Fatalf("NewFromConfig() error: %v", err)
-	}
-
-	if registry.Branch() != "main" {
-		t.Errorf("Branch() = %q, want 'main'", registry.Branch())
-	}
-
-	if !registry.ForceTags() {
-		t.Error("ForceTags() = false, want true")
-	}
-
-	gp, ok := registry.provider.(*GitProvider)
-	if !ok {
-		t.Fatal("expected GitProvider")
-	}
-
-	if gp.RepoURL() != "https://github.com/MyOrg/my-registry.git" {
-		t.Errorf("RepoURL() = %q, want custom URL", gp.RepoURL())
 	}
 }
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -22,8 +22,8 @@ For each field, the first source with a value wins:
 
 	| Field        | CLI Flag           | Environment Variable       | Config Key     | Keystore         |
 	|--------------|--------------------|-----------------------------|----------------|------------------|
-	| model        | --model            | DEVLORE_MODEL              | model.model    | —                |
-	| api-key      | --model-api-key    | DEVLORE_MODEL_API_KEY      | model.api-key  | Account=provider |
+	| name         | --model            | DEVLORE_MODEL              | model.name     | —                |
+	| api_key      | --model-api-key    | DEVLORE_MODEL_API_KEY      | model.api_key  | Account=provider |
 	| endpoint     | --model-endpoint   | DEVLORE_MODEL_ENDPOINT     | model.endpoint | —                |
 	| provider     | --model-provider   | DEVLORE_MODEL_PROVIDER     | model.provider | —                |
 
@@ -57,7 +57,7 @@ Keystore entry format:
 
 	# ~/.config/devlore/config.yaml
 	model:
-	  model: claude-sonnet-4-20250514
+	  name: claude-sonnet-4-20250514
 	  provider: anthropic
 
 API keys should be stored in the native keystore, not the config file.
@@ -77,22 +77,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/internal/config"
 	"github.com/NobleFactor/devlore-cli/internal/credentials"
-)
-
-// Environment variables for model configuration (sorted alphabetically).
-const (
-	EnvModel         = "DEVLORE_MODEL"
-	EnvModelAPIKey   = "DEVLORE_MODEL_API_KEY"
-	EnvModelEndpoint = "DEVLORE_MODEL_ENDPOINT"
-	EnvModelProvider = "DEVLORE_MODEL_PROVIDER"
 )
 
 // CLIFlags holds model configuration from command-line flags.
@@ -105,7 +96,7 @@ type CLIFlags struct {
 }
 
 // ApplyTo applies CLI flags to a config. CLI flags take highest priority.
-func (f CLIFlags) ApplyTo(cfg *Config) {
+func (f CLIFlags) ApplyTo(cfg *config.ModelConfig) {
 	if f.APIKey != "" {
 		cfg.APIKey = f.APIKey
 	}
@@ -113,145 +104,11 @@ func (f CLIFlags) ApplyTo(cfg *Config) {
 		cfg.Endpoint = f.Endpoint
 	}
 	if f.Model != "" {
-		cfg.Model = f.Model
+		cfg.Name = f.Model
 	}
 	if f.Provider != "" {
 		cfg.Provider = f.Provider
 	}
-}
-
-// devloreConfig is the full config file structure.
-type devloreConfig struct {
-	Model modelConfig `yaml:"model"`
-}
-
-// modelConfig holds model provider configuration in the config file.
-// Fields are sorted alphabetically.
-type modelConfig struct {
-	APIKey   string `yaml:"api-key"`  // API key (prefer native keystore)
-	Endpoint string `yaml:"endpoint"` // Optional endpoint URL override
-	Model    string `yaml:"model"`    // Model name (e.g., claude-sonnet-4-20250514)
-	Provider string `yaml:"provider"` // Provider: anthropic, azure-openai, github, ollama, openai
-}
-
-// ConfigPath returns the path to the devlore config file.
-func ConfigPath() (string, error) {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		configHome = filepath.Join(home, ".config")
-	}
-	return filepath.Join(configHome, "devlore", "config.yaml"), nil
-}
-
-// credentialKey returns the keystore account name for an AI provider.
-func credentialKey(provider string) string {
-	return provider
-}
-
-// LoadConfig loads model configuration with consistent fallback:
-//
-//	CLI (handled by caller) → Environment → Config → Keystore
-//
-// First source with a value wins. If config has api-key, keystore is not checked.
-func LoadConfig() (*Config, error) {
-	// Start with environment variables
-	provider := os.Getenv(EnvModelProvider)
-	model := os.Getenv(EnvModel)
-	endpoint := os.Getenv(EnvModelEndpoint)
-	apiKey := os.Getenv(EnvModelAPIKey)
-
-	// Load config file for any missing values
-	path, err := ConfigPath()
-	if err != nil {
-		return nil, err
-	}
-
-	var fileCfg devloreConfig
-	data, err := os.ReadFile(path)
-	if err == nil {
-		if err := yaml.Unmarshal(data, &fileCfg); err != nil {
-			return nil, fmt.Errorf("parsing config: %w", err)
-		}
-	} else if !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	// Fill missing values from config file
-	if provider == "" {
-		provider = fileCfg.Model.Provider
-	}
-	if model == "" {
-		model = fileCfg.Model.Model
-	}
-	if endpoint == "" {
-		endpoint = fileCfg.Model.Endpoint
-	}
-	if apiKey == "" {
-		apiKey = fileCfg.Model.APIKey
-	}
-
-	// No provider configured
-	if provider == "" {
-		return nil, nil
-	}
-
-	// Keystore is last resort - only if nothing else provided api-key
-	if apiKey == "" {
-		apiKey, _ = credentials.Get(credentialKey(provider))
-	}
-
-	return &Config{
-		Provider: provider,
-		Model:    model,
-		Endpoint: endpoint,
-		APIKey:   apiKey,
-	}, nil
-}
-
-// SaveConfig saves model configuration to the config file.
-// API keys are stored in the native keystore, not the config file.
-func SaveConfig(cfg *Config) error {
-	// Store API key in native keystore (if provided and not Ollama)
-	if cfg.APIKey != "" && cfg.Provider != "ollama" {
-		if err := credentials.Set(credentialKey(cfg.Provider), cfg.APIKey); err != nil {
-			cli.Warn("could not store API key in keystore: %v", err)
-		}
-	}
-
-	// Save config (without API key - it's in keystore)
-	path, err := ConfigPath()
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-
-	// Load existing config to preserve other sections
-	var existing devloreConfig
-	data, err := os.ReadFile(path)
-	if err == nil {
-		_ = yaml.Unmarshal(data, &existing)
-	}
-
-	// Update model section
-	existing.Model = modelConfig{
-		Provider: cfg.Provider,
-		Model:    cfg.Model,
-		Endpoint: cfg.Endpoint,
-	}
-
-	data, err = yaml.Marshal(&existing)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, data, 0644)
 }
 
 // autoDetectProvider checks for common API key environment variables and keystore entries.
@@ -279,9 +136,9 @@ func autoDetectProvider(ctx context.Context) Provider {
 		}
 
 		if apiKey != "" {
-			cfg := Config{
+			cfg := config.ModelConfig{
 				Provider: check.name,
-				Model:    check.model,
+				Name:     check.model,
 				APIKey:   apiKey,
 			}
 			provider, err := NewProvider(cfg)
@@ -311,24 +168,18 @@ func autoDetectProvider(ctx context.Context) Provider {
 //  7. Fallback to Ollama if available locally
 //  8. Interactive prompt (only if interactive=true)
 func EnsureProvider(ctx context.Context, interactive bool, cliFlags CLIFlags) (Provider, error) {
-
-	// 1. Try loading config (env > config file, API key from env > config > keystore)
-	cfg, err := LoadConfig()
+	// Load config (handles env vars, config file, and keystore)
+	cfg, err := config.Load()
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
-	// Initialize empty config if nil
-	if cfg == nil {
-		cfg = &Config{}
-	}
+	// Apply CLI flags (highest priority)
+	cliFlags.ApplyTo(&cfg.Model)
 
-	// 2. Apply CLI flags (highest priority)
-	cliFlags.ApplyTo(cfg)
-
-	if cfg.Provider != "" {
+	if cfg.Model.Provider != "" {
 		// Config exists, create provider
-		provider, err := NewProvider(*cfg)
+		provider, err := NewProvider(cfg.Model)
 		if err != nil {
 			return nil, err
 		}
@@ -339,29 +190,29 @@ func EnsureProvider(ctx context.Context, interactive bool, cliFlags CLIFlags) (P
 		}
 
 		// Provider configured but not available
-		cli.Error("AI provider %q configured but not available.", cfg.Provider)
-		if cfg.Provider == "ollama" {
+		cli.Error("AI provider %q configured but not available.", cfg.Model.Provider)
+		if cfg.Model.Provider == "ollama" {
 			cli.Note("Is Ollama running? Start with: ollama serve")
-			cli.Note("Is model pulled? Run: ollama pull %s", cfg.Model)
-		} else if cfg.APIKey == "" {
-			cli.Note("No API key found. Set DEVLORE_AI_API_KEY or store in keystore.")
+			cli.Note("Is model pulled? Run: ollama pull %s", cfg.Model.Name)
+		} else if cfg.Model.APIKey == "" {
+			cli.Note("No API key found. Set DEVLORE_MODEL_API_KEY or store in keystore.")
 		}
 	}
 
-	// 3. Auto-detect from common environment variables
+	// Auto-detect from common environment variables
 	if provider := autoDetectProvider(ctx); provider != nil {
 		return provider, nil
 	}
 
-	// 4. Fallback: Check if Ollama is available locally
-	ollamaCfg := DefaultConfig()
-	ollamaProvider := NewOllamaProvider(ollamaCfg.Endpoint, ollamaCfg.Model)
+	// Fallback: Check if Ollama is available locally
+	ollamaCfg := config.ModelConfig{}.WithDefaults()
+	ollamaProvider := NewOllamaProvider(ollamaCfg.Endpoint, ollamaCfg.Name)
 	if ollamaProvider.Available(ctx) {
 		cli.Note("Using Ollama (detected locally)")
 		return ollamaProvider, nil
 	}
 
-	// 4. No provider available - fail in non-interactive mode, prompt otherwise
+	// No provider available - fail in non-interactive mode, prompt otherwise
 	if !interactive {
 		return nil, fmt.Errorf("no AI provider configured; set DEVLORE_MODEL_PROVIDER and DEVLORE_MODEL_API_KEY, or use --model-provider and --model-api-key flags")
 	}
@@ -374,12 +225,15 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 	// Non-interactive: default to Ollama
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		cli.Note("No AI provider configured. Defaulting to Ollama.")
-		cfg := DefaultConfig()
-		provider := NewOllamaProvider(cfg.Endpoint, cfg.Model)
+		modelCfg := config.ModelConfig{}.WithDefaults()
+		provider := NewOllamaProvider(modelCfg.Endpoint, modelCfg.Name)
 		if !provider.Available(ctx) {
-			return nil, fmt.Errorf("ollama not available; install from https://ollama.ai, run 'ollama serve', then 'ollama pull %s'", cfg.Model)
+			return nil, fmt.Errorf("ollama not available; install from https://ollama.ai, run 'ollama serve', then 'ollama pull %s'", modelCfg.Name)
 		}
-		if err := SaveConfig(&cfg); err != nil {
+		// Save config with Ollama defaults
+		cfg, _ := config.Load()
+		cfg.Model = modelCfg
+		if err := config.Save(cfg); err != nil {
 			cli.Warn("could not save config: %v", err)
 		}
 		return provider, nil
@@ -409,7 +263,7 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 	}
 	choice := strings.TrimSpace(input)
 
-	var cfg Config
+	var modelCfg config.ModelConfig
 
 	switch choice {
 	case "1", "":
@@ -418,23 +272,11 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		apiKey = strings.TrimSpace(apiKey)
-
-		cfg = Config{
+		modelCfg = config.ModelConfig{
 			Provider: "groq",
-			Model:    "llama-3.3-70b-versatile",
-			APIKey:   apiKey,
+			Name:     "llama-3.3-70b-versatile",
+			APIKey:   strings.TrimSpace(apiKey),
 		}
-
-		if err := SaveConfig(&cfg); err != nil {
-			cli.Warn("could not save config: %v", err)
-		}
-
-		provider, err := NewProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
 
 	case "2":
 		fmt.Fprint(os.Stderr, "Gemini API key: ")
@@ -442,23 +284,11 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		apiKey = strings.TrimSpace(apiKey)
-
-		cfg = Config{
+		modelCfg = config.ModelConfig{
 			Provider: "gemini",
-			Model:    "gemini-2.5-flash",
-			APIKey:   apiKey,
+			Name:     "gemini-2.5-flash",
+			APIKey:   strings.TrimSpace(apiKey),
 		}
-
-		if err := SaveConfig(&cfg); err != nil {
-			cli.Warn("could not save config: %v", err)
-		}
-
-		provider, err := NewProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
 
 	case "3":
 		fmt.Fprint(os.Stderr, "Anthropic API key: ")
@@ -466,23 +296,11 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		apiKey = strings.TrimSpace(apiKey)
-
-		cfg = Config{
+		modelCfg = config.ModelConfig{
 			Provider: "anthropic",
-			Model:    "claude-sonnet-4-20250514",
-			APIKey:   apiKey,
+			Name:     "claude-sonnet-4-20250514",
+			APIKey:   strings.TrimSpace(apiKey),
 		}
-
-		if err := SaveConfig(&cfg); err != nil {
-			cli.Warn("could not save config: %v", err)
-		}
-
-		provider, err := NewProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
 
 	case "4":
 		fmt.Fprint(os.Stderr, "OpenAI API key: ")
@@ -490,23 +308,11 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		apiKey = strings.TrimSpace(apiKey)
-
-		cfg = Config{
+		modelCfg = config.ModelConfig{
 			Provider: "openai",
-			Model:    "gpt-4o-mini",
-			APIKey:   apiKey,
+			Name:     "gpt-4o-mini",
+			APIKey:   strings.TrimSpace(apiKey),
 		}
-
-		if err := SaveConfig(&cfg); err != nil {
-			cli.Warn("could not save config: %v", err)
-		}
-
-		provider, err := NewProvider(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
 
 	case "5":
 		cli.Note("Skipping AI setup.")
@@ -517,4 +323,17 @@ func promptForProvider(ctx context.Context) (Provider, error) {
 	default:
 		return nil, fmt.Errorf("invalid choice: %s", choice)
 	}
+
+	// Save config with new model settings
+	cfg, _ := config.Load()
+	cfg.Model = modelCfg
+	if err := config.Save(cfg); err != nil {
+		cli.Warn("could not save config: %v", err)
+	}
+
+	provider, err := NewProvider(modelCfg)
+	if err != nil {
+		return nil, err
+	}
+	return provider, nil
 }

--- a/internal/model/provider.go
+++ b/internal/model/provider.go
@@ -50,6 +50,8 @@ package model
 import (
 	"context"
 	"fmt"
+
+	"github.com/NobleFactor/devlore-cli/internal/config"
 )
 
 // Provider is the opaque interface for AI/LLM backends.
@@ -109,40 +111,23 @@ type ChatResponse struct {
 	TokensUsed   int    // Total tokens consumed
 }
 
-// Config holds AI provider configuration per ADR-017.
-type Config struct {
-	Provider string `yaml:"provider"` // ollama, anthropic, openai, azure-openai
-	Model    string `yaml:"model"`    // Model name (e.g., "llama3.1:8b", "claude-sonnet-4-20250514")
-	Endpoint string `yaml:"endpoint"` // API endpoint (optional, for custom/azure)
-	APIKey   string `yaml:"api_key"`  // API key (for cloud providers)
-}
-
-// DefaultConfig returns the default configuration (Ollama).
-func DefaultConfig() Config {
-	return Config{
-		Provider: "ollama",
-		Model:    "llama3.1:8b",
-		Endpoint: "http://localhost:11434",
-	}
-}
-
 // NewProvider creates a provider from configuration.
-func NewProvider(cfg Config) (Provider, error) {
+func NewProvider(cfg config.ModelConfig) (Provider, error) {
 	switch cfg.Provider {
 	case "ollama":
-		return NewOllamaProvider(cfg.Endpoint, cfg.Model), nil
+		return NewOllamaProvider(cfg.Endpoint, cfg.Name), nil
 
 	case "anthropic":
 		if cfg.APIKey == "" {
 			return nil, fmt.Errorf("anthropic provider requires api_key")
 		}
-		return NewAnthropicProvider(cfg.APIKey, cfg.Model), nil
+		return NewAnthropicProvider(cfg.APIKey, cfg.Name), nil
 
 	case "openai":
 		if cfg.APIKey == "" {
 			return nil, fmt.Errorf("openai provider requires api_key")
 		}
-		return NewOpenAIProvider(cfg.APIKey, cfg.Model, cfg.Endpoint), nil
+		return NewOpenAIProvider(cfg.APIKey, cfg.Name, cfg.Endpoint), nil
 
 	case "github":
 		// GitHub Models uses OpenAI-compatible API
@@ -153,7 +138,7 @@ func NewProvider(cfg Config) (Provider, error) {
 		if endpoint == "" {
 			endpoint = "https://models.inference.ai.azure.com"
 		}
-		model := cfg.Model
+		model := cfg.Name
 		if model == "" {
 			model = "gpt-4o"
 		}
@@ -163,13 +148,13 @@ func NewProvider(cfg Config) (Provider, error) {
 		if cfg.APIKey == "" {
 			return nil, fmt.Errorf("groq provider requires api_key")
 		}
-		return NewGroqProvider(cfg.APIKey, cfg.Model), nil
+		return NewGroqProvider(cfg.APIKey, cfg.Name), nil
 
 	case "gemini":
 		if cfg.APIKey == "" {
 			return nil, fmt.Errorf("gemini provider requires api_key")
 		}
-		return NewGeminiProvider(cfg.APIKey, cfg.Model), nil
+		return NewGeminiProvider(cfg.APIKey, cfg.Name), nil
 
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", cfg.Provider)

--- a/internal/model/provider_test.go
+++ b/internal/model/provider_test.go
@@ -6,16 +6,18 @@ package model
 import (
 	"context"
 	"testing"
+
+	"github.com/NobleFactor/devlore-cli/internal/config"
 )
 
-func TestDefaultConfig(t *testing.T) {
-	cfg := DefaultConfig()
+func TestModelConfigDefaults(t *testing.T) {
+	cfg := config.ModelConfig{}.WithDefaults()
 
 	if cfg.Provider != "ollama" {
 		t.Errorf("expected provider 'ollama', got %q", cfg.Provider)
 	}
-	if cfg.Model != "llama3.1:8b" {
-		t.Errorf("expected model 'llama3.1:8b', got %q", cfg.Model)
+	if cfg.Name != "llama3.1:8b" {
+		t.Errorf("expected model 'llama3.1:8b', got %q", cfg.Name)
 	}
 	if cfg.Endpoint != "http://localhost:11434" {
 		t.Errorf("expected endpoint 'http://localhost:11434', got %q", cfg.Endpoint)
@@ -23,7 +25,7 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestNewProvider_Ollama(t *testing.T) {
-	cfg := DefaultConfig()
+	cfg := config.ModelConfig{}.WithDefaults()
 	provider, err := NewProvider(cfg)
 	if err != nil {
 		t.Fatalf("NewProvider() error: %v", err)
@@ -34,9 +36,9 @@ func TestNewProvider_Ollama(t *testing.T) {
 }
 
 func TestNewProvider_Anthropic(t *testing.T) {
-	cfg := Config{
+	cfg := config.ModelConfig{
 		Provider: "anthropic",
-		Model:    "claude-sonnet-4-20250514",
+		Name:     "claude-sonnet-4-20250514",
 		APIKey:   "test-key",
 	}
 	provider, err := NewProvider(cfg)
@@ -49,9 +51,9 @@ func TestNewProvider_Anthropic(t *testing.T) {
 }
 
 func TestNewProvider_Anthropic_NoKey(t *testing.T) {
-	cfg := Config{
+	cfg := config.ModelConfig{
 		Provider: "anthropic",
-		Model:    "claude-sonnet-4-20250514",
+		Name:     "claude-sonnet-4-20250514",
 	}
 	_, err := NewProvider(cfg)
 	if err == nil {
@@ -60,9 +62,9 @@ func TestNewProvider_Anthropic_NoKey(t *testing.T) {
 }
 
 func TestNewProvider_OpenAI(t *testing.T) {
-	cfg := Config{
+	cfg := config.ModelConfig{
 		Provider: "openai",
-		Model:    "gpt-4-turbo",
+		Name:     "gpt-4-turbo",
 		APIKey:   "test-key",
 	}
 	provider, err := NewProvider(cfg)
@@ -75,7 +77,7 @@ func TestNewProvider_OpenAI(t *testing.T) {
 }
 
 func TestNewProvider_Unknown(t *testing.T) {
-	cfg := Config{
+	cfg := config.ModelConfig{
 		Provider: "unknown",
 	}
 	_, err := NewProvider(cfg)
@@ -91,19 +93,5 @@ func TestOllamaProvider_Available_NotRunning(t *testing.T) {
 
 	if provider.Available(ctx) {
 		t.Error("expected Available() = false when Ollama not running")
-	}
-}
-
-func TestConfigPath(t *testing.T) {
-	path, err := ConfigPath()
-	if err != nil {
-		t.Fatalf("ConfigPath() error: %v", err)
-	}
-	if path == "" {
-		t.Error("expected non-empty path")
-	}
-	// Should end with config.yaml
-	if len(path) < 11 || path[len(path)-11:] != "config.yaml" {
-		t.Errorf("expected path ending in 'config.yaml', got %q", path)
 	}
 }

--- a/internal/writ/migrate_cmd.go
+++ b/internal/writ/migrate_cmd.go
@@ -99,7 +99,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	}
 
 	// All structures go through AI for analysis, validation, and secret detection
-	regClient, err := lorepackage.NewDefault()
+	regClient, err := lorepackage.NewRegistry()
 	if err != nil {
 		return fmt.Errorf("initializing registry: %w", err)
 	}

--- a/schema/devlore-config.json
+++ b/schema/devlore-config.json
@@ -5,6 +5,65 @@
   "description": "Shared configuration schema for the devlore ecosystem (lore and writ)",
   "type": "object",
   "properties": {
+    "verbosity": {
+      "type": "string",
+      "enum": ["quiet", "normal", "verbose"],
+      "description": "Output verbosity level (shared across lore and writ)",
+      "default": "normal"
+    },
+    "dry_run": {
+      "type": "boolean",
+      "description": "Show what would be done without making changes (shared across lore and writ)",
+      "default": false
+    },
+    "model": {
+      "type": "object",
+      "description": "Shared AI/LLM provider configuration (used by both lore and writ)",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["ollama", "anthropic", "openai", "github", "groq", "gemini"],
+          "description": "AI provider backend",
+          "default": "ollama"
+        },
+        "name": {
+          "type": "string",
+          "description": "Model identifier (e.g., 'llama3.1:8b', 'claude-sonnet-4-20250514')",
+          "default": "llama3.1:8b"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "Custom endpoint URL (for custom providers)"
+        },
+        "api_key": {
+          "type": "string",
+          "description": "API key (prefer native keystore over config file)"
+        }
+      }
+    },
+    "registry": {
+      "type": "object",
+      "description": "Shared package registry configuration (used by both lore and writ)",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Registry repository URL",
+          "default": "https://github.com/NobleFactor/devlore-registry.git"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Git branch to use",
+          "default": "develop"
+        },
+        "force_tags": {
+          "type": "boolean",
+          "description": "Force tag resolution even on non-main branches",
+          "default": false
+        }
+      }
+    },
     "secrets": {
       "type": "object",
       "description": "Shared secrets configuration for age-encrypted files (ADR-050)",
@@ -37,77 +96,68 @@
     },
     "lore": {
       "type": "object",
-      "description": "Lore-specific configuration",
+      "description": "Lore-specific configuration (verbosity and dry_run are shared at root level)",
       "properties": {
-        "registry": {
-          "type": "string",
-          "description": "Path to the package registry"
-        },
-        "verbose": {
-          "type": "boolean",
-          "description": "Enable verbose output",
-          "default": false
-        },
-        "quiet": {
-          "type": "boolean",
-          "description": "Suppress non-error output",
-          "default": false
-        },
-        "dry_run": {
-          "type": "boolean",
-          "description": "Show what would be done without making changes",
-          "default": false
-        },
-        "ai_provider": {
+        "preferences": {
           "type": "object",
-          "description": "AI provider configuration for manifest authoring",
+          "description": "User preferences for lore operations",
           "properties": {
-            "model": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Model identifier (e.g., 'llama3.1:8b', 'claude-sonnet-4-20250514')",
-                  "default": "llama3.1:8b"
-                },
-                "provider": {
-                  "type": "string",
-                  "enum": ["ollama", "anthropic", "openai", "azure-openai", "groq", "openrouter", "custom"],
-                  "description": "AI provider backend",
-                  "default": "ollama"
-                },
-                "api_key": {
-                  "type": "string",
-                  "description": "API key (supports ${ENV_VAR} expansion)"
-                },
-                "endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "Custom endpoint URL (for azure-openai or custom providers)"
-                }
-              },
-              "required": ["name", "provider"]
+            "shell": {
+              "type": "string",
+              "description": "Preferred shell"
             },
-            "preferences": {
-              "type": "object",
-              "properties": {
-                "consult_user_before_changes": {
-                  "type": "boolean",
-                  "description": "Require user approval before modifying existing packages",
-                  "default": true
-                },
-                "validate_existing_packages": {
-                  "type": "boolean",
-                  "description": "Check upstream for updates even if package exists locally",
-                  "default": true
-                },
-                "search_internet": {
-                  "type": "string",
-                  "enum": ["always", "on-demand", "never"],
-                  "description": "When to search internet for installation information",
-                  "default": "always"
-                }
-              }
+            "editor": {
+              "type": "string",
+              "description": "Preferred editor"
+            },
+            "pager": {
+              "type": "string",
+              "description": "Preferred pager"
+            },
+            "auto_confirm": {
+              "type": "boolean",
+              "description": "Skip confirmation prompts",
+              "default": false
+            },
+            "color_output": {
+              "type": "boolean",
+              "description": "Enable colored output",
+              "default": true
+            },
+            "install_path": {
+              "type": "string",
+              "description": "Default installation path"
+            },
+            "backup_path": {
+              "type": "string",
+              "description": "Backup directory for replaced files"
+            },
+            "max_backups": {
+              "type": "integer",
+              "description": "Maximum number of backups to keep",
+              "default": 5
+            },
+            "symlink_strategy": {
+              "type": "string",
+              "enum": ["prefer", "avoid", "always"],
+              "description": "Symlink creation strategy",
+              "default": "prefer"
+            },
+            "conflict_policy": {
+              "type": "string",
+              "enum": ["backup", "overwrite", "skip", "ask"],
+              "description": "How to handle file conflicts",
+              "default": "ask"
+            },
+            "enable_hooks": {
+              "type": "boolean",
+              "description": "Enable pre/post hooks",
+              "default": true
+            },
+            "hooks_timeout": {
+              "type": "integer",
+              "description": "Hook execution timeout in seconds",
+              "default": 300
             }
           }
         },
@@ -122,20 +172,12 @@
                 "type": "object",
                 "properties": {
                   "name": {"type": "string"},
-                  "url": {"type": "string", "format": "uri"}
+                  "url": {"type": "string", "format": "uri"},
+                  "priority": {"type": "integer"},
+                  "enabled": {"type": "boolean", "default": true}
                 },
                 "required": ["name", "url"]
               }
-            },
-            "trusted_domains": {
-              "type": "array",
-              "description": "Additional domains to trust (extends embedded whitelist)",
-              "items": {"type": "string", "format": "hostname"}
-            },
-            "blocked_domains": {
-              "type": "array",
-              "description": "Domains to never consult (overrides embedded whitelist)",
-              "items": {"type": "string", "format": "hostname"}
             }
           }
         }
@@ -143,7 +185,7 @@
     },
     "writ": {
       "type": "object",
-      "description": "Writ-specific configuration. Layers are directories at ~/.local/share/devlore/writ/layers/",
+      "description": "Writ-specific configuration (verbosity and dry_run are shared at root level). Layers are directories at ~/.local/share/devlore/writ/layers/",
       "properties": {
         "segments": {
           "type": "array",


### PR DESCRIPTION
## Summary

- Centralizes configuration into `internal/config/` package so both `lore` and `writ` consume config from the same place
- Shared resources (model, registry) and runtime options (verbosity, dry_run) at root level
- Tool-specific settings nested under `lore` and `writ` keys
- rclone-style environment variable naming: `DEVLORE_` + config path, uppercase, underscores
- Single `verbosity` field with values `quiet`, `normal`, `verbose` (replaces separate verbose/quiet bools)

## Config Package Structure

```
internal/config/
├── config.go    # Root Config struct, Load(), Save()
├── lore.go      # LoreConfig, Preferences, Sources
├── model.go     # ModelConfig with defaults
├── registry.go  # RegistryConfig with defaults
└── writ.go      # WritConfig (Segments, Vars)
```

## Unified Config Verification

Tests in `internal/cli/config_test.go` verify that `lore config list` and `writ config list` show the same unified config:

- `TestSharedConfigPath` - Both tools use same config path
- `TestUnifiedConfig_BothToolsSeeSharedSettings` - Shared settings visible to both
- `TestUnifiedConfig_ToolSpecificSettingsVisible` - Tool-specific settings accessible
- `TestConfigListOutput_SameForBothTools` - Identical output from both tools

## Test plan

- [x] `go test ./...` passes
- [x] `lore config list` and `writ config list` use shared config path
- [x] Environment variable overrides work (DEVLORE_*)
- [x] API keys stored in native keystore, not config file

Closes #67