### PR TITLE
docs: GenReceiver extension and graph execution model plan

### DIFF
--- a/docs/plans/star-gen-receiver.md
+++ b/docs/plans/star-gen-receiver.md
@@ -37,6 +37,178 @@ files ready to compile.
 | Real-time receivers | Manual | `receiver_git.go` etc. written by hand |
 | Dict-based receiver ban | Enforced | `TestNoDictBasedReceivers` catches violations in CI |
 
+## Graph Execution Model
+
+### Single-Operation Nodes
+
+Each node executes exactly one operation. `Node.Operations []string` is replaced by
+`Node.Operation string`. Chained operations (e.g., decrypt → expand → copy) are
+expressed as separate nodes connected by edges, with data flowing through
+slots and promises — the same mechanism used for all inter-node data binding.
+
+This eliminates the implicit `[]byte` accumulator in the executor pipeline loop.
+The plan receiver is responsible for decomposing multi-step workflows into
+individual nodes with edges between them.
+
+### Implementation-to-Node Mapping
+
+The mapping from Go implementation structs to graph nodes is fully mechanical
+and discovered from the source:
+
+| Implementation | Graph Concept | Example |
+|---|---|---|
+| Struct name | Node category | `FileOps` → `file` |
+| Method name | Node operation | `FileOps.Copy` → `file.copy` |
+| Node ID | `category.name-N` | `file.copy-1`, `file.copy-2` |
+| Method params | Input slots | `(source, path string)` → slots `source`, `path` |
+| Return value | Output edge | → edge to named slot on downstream node |
+
+**Node ID**: The `-N` suffix is an auto-incrementing counter that tracks
+how many nodes of a given category/name exist in the execution graph.
+
+**Input slots** are filled by either:
+- An edge (promise from an upstream node's output)
+- A literal value provided at plan time
+
+**Output** is the fulfillment of a promise. When a downstream node has an
+input slot that references this node, the executor resolves the promise
+via the edge.
+
+### Name Normalization
+
+All Go names are normalized to snake_case for Starlark and graph identifiers:
+
+| Go Name | Starlark / Graph Name |
+|---|---|
+| `File` | `file` |
+| `Copy` | `copy` |
+| `WalkTree` | `walk_tree` |
+| `ConfigGet` | `config_get` |
+| `PackageInstall` | `package_install` |
+
+This applies to: category names, operation names, slot names, and Starlark
+method names.
+
+### Error Handling
+
+Error handling follows the PowerShell `ErrorActionPreference` model. Each node
+declares how errors propagate via a per-node `ErrorAction` field:
+
+```go
+ErrorAction ErrorAction `json:"error_action" yaml:"error_action"`
+```
+
+| ErrorAction | Behavior |
+|---|---|
+| `ErrorActionStop` | Node fails → graph stops, no downstream nodes execute |
+| `ErrorActionContinue` | Node fails → log error, skip dependent downstream nodes (unfulfilled promise), independent branches continue |
+| `ErrorActionSilent` | Same as Continue but suppress error output |
+
+This replaces and subsumes the current `ConflictResolution` on `ExecutorOptions`.
+A conflict is an error from the operation — the node's `ErrorAction` determines
+what happens next. The executor loop checks the failing node's `ErrorAction`
+instead of a global `ConflictResolution` setting.
+
+Operations return `(value, error)`. The value flows through the output edge
+to downstream nodes. The error is processed according to the node's `ErrorAction`.
+When a node with `ErrorActionContinue` fails, the executor skips all downstream
+nodes whose input slots reference the failed node's output (promise unfulfilled),
+but independent branches of the graph continue executing.
+
+### Implementation Struct Contract
+
+Implementation structs are the source of truth for code generation. The generator
+enforces two hard constraints — violation is a generator error, not a TODO.
+
+**Gate 1: All types must map to Starlark.** Every parameter type and return type
+must resolve to a concrete Starlark type. If a method has a parameter or return
+type outside the supported set, the generator errors and reports the method name
+and the unmappable type.
+
+Supported type mappings:
+
+| Go Type | Starlark Type | Direction |
+|---|---|---|
+| `string` | `starlark.String` | param + return |
+| `bool` | `starlark.Bool` | param + return |
+| `int`, `int64` | `starlark.Int` | param + return |
+| `[]string` | `*starlark.List` | param + return |
+| `...string` | positional `*args` | param only |
+
+Any type outside this set → generator error.
+
+**Gate 2: Return signature must be `(T, error)`.** Every method returns
+exactly one value and one error — standard Go convention, no exceptions:
+
+| Return Signature | Meaning |
+|---|---|
+| `(string, error)` | Value flows through output edge, error checked by `ErrorAction` |
+| `(bool, error)` | Same |
+| `(int, error)` | Same |
+| `([]string, error)` | Same |
+| `(MyStruct, error)` | Struct value → generated Starlark struct type (see below) |
+
+Methods with any other return shape — `error` alone, `(string, int, error)`,
+`([]byte, error)`, no return — are rejected. Generator error.
+
+The implementation struct is a contract. If a method doesn't fit the mold,
+the generator rejects it and tells you exactly what failed. No partial output,
+no placeholders.
+
+### Starlark Struct Types
+
+When an implementation method returns `(SomeStruct, error)`, the generator
+must produce a matching Starlark struct type. These types are data structs
+(read-only attribute bags), not namespace receivers.
+
+**Canonical location**: `internal/starlark/types.go` for hand-written types,
+`internal/starlark/types_gen.go` for generator output.
+
+**Create-once semantics**: Starlark struct types are stable artifacts. They
+are generated or hand-written once, then reused across all receivers that
+return the same Go struct. The generator checks whether a converter already
+exists before creating one:
+
+1. If `types.go` or `types_gen.go` already has a converter for the return
+   struct → the generator references it in the generated receiver code.
+2. If no converter exists → the generator creates one in `types_gen.go`.
+3. Once created, the type definition may be hand-tuned (renamed fields,
+   convenience methods, etc.) without being overwritten by subsequent runs.
+
+This prevents duplication — many methods across different receivers return
+`host.Result`, but the Starlark type for it exists exactly once.
+
+Currently, result structs are scattered as inline `FromStringDict` calls:
+- `resultToStarlark()` in `bindings.go` (converts `host.Result`)
+- Inline in `receiver_git.go`, `receiver_docker.go`, `receiver_npm.go`
+
+The generator consolidates this. Example for `host.Result`:
+
+```go
+// resultToStarlark converts host.Result to a Starlark struct.
+// Generated from host.Result by gen.receiver.
+func resultToStarlark(r host.Result) *starlarkstruct.Struct {
+    return starlarkstruct.FromStringDict(starlark.String("result"), starlark.StringDict{
+        "ok":     starlark.Bool(r.OK),
+        "stdout": starlark.String(r.Stdout),
+        "stderr": starlark.String(r.Stderr),
+        "code":   starlark.MakeInt(r.Code),
+    })
+}
+```
+
+The generator inspects the Go struct's fields (via `go.structs()`) and
+applies Gate 1 recursively — every field must map to a Starlark type.
+Structs with unmappable fields → generator error.
+
+| Go Struct Field Type | Starlark Struct Field |
+|---|---|
+| `string` | `starlark.String` |
+| `bool` | `starlark.Bool` |
+| `int`, `int64` | `starlark.MakeInt` |
+| `[]string` | `starlark.NewList(...)` |
+| _(unmapped)_ | **generator error** |
+
 ## Requirements
 
 ### Prerequisite: Extend `go.methods()` and `go.funcs()` with Parameter Info
@@ -80,19 +252,29 @@ Templates live as raw string constants in a new file:
 | `bool` | `starlark.Bool` | `FillSlot()` | `node.GetSlot("x") == "true"` |
 | `int` / `int64` | `starlark.Int` | `FillSlot()` | `strconv.Atoi(node.GetSlot("x"))` |
 | `[]string` | `*starlark.List` | `FillSlot()` | `strings.Split(node.GetSlot("x"), ",")` |
-| `...string` (variadic) | positional `*args` | join -> single slot | `strings.Split()` |
-| complex/interface | **skip** — emit TODO | — | — |
+| `...string` (variadic) | positional `*args` | join → single slot | `strings.Split()` |
+| Go struct (return only) | Generated Starlark struct (`types_gen.go`) | — | — |
+| _(unmapped type)_ | **generator error** | — | — |
 
 #### Template 1: Plan Receiver
 
-Each method: unpacks Starlark args, creates `*execution.Node`, fills slots, appends
-to graph, returns `NewOutput()`. Reference: `devlore-cli/internal/starlark/plan_file.go`
+Each method: unpacks Starlark args, creates `*execution.Node` with a single
+`Operation` derived from the struct/method name, fills input slots from args,
+appends node to graph, returns promise. When the Starlark script chains
+operations (e.g., passes a promise as an arg), the plan receiver creates
+an edge between the upstream and downstream nodes.
+
+Reference: `devlore-cli/internal/starlark/plan_file.go`
 
 #### Template 2: Graph Operations
 
-Each operation: implements `Operation` interface, reads slots, handles `DryRun`,
-emits TODO placeholder for backing implementation call. Registration function returns
-all ops. Reference: `devlore-cli/internal/execution/ops_package.go`
+Each operation: implements the appropriate `Operation` interface (`Transform`,
+`Writer`, or `Direct`) based on its category. Reads input slots, handles
+`DryRun`, calls backing implementation, returns `(value, error)`. The value
+flows through the output edge; the error is processed by the executor
+according to the node's `ErrorAction`. Registration function returns all ops.
+
+Reference: `devlore-cli/internal/execution/ops_package.go`
 
 #### Template 3: Real-time Receiver
 
@@ -105,12 +287,15 @@ args, call backing impl, convert result. Reference: `devlore-cli/internal/starla
 |---|---|---|
 | Plan receiver struct | `XxxPlan` | `FilePlan`, `GitPlan` |
 | Generated plan file | `plan_xxx_gen.go` | `plan_file_gen.go` |
-| Op struct | `XxxYyyOp` | `FileConfigureOp` |
-| Op name | `"namespace-method"` | `"file-copy"` |
+| Op struct | `XxxYyyOp` | `FileCopyOp` |
+| Op name | `"category.method"` | `"file.copy"` |
 | Generated ops file | `ops_xxx_gen.go` | `ops_file_gen.go` |
+| Ops registration | `XxxOps() []Operation` | `FileOps()` |
 | Real-time struct | `XxxReceiver` | `GitReceiver` |
 | Generated receiver file | `receiver_xxx_gen.go` | `receiver_git_gen.go` |
-| Starlark method | `snake_case(GoMethod)` | `ConfigGet` -> `config_get` |
+| Starlark method | `snake_case(GoMethod)` | `ConfigGet` → `config_get` |
+| Slot name | `snake_case(param)` | `SourceRoot` → `source_root` |
+| Node ID | `category.name-N` | `file.copy-1` |
 
 ### Skip List
 
@@ -127,14 +312,133 @@ noblefactor-ops/star/extensions/com.noblefactor.star.GenReceiver/
 ```
 
 The `.star` command orchestrates:
-1. `go.methods(path, receiver_type=struct_name)` -> get methods with params
+1. `go.methods(path, receiver_type=struct_name)` → get methods with params
 2. Filter: public methods only, optional `--methods` inclusion list
-3. Build descriptor dict with method info, namespace, type mappings
-4. `go.generate("plan_receiver", descriptor)` -> write to `plan_xxx_gen.go`
-5. `go.generate("graph_ops", descriptor)` -> write to `ops_xxx_gen.go`
-6. `go.generate("realtime_receiver", descriptor)` -> write to `receiver_xxx_gen.go`
+3. Normalize names: struct → category (snake_case), methods → operations (snake_case)
+4. Build descriptor dict with method info, namespace, type mappings
+5. `go.generate("plan_receiver", descriptor)` → write to `plan_xxx_gen.go`
+6. `go.generate("graph_ops", descriptor)` → write to `ops_xxx_gen.go`
+7. `go.generate("realtime_receiver", descriptor)` → write to `receiver_xxx_gen.go`
+
+## Execution Model Changes
+
+### `Node.Operation` (singular)
+
+The `Node` struct changes from:
+
+```go
+Operations []string `json:"operations" yaml:"operations"`
+```
+
+to:
+
+```go
+Operation string `json:"operation" yaml:"operation"`
+```
+
+The executor no longer loops over operations. Each node runs one operation.
+Error handling is per-node via `ErrorAction`:
+
+```go
+func (e *GraphExecutor) executeNode(ctx *Context, node Executable) *Result {
+    op, ok := e.registry.Get(node.GetOperation())
+    if !ok {
+        return &Result{Status: ResultFailed, Error: ...}
+    }
+
+    var value any
+    var err error
+    switch typed := op.(type) {
+    case Transform:
+        value, err = typed.Transform(ctx, node, content)
+    case Writer:
+        value, err = typed.Write(ctx, node, content)
+    case Direct:
+        err = typed.Execute(ctx, node)
+    }
+
+    if err != nil {
+        switch node.GetErrorAction() {
+        case ErrorActionStop:
+            return &Result{Status: ResultFailed, Error: err}
+        case ErrorActionContinue:
+            log(err)
+            return &Result{Status: ResultFailed, Error: err}
+        case ErrorActionSilent:
+            return &Result{Status: ResultFailed, Error: err}
+        }
+    }
+    // value flows through output edge to downstream nodes
+}
+```
+
+### Chained operations become node chains
+
+A plan receiver that previously created:
+
+```go
+node := &execution.Node{
+    Operation: "render",  // old: Operations: []string{"render", "copy"}
+}
+```
+
+Now creates two nodes with an edge:
+
+```go
+renderNode := &execution.Node{ID: "file.render-1", Operation: "render", ...}
+copyNode   := &execution.Node{ID: "file.copy-1",   Operation: "copy", ...}
+// copyNode's "content" slot is a promise referencing renderNode's output
+// Edge: renderNode → copyNode
+```
 
 ## Implementation Phases
+
+### Phase 0: Single-Operation Node Migration (devlore-cli)
+
+- [ ] Change `Node.Operations []string` to `Node.Operation string`
+- [ ] Update `Executable` interface: `GetOperations()` → `GetOperation()`
+- [ ] Update executor to remove pipeline loop
+- [ ] Add `ErrorAction` field to `Node`
+- [ ] Replace `ConflictResolution` on `ExecutorOptions` with per-node `ErrorAction`
+- [ ] Update executor error handling: check failing node's `ErrorAction`, skip dependent downstream nodes on `Continue`/`Silent`
+- [ ] Update lore plan receivers to emit node chains for multi-step workflows
+- [ ] Update writ graph builder to emit node chains instead of operation lists
+- [ ] Update writ reconciler to emit node chains
+- [ ] Update stateview and history to use singular `Operation`
+- [ ] Consolidate scattered `FromStringDict` result converters into `types.go`
+- [ ] Update all existing tests
+
+The only multi-op patterns in the codebase are `["render", "copy"]` and
+`["decrypt", "render", "copy"]` — the writ template expansion pipeline.
+These become node chains: `render → copy` or `decrypt → render → copy`,
+with edges carrying content between them.
+
+**Files**:
+
+| File | Action |
+|---|---|
+| `internal/execution/graph.go` | Modify (`Operation` singular, `GetOperation()`, add `ErrorAction`) |
+| `internal/execution/executor.go` | Simplify (no pipeline loop), replace `ConflictResolution` with per-node `ErrorAction` |
+| `internal/execution/operation.go` | No change (interfaces unchanged) |
+| `internal/starlark/types.go` | Create (consolidate `resultToStarlark` and other struct converters) |
+| `internal/execution/stateview.go` | Modify (singular `Operation`) |
+| `internal/execution/plan.go` | Modify (singular `Operation`) |
+| `internal/starlark/plan_file.go` | Modify (emit node chains for `configure`) |
+| `internal/starlark/plan.go` | Modify (singular, chain for `configure`) |
+| `internal/starlark/platform/darwin.go` | Modify (emit node chains) |
+| `internal/starlark/platform/linux.go` | Modify (emit node chains) |
+| `internal/starlark/platform/windows.go` | Modify (emit node chains) |
+| `internal/starlark/platform/common.go` | Modify (singular `Operation`) |
+| `internal/writ/graph_builder.go` | Modify (emit node chains) |
+| `internal/writ/reconcile/reconcile.go` | Modify (emit node chains) |
+| `internal/writ/tree/builder.go` | Modify (singular `Operation`) |
+| `internal/writ/tree/operation.go` | Modify (singular `Operation`) |
+| `internal/writ/commands.go` | Modify (singular `Operation`) |
+| `internal/writ/migrate/format.go` | Modify (singular `Operation`) |
+| `internal/execution/*_test.go` | Update |
+| `internal/writ/*_test.go` | Update |
+| `internal/lore/*_test.go` | Update |
+| `docs/architecture/*.md` | Update |
 
 ### Phase 1: Extend GoReceiver AST Primitives (noblefactor-ops)
 
@@ -151,17 +455,20 @@ The `.star` command orchestrates:
 
 ### Phase 2: Add `go.generate()` with Templates (noblefactor-ops)
 
-- [ ] Create template constants for all three receiver types
-- [ ] Implement `go.generate()` method with type mapping
+- [ ] Create template constants for all three receiver types + struct type template
+- [ ] Implement `go.generate()` method with type mapping and name normalization
+- [ ] Implement Gate 1 (all types must map) and Gate 2 (`(T, error)` return) validation
+- [ ] Generate Starlark struct types for Go struct return values into `types_gen.go`
 - [ ] Add `"generate"` to `Attr()`/`AttrNames()`
 - [ ] Test each template against known patterns
+- [ ] Test gate enforcement: verify generator errors on unmapped types and invalid return shapes
 
 **Files**:
 
 | File | Action |
 |---|---|
-| `internal/starlark/receiver_go_gen.go` | Create |
-| `internal/starlark/receiver_go_gen_test.go` | Create |
+| `internal/starlark/receiver_go_gen.go` | Create (templates + generate method + gate validation) |
+| `internal/starlark/receiver_go_gen_test.go` | Create (template tests + gate enforcement tests) |
 | `internal/starlark/receiver_go.go` | Modify |
 
 ### Phase 3: Create the Star Extension (noblefactor-ops)
@@ -179,9 +486,9 @@ The `.star` command orchestrates:
 
 ### Phase 4: Validate Against Existing Hand-Written Code
 
-- [ ] Run `star gen.receiver` against devlore-cli's `FilePlan` -> diff with `plan_file.go`
-- [ ] Run against `PackageInstallOp` -> diff with `ops_package.go`
-- [ ] Run against `GitReceiver` -> diff with `receiver_git.go`
+- [ ] Run `star gen.receiver` against devlore-cli's `FilePlan` → diff with `plan_file.go`
+- [ ] Run against `PackageInstallOp` → diff with `ops_package.go`
+- [ ] Run against `GitReceiver` → diff with `receiver_git.go`
 - [ ] Adjust templates until generated output matches hand-written patterns
 
 ## Integration


### PR DESCRIPTION
## Summary

- Comprehensive plan for `com.noblefactor.star.GenReceiver` — a star extension that generates plan receivers, graph operations, and real-time receivers from Go implementation structs
- Defines the graph execution model: single-operation nodes, implementation-to-node mapping, name normalization (Go CamelCase → snake_case)
- Per-node error handling modeled after PowerShell's `ErrorActionPreference` (Stop, Continue, Silent), replacing the global `ConflictResolution`
- Implementation struct contract with two hard gates: all types must map to Starlark (Gate 1), return signature must be `(T, error)` (Gate 2)
- Create-once Starlark struct types in `types.go` / `types_gen.go` — generated once, reused across receivers
- Five implementation phases: Phase 0 (single-op node migration in devlore-cli), Phases 1-4 (AST primitives, templates, extension, validation in noblefactor-ops)

## Test plan

- [ ] Plan document reviewed for completeness and accuracy
- [ ] No code changes — documentation only