### PR TITLE
fix: address Claude judgment errors - stub functions, legacy code, session protocol

### DIFF
--- a/.github/workflows/sync-knowledge.yaml
+++ b/.github/workflows/sync-knowledge.yaml
@@ -9,21 +9,11 @@ on:
       - develop
       - main
       - 'release/*'
-    paths:
-      # Starlark binding code
-      - 'internal/starlark/**'
-      # Writ migrate code
-      - 'internal/writ/migrate/**'
   pull_request:
     branches:
       - develop
       - main
       - 'release/*'
-    paths:
-      # Starlark binding code
-      - 'internal/starlark/**'
-      # Writ migrate code
-      - 'internal/writ/migrate/**'
 
 jobs:
   sync-knowledge:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Claude Code Instructions for devlore-cli
+
+## Session Protocol
+
+**At the start of EVERY session and after EVERY compact:**
+1. Read this file (`CLAUDE.md`) in full
+2. Read `~/.claude/CLAUDE.md` (root instructions)
+3. Review issue #65: https://github.com/NobleFactor/devlore-cli/issues/65
+
+## Error Tracking
+
+All errors of judgment are tracked in **issue #65**. Before completing any task, consult this issue and follow the verification checklist.
+
+## Governing Principle
+
+**This is a greenfield product. There is NO legacy. There are NO old APIs. There are NO previous versions to support.**
+
+Any code that:
+- Maintains backward compatibility
+- Preserves old API signatures
+- Accepts legacy formats
+- Provides fallbacks for old behavior
+
+**IS A CRITICAL BUG.**
+
+When in doubt, DELETE. There are no legacy users to break.
+
+## Verification Checklist
+
+Before completing any task:
+
+- [ ] Grep for `legacy|backward|compat|deprecated` — remove all matches
+- [ ] Verify no stub functions return success without implementation
+- [ ] Verify removed comments have corresponding code removal
+- [ ] Run tests to confirm rejection of old formats/signatures
+- [ ] Consult issue #65 for known error patterns
+
+## Repository-Specific Notes
+
+- Default branch: `develop`
+- Package manifest filename: `packages-manifest.yaml` or `packages-manifest.json` (NO other names)
+- Schema: `schema.DevloreSchema` only (NO aliases)
+- Decryptor signature: `func(string, []byte) ([]byte, error)` only (NO fallbacks)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ make install-all    # Install binaries, completions, and man pages
 Use `self-install` to install binaries, man pages, and shell completions:
 
 ```bash
-# Install to ~/.local (default)
-writ self-install ~/.local
-lore self-install ~/.local
+# Install to ~/.local
+writ self-install --prefix=~/.local
+lore self-install --prefix=~/.local
 
 # Specify shells explicitly (auto-detects by default)
-writ self-install ~/.local --shell bash --shell zsh
+writ self-install --prefix=~/.local --shell bash --shell zsh
 
 # Man pages
 lore man                          # Display with pager

--- a/TODO.md
+++ b/TODO.md
@@ -809,7 +809,7 @@ var TargetOrder = []TargetSpec{
 ```go
 type BuildConfig struct {
     Sources    []LayerSource  // Replaces single SourceRoot
-    TargetRoot string         // Default target (for backwards compat)
+    TargetRoot string         // Default target
     Projects   []string
     Segments   segment.Segments
 }
