### PR TITLE
feat(star): update extensions to use file.walk_tree()

### DIFF
--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/build-modelfile.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/build-modelfile.star
@@ -101,21 +101,21 @@ def _build_section(asset_dir, section_name, extension):
     return "\n".join(lines)
 
 
-def _list_asset_files(dir_path, extension):
-    """List files in directory matching extension."""
-    files = []
+def _list_asset_files(dir_path, extension=""):
+    """List files in directory matching extension (non-recursive)."""
     if not file.exists(dir_path):
-        return files
+        return []
 
-    for entry in file.list(dir_path):
+    files = []
+    def collect(entry):
         if entry.is_dir:
-            continue
+            return "skip"
         if entry.name.startswith("."):
-            continue
+            return
         if extension and not entry.name.endswith(extension):
-            continue
+            return
         files.append(entry.name)
-
+    file.walk_tree(root=dir_path, callback=collect)
     return sorted(files)
 
 

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index-domains.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index-domains.star
@@ -22,18 +22,17 @@ ASSET_TYPES = ["prompts", "schemas", "examples", "transforms", "signatures", "sl
 
 def list_files(dir_path):
     """List all files in a directory (non-recursive)."""
-    files = []
     if not file.exists(dir_path):
-        return files
+        return []
 
-    for entry in file.list(dir_path):
+    files = []
+    def collect(entry):
         if entry.is_dir:
-            continue
-        # Skip hidden files
+            return "skip"
         if entry.name.startswith("."):
-            continue
+            return
         files.append(entry.name)
-
+    file.walk_tree(root=dir_path, callback=collect)
     return sorted(files)
 
 def build_asset_entries(dir_path):

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index-packages.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index-packages.star
@@ -34,36 +34,44 @@ def parse_lifecycle(content):
 
 def scan_packages(packages_dir):
     """Scan packages directory and collect metadata."""
-    packages = []
+    # Collect package dirs and variant dirs in a single walk.
+    # Depth 1 = package dir, depth 2 = variant dir.
+    pkg_dirs = []     # [(name, abs_path)]
+    variant_map = {}  # pkg_name -> [variant_name]
 
-    for entry in file.list(packages_dir):
+    def collect(entry):
         if not entry.is_dir:
-            continue
+            return
+        depth = entry.path.count("/") + 1
+        if depth == 1:
+            pkg_dirs.append((entry.name, file.join(packages_dir, entry.path)))
+        elif depth == 2 and not entry.name.startswith("."):
+            parent = entry.path.split("/")[0]
+            if parent not in variant_map:
+                variant_map[parent] = []
+            variant_map[parent].append(entry.name)
+            return "skip"
+        elif depth > 2:
+            return "skip"
 
-        lifecycle_path = file.join(entry.path, "lifecycle.yaml")
+    file.walk_tree(root=packages_dir, callback=collect)
+
+    packages = []
+    for pkg_name, pkg_path in pkg_dirs:
+        lifecycle_path = file.join(pkg_path, "lifecycle.yaml")
         if not file.exists(lifecycle_path):
-            warn("Skipping " + entry.name + " (no lifecycle.yaml)")
+            warn("Skipping " + pkg_name + " (no lifecycle.yaml)")
             continue
 
         content = file.read(lifecycle_path)
         pkg = parse_lifecycle(content)
         if pkg == None:
-            warn("Skipping " + entry.name + " (invalid lifecycle.yaml)")
+            warn("Skipping " + pkg_name + " (invalid lifecycle.yaml)")
             continue
 
-        # Add directory name for reference
-        pkg["dir"] = entry.name
-
-        # Check for README
-        readme_path = file.join(entry.path, "README.md")
-        pkg["has_readme"] = file.exists(readme_path)
-
-        # List available platform variants
-        variants = []
-        for subentry in file.list(entry.path):
-            if subentry.is_dir and not subentry.name.startswith("."):
-                variants.append(subentry.name)
-        pkg["variants"] = variants
+        pkg["dir"] = pkg_name
+        pkg["has_readme"] = file.exists(file.join(pkg_path, "README.md"))
+        pkg["variants"] = variant_map.get(pkg_name, [])
 
         packages.append(pkg)
         note("Found: " + pkg["name"] + " v" + pkg["version"])

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
@@ -46,33 +46,26 @@ def matches_type_filter(schema_type, type_filter):
 
 def find_files(target, pattern):
     """Find files matching a glob-like pattern."""
-    files = []
-
-    # Handle patterns with wildcards
-    if "*" in pattern:
-        parts = pattern.split("/")
-        base_path = target
-
-        # Find the directory containing the wildcard
-        for i, part in enumerate(parts):
-            if "*" in part:
-                # Scan this directory
-                remaining = "/".join(parts[i+1:])
-                if file.exists(base_path) and file.is_directory(base_path):
-                    for entry in file.list(base_path):
-                        if entry.is_dir and part == "*":
-                            candidate = file.join(entry.path, remaining)
-                            if file.exists(candidate):
-                                files.append(candidate)
-                break
-            else:
-                base_path = file.join(base_path, part)
-    else:
-        # No wildcard - direct file
+    if "*" not in pattern:
         path = file.join(target, pattern)
-        if file.exists(path):
-            files.append(path)
+        return [path] if file.exists(path) else []
 
+    parts = pattern.split("/")
+    filename = parts[-1]
+    search_root = target
+    for part in parts:
+        if "*" in part:
+            break
+        search_root = file.join(search_root, part)
+
+    if not file.exists(search_root) or not file.is_directory(search_root):
+        return []
+
+    files = []
+    def collect(entry):
+        if not entry.is_dir and entry.name == filename:
+            files.append(file.join(search_root, entry.path))
+    file.walk_tree(root=search_root, callback=collect)
     return files
 
 def validate_file(file_path, schema_json):


### PR DESCRIPTION
## Summary

- Update all four Knowledge extension commands to use the new `file.walk_tree()` API instead of manual `file.list()` loops
- `validate.star`: `find_files()` uses `walk_tree` for wildcard pattern matching, replacing nested `file.list()` + manual `*` matching
- `index-packages.star`: `scan_packages()` uses single `walk_tree` pass with depth-based package/variant detection, replacing two nested `file.list()` loops
- `build-modelfile.star` and `index-domains.star`: `_list_asset_files()` / `list_files()` use `walk_tree` with `"skip"` return for non-recursive directory listing

**Depends on:** NobleFactor/noblefactor-ops#59 (adds `file.walk_tree()` to the star runtime)

## Test plan

- [x] `go test ./...` — all 22 devlore-cli packages pass
- [ ] Run `star devlore knowledge validate` against devlore-registry (if available)
- [ ] Run `star devlore knowledge index packages` against devlore-registry
- [ ] Run `star devlore knowledge index domains` against devlore-registry
- [ ] Run `star devlore knowledge build modelfile` against devlore-registry