@@ -931,7 +931,7 @@ type WritContext struct {
 
 ### 6.5 Test Cases
 
-1. **Single layer** — backwards compatible, works like today
+1. **Single layer** — single source root, simple case
 2. **Two layers, no conflict** — base + personal, disjoint files
 3. **Two layers, conflict** — personal overrides base for same target
 4. **Three layers** — base → team → personal cascade

--- a/docs/architecture/execution-graph.md
+++ b/docs/architecture/execution-graph.md
@@ -90,7 +90,7 @@ Each lifecycle command has its own config type containing all resolved settings:
 type DeployConfig struct {
     // Sources
     LayerSources []tree.LayerSource
-    SourceRoot   string  // legacy single-repo mode
+    SourceRoot   string  // single-repo mode (when no layers configured)
     TargetRoot   string
 
     // Selection

--- a/docs/architecture/llm-integration.md
+++ b/docs/architecture/llm-integration.md
@@ -59,10 +59,10 @@ for intelligent analysis tasks in `writ migrate` and `lore onboard`.
 // 2. DEVLORE_MODEL_PROVIDER environment variable
 // 3. Default: "ollama"
 
-provider := model.NewProvider(model.Config{
+provider := model.NewProvider(config.ModelConfig{
     Provider: os.Getenv("DEVLORE_MODEL_PROVIDER"),
     APIKey:   os.Getenv("DEVLORE_MODEL_API_KEY"),
-    Model:    os.Getenv("DEVLORE_MODEL"),
+    Name:     os.Getenv("DEVLORE_MODEL"),
 })
 ```
 
@@ -323,7 +323,7 @@ func TestMigrationWithOllama(t *testing.T) {
         t.Skip("skipping integration test")
     }
 
-    provider, err := model.NewProvider(model.Config{Provider: "ollama"})
+    provider, err := model.NewProvider(config.ModelConfig{Provider: "ollama"})
     require.NoError(t, err)
 
     // Test with real fixture

--- a/docs/guides/writ/receipts.md
+++ b/docs/guides/writ/receipts.md
@@ -167,14 +167,7 @@ writ receipt list --filter target=~/.config/git/config
 
 ## Receipt Versions
 
-| Version | Description |
-|---------|-------------|
-| v1 | Initial format (flat entries) |
-| v2 | Added source/target checksums |
-| v3 | Added age-encrypted signature |
-| v4 | Graph format with git-style checksum |
-
-Legacy receipts (v1-v3) are automatically converted when loaded.
+Receipts use a graph format with git-style checksums and optional age-encrypted signatures.
 
 ## Troubleshooting
 

--- a/docs/package-reference.md
+++ b/docs/package-reference.md
@@ -490,13 +490,10 @@ Two-tiered list of all Go packages. Public elements (uppercase) listed first, th
 
 ## schema
 - **DevloreSchema** (var): Shared JSON schema for devlore config
-- **LifecycleSchema** (var): JSON schema for lifecycle
 - **LoreDefaultConfig** (var): Default lore configuration
-- **LoreSchema** (var): Legacy alias for DevloreSchema
 - **PackagesManifestSchema** (var): JSON schema for packages manifest
 - **SharedDefaultConfig** (var): Default shared configuration
 - **WritDefaultConfig** (var): Default writ configuration
-- **WritSchema** (var): Legacy alias for DevloreSchema
 
 ---
 

--- a/docs/plans/self-command.md
+++ b/docs/plans/self-command.md
@@ -1,0 +1,239 @@
+# Plan: Self Command with Install and Upgrade Subcommands
+
+---
+title: Self Command with Install and Upgrade Subcommands
+issue: https://github.com/NobleFactor/devlore-cli/issues/83
+status: draft
+created: 2026-02-06
+updated: 2026-02-06
+---
+
+## Summary
+
+Refactor the current `self-install` command into a `self` parent command with two subcommands: `self install` (offline, generates local files) and `self upgrade` (network, downloads newer LKG). This aligns with package manager conventions and matches star's behavior.
+
+## Goals
+
+1. **Offline install**: `self install` generates completions, man pages, config without network
+2. **Explicit upgrade**: `self upgrade` checks GitHub for newer LKG release
+3. **In-place upgrade**: `self upgrade` replaces the running binary (no --prefix)
+4. **Consistent with star**: Same command structure across all NobleFactor CLI tools
+
+## Prior Art
+
+| Tool | update | upgrade |
+|------|--------|---------|
+| apt | Refresh package index | Install newer versions |
+| brew | Fetch newest formulae | Install newer versions |
+| port | selfupdate = refresh + upgrade | - |
+| pip | - | `install --upgrade` |
+
+Our `self upgrade` = install newer version (like `apt upgrade`, `brew upgrade`).
+
+## Current State
+
+| Command | Status | Notes |
+|---------|--------|-------|
+| `lore self-install --prefix <dir>` | ✅ Working | Generates completions, man pages, config |
+| `writ self-install --prefix <dir>` | ✅ Working | Same as lore |
+| Version check | ❌ Missing | No LKG check or download |
+| Release caching | ❌ Missing | No cache for downloaded releases |
+
+### Current Implementation
+
+`internal/cli/selfinstall.go` provides:
+- `detectShells()` - auto-detect bash, fish, powershell, zsh
+- `shellCompletionPath()` - XDG-compliant paths for each shell
+- `installCompletionsForShells()` - generate completions using Cobra
+- `installManPagesTo()` - generate man pages
+- `initDevloreConfig()` - create config files
+
+## Requirements
+
+### Self Install (Offline)
+
+Generate supporting files locally - no network required:
+
+```bash
+lore self install                    # Default: ~/.local
+lore self install --prefix /usr/local
+writ self install --prefix ~/.local
+```
+
+**Arguments**:
+- `--prefix <dir>` - Installation prefix (default: `~/.local`)
+
+**What it does**:
+1. Generate and install to XDG locations:
+   - `${XDG_DATA_HOME}/man/man1/{lore,writ}*.1` (man pages)
+   - `${XDG_DATA_HOME}/bash-completion/completions/{lore,writ}` (bash)
+   - `${XDG_DATA_HOME}/fish/vendor_completions.d/{lore,writ}.fish` (fish)
+   - `${XDG_DATA_HOME}/zsh/site-functions/_{lore,writ}` (zsh)
+   - `${XDG_DATA_HOME}/powershell/Completions/{lore,writ}.ps1` (PowerShell)
+   - `${XDG_CONFIG_HOME}/devlore/config.yaml` (shared config)
+   - `${XDG_CONFIG_HOME}/devlore/config.d/{lore,writ}.yaml` (tool config)
+2. Report what was installed
+
+**Key behaviors**:
+- Works offline - no network required
+- Idempotent - safe to run anytime
+- XDG compliant
+
+### Self Upgrade (Network)
+
+Check for and install newer LKG release:
+
+```bash
+lore self upgrade                    # Requires GH_TOKEN for private repo
+writ self upgrade
+```
+
+**No arguments** - upgrade is always in-place:
+- Replaces the currently running binary
+- Uses the same location where the binary was found
+- No `--prefix` flag (unlike `self install`)
+
+**What it does**:
+1. Determine current binary location via `os.Executable()`
+2. Check current version vs latest LKG on GitHub (requires `GH_TOKEN`)
+3. If newer version available:
+   - Download release tarball (uses cache if available)
+   - Verify checksum
+   - Replace binary in-place
+4. Run `self install --prefix <detected-prefix>` to regenerate completions/man pages
+5. Report what was updated
+
+**Key behaviors**:
+- In-place upgrade - no prefix argument
+- Requires network and `GH_TOKEN` (private repo)
+- Fail-fast on network errors
+- Uses release cache to reduce downloads
+- No-op if already at latest LKG
+
+### Release Caching
+
+Downloaded releases are cached to reduce redundant downloads:
+
+**Cache location**: `${XDG_CACHE_HOME}/devlore/releases/`
+
+**Structure**:
+```
+${XDG_CACHE_HOME}/devlore/releases/
+├── devlore-cli_v1.0.0_darwin_arm64.tar.gz
+├── devlore-cli_v1.0.0_darwin_arm64.tar.gz.sha256
+└── latest.txt  # Last known LKG version
+```
+
+**Behavior**: If cached tarball matches latest version and checksum is valid, skip download.
+
+### Error Handling
+
+**self install**: Always succeeds (local operations only).
+
+**self upgrade**: Fail-fast on network errors:
+```
+error: failed to fetch latest release: connection refused
+error: GH_TOKEN required for private repository access
+error: checksum verification failed for devlore-cli_v1.0.0_darwin_arm64.tar.gz
+```
+
+## Implementation Phases
+
+### Phase 1: Create Self Parent Command
+
+1. Create `internal/cli/self.go`:
+   - `self` parent command
+   - Register `install` and `upgrade` subcommands
+
+2. Refactor `internal/cli/selfinstall.go` → `internal/cli/self_install.go`:
+   - Change from `self-install` to `self install` subcommand
+   - Keep all existing functionality
+   - Default `--prefix` to `~/.local`
+
+3. Update `cmd/lore/main.go` and `cmd/writ/main.go`:
+   - Register new `self` command tree
+
+4. Test: `lore self install` works same as old `lore self-install`
+
+### Phase 2: Add Self Upgrade
+
+1. Create `internal/cli/self_upgrade.go`:
+   - No `--prefix` flag
+   - Detect current binary location
+   - Check GitHub for latest LKG
+   - Download and replace in-place
+   - Call `self install` with detected prefix
+
+2. Create `internal/cli/release.go`:
+   - GitHub release API client (authenticated via `GH_TOKEN`)
+   - `GetLatestRelease()` - fetch latest LKG version
+   - `DownloadRelease(version, os, arch)` - download tarball
+   - Release caching in `${XDG_CACHE_HOME}/devlore/releases/`
+
+3. Test: `lore self upgrade` downloads and replaces binary
+
+### Phase 3: Update Bootstrap Script
+
+1. Update `install.sh`:
+   - Run `lore self install` / `writ self install` (not `self-install`)
+   - Same for PowerShell if we add `install.ps1`
+
+2. Test: Fresh install via `curl | bash` works
+
+### Phase 4: Deprecation and Cleanup
+
+1. Add deprecation warning to old `self-install` command:
+   ```
+   warning: 'self-install' is deprecated, use 'self install'
+   ```
+
+2. After one release cycle, remove `self-install` entirely
+
+## Files to Create/Modify
+
+| File | Action | Phase |
+|------|--------|-------|
+| `internal/cli/self.go` | Create - `self` parent command | 1 |
+| `internal/cli/self_install.go` | Rename from selfinstall.go, refactor | 1 |
+| `internal/cli/selfinstall.go` | Delete (after rename) | 1 |
+| `cmd/lore/main.go` | Modify - register self command | 1 |
+| `cmd/writ/main.go` | Modify - register self command | 1 |
+| `internal/cli/self_upgrade.go` | Create - `self upgrade` subcommand | 2 |
+| `internal/cli/release.go` | Create - GitHub release API + caching | 2 |
+| `install.sh` | Modify - use `self install` | 3 |
+
+## Migration Path
+
+### For users
+
+**Before** (deprecated):
+```bash
+lore self-install --prefix ~/.local
+```
+
+**After**:
+```bash
+lore self install --prefix ~/.local   # Same behavior
+lore self upgrade                      # New: check for updates
+```
+
+### For CI
+
+```yaml
+- name: Upgrade devlore tools
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    lore self upgrade || true
+    writ self upgrade || true
+```
+
+## Dependencies
+
+- Issue #82 - Versioning with timestamps and commit hashes (needed for version comparison)
+
+## Related Documents
+
+- [noblefactor-ops: star-release-install.md](https://github.com/NobleFactor/noblefactor-ops/blob/develop/docs/plans/star-release-install.md) - Reference implementation
+- Issue #82 - Versioning scheme
+- Issue #83 - This plan's tracking issue

--- a/docs/plans/unified-segment-resolution.md
+++ b/docs/plans/unified-segment-resolution.md
@@ -308,12 +308,7 @@ func (p Platform) MatchingSegments() []string {
 
 The docker package already uses the directory structure. No migration needed for existing packages using the new structure.
 
-Packages using the old `phases:` field in lifecycle.yaml will continue to work until deprecated. Add:
-
-```yaml
-# DEPRECATED: phases field. Use directory structure instead.
-# See: packages/<name>/<platform>/<pipeline>/<phase>.star
-```
+All packages use the directory structure for phase scripts. There is no `phases:` field in lifecycle.yaml.
 
 ### 3.2. Schema Update
 

--- a/install.sh
+++ b/install.sh
@@ -322,7 +322,7 @@ main() {
     # Run self-install for each tool to install man pages and completions
     for tool in "${installed[@]}"; do
         info "Running ${tool} self-install..."
-        "${INSTALL_DIR}/${tool}" self-install "$PREFIX" --unattended || warn "${tool} self-install failed"
+        "${INSTALL_DIR}/${tool}" self-install --prefix="$PREFIX" --unattended || warn "${tool} self-install failed"
     done
 
     echo

--- a/internal/cli/selfinstall.go
+++ b/internal/cli/selfinstall.go
@@ -27,8 +27,8 @@ type SelfInstallInfo struct {
 // NewSelfInstallCmd creates the self-install command.
 // Usage:
 //
-//	./tool self-install ~/.local
-//	./tool self-install --shell bash --shell zsh ~/.local
+//	./tool self-install --prefix=~/.local
+//	./tool self-install --prefix=~/.local --shell bash --shell zsh
 //
 // This performs complete installation:
 //   - Copies binary to <root>/bin/
@@ -39,15 +39,16 @@ type SelfInstallInfo struct {
 //   - Creates layer directories in XDG_DATA_HOME/devlore/writ/layers/
 func NewSelfInstallCmd(rootCmd *cobra.Command, info SelfInstallInfo) *cobra.Command {
 	var shells []string
+	var prefix string
 
 	cmd := &cobra.Command{
-		Use:   "self-install <root-directory>",
+		Use:   "self-install --prefix=<directory>",
 		Short: "Complete installation to specified directory",
-		Long: `Install ` + info.Name + ` and all supporting files to the specified root directory.
+		Long: `Install ` + info.Name + ` and all supporting files to the specified prefix directory.
 
 This command:
-  1. Copies the binary to <root>/bin/` + info.Name + `
-  2. Installs man pages to <root>/share/man/man1/ (if man command exists)
+  1. Copies the binary to <prefix>/bin/` + info.Name + `
+  2. Installs man pages to <prefix>/share/man/man1/ (if man command exists)
   3. Installs shell completions (auto-detects bash, fish, powershell, zsh or use --shell)
   4. Creates shared config at $XDG_CONFIG_HOME/devlore/config.yaml
   5. Creates tool config at $XDG_CONFIG_HOME/devlore/config.d/` + info.Name + `.yaml
@@ -55,18 +56,20 @@ This command:
   7. Creates layer directories at $XDG_DATA_HOME/devlore/writ/layers/
 
 Shell completions are auto-detected by default. Use --shell to override:
-  ` + info.Name + ` self-install --shell bash --shell zsh ~/.local
+  ` + info.Name + ` self-install --prefix=~/.local --shell bash --shell zsh
 
 Example:
-  ` + info.Name + ` self-install ~/.local
-  ` + info.Name + ` self-install --shell bash --shell zsh ~/.local
+  ` + info.Name + ` self-install --prefix=~/.local
+  ` + info.Name + ` self-install --prefix=~/.local --shell bash --shell zsh
 
-After installation, ensure <root>/bin is in your PATH.
+After installation, ensure <prefix>/bin is in your PATH.
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			root := args[0]
-			root = expandTilde(root)
+			if prefix == "" {
+				return fmt.Errorf("--prefix is required")
+			}
+			root := expandTilde(prefix)
 
 			return runSelfInstall(rootCmd, root, info, installFlags{
 				Shells: shells,
@@ -74,6 +77,7 @@ After installation, ensure <root>/bin is in your PATH.
 		},
 	}
 
+	cmd.Flags().StringVar(&prefix, "prefix", "", "Installation prefix directory (required, e.g., ~/.local)")
 	cmd.Flags().StringArrayVar(&shells, "shell", nil, "Shell to install completions for (repeatable, e.g., --shell bash --shell zsh)")
 
 	return cmd

--- a/internal/cli/selfinstall_test.go
+++ b/internal/cli/selfinstall_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestExpandTilde tests the tilde expansion function.
+func TestExpandTilde(t *testing.T) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		t.Skip("HOME not set")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~", home},
+		{"~/", home},
+		{"~/.local", filepath.Join(home, ".local")},
+		{"~/foo/bar", filepath.Join(home, "foo", "bar")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+		{"~user/path", "~user/path"}, // Only ~/... is expanded, not ~user/...
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := expandTilde(tt.input)
+			if got != tt.want {
+				t.Errorf("expandTilde(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewSelfInstallCmd_RequiresPrefix tests that --prefix is required.
+// This test verifies that positional arguments are NOT accepted (they were removed).
+func TestNewSelfInstallCmd_RequiresPrefix(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test"}
+	info := SelfInstallInfo{Name: "test"}
+	cmd := NewSelfInstallCmd(rootCmd, info)
+
+	// Capture output
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	// Test: no args, no flags should fail
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when --prefix is not provided")
+	}
+	if !strings.Contains(err.Error(), "--prefix is required") {
+		t.Errorf("expected '--prefix is required' error, got: %v", err)
+	}
+}
+
+// TestNewSelfInstallCmd_RejectsPositionalArgs tests that positional args are rejected.
+// Previously, the command accepted a positional directory argument. This was changed
+// to --prefix flag for Unix convention compliance.
+func TestNewSelfInstallCmd_RejectsPositionalArgs(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test"}
+	info := SelfInstallInfo{Name: "test"}
+	cmd := NewSelfInstallCmd(rootCmd, info)
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	// Test: positional arg should fail (cobra.NoArgs enforces this)
+	cmd.SetArgs([]string{"~/.local"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when positional argument is provided")
+	}
+	// The error message depends on cobra's implementation
+	if !strings.Contains(err.Error(), "unknown command") && !strings.Contains(err.Error(), "accepts 0 arg") {
+		t.Errorf("expected rejection of positional arg, got: %v", err)
+	}
+}
+
+// TestNewSelfInstallCmd_AcceptsPrefix tests that --prefix flag works.
+func TestNewSelfInstallCmd_AcceptsPrefix(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test"}
+	info := SelfInstallInfo{Name: "test"}
+	cmd := NewSelfInstallCmd(rootCmd, info)
+
+	// We can't fully run self-install in tests (it copies binaries),
+	// but we can verify the flag parsing works
+	cmd.SetArgs([]string{"--prefix=/tmp/test"})
+
+	// The command will fail during execution (no binary to copy, etc.)
+	// but it should NOT fail during flag parsing
+	err := cmd.Execute()
+	if err != nil {
+		// If error is about prefix, that's wrong
+		if strings.Contains(err.Error(), "--prefix is required") {
+			t.Errorf("--prefix flag not recognized: %v", err)
+		}
+		// Other errors (like "failed to install binary") are expected
+	}
+}
+
+// TestNewSelfInstallCmd_ShellFlag tests that --shell flag is repeatable.
+func TestNewSelfInstallCmd_ShellFlag(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test"}
+	info := SelfInstallInfo{Name: "test"}
+	cmd := NewSelfInstallCmd(rootCmd, info)
+
+	// Test multiple --shell flags
+	cmd.SetArgs([]string{"--prefix=/tmp/test", "--shell", "bash", "--shell", "zsh"})
+
+	// The command will fail during execution but should parse flags correctly
+	_ = cmd.Execute()
+
+	// Verify the flag was properly configured (checking the flag exists)
+	shellFlag := cmd.Flag("shell")
+	if shellFlag == nil {
+		t.Error("--shell flag should exist")
+	}
+}
+
+// TestNewSelfInstallCmd_Usage tests the command usage string.
+func TestNewSelfInstallCmd_Usage(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test"}
+	info := SelfInstallInfo{Name: "test"}
+	cmd := NewSelfInstallCmd(rootCmd, info)
+
+	usage := cmd.Use
+	if !strings.Contains(usage, "--prefix") {
+		t.Errorf("usage should mention --prefix, got: %q", usage)
+	}
+}
+
+// TestShellCompletionPath tests the shell completion path function.
+func TestShellCompletionPath(t *testing.T) {
+	tests := []struct {
+		shell    string
+		cmdName  string
+		wantRel  string
+		wantFile string
+	}{
+		{"bash", "writ", "share/bash-completion/completions", "writ"},
+		{"fish", "writ", "share/fish/vendor_completions.d", "writ.fish"},
+		{"zsh", "writ", "share/zsh/site-functions", "_writ"},
+		{"powershell", "writ", "share/powershell/completions", "writ.ps1"},
+		{"unknown", "writ", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			gotRel, gotFile := shellCompletionPath(tt.shell, tt.cmdName)
+			// Normalize path separators for cross-platform
+			wantRel := filepath.FromSlash(tt.wantRel)
+			if gotRel != wantRel {
+				t.Errorf("shellCompletionPath(%q, %q) relPath = %q, want %q", tt.shell, tt.cmdName, gotRel, wantRel)
+			}
+			if gotFile != tt.wantFile {
+				t.Errorf("shellCompletionPath(%q, %q) filename = %q, want %q", tt.shell, tt.cmdName, gotFile, tt.wantFile)
+			}
+		})
+	}
+}
+
+// TestHasMan tests the man command detection.
+func TestHasMan(t *testing.T) {
+	// This is environment-dependent, so we just test it doesn't panic
+	_ = hasMan()
+}
+
+// TestDetectShells tests the shell detection function.
+func TestDetectShells(t *testing.T) {
+	// This is environment-dependent, so we just test it returns valid values
+	shells := detectShells()
+	validShells := map[string]bool{"bash": true, "fish": true, "powershell": true, "zsh": true}
+
+	for _, shell := range shells {
+		if !validShells[shell] {
+			t.Errorf("detectShells() returned invalid shell: %q", shell)
+		}
+	}
+
+	// Verify alphabetical order
+	for i := 1; i < len(shells); i++ {
+		if shells[i] < shells[i-1] {
+			t.Errorf("detectShells() not sorted: %v", shells)
+			break
+		}
+	}
+}
+
+// TestCopyFile tests the file copy function.
+func TestCopyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "source.txt")
+	dst := filepath.Join(tmpDir, "dest.txt")
+
+	content := []byte("test content")
+	if err := os.WriteFile(src, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", string(got), string(content))
+	}
+}
+
+// TestCopyFile_NonExistentSource tests that copying a non-existent file fails.
+func TestCopyFile_NonExistentSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "nonexistent.txt")
+	dst := filepath.Join(tmpDir, "dest.txt")
+
+	err := copyFile(src, dst)
+	if err == nil {
+		t.Error("expected error for non-existent source")
+	}
+}

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -13,8 +13,8 @@ const (
 // ModelConfig configures the AI/LLM provider.
 // This is shared across lore and writ for AI-assisted features.
 type ModelConfig struct {
-	Provider string `yaml:"provider" json:"provider"` // ollama, anthropic, openai, groq, gemini, github
-	Name     string `yaml:"name" json:"name"`         // Model identifier (e.g., claude-sonnet-4-20250514)
+	Provider string `yaml:"provider" json:"provider"`                     // ollama, anthropic, openai, groq, gemini, github
+	Name     string `yaml:"name" json:"name"`                             // Model identifier (e.g., claude-sonnet-4-20250514)
 	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // Custom endpoint URL
 	APIKey   string `yaml:"api_key,omitempty" json:"api_key,omitempty"`   // API key (prefer keystore)
 }

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -134,18 +134,18 @@ type PerformanceMetrics struct {
 // CorrectnessMetrics captures correctness data for test validation.
 type CorrectnessMetrics struct {
 	// Generic metrics
-	TotalExpected int     `json:"total_expected" yaml:"total_expected"`
-	TotalFound    int     `json:"total_found" yaml:"total_found"`
-	TruePositives int     `json:"true_positives" yaml:"true_positives"`
-	FalsePositives int    `json:"false_positives" yaml:"false_positives"`
-	FalseNegatives int    `json:"false_negatives" yaml:"false_negatives"`
+	TotalExpected  int     `json:"total_expected" yaml:"total_expected"`
+	TotalFound     int     `json:"total_found" yaml:"total_found"`
+	TruePositives  int     `json:"true_positives" yaml:"true_positives"`
+	FalsePositives int     `json:"false_positives" yaml:"false_positives"`
+	FalseNegatives int     `json:"false_negatives" yaml:"false_negatives"`
 	Precision      float64 `json:"precision" yaml:"precision"`
 	Recall         float64 `json:"recall" yaml:"recall"`
 	F1Score        float64 `json:"f1_score" yaml:"f1_score"`
 
 	// Domain-specific flags
-	SystemCorrect   bool `json:"system_correct,omitempty" yaml:"system_correct,omitempty"`
-	ProductCorrect  bool `json:"product_correct,omitempty" yaml:"product_correct,omitempty"`
+	SystemCorrect    bool `json:"system_correct,omitempty" yaml:"system_correct,omitempty"`
+	ProductCorrect   bool `json:"product_correct,omitempty" yaml:"product_correct,omitempty"`
 	PlatformsCorrect bool `json:"platforms_correct,omitempty" yaml:"platforms_correct,omitempty"`
 }
 
@@ -164,23 +164,23 @@ func (c *CorrectnessMetrics) ComputePrecisionRecall() {
 
 // TestResult captures the complete result of a single test run.
 type TestResult struct {
-	TestName    string              `json:"test_name" yaml:"test_name"`
-	Provider    string              `json:"provider" yaml:"provider"`
-	Model       string              `json:"model" yaml:"model"`
-	StartTime   time.Time           `json:"start_time" yaml:"start_time"`
-	EndTime     time.Time           `json:"end_time" yaml:"end_time"`
-	Success     bool                `json:"success" yaml:"success"`
-	Error       string              `json:"error,omitempty" yaml:"error,omitempty"`
-	Performance PerformanceMetrics  `json:"performance" yaml:"performance"`
-	Correctness CorrectnessMetrics  `json:"correctness" yaml:"correctness"`
-	Details     map[string]any      `json:"details,omitempty" yaml:"details,omitempty"`
+	TestName    string             `json:"test_name" yaml:"test_name"`
+	Provider    string             `json:"provider" yaml:"provider"`
+	Model       string             `json:"model" yaml:"model"`
+	StartTime   time.Time          `json:"start_time" yaml:"start_time"`
+	EndTime     time.Time          `json:"end_time" yaml:"end_time"`
+	Success     bool               `json:"success" yaml:"success"`
+	Error       string             `json:"error,omitempty" yaml:"error,omitempty"`
+	Performance PerformanceMetrics `json:"performance" yaml:"performance"`
+	Correctness CorrectnessMetrics `json:"correctness" yaml:"correctness"`
+	Details     map[string]any     `json:"details,omitempty" yaml:"details,omitempty"`
 }
 
 // TestSuite holds results for all providers on a single test.
 type TestSuite struct {
-	Name      string       `json:"name" yaml:"name"`
-	RunAt     time.Time    `json:"run_at" yaml:"run_at"`
-	Results   []TestResult `json:"results" yaml:"results"`
+	Name    string       `json:"name" yaml:"name"`
+	RunAt   time.Time    `json:"run_at" yaml:"run_at"`
+	Results []TestResult `json:"results" yaml:"results"`
 }
 
 // TestReport aggregates results across all tests and providers.

--- a/internal/e2e/migrate_test.go
+++ b/internal/e2e/migrate_test.go
@@ -274,4 +274,3 @@ func evaluateMigrateCorrectness(analysis *migrate.MigrationAnalysis, graph *exec
 
 	return metrics
 }
-

--- a/internal/e2e/onboard_test.go
+++ b/internal/e2e/onboard_test.go
@@ -22,10 +22,10 @@ import (
 
 // OnboardExpected represents the expected output for an onboarding test.
 type OnboardExpected struct {
-	Product       OnboardProduct       `yaml:"product"`
-	Sources       OnboardSources       `yaml:"sources,omitempty"`
-	Platforms     OnboardPlatforms     `yaml:"platforms,omitempty"`
-	Complexity    OnboardComplexity    `yaml:"complexity,omitempty"`
+	Product       OnboardProduct        `yaml:"product"`
+	Sources       OnboardSources        `yaml:"sources,omitempty"`
+	Platforms     OnboardPlatforms      `yaml:"platforms,omitempty"`
+	Complexity    OnboardComplexity     `yaml:"complexity,omitempty"`
 	ExpectedSlots []OnboardExpectedSlot `yaml:"expected_slots,omitempty"`
 }
 

--- a/internal/e2e/testdata/migrate/stow-style/bash/.bash_profile
+++ b/internal/e2e/testdata/migrate/stow-style/bash/.bash_profile
@@ -1,2 +1,4 @@
+# shellcheck shell=bash
 # Bash profile - source bashrc
+# shellcheck source=/dev/null
 [[ -f ~/.bashrc ]] && source ~/.bashrc

--- a/internal/e2e/testdata/migrate/stow-style/bash/.bashrc
+++ b/internal/e2e/testdata/migrate/stow-style/bash/.bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Bash configuration managed by stow
 export PATH="$HOME/.local/bin:$PATH"
 export HISTSIZE=10000

--- a/internal/e2e/testdata/migrate/tuckr-style/Configs/all/.bashrc
+++ b/internal/e2e/testdata/migrate/tuckr-style/Configs/all/.bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Common bash configuration
 export EDITOR=nvim
 alias ll='ls -la'

--- a/internal/e2e/testdata/migrate/tuckr-style/Configs/zsh/.zshrc
+++ b/internal/e2e/testdata/migrate/tuckr-style/Configs/zsh/.zshrc
@@ -1,5 +1,9 @@
+# shellcheck shell=bash
 # Zsh configuration
 export ZSH="$HOME/.oh-my-zsh"
+# shellcheck disable=SC2034
 ZSH_THEME="robbyrussell"
+# shellcheck disable=SC2034
 plugins=(git docker kubectl)
+# shellcheck source=/dev/null
 source $ZSH/oh-my-zsh.sh

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -193,7 +193,7 @@ func TestDecryptOperation(t *testing.T) {
 	op := &DecryptOp{}
 
 	// Provide a mock decryptor
-	mockDecrypt := func(ciphertext []byte) ([]byte, error) {
+	mockDecrypt := func(source string, ciphertext []byte) ([]byte, error) {
 		return []byte("decrypted:" + string(ciphertext)), nil
 	}
 
@@ -222,6 +222,81 @@ func TestDecryptOperationNoDecryptor(t *testing.T) {
 
 	if _, err := op.Transform(ctx, node, inputContent); err == nil {
 		t.Error("expected error when no decryptor configured")
+	}
+}
+
+// TestDecryptOperationInvalidSignature tests that invalid decryptor signatures are rejected.
+// This is a critical test: we previously had a legacy signature fallback that accepted
+// func([]byte) ([]byte, error) which is a security issue since it doesn't track the source.
+func TestDecryptOperationInvalidSignature(t *testing.T) {
+	op := &DecryptOp{}
+	node := &Node{ID: "secret.txt"}
+	node.SetSlotImmediate("source", "/path/to/secret")
+	inputContent := []byte("encrypted-data")
+
+	tests := []struct {
+		name      string
+		decryptor any
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "valid signature func(string, []byte) ([]byte, error)",
+			decryptor: func(source string, data []byte) ([]byte, error) {
+				return []byte("decrypted"), nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid legacy signature func([]byte) ([]byte, error)",
+			decryptor: func(data []byte) ([]byte, error) {
+				return []byte("decrypted"), nil
+			},
+			wantErr: true,
+			errMsg:  "must be func(string, []byte)",
+		},
+		{
+			name:      "invalid type string",
+			decryptor: "not a function",
+			wantErr:   true,
+			errMsg:    "must be func(string, []byte)",
+		},
+		{
+			name:      "invalid type int",
+			decryptor: 42,
+			wantErr:   true,
+			errMsg:    "must be func(string, []byte)",
+		},
+		{
+			name: "invalid signature wrong return type",
+			decryptor: func(source string, data []byte) string {
+				return "wrong return"
+			},
+			wantErr: true,
+			errMsg:  "must be func(string, []byte)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{
+				Context: context.Background(),
+				Data:    map[string]any{"decryptor": tt.decryptor},
+			}
+
+			_, err := op.Transform(ctx, node, inputContent)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %s, got nil", tt.name)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got: %v", tt.errMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for %s: %v", tt.name, err)
+				}
+			}
+		})
 	}
 }
 
@@ -448,7 +523,7 @@ func TestEngineRunDecryptRenderCopyPipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockDecrypt := func(ciphertext []byte) ([]byte, error) {
+	mockDecrypt := func(source string, ciphertext []byte) ([]byte, error) {
 		// Strip "encrypted:" prefix
 		return []byte(strings.TrimPrefix(string(ciphertext), "encrypted:")), nil
 	}

--- a/internal/execution/ops.go
+++ b/internal/execution/ops.go
@@ -132,20 +132,14 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 	// (SOPS, age, or any other backend) without the engine depending on
 	// specific crypto libraries.
 	//
-	// Two signatures are supported:
-	//   func(source string, data []byte) ([]byte, error) — preferred, includes source path
-	//   func(data []byte) ([]byte, error) — legacy, data only
+	// Signature: func(source string, data []byte) ([]byte, error)
+	// The source path enables format detection (e.g., .sops vs .age).
 
-	// Try new signature first (includes source path for format detection)
-	if decrypt, ok := decryptor.(func(string, []byte) ([]byte, error)); ok {
-		return decrypt(node.GetSlot("source"), content)
+	decrypt, ok := decryptor.(func(string, []byte) ([]byte, error))
+	if !ok {
+		return nil, fmt.Errorf("decryptor must be func(string, []byte) ([]byte, error)")
 	}
-	if decrypt, ok := decryptor.(func([]byte) ([]byte, error)); ok {
-		// Fall back to legacy signature
-		return decrypt(content)
-	}
-
-	return nil, fmt.Errorf("decryptor must be func(string, []byte) ([]byte, error) or func([]byte) ([]byte, error)")
+	return decrypt(node.GetSlot("source"), content)
 }
 
 // NOTE: There is no DelegateOp. writ and lore share the same execution engine.

--- a/internal/execution/stateview_test.go
+++ b/internal/execution/stateview_test.go
@@ -247,10 +247,10 @@ func TestFileTreeBuildTree(t *testing.T) {
 	tree := &FileTree{
 		Root: "/home/user",
 		Entries: map[string]*FileEntry{
-			".bashrc":             {Target: ".bashrc"},
-			".config/nvim/init.lua": {Target: ".config/nvim/init.lua"},
+			".bashrc":                      {Target: ".bashrc"},
+			".config/nvim/init.lua":        {Target: ".config/nvim/init.lua"},
 			".config/nvim/lua/plugins.lua": {Target: ".config/nvim/lua/plugins.lua"},
-			".ssh/config":         {Target: ".ssh/config"},
+			".ssh/config":                  {Target: ".ssh/config"},
 		},
 	}
 	tree.buildTree()

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -319,8 +319,7 @@ func newUpgradeCmd() *cobra.Command {
 		Use:   "upgrade [@<receipt>]",
 		Short: "Upgrade previously deployed packages to newer versions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("upgrade: not yet implemented")
-			return nil
+			return fmt.Errorf("upgrade: not yet implemented")
 		},
 	}
 	return cmd
@@ -334,8 +333,7 @@ func newDecommissionCmd() *cobra.Command {
 		Example: `  lore decommission @workstation
   lore decommission docker kubectl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("decommission: not yet implemented")
-			return nil
+			return fmt.Errorf("decommission: not yet implemented")
 		},
 	}
 
@@ -351,8 +349,7 @@ func newReconcileCmd() *cobra.Command {
 Use this to verify that your system matches what was deployed, detect
 configuration changes, or audit compliance.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("reconcile: not yet implemented")
-			return nil
+			return fmt.Errorf("reconcile: not yet implemented")
 		},
 	}
 	return cmd
@@ -363,8 +360,7 @@ func newBundleCmd() *cobra.Command {
 		Use:   "bundle @<manifest> -o <output>",
 		Short: "Create self-extracting deployment bundles for air-gapped environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("bundle: not yet implemented")
-			return nil
+			return fmt.Errorf("bundle: not yet implemented")
 		},
 	}
 
@@ -394,8 +390,7 @@ Use --from-url to import from upstream documentation.`,
   lore manifest create pandoc --from ~/scripts/install-pandoc/`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("manifest create %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("manifest create: not yet implemented")
 		},
 	}
 	createCmd.Flags().Bool("ai", false, "Enable AI-assisted creation")
@@ -418,8 +413,7 @@ Checks:
   - Platform coverage (conditionals cover declared platforms)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("manifest validate %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("manifest validate: not yet implemented")
 		},
 	})
 
@@ -435,8 +429,7 @@ Use --set to test with specific settings. Use --debug for verbose output.`,
   lore manifest test mypackage --set shell=zsh`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("manifest test %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("manifest test: not yet implemented")
 		},
 	}
 	testCmd.Flags().StringArray("with", nil, "Enable feature for testing")
@@ -450,8 +443,7 @@ Use --set to test with specific settings. Use --debug for verbose output.`,
 		Short: "Display package manifest details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("manifest show %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("manifest show: not yet implemented")
 		},
 	})
 
@@ -466,8 +458,7 @@ Add new features, platform support, or import updates from documentation.`,
   lore manifest update docker --from-url https://docs.docker.com/engine/install/`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("manifest update %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("manifest update: not yet implemented")
 		},
 	}
 	updateCmd.Flags().String("add-feature", "", "Add a new feature to the package")
@@ -576,8 +567,7 @@ func newListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List deployed packages from pipeline receipts",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("list: not yet implemented")
-			return nil
+			return fmt.Errorf("list: not yet implemented")
 		},
 	}
 
@@ -592,8 +582,7 @@ func newResolveCmd() *cobra.Command {
 		Short: "Show how a package would be installed on this platform",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("resolve %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("resolve: not yet implemented")
 		},
 	}
 	return cmd
@@ -604,8 +593,7 @@ func newUpdateCmd() *cobra.Command {
 		Use:   "update",
 		Short: "Synchronize the local registry cache from the central registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("update: not yet implemented")
-			return nil
+			return fmt.Errorf("update: not yet implemented")
 		},
 	}
 	return cmd
@@ -768,8 +756,7 @@ Output is JSON by default for scripting. Use --format for alternatives.`,
   lore inspect docker --format '{{.Name}}\t{{.Version}}'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("inspect %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("inspect: not yet implemented")
 		},
 	}
 
@@ -789,8 +776,7 @@ and triggers automated testing on macOS, Linux, and Windows.`,
 		Example: `  lore publish mypackage`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("publish %s: not yet implemented", args[0])
-			return nil
+			return fmt.Errorf("publish: not yet implemented")
 		},
 	}
 
@@ -816,8 +802,7 @@ Log location: ~/.local/share/lore/audit.log`,
   lore audit --package kubectl
   lore audit --event privilege`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("audit: not yet implemented")
-			return nil
+			return fmt.Errorf("audit: not yet implemented")
 		},
 	}
 

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -613,14 +613,14 @@ func newUpdateCmd() *cobra.Command {
 func newOnboardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "onboard --from <source>",
-		Short: "Parse wiki or script and generate packages.manifest and config",
+		Short: "Parse wiki or script and generate packages-manifest.yaml and config",
 		Long: `Parse an onboarding wiki page or setup script and generate both a
-packages.manifest file and a config/ directory with configuration files.
+packages-manifest.yaml file and a config/ directory with configuration files.
 
 Lore uses AI to extract installation steps, map them to known registry packages,
 and flag org-specific items for human review.
 
-After onboarding, use 'lore deploy @packages.manifest' to install software,
+After onboarding, use 'lore deploy @packages-manifest.yaml' to install software,
 then 'writ adopt --from-receipt' to bring the generated config into your
 environment repository.`,
 		Example: `  lore onboard --from https://wiki.acme.com/backend-setup
@@ -628,7 +628,7 @@ environment repository.`,
 
   # Full workflow:
   lore onboard --from https://wiki.acme.com/setup
-  lore deploy @packages.manifest
+  lore deploy @packages-manifest.yaml
   writ adopt --from-receipt`,
 		RunE: runOnboard,
 	}
@@ -736,7 +736,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write manifest
-	manifestPath := outputDir + "/packages.manifest"
+	manifestPath := outputDir + "/packages-manifest.yaml"
 	if err := os.WriteFile(manifestPath, []byte(result.Manifest), 0644); err != nil {
 		return fmt.Errorf("writing manifest: %w", err)
 	}
@@ -745,7 +745,7 @@ func runOnboard(cmd *cobra.Command, args []string) error {
 	cli.Note("")
 	cli.Note("Next steps:")
 	cli.Note("  1. Review the generated manifest")
-	cli.Note("  2. lore deploy @packages.manifest")
+	cli.Note("  2. lore deploy @packages-manifest.yaml")
 
 	return nil
 }

--- a/internal/lore/onboard/onboard.go
+++ b/internal/lore/onboard/onboard.go
@@ -22,25 +22,25 @@ import (
 
 // Options controls onboarding behavior.
 type Options struct {
-	Source     string              // URL or file path
-	OutputDir  string              // Output directory (default: current)
-	Format     string              // Manifest format: "plain" or "yaml"
-	Verbose    bool                // Show AI reasoning
-	Explain    bool                // Show detailed confidence decisions
-	Provider   model.Provider      // AI provider
+	Source     string                // URL or file path
+	OutputDir  string                // Output directory (default: current)
+	Format     string                // Manifest format: "plain" or "yaml"
+	Verbose    bool                  // Show AI reasoning
+	Explain    bool                  // Show detailed confidence decisions
+	Provider   model.Provider        // AI provider
 	RegClient  *lorepackage.Registry // Registry for prompts and matching
-	MaxFetches int                 // Max additional URLs to fetch (default: 5)
+	MaxFetches int                   // Max additional URLs to fetch (default: 5)
 }
 
 // Result contains the onboarding output.
 type Result struct {
-	Product     *ProductInfo       `json:"product"`
-	Sources     *SourceInfo        `json:"sources"`
-	Platforms   *PlatformInfo      `json:"platforms"`
-	Complexity  *ComplexityInfo    `json:"complexity"`
-	Slots       []ExtractedSlot    `json:"slots"`
-	Manifest    string             `json:"manifest"`      // Generated packages-manifest.yaml content
-	Warnings    []string           `json:"warnings"`
+	Product    *ProductInfo    `json:"product"`
+	Sources    *SourceInfo     `json:"sources"`
+	Platforms  *PlatformInfo   `json:"platforms"`
+	Complexity *ComplexityInfo `json:"complexity"`
+	Slots      []ExtractedSlot `json:"slots"`
+	Manifest   string          `json:"manifest"` // Generated packages-manifest.yaml content
+	Warnings   []string        `json:"warnings"`
 }
 
 // ProductInfo contains identified product information.

--- a/internal/lore/onboard/onboard.go
+++ b/internal/lore/onboard/onboard.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
 // Package onboard implements the multi-phase onboarding pipeline for lore.
-// It parses wiki pages or setup scripts and generates packages.manifest files.
+// It parses wiki pages or setup scripts and generates packages-manifest.yaml files.
 package onboard
 
 import (
@@ -39,7 +39,7 @@ type Result struct {
 	Platforms   *PlatformInfo      `json:"platforms"`
 	Complexity  *ComplexityInfo    `json:"complexity"`
 	Slots       []ExtractedSlot    `json:"slots"`
-	Manifest    string             `json:"manifest"`      // Generated packages.manifest content
+	Manifest    string             `json:"manifest"`      // Generated packages-manifest.yaml content
 	Warnings    []string           `json:"warnings"`
 }
 
@@ -302,7 +302,7 @@ func parseDocuments(ctx context.Context, opts Options, docs []documentContent) (
 	return parseResult.Slots, nil
 }
 
-// generateManifest creates a packages.manifest from discovery and slots.
+// generateManifest creates a packages-manifest.yaml from discovery and slots.
 func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, format string) string {
 	var sb strings.Builder
 
@@ -363,6 +363,6 @@ func truncateContent(content string, maxLen int) string {
 
 // WriteManifest writes the manifest to a file.
 func WriteManifest(result *Result, outputDir string) error {
-	path := filepath.Join(outputDir, "packages.manifest")
+	path := filepath.Join(outputDir, "packages-manifest.yaml")
 	return os.WriteFile(path, []byte(result.Manifest), 0644)
 }

--- a/internal/lore/root.go
+++ b/internal/lore/root.go
@@ -96,7 +96,7 @@ What took someone hours to figure out, you get in minutes.`,
 	}
 	configInfo := cli.ConfigInfo{
 		Name:          "lore",
-		Schema:        schema.LoreSchema,
+		Schema:        schema.DevloreSchema,
 		DefaultConfig: schema.LoreDefaultConfig,
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -63,7 +63,7 @@ func Parse(data []byte, path string) (*PackagesManifest, error) {
 		if err := json.Unmarshal(data, &raw); err != nil {
 			return nil, fmt.Errorf("invalid JSON: %w", err)
 		}
-	default: // .yaml, .yml, or legacy .manifest
+	default: // .yaml, .yml
 		if err := yaml.Unmarshal(data, &raw); err != nil {
 			return nil, fmt.Errorf("invalid YAML: %w", err)
 		}
@@ -270,8 +270,7 @@ func validatePackageEntry(pkg interface{}, index int) error {
 func IsManifestFile(filename string) bool {
 	base := filepath.Base(filename)
 	return base == "packages-manifest.yaml" ||
-		base == "packages-manifest.json" ||
-		base == "packages.manifest" // legacy
+		base == "packages-manifest.json"
 }
 
 // PackageNames returns the list of package names from the manifest.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -212,7 +212,7 @@ func TestIsManifestFile(t *testing.T) {
 	}{
 		{"packages-manifest.yaml", true},
 		{"packages-manifest.json", true},
-		{"packages.manifest", true},
+		{"packages.manifest", false},
 		{"packages.yaml", false},
 		{"manifest.yaml", false},
 		{".packages-manifest.yaml", false},

--- a/internal/model/gemini.go
+++ b/internal/model/gemini.go
@@ -140,9 +140,9 @@ func (g *GeminiProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 // Gemini API types
 
 type geminiRequest struct {
-	Contents          []geminiContent         `json:"contents"`
-	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
-	GenerationConfig  geminiGenerationConfig  `json:"generationConfig"`
+	Contents          []geminiContent        `json:"contents"`
+	SystemInstruction *geminiContent         `json:"systemInstruction,omitempty"`
+	GenerationConfig  geminiGenerationConfig `json:"generationConfig"`
 }
 
 type geminiContent struct {

--- a/internal/signing/gcp_kms.go
+++ b/internal/signing/gcp_kms.go
@@ -5,8 +5,14 @@ package signing
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"hash/crc32"
 	"strings"
@@ -188,9 +194,7 @@ func VerifyGCPKMS(data []byte, sig *Signature) error {
 		return &VerifyError{Backend: "gcp_kms", Err: err}
 	}
 
-	hash := sha256.Sum256(data)
-
-	// Get the public key
+	// Get the public key and algorithm info
 	pubKeyResp, err := client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
 		Name: sig.KeyID,
 	})
@@ -198,17 +202,91 @@ func VerifyGCPKMS(data []byte, sig *Signature) error {
 		return &VerifyError{Backend: "gcp_kms", Err: err}
 	}
 
-	// Use AsymmetricVerify (available in some regions) or verify locally
-	// For simplicity, we'll use the Cloud KMS verify if available
-	// Note: Not all key types support server-side verification
+	// Parse the PEM-encoded public key
+	block, _ := pem.Decode([]byte(pubKeyResp.Pem))
+	if block == nil {
+		return &VerifyError{Backend: "gcp_kms", Err: fmt.Errorf("failed to parse PEM public key")}
+	}
 
-	// Fallback: Parse public key and verify locally
-	_ = pubKeyResp // Could parse PEM and verify with crypto/x509
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return &VerifyError{Backend: "gcp_kms", Err: fmt.Errorf("failed to parse public key: %w", err)}
+	}
 
-	// For now, assume signature is valid if we can get the public key
-	// A full implementation would verify cryptographically
-	_ = sigBytes
-	_ = hash
+	// Verify based on algorithm
+	if err := verifyGCPSignature(pubKey, pubKeyResp.Algorithm, data, sigBytes); err != nil {
+		return &VerifyError{Backend: "gcp_kms", Err: err}
+	}
 
 	return nil
+}
+
+// verifyGCPSignature verifies a signature using the appropriate algorithm.
+func verifyGCPSignature(pubKey any, algorithm kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm, data, sig []byte) error {
+	switch algorithm {
+	// RSA-PSS algorithms
+	case kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256:
+		rsaKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected RSA public key")
+		}
+		hash := sha256.Sum256(data)
+		return rsa.VerifyPSS(rsaKey, crypto.SHA256, hash[:], sig, nil)
+
+	case kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512:
+		rsaKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected RSA public key")
+		}
+		hash := sha512.Sum512(data)
+		return rsa.VerifyPSS(rsaKey, crypto.SHA512, hash[:], sig, nil)
+
+	// RSA PKCS1 algorithms
+	case kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256:
+		rsaKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected RSA public key")
+		}
+		hash := sha256.Sum256(data)
+		return rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, hash[:], sig)
+
+	case kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512:
+		rsaKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected RSA public key")
+		}
+		hash := sha512.Sum512(data)
+		return rsa.VerifyPKCS1v15(rsaKey, crypto.SHA512, hash[:], sig)
+
+	// ECDSA algorithms
+	case kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+		kmspb.CryptoKeyVersion_EC_SIGN_SECP256K1_SHA256:
+		ecKey, ok := pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected ECDSA public key")
+		}
+		hash := sha256.Sum256(data)
+		if !ecdsa.VerifyASN1(ecKey, hash[:], sig) {
+			return fmt.Errorf("ECDSA signature verification failed")
+		}
+		return nil
+
+	case kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384:
+		ecKey, ok := pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected ECDSA public key")
+		}
+		hash := sha512.Sum384(data)
+		if !ecdsa.VerifyASN1(ecKey, hash[:], sig) {
+			return fmt.Errorf("ECDSA signature verification failed")
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported algorithm: %v", algorithm)
+	}
 }

--- a/internal/signing/gcp_kms_test.go
+++ b/internal/signing/gcp_kms_test.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package signing
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"testing"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+)
+
+// TestVerifyGCPSignature_RSA_PSS_SHA256 tests RSA-PSS SHA256 signature verification.
+func TestVerifyGCPSignature_RSA_PSS_SHA256(t *testing.T) {
+	// Generate test RSA key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	data := []byte("test data for signing")
+	hash := sha256.Sum256(data)
+
+	// Sign with RSA-PSS
+	signature, err := rsa.SignPSS(rand.Reader, privateKey, crypto.SHA256, hash[:], nil)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	// Test verification succeeds with correct signature
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256, data, signature)
+	if err != nil {
+		t.Errorf("verification should succeed: %v", err)
+	}
+
+	// Test verification fails with wrong data
+	wrongData := []byte("wrong data")
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256, wrongData, signature)
+	if err == nil {
+		t.Error("verification should fail with wrong data")
+	}
+
+	// Test verification fails with tampered signature
+	tamperedSig := make([]byte, len(signature))
+	copy(tamperedSig, signature)
+	tamperedSig[0] ^= 0xFF
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256, data, tamperedSig)
+	if err == nil {
+		t.Error("verification should fail with tampered signature")
+	}
+}
+
+// TestVerifyGCPSignature_RSA_PSS_SHA512 tests RSA-PSS SHA512 signature verification.
+func TestVerifyGCPSignature_RSA_PSS_SHA512(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	data := []byte("test data for signing with SHA512")
+	hash := sha512.Sum512(data)
+
+	signature, err := rsa.SignPSS(rand.Reader, privateKey, crypto.SHA512, hash[:], nil)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512, data, signature)
+	if err != nil {
+		t.Errorf("verification should succeed: %v", err)
+	}
+
+	// Test with wrong algorithm
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256, data, signature)
+	if err == nil {
+		t.Error("verification should fail with wrong algorithm")
+	}
+}
+
+// TestVerifyGCPSignature_RSA_PKCS1_SHA256 tests RSA PKCS1v15 SHA256 signature verification.
+func TestVerifyGCPSignature_RSA_PKCS1_SHA256(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	data := []byte("test data for PKCS1 signing")
+	hash := sha256.Sum256(data)
+
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hash[:])
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256, data, signature)
+	if err != nil {
+		t.Errorf("verification should succeed: %v", err)
+	}
+
+	// Test failure with wrong data
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256, []byte("wrong"), signature)
+	if err == nil {
+		t.Error("verification should fail with wrong data")
+	}
+}
+
+// TestVerifyGCPSignature_ECDSA_P256 tests ECDSA P256 signature verification.
+func TestVerifyGCPSignature_ECDSA_P256(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+
+	data := []byte("test data for ECDSA signing")
+	hash := sha256.Sum256(data)
+
+	signature, err := ecdsa.SignASN1(rand.Reader, privateKey, hash[:])
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256, data, signature)
+	if err != nil {
+		t.Errorf("verification should succeed: %v", err)
+	}
+
+	// Test failure with wrong data
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256, []byte("wrong"), signature)
+	if err == nil {
+		t.Error("verification should fail with wrong data")
+	}
+
+	// Test failure with tampered signature
+	tamperedSig := make([]byte, len(signature))
+	copy(tamperedSig, signature)
+	tamperedSig[len(tamperedSig)-1] ^= 0xFF
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256, data, tamperedSig)
+	if err == nil {
+		t.Error("verification should fail with tampered signature")
+	}
+}
+
+// TestVerifyGCPSignature_ECDSA_P384 tests ECDSA P384 signature verification.
+func TestVerifyGCPSignature_ECDSA_P384(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+
+	data := []byte("test data for ECDSA P384 signing")
+	hash := sha512.Sum384(data)
+
+	signature, err := ecdsa.SignASN1(rand.Reader, privateKey, hash[:])
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	err = verifyGCPSignature(&privateKey.PublicKey, kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384, data, signature)
+	if err != nil {
+		t.Errorf("verification should succeed: %v", err)
+	}
+}
+
+// TestVerifyGCPSignature_WrongKeyType tests that wrong key types are rejected.
+func TestVerifyGCPSignature_WrongKeyType(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	data := []byte("test data")
+
+	// Try to verify ECDSA algorithm with RSA key
+	err := verifyGCPSignature(&rsaKey.PublicKey, kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256, data, []byte("sig"))
+	if err == nil {
+		t.Error("should reject RSA key for ECDSA algorithm")
+	}
+
+	// Try to verify RSA algorithm with ECDSA key
+	err = verifyGCPSignature(&ecdsaKey.PublicKey, kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256, data, []byte("sig"))
+	if err == nil {
+		t.Error("should reject ECDSA key for RSA algorithm")
+	}
+}
+
+// TestVerifyGCPSignature_UnsupportedAlgorithm tests that unsupported algorithms are rejected.
+func TestVerifyGCPSignature_UnsupportedAlgorithm(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	data := []byte("test data")
+
+	err := verifyGCPSignature(&rsaKey.PublicKey, kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED, data, []byte("sig"))
+	if err == nil {
+		t.Error("should reject unspecified algorithm")
+	}
+}
+
+// TestVerifyGCPKMS_WrongMethod tests that wrong signature method is rejected.
+func TestVerifyGCPKMS_WrongMethod(t *testing.T) {
+	sig := &Signature{
+		Method: "aws_kms",
+		Value:  base64.StdEncoding.EncodeToString([]byte("sig")),
+		KeyID:  "projects/test/locations/test/keyRings/test/cryptoKeys/test/cryptoKeyVersions/1",
+	}
+
+	err := VerifyGCPKMS([]byte("data"), sig)
+	if err == nil {
+		t.Error("should reject wrong method")
+	}
+
+	var verifyErr *VerifyError
+	if err != nil {
+		verifyErr, _ = err.(*VerifyError)
+	}
+	if verifyErr == nil || verifyErr.Err != ErrWrongMethod {
+		t.Errorf("expected ErrWrongMethod, got: %v", err)
+	}
+}
+
+// TestVerifyGCPKMS_InvalidBase64 tests that invalid base64 signature is rejected.
+func TestVerifyGCPKMS_InvalidBase64(t *testing.T) {
+	sig := &Signature{
+		Method: "gcp_kms",
+		Value:  "not-valid-base64!!!",
+		KeyID:  "projects/test/locations/test/keyRings/test/cryptoKeys/test/cryptoKeyVersions/1",
+	}
+
+	err := VerifyGCPKMS([]byte("data"), sig)
+	if err == nil {
+		t.Error("should reject invalid base64")
+	}
+}
+
+// TestNewGCPKMSSigner tests the signer constructor.
+func TestNewGCPKMSSigner(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantKeys int
+	}{
+		{
+			name:     "single key",
+			input:    "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+			wantKeys: 1,
+		},
+		{
+			name:     "comma separated",
+			input:    "projects/p1/locations/l/keyRings/r/cryptoKeys/k1,projects/p2/locations/l/keyRings/r/cryptoKeys/k2",
+			wantKeys: 2,
+		},
+		{
+			name:     "newline separated",
+			input:    "projects/p1/locations/l/keyRings/r/cryptoKeys/k1\nprojects/p2/locations/l/keyRings/r/cryptoKeys/k2",
+			wantKeys: 2,
+		},
+		{
+			name:     "mixed with whitespace",
+			input:    "  projects/p1/locations/l/keyRings/r/cryptoKeys/k1  ,  projects/p2/locations/l/keyRings/r/cryptoKeys/k2  \n  projects/p3/locations/l/keyRings/r/cryptoKeys/k3  ",
+			wantKeys: 3,
+		},
+		{
+			name:     "empty",
+			input:    "",
+			wantKeys: 0,
+		},
+		{
+			name:     "whitespace only",
+			input:    "   \n   ",
+			wantKeys: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer := NewGCPKMSSigner(tt.input)
+			if len(signer.keyNames) != tt.wantKeys {
+				t.Errorf("NewGCPKMSSigner() got %d keys, want %d", len(signer.keyNames), tt.wantKeys)
+			}
+		})
+	}
+}
+
+// TestGCPKMSSigner_Name tests the signer name.
+func TestGCPKMSSigner_Name(t *testing.T) {
+	signer := NewGCPKMSSigner("projects/p/locations/l/keyRings/r/cryptoKeys/k")
+	if signer.Name() != "gcp_kms" {
+		t.Errorf("Name() = %q, want %q", signer.Name(), "gcp_kms")
+	}
+}
+
+// TestEnsureKeyVersion tests the key version helper.
+func TestEnsureKeyVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+			want:  "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+		},
+		{
+			input: "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+			want:  "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+		},
+		{
+			input: "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/5",
+			want:  "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ensureKeyVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("ensureKeyVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGCPKMSSigner_Available_NoKeys tests that Available returns false with no keys.
+func TestGCPKMSSigner_Available_NoKeys(t *testing.T) {
+	signer := NewGCPKMSSigner("")
+	if signer.Available() {
+		t.Error("Available() should return false when no keys configured")
+	}
+}

--- a/internal/starlark/output.go
+++ b/internal/starlark/output.go
@@ -159,7 +159,6 @@ func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, val
 	return fmt.Errorf("unsupported value type %s for slot %q", value.Type(), slotName)
 }
 
-
 // Path returns a path from the node's slots.
 func (o *Output) Path() string {
 	return o.node.GetSlot("path")

--- a/internal/starlark/plan.go
+++ b/internal/starlark/plan.go
@@ -328,4 +328,3 @@ func extractNodeID(arg starlark.Value, position string) (string, error) {
 
 	return "", fmt.Errorf("%s argument must be an Output or node struct", position)
 }
-

--- a/internal/starlark/platform/darwin.go
+++ b/internal/starlark/platform/darwin.go
@@ -363,8 +363,7 @@ func (d *DarwinPlanBindings) gatherBuiltin(_ *starlark.Thread, _ *starlark.Built
 	return loreStar.NewGather(d.graph, outputs...), nil
 }
 
-// Legacy Go API methods - still use old fields for backward compatibility
-// These are used by internal Go code, not Starlark scripts
+// Go API methods for internal use (not exposed to Starlark scripts)
 
 func (d *DarwinPlanBindings) PackageInstall(packages ...string) *execution.Node {
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -1476,4 +1476,3 @@ func hasDecryptOp(ops []string) bool {
 	}
 	return false
 }
-

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -1020,7 +1020,7 @@ Scope (Home or System) is inferred from the item's location:
 Directories are adopted recursively—all files within are moved and symlinked.
 Existing symlinks within directories are skipped.
 
-With --from-receipt, reads a lore receipt and adopts packages.manifest and
+With --from-receipt, reads a lore receipt and adopts packages-manifest.yaml and
 config files into the environment repository.`,
 		Example: `  # Adopt a single file into personal layer
   writ adopt --project noblefactor ~/.zshrc
@@ -1046,7 +1046,7 @@ config files into the environment repository.`,
 
 	cmd.Flags().String("layer", "personal", "Layer to adopt into: personal, team, or base")
 	cmd.Flags().String("project", "", "Project name within the layer (required)")
-	cmd.Flags().Bool("from-receipt", false, "Adopt packages.manifest and config from lore receipt")
+	cmd.Flags().Bool("from-receipt", false, "Adopt packages-manifest.yaml and config from lore receipt")
 
 	return cmd
 }
@@ -1201,7 +1201,7 @@ func inferScope(filePath, homeDir string) string {
 
 // runAdoptFromReceipt adopts files from a lore receipt.
 func runAdoptFromReceipt(receiptPath, layer, project string, verbose, dryRun bool) error {
-	// TODO: Implement reading lore receipt and adopting packages.manifest + config
+	// TODO: Implement reading lore receipt and adopting packages-manifest.yaml + config
 	if receiptPath == "" {
 		cli.Warn("adopt --from-receipt: not yet implemented (would use most recent receipt)")
 	} else {

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -1202,12 +1202,7 @@ func inferScope(filePath, homeDir string) string {
 // runAdoptFromReceipt adopts files from a lore receipt.
 func runAdoptFromReceipt(receiptPath, layer, project string, verbose, dryRun bool) error {
 	// TODO: Implement reading lore receipt and adopting packages-manifest.yaml + config
-	if receiptPath == "" {
-		cli.Warn("adopt --from-receipt: not yet implemented (would use most recent receipt)")
-	} else {
-		cli.Warn("adopt --from-receipt %s: not yet implemented", receiptPath)
-	}
-	return nil
+	return fmt.Errorf("adopt --from-receipt: not yet implemented")
 }
 
 // adoptFile moves a single file to the project directory and creates a symlink back.
@@ -1324,8 +1319,7 @@ Output is JSON by default for scripting. Use --format for alternatives.`,
   writ inspect noblefactor --format '{{.Name}}\t{{.Source}}'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("inspect: not yet implemented")
-			return nil
+			return fmt.Errorf("inspect: not yet implemented")
 		},
 	}
 
@@ -1339,8 +1333,7 @@ func newListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List available projects for the current target",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("list: not yet implemented")
-			return nil
+			return fmt.Errorf("list: not yet implemented")
 		},
 	}
 	return cmd
@@ -1395,17 +1388,7 @@ of your environment deploystate.`,
   writ receipt show workstation --unified # Include lore software receipts`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := "default"
-			if len(args) > 0 {
-				name = args[0]
-			}
-			unified, _ := cmd.Flags().GetBool("unified")
-			if unified {
-				cli.Note("receipt show %s --unified: not yet implemented", name)
-			} else {
-				cli.Note("receipt show %s: not yet implemented", name)
-			}
-			return nil
+			return fmt.Errorf("receipt show: not yet implemented")
 		},
 	}
 	showCmd.Flags().Bool("unified", false, "Include lore receipts (software + configuration)")
@@ -1415,8 +1398,7 @@ of your environment deploystate.`,
 		Use:   "list",
 		Short: "List available receipts",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.Note("receipt list: not yet implemented")
-			return nil
+			return fmt.Errorf("receipt list: not yet implemented")
 		},
 	})
 

--- a/internal/writ/config.go
+++ b/internal/writ/config.go
@@ -49,7 +49,7 @@ func parseDeployConfig(cmd *cobra.Command, args []string) (*DeployConfig, error)
 	}
 	cfg.LayerSources = layerSources
 
-	// Legacy single-repo mode
+	// Single-repo mode (when no layers configured)
 	if len(layerSources) == 0 {
 		sourceRoot := cli.GetString("writ", "repo", true)
 		if sourceRoot == "" {

--- a/internal/writ/graph_types.go
+++ b/internal/writ/graph_types.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// Sources
 	LayerSources []tree.LayerSource
-	SourceRoot   string // legacy single-repo mode
+	SourceRoot   string // single-repo mode (when no layers configured)
 	TargetRoot   string
 
 	// Selection

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -5,7 +5,6 @@ package migrate
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -31,10 +30,7 @@ type Rename struct {
 
 // Execute performs the directory renames specified in the execution graph.
 // It writes progress to stderr using standard cli output functions.
-// The w parameter is kept for API compatibility but is not used.
-func Execute(w io.Writer, graph *execution.Graph, analysis *MigrationAnalysis) error {
-	_ = w // kept for API compatibility
-
+func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 	// Find rename nodes in the graph
 	var renameNodes []*execution.Node
 	for _, node := range graph.Nodes {

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -17,8 +17,7 @@ import (
 )
 
 // FormatMigrationPlan renders the execution Graph and MigrationAnalysis as
-// human-readable output. This is the derived view that replaces the legacy
-// MigrationPlan struct.
+// human-readable output.
 //
 // Supported formats: "text" (default), "yaml", "json"
 // For "explain" format, use FormatMigrationExplain which requires an AI provider.

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -35,18 +35,18 @@ func FormatMigrationPlan(w io.Writer, graph *execution.Graph, analysis *Migratio
 // migrationView is the combined view for YAML/JSON serialization.
 // Outputs both analysis and execution_graph at the top level as per the plan.
 type migrationView struct {
-	Analysis       *MigrationAnalysis     `json:"analysis" yaml:"analysis"`
-	ExecutionGraph *executionGraphView    `json:"execution_graph" yaml:"execution_graph"`
+	Analysis       *MigrationAnalysis  `json:"analysis" yaml:"analysis"`
+	ExecutionGraph *executionGraphView `json:"execution_graph" yaml:"execution_graph"`
 }
 
 // executionGraphView represents the execution graph for serialization.
 type executionGraphView struct {
-	Version string          `json:"version" yaml:"version"`
-	Tool    string          `json:"tool" yaml:"tool"`
-	State   string          `json:"state" yaml:"state"`
-	Context graphContext    `json:"context,omitempty" yaml:"context,omitempty"`
-	Nodes   []nodeView      `json:"nodes" yaml:"nodes"`
-	Edges   []edgeView      `json:"edges" yaml:"edges"`
+	Version string       `json:"version" yaml:"version"`
+	Tool    string       `json:"tool" yaml:"tool"`
+	State   string       `json:"state" yaml:"state"`
+	Context graphContext `json:"context,omitempty" yaml:"context,omitempty"`
+	Nodes   []nodeView   `json:"nodes" yaml:"nodes"`
+	Edges   []edgeView   `json:"edges" yaml:"edges"`
 }
 
 type graphContext struct {

--- a/internal/writ/migrate/migrate_test.go
+++ b/internal/writ/migrate/migrate_test.go
@@ -457,10 +457,10 @@ type mockProvider struct {
 func (m *mockProvider) Chat(_ context.Context, _ model.ChatRequest) (*model.ChatResponse, error) {
 	return nil, nil
 }
-func (m *mockProvider) Name() string                      { return m.name }
-func (m *mockProvider) Model() string                     { return "test-model" }
-func (m *mockProvider) Endpoint() string                  { return "" }
-func (m *mockProvider) Available(_ context.Context) bool  { return true }
+func (m *mockProvider) Name() string                     { return m.name }
+func (m *mockProvider) Model() string                    { return "test-model" }
+func (m *mockProvider) Endpoint() string                 { return "" }
+func (m *mockProvider) Available(_ context.Context) bool { return true }
 
 func TestLoadInputLimits(t *testing.T) {
 	// LoadInputLimits requires both registry and provider

--- a/internal/writ/migrate/migrate_test.go
+++ b/internal/writ/migrate/migrate_test.go
@@ -362,8 +362,7 @@ func TestExecuteWithMockGraph(t *testing.T) {
 		Edges: []registryEdge{},
 	})
 
-	var buf bytes.Buffer
-	if err := Execute(&buf, graph, analysis); err != nil {
+	if err := Execute(graph, analysis); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
@@ -408,8 +407,7 @@ func TestExecuteConflict(t *testing.T) {
 		Edges: []registryEdge{},
 	})
 
-	var buf bytes.Buffer
-	err := Execute(&buf, graph, analysis)
+	err := Execute(graph, analysis)
 	if err == nil {
 		t.Fatal("Execute should fail when target exists")
 	}

--- a/internal/writ/migrate/plan.go
+++ b/internal/writ/migrate/plan.go
@@ -44,17 +44,17 @@ type ProviderConfig struct {
 
 // ProviderInfo holds configuration for a specific provider.
 type ProviderInfo struct {
-	Description      string      `yaml:"description"`
-	LiteLLMProvider  string      `yaml:"litellm_provider"`   // Maps to litellm_provider in cache
-	MaxInputOverride int         `yaml:"max_input_override"` // Provider-enforced limit (e.g., GitHub)
-	MaxOutputOverride int        `yaml:"max_output_override"`
-	InputLimits      InputLimits `yaml:"input_limits"` // Default limits if model not in cache
+	Description       string      `yaml:"description"`
+	LiteLLMProvider   string      `yaml:"litellm_provider"`   // Maps to litellm_provider in cache
+	MaxInputOverride  int         `yaml:"max_input_override"` // Provider-enforced limit (e.g., GitHub)
+	MaxOutputOverride int         `yaml:"max_output_override"`
+	InputLimits       InputLimits `yaml:"input_limits"` // Default limits if model not in cache
 }
 
 // ModelCache represents the litellm-cache.json structure.
 type ModelCache struct {
-	Meta   ModelCacheMeta          `json:"_meta"`
-	Models map[string]ModelLimits  `json:"models"`
+	Meta   ModelCacheMeta         `json:"_meta"`
+	Models map[string]ModelLimits `json:"models"`
 }
 
 // ModelCacheMeta contains metadata about the cache.
@@ -284,13 +284,13 @@ func buildUserMessage(input *GatherInput) string {
 
 // registryResponse is the JSON structure from the registry migration prompt.
 type registryResponse struct {
-	SourceSystem   string                `json:"source_system"`
-	RepoLayer      string                `json:"repo_layer"`
-	Projects       []registryProject     `json:"projects"`
+	SourceSystem   string                 `json:"source_system"`
+	RepoLayer      string                 `json:"repo_layer"`
+	Projects       []registryProject      `json:"projects"`
 	ExecutionGraph registryExecutionGraph `json:"execution_graph"`
 	// Optional fields that may be included
-	Warnings              []string              `json:"warnings,omitempty"`
-	UnencryptedSecrets    []registrySecret      `json:"unencrypted_secrets,omitempty"`
+	Warnings           []string         `json:"warnings,omitempty"`
+	UnencryptedSecrets []registrySecret `json:"unencrypted_secrets,omitempty"`
 }
 
 type registryProject struct {

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -34,10 +34,10 @@ const (
 type Session struct {
 	opts Options
 
-	state    SessionState
-	step     *console.Step
-	err      error
-	result   *SessionResult
+	state  SessionState
+	step   *console.Step
+	err    error
+	result *SessionResult
 
 	// Analysis results
 	graph    *execution.Graph

--- a/internal/writ/migrate/testdata/fixture/all-Darwin/.zprofile
+++ b/internal/writ/migrate/testdata/fixture/all-Darwin/.zprofile
@@ -1,2 +1,3 @@
+# shellcheck shell=bash
 # macOS zsh profile
 export PATH="$HOME/local/bin:$PATH"

--- a/internal/writ/migrate/testdata/fixture/all-Unix/.bashrc
+++ b/internal/writ/migrate/testdata/fixture/all-Unix/.bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared Unix bashrc
 export EDITOR=vim
 alias ll='ls -la'

--- a/internal/writ/migrate_cmd.go
+++ b/internal/writ/migrate_cmd.go
@@ -209,7 +209,7 @@ func runMigrateBatch(ctx context.Context, opts migrate.Options, layer string, us
 	}
 
 	// Restructure content to writ conventions
-	if err := migrate.Execute(os.Stderr, graph, analysis); err != nil {
+	if err := migrate.Execute(graph, analysis); err != nil {
 		return err
 	}
 

--- a/internal/writ/migrate_cmd.go
+++ b/internal/writ/migrate_cmd.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/internal/console"
-	"github.com/NobleFactor/devlore-cli/internal/model"
 	"github.com/NobleFactor/devlore-cli/internal/lorepackage"
+	"github.com/NobleFactor/devlore-cli/internal/model"
 	"github.com/NobleFactor/devlore-cli/internal/writ/migrate"
 )
 

--- a/internal/writ/reconcile/reconcile.go
+++ b/internal/writ/reconcile/reconcile.go
@@ -159,9 +159,14 @@ func (r *Report) HasIssues() bool {
 
 // FromBuildResult generates status by checking entries in a build result.
 func FromBuildResult(br *tree.BuildResult) *Report {
+	// For multi-source mode, SourceRoot is empty; use first layer's source
+	sourceRoot := br.SourceRoot
+	if sourceRoot == "" && len(br.Sources) > 0 {
+		sourceRoot = br.Sources[0].SourceRoot
+	}
 	report := &Report{
 		TargetRoot:  br.TargetRoot,
-		SourceRoot:  br.SourceRoot,
+		SourceRoot:  sourceRoot,
 		Projects:    br.Projects,
 		FromReceipt: false,
 	}

--- a/internal/writ/root.go
+++ b/internal/writ/root.go
@@ -86,7 +86,7 @@ Declare your environment once — writ deploys it everywhere you work.`,
 	}
 	configInfo := cli.ConfigInfo{
 		Name:          "writ",
-		Schema:        schema.WritSchema,
+		Schema:        schema.DevloreSchema,
 		DefaultConfig: schema.WritDefaultConfig,
 	}
 

--- a/internal/writ/tree/builder.go
+++ b/internal/writ/tree/builder.go
@@ -101,7 +101,7 @@ type Collision struct {
 // BuildConfig holds configuration for building a deployment graph.
 type BuildConfig struct {
 	// SourceRoot is the source directory for single-source mode.
-	// Deprecated: Use Sources for multi-layer support.
+	// For multi-layer support, use Sources instead.
 	SourceRoot string
 
 	// TargetRoot is the target directory (e.g., $HOME).
@@ -135,11 +135,11 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 		return buildMultiSource(cfg)
 	}
 
-	// Single-source mode: backwards compatible
+	// Single-source mode
 	return buildSingleSource(cfg)
 }
 
-// buildSingleSource builds from a single source root (backwards compatible).
+// buildSingleSource builds from a single source root.
 func buildSingleSource(cfg BuildConfig) (*BuildResult, error) {
 	matches, err := segment.MatchDirectories(cfg.SourceRoot, cfg.Projects, cfg.Segments)
 	if err != nil {
@@ -220,11 +220,6 @@ func buildMultiSource(cfg BuildConfig) (*BuildResult, error) {
 		Sources:    cfg.Sources,
 		TargetRoot: cfg.TargetRoot,
 		Projects:   cfg.Projects,
-	}
-
-	// Set SourceRoot to first source for backwards compatibility
-	if len(cfg.Sources) > 0 {
-		result.SourceRoot = cfg.Sources[0].SourceRoot
 	}
 
 	entriesByTarget := make(map[string]fileEntryWithMeta)

--- a/internal/writ/tree/node.go
+++ b/internal/writ/tree/node.go
@@ -11,13 +11,9 @@ import (
 // PackagesManifestFiles are filenames that contain package specifications.
 // These files are processed by the Package Graph Builder to produce package
 // installation nodes in the execution graph.
-//
-// packages-manifest.{yaml,json} is the canonical format.
-// packages.manifest is supported for backward compatibility.
 var PackagesManifestFiles = []string{
 	"packages-manifest.yaml",
 	"packages-manifest.json",
-	"packages.manifest", // legacy
 }
 
 // ProcessingPipeline determines operations from a filename.

--- a/internal/writ/tree/output.go
+++ b/internal/writ/tree/output.go
@@ -19,7 +19,17 @@ func (r *BuildResult) CompactString() string {
 func (r *BuildResult) String() string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Deployment: %s → %s\n\n", r.SourceRoot, r.TargetRoot))
+	// Multi-source mode: show all sources
+	if len(r.Sources) > 0 {
+		sb.WriteString(fmt.Sprintf("Deployment: %d layers → %s\n", len(r.Sources), r.TargetRoot))
+		for _, src := range r.Sources {
+			sb.WriteString(fmt.Sprintf("  %s: %s\n", src.Layer, src.SourceRoot))
+		}
+		sb.WriteString("\n")
+	} else {
+		// Single-source mode
+		sb.WriteString(fmt.Sprintf("Deployment: %s → %s\n\n", r.SourceRoot, r.TargetRoot))
+	}
 	sb.WriteString(fmt.Sprintf("Projects: %s\n\n", strings.Join(r.Projects, ", ")))
 
 	sb.WriteString("Matched directories:\n")

--- a/internal/writ/tree/tree_test.go
+++ b/internal/writ/tree/tree_test.go
@@ -27,7 +27,7 @@ func TestProcessingPipeline(t *testing.T) {
 		{".bashrc", ".bashrc", []Operation{OpLink}},
 		{".bashrc.template", ".bashrc", []Operation{OpRender, OpCopy}},
 		{"config.yaml.template.age", "config.yaml", []Operation{OpDecrypt, OpRender, OpCopy}},
-		{"packages.manifest", "packages.manifest", []Operation{OpPackages}},
+		{"packages-manifest.yaml", "packages-manifest.yaml", []Operation{OpPackages}},
 	}
 
 	for _, tt := range tests {
@@ -229,6 +229,71 @@ func TestBuildWithCollisions(t *testing.T) {
 	}
 
 	t.Logf("Tree output:\n%s", output)
+}
+
+// TestPackagesManifestFiles tests that only valid manifest filenames are recognized.
+// This test ensures that legacy filenames like "packages.manifest" are rejected.
+func TestPackagesManifestFiles(t *testing.T) {
+	// Verify the list contains only the expected valid filenames
+	expected := map[string]bool{
+		"packages-manifest.yaml": true,
+		"packages-manifest.json": true,
+	}
+
+	if len(PackagesManifestFiles) != len(expected) {
+		t.Errorf("PackagesManifestFiles has %d entries, want %d", len(PackagesManifestFiles), len(expected))
+	}
+
+	for _, f := range PackagesManifestFiles {
+		if !expected[f] {
+			t.Errorf("unexpected filename in PackagesManifestFiles: %q", f)
+		}
+	}
+
+	// Verify legacy filenames are NOT in the list
+	legacyFiles := []string{
+		"packages.manifest",
+		"packages.yaml",
+		"manifest.yaml",
+		"packages.json",
+	}
+
+	for _, legacy := range legacyFiles {
+		for _, valid := range PackagesManifestFiles {
+			if legacy == valid {
+				t.Errorf("legacy filename %q should NOT be in PackagesManifestFiles", legacy)
+			}
+		}
+	}
+}
+
+// TestProcessingPipeline_ManifestFilenames tests that only valid manifest filenames
+// trigger the OpPackages operation, and legacy filenames are treated as regular files.
+func TestProcessingPipeline_ManifestFilenames(t *testing.T) {
+	tests := []struct {
+		filename    string
+		wantOps     bool // true if should get OpPackages
+		description string
+	}{
+		{"packages-manifest.yaml", true, "valid YAML manifest"},
+		{"packages-manifest.json", true, "valid JSON manifest"},
+		{"packages.manifest", false, "legacy filename must be rejected"},
+		{"packages.yaml", false, "invalid manifest name"},
+		{"manifest.yaml", false, "invalid manifest name"},
+		{"packages-manifest.yml", false, "wrong extension"},
+		{"PACKAGES-MANIFEST.YAML", false, "case-sensitive check"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			_, ops := ProcessingPipeline(tt.filename)
+			hasPackages := ops.HasPackages()
+			if hasPackages != tt.wantOps {
+				t.Errorf("ProcessingPipeline(%q) HasPackages() = %v, want %v (%s)",
+					tt.filename, hasPackages, tt.wantOps, tt.description)
+			}
+		})
+	}
 }
 
 func TestOperationHelpers(t *testing.T) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -36,15 +36,3 @@ var WritDefaultConfig []byte
 //go:embed packages-manifest.json
 var PackagesManifestSchema []byte
 
-// LifecycleSchema is provided by internal/lorepackage for backward compatibility.
-// Prefer using lorepackage.LifecycleSchema directly.
-// TODO: Remove this re-export once callers are updated.
-//
-//go:embed lifecycle.json
-var LifecycleSchema []byte
-
-// Legacy aliases for backward compatibility.
-var (
-	LoreSchema = DevloreSchema
-	WritSchema = DevloreSchema
-)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -35,4 +35,3 @@ var WritDefaultConfig []byte
 //
 //go:embed packages-manifest.json
 var PackagesManifestSchema []byte
-


### PR DESCRIPTION
## Summary

This PR addresses errors in judgment documented in issue #65. The primary fixes are:

1. **20 stub functions now return errors instead of false success**
2. **Legacy code removal** (schema aliases, compat patterns)
3. **GCP KMS verify implementation** (was returning success without verification)
4. **Session protocol added to CLAUDE.md**
5. **Self command plan** for `self install` / `self upgrade` (#83)

## Changes

### Self Command Plan (commit 10f7ba4)

Added `docs/plans/self-command.md` specifying:
- `self install` - generate completions, man pages, config (has `--prefix`, offline)
- `self upgrade` - check and download latest LKG (no `--prefix`, in-place, network)
- Matches star's command structure in noblefactor-ops

### Stub Functions Fixed (commit e7199a9)

Commands that printed "not yet implemented" but returned `nil` (success) now return proper errors:

**Lore CLI** (15 commands):
- `upgrade`, `decommission`, `reconcile`, `bundle`
- `manifest create`, `manifest validate`, `manifest test`, `manifest show`, `manifest update`
- `list`, `resolve`, `update`, `inspect`, `publish`, `audit`

**Writ CLI** (5 commands):
- `adopt --from-receipt`
- `inspect`, `list`
- `receipt show`, `receipt list`

### Legacy Code Removed (commit 2957540)

- Removed `LoreSchema`/`WritSchema` aliases from `schema/schema.go`
- Removed unused imports and dead code paths
- Cleaned up legacy filename references

### GCP KMS Verify (commit 2957540)

- `gcp_kms.go`: Now performs actual signature verification
- Added comprehensive tests in `gcp_kms_test.go`

### Session Protocol (commit b9857de)

- Added error tracking protocol to `CLAUDE.md`
- Reference to issue #65 for verification checklist

## Files Changed

- `docs/plans/self-command.md` - New plan for self install/upgrade
- `internal/lore/commands.go` - 15 stub functions return errors
- `internal/writ/commands.go` - 5 stub functions return errors
- `internal/signing/gcp_kms.go` - Actual verification implementation
- `internal/signing/gcp_kms_test.go` - New test file (331 lines)
- `schema/schema.go` - Removed legacy aliases
- `CLAUDE.md` - Session protocol for error tracking

## Open Issues Summary

Issues created during this error scan session:

| # | Title | Functional Area | Error Category |
|---|-------|-----------------|----------------|
| **65** | Claude Code: Errors of Judgment | Meta | Tracking |
| **70** | Implement `writ adopt --from-receipt` | Writ CLI | Stub returning false success |
| **71** | Implement lore lifecycle commands | Lore CLI | Stub returning false success |
| **72** | Implement lore manifest commands | Lore CLI | Stub returning false success |
| **73** | Implement lore registry commands | Lore CLI | Stub returning false success |
| **74** | Implement writ commands | Writ CLI | Stub returning false success |
| **75** | Fix ignored errors in security-sensitive operations | Error Handling | Ignored errors |
| **76** | Logging strategy | Architecture | Design gap |
| **77** | Claude lied about implementing `--verbosity` flag | CLI Flags | Fabricated implementation |
| **78** | Claude lied about verifying config precedence rollup | Testing | Fabricated verification |
| **79** | Unify configuration: single path for all CLI options | Architecture | Design defect |
| **80** | Fix golangci-lint failures (236 issues) | Code Quality | Pre-existing debt |
| **82** | Versioning with timestamps and commit hashes | Release | New requirement |
| **83** | Self command with install and upgrade | CLI | New requirement |

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Pre-commit checks (236 pre-existing lint issues documented in #80)

## Related Issues

Closes #65 (tracking issue remains open for future errors)

References: #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80, #82, #83