### PR TITLE
refactor(execution): single-operation node migration

### DIFF
--- a/docs/plans/star-gen-receiver.md
+++ b/docs/plans/star-gen-receiver.md
@@ -50,6 +50,33 @@ This eliminates the implicit `[]byte` accumulator in the executor pipeline loop.
 The plan receiver is responsible for decomposing multi-step workflows into
 individual nodes with edges between them.
 
+### Typed Operation Results
+
+Operations carry their own input/output contracts as typed objects rather than
+relying on generic fields on `Node`. Currently, `Node` has `SourceChecksum` and
+`TargetChecksum` fields — but checksums are only meaningful for specific operations
+(e.g., `copy` produces a target checksum, `render` produces a source checksum,
+`link` produces neither). Generic fields on every node conflate the node's
+structural identity with operation-specific state.
+
+The executor's `Result` type should return a typed result object per operation.
+Each operation defines what data it produces:
+
+| Operation | Result Data |
+|---|---|
+| `copy` | `TargetChecksum string` |
+| `render` | `SourceChecksum string`, rendered content (flows via outputs map) |
+| `link` | (none — symlink has no content checksum) |
+| `package_install` | installed version, package manager used |
+
+The node stores the operation's result object (serialized to the receipt), not
+a fixed set of checksum fields. This generalizes: any operation-specific state
+(checksums, versions, paths created, etc.) lives in the operation's typed result,
+not in generic node fields.
+
+This aligns with the code generator: the generator reads the operation struct's
+return type and produces the correct serialization. No hand-maintained field lists.
+
 ### Implementation-to-Node Mapping
 
 The mapping from Go implementation structs to graph nodes is fully mechanical

--- a/docs/plans/star-gen-receiver/phase-0.md
+++ b/docs/plans/star-gen-receiver/phase-0.md
@@ -1,0 +1,247 @@
+# Phase 0: Single-Operation Node Migration
+
+## Context
+
+The plan document at `docs/plans/star-gen-receiver.md` defines a Graph Execution Model
+where each node performs exactly one operation. This is a prerequisite for code generation
+-- the generator needs a 1:1 mapping between implementation methods and graph nodes.
+
+Currently, nodes support multi-op pipelines (e.g., `Operations: ["render", "copy"]`).
+This prevents 1:1 mapping and bakes implicit ordering into a single node. The migration
+changes `Node.Operations []string` to `Node.Operation string`. Multi-op pipelines become
+node chains connected by edges, with content flowing between them.
+
+**Scope**: Structural migration only. ErrorAction (replacing ConflictResolution) is a
+separate follow-up PR -- it's an orthogonal concern and keeping it separate makes each
+PR reviewable.
+
+## Step 1: Core Struct Changes (`internal/execution/graph.go`)
+
+| Change | Before | After |
+|---|---|---|
+| Node field | `Operations []string` | `Operation string` |
+| JSON/YAML tag | `operations` | `operation` |
+| Executable interface | `GetOperations() []string` | `GetOperation() string` |
+| Node method | `GetOperations() []string` | `GetOperation() string` |
+| ComputeSummary | `n.Operations[0]` | `n.Operation` |
+| Graph version constant | (lives in graph_builder.go) | bump `"5"` → `"6"` |
+
+Also update `CanonicalContent()` if it references Operations.
+
+## Step 2: Executor — Remove Pipeline Loop, Add Content Flow (`internal/execution/executor.go`)
+
+**Current** (`executeExecutable`, line 188): iterates `node.GetOperations()` in a pipeline
+loop, accumulating `content []byte` across transforms.
+
+**New**: Single operation dispatch per node. Content flows between chained nodes via an
+`outputs map[string][]byte` maintained by the executor during `Run()`.
+
+```
+Run():
+  outputs := map[string][]byte{}
+  for _, node := range ordered:
+    result := executeNode(ctx, node, g.Edges, outputs)
+    // ...
+
+executeNode(ctx, node, edges, outputs):
+  op := registry.Get(node.Operation)
+
+  // Resolve input content
+  var content []byte
+  if upstream := findContentUpstream(node.ID, edges, outputs); upstream != nil:
+    content = upstream
+  else if needsContent(op):
+    content = readFile(node.GetSlot("source"))
+
+  // Single dispatch
+  switch op.(type):
+    Transform: outputs[node.ID] = op.Transform(ctx, node, content)
+    Writer:    op.Write(ctx, node, content)
+    Direct:    op.Execute(ctx, node)
+```
+
+**`findContentUpstream`**: For a given node, walk incoming edges. If any upstream node
+has stored content in the outputs map, return it. This is how render→copy chains work.
+
+**`needsContent`**: Simplified — just check `op.Category() != OpDirect`.
+
+**`RunNodes`**: Same pattern — accept edges, maintain outputs map.
+
+## Step 3: Plan API (`internal/execution/plan.go`)
+
+All single-op methods change from `Operations: []string{"foo"}` to `Operation: "foo"`:
+- `Mkdir`, `Link`, `Remove`, `Unlink`, `Backup`, `Validate`, `Rename`
+
+**`Copy(source, path, transforms ...string)`** — creates a node chain when
+transforms are provided:
+
+```go
+func (p *Plan) Copy(source, path string, transforms ...string) *Node {
+    if len(transforms) == 0 {
+        // Simple copy — single node
+        node := &Node{ID: p.nextID("copy"), Operation: "copy", ...}
+        node.SetSlotImmediate("source", source)
+        node.SetSlotImmediate("path", path)
+        p.graph.Nodes = append(p.graph.Nodes, node)
+        return node
+    }
+
+    // Chain: transform1 → transform2 → ... → copy
+    allOps := append(transforms, "copy")
+    var prevNode *Node
+    var lastNode *Node
+    for i, op := range allOps {
+        isLast := (i == len(allOps)-1)
+        node := &Node{ID: p.nextID(op), Operation: op, ...}
+        if i == 0 {
+            node.SetSlotImmediate("source", source)
+        }
+        if isLast {
+            node.SetSlotImmediate("path", path)
+        }
+        p.graph.Nodes = append(p.graph.Nodes, node)
+        if prevNode != nil {
+            p.graph.Edges = append(p.graph.Edges, Edge{From: prevNode.ID, To: node.ID})
+        }
+        prevNode = node
+        lastNode = node
+    }
+    return lastNode  // Return final node for DependsOn
+}
+```
+
+Same pattern for `CopyWithMode`.
+
+## Step 4: StateView (`internal/execution/stateview.go`)
+
+| Change | Before | After |
+|---|---|---|
+| `HistoryRecord.Operations` | `[]string` | `Operation string` |
+| `IsCopied()` | iterates ops for render/decrypt/copy | `op == "copy"` |
+| `IsLinked()` | `len(ops) == 1 && ops[0] == "link"` | `op == "link"` |
+| `FileEntry.Operations()` | returns `[]string` | returns `string` (rename to `LastOp()`) |
+| `processGraph` | `record.Operations = node.Operations` | `record.Operation = node.Operation` |
+| `isPackageNode` | iterates operations | check `node.Operation` |
+
+**Skip transform nodes in processGraph**: Nodes with operations like "render" or "decrypt"
+are intermediate transform nodes — they don't represent file entries. Add a guard:
+
+```go
+func isTransformOnlyNode(node *Node) bool {
+    switch node.Operation {
+    case "render", "decrypt":
+        return true
+    }
+    return false
+}
+
+// In processGraph:
+if node.Status == StatusSkipped || isTransformOnlyNode(node) {
+    continue
+}
+```
+
+**Decision**: Keep it simple. `IsCopied` returns true for `copy`, `IsLinked` for `link`.
+The `ComputeSummary` in graph.go counts "render" and "decrypt" nodes as templates/secrets.
+
+## Step 5: Preflight (`internal/execution/preflight.go`)
+
+`nodeWritesToTarget`: change from iterating `node.Operations` to checking `node.Operation`:
+
+```go
+func nodeWritesToTarget(node *Node) bool {
+    if node.GetSlot("path") == "" {
+        return false
+    }
+    return node.Operation == "link" || node.Operation == "copy"
+}
+```
+
+## Step 6: Starlark Plan Bindings
+
+### `internal/starlark/plan_*.go`
+
+All single-op methods change `Operations: []string{"foo"}` to `Operation: "foo"`:
+- `plan_root.go`: source, literal, download, service, shell
+- `plan_package.go`: install, upgrade, remove, update
+- `plan_file.go`: link, copy, write, remove
+- `plan_git.go`: clone, checkout, pull
+- `plan_archive.go`: extract
+
+`configure` methods create render→copy chains (render node + copy node + edge).
+
+### `internal/starlark/platform/common.go`, `darwin.go`, `linux.go`, `windows.go`
+
+All single-op methods updated. `Configure` methods create render+copy chains.
+
+## Step 7: Writ Package
+
+### `internal/writ/graph_builder.go`
+
+**Version bump**: `CurrentVersion = "6"`
+
+**`BuildTree`**: Decompose multi-op FileEntry pipelines into node chains. Single-op
+entries produce one node. Multi-op entries (e.g., `["render", "copy"]`) produce a chain
+of nodes connected by edges, with intermediate nodes having IDs like `fileID:opName`.
+
+### `internal/writ/commands.go`
+
+All node construction and references updated to single-op pattern.
+
+### `internal/execution/builder.go`
+
+`isDelegateNode` simplified to `node.Operation == "delegate"`.
+
+## Step 8: Writ Subpackages
+
+### `internal/writ/migrate/format.go`, `execute.go`, `session.go`
+
+`nodeView.Operations []string` → `Operation string`. All iteration replaced with
+direct `node.Operation` checks.
+
+### `internal/writ/reconcile/reconcile.go`
+
+`checkEntry` signature changed from `operations []string` to `operation string`.
+`FromBuildResult` extracts final op from tree's `f.Operations[]` pipeline.
+
+### `internal/lore/builder.go`
+
+`Operation: opName` (was `Operations: []string{opName}`).
+
+### `internal/manifest/builder.go`
+
+Converted `buildPackageNode` (single node with 4 ops) to `buildPackageNodes` (chain of
+4 single-op nodes: prepare → install → provision → verify).
+
+### `internal/writ/tree/` — NO CHANGES
+
+The tree package describes processing pipelines as metadata. `FileEntry.Operations []string`
+stays as-is (input to graph building, not execution model).
+
+## Step 9: Tests
+
+All test files updated to use `Operation: "op"` instead of `Operations: []string{"op"}`.
+Multi-op pipeline tests converted to chain tests (multiple nodes + edges).
+
+Key test conversions:
+- `TestEngineRunRenderCopyPipeline`: 2-node chain (render → copy)
+- `TestEngineRunDecryptRenderCopyPipeline`: 3-node chain (decrypt → render → copy)
+- `TestIsPackageNode`: single operation string tests
+- `TestFileEntryIsCopied`/`IsLinked`: single operation tests
+- `TestBuilder_BuildGraphFromManifest`: 3 packages × 4 phases = 12 nodes, 9 edges
+
+## Content Flow Verification
+
+| Pipeline | Chain | Content Flow |
+|---|---|---|
+| `["link"]` | single node | no content |
+| `["copy"]` | single node | source → copy |
+| `["render", "copy"]` | render → copy | source → render → outputs → copy → target |
+| `["decrypt", "copy"]` | decrypt → copy | source → decrypt → outputs → copy → target |
+| `["decrypt", "render", "copy"]` | decrypt → render → copy | source → decrypt → render → copy → target |
+
+## Verification
+
+1. `go build ./...` — compiles
+2. `go test ./...` — all tests pass
+3. `go vet ./...` — no issues

--- a/internal/cli/receipts_test.go
+++ b/internal/cli/receipts_test.go
@@ -17,7 +17,7 @@ import (
 func createTestGraph() *execution.Graph {
 	node := &execution.Node{
 		ID:         ".bashrc",
-		Operations: []string{"link"},
+		Operation: "link",
 		Status:     execution.StatusCompleted,
 	}
 	node.SetSlotImmediate("source", "/home/user/env/.bashrc")

--- a/internal/execution/builder.go
+++ b/internal/execution/builder.go
@@ -81,5 +81,5 @@ func ExpandDelegates(ctx context.Context, graph *Graph, builder SubgraphBuilder,
 
 // isDelegateNode returns true if the node is a pure delegate operation.
 func isDelegateNode(node *Node) bool {
-	return len(node.Operations) == 1 && node.Operations[0] == "delegate"
+	return node.Operation == "delegate"
 }

--- a/internal/execution/dependencyview_test.go
+++ b/internal/execution/dependencyview_test.go
@@ -361,8 +361,8 @@ func TestDependencyViewSubgraph(t *testing.T) {
 func TestDependencyViewNode(t *testing.T) {
 	g := &Graph{
 		Nodes: []*Node{
-			{ID: "a", Operations: []string{"link"}},
-			{ID: "b", Operations: []string{"copy"}},
+			{ID: "a", Operation: "link"},
+			{ID: "b", Operation: "copy"},
 		},
 	}
 	v := NewDependencyView(g)
@@ -371,7 +371,7 @@ func TestDependencyViewNode(t *testing.T) {
 	if nodeA == nil {
 		t.Fatal("expected to find node a")
 	}
-	if nodeA.Operations[0] != "link" {
+	if nodeA.Operation != "link" {
 		t.Errorf("expected node a to have link operation")
 	}
 

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -21,8 +21,8 @@ func runGraph(ctx context.Context, e *GraphExecutor, g *Graph) ([]*Result, error
 }
 
 // testNode creates a node with source and path slots for testing.
-func testNode(id string, ops []string, source, path string) *Node {
-	node := &Node{ID: id, Operations: ops}
+func testNode(id string, op string, source, path string) *Node {
+	node := &Node{ID: id, Operation: op}
 	if source != "" {
 		node.SetSlotImmediate("source", source)
 	}
@@ -448,7 +448,7 @@ func TestEngineRunLinkPipeline(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode(".bashrc", []string{"link"}, source, target),
+			testNode(".bashrc", "link", source, target),
 		},
 	}
 
@@ -486,10 +486,12 @@ func TestEngineRunRenderCopyPipeline(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{
 		Data: map[string]any{"Username": "david"},
 	})
+
+	renderNode := testNode(".greeting:render", "render", source, "")
+	copyNode := testNode(".greeting", "copy", "", target)
 	graph := &Graph{
-		Nodes: []*Node{
-			testNode(".greeting", []string{"render", "copy"}, source, target),
-		},
+		Nodes: []*Node{renderNode, copyNode},
+		Edges: []Edge{{From: ".greeting:render", To: ".greeting"}},
 	}
 
 	results, err := runGraph(context.Background(), engine, graph)
@@ -497,8 +499,11 @@ func TestEngineRunRenderCopyPipeline(t *testing.T) {
 		t.Fatalf("run: %v", err)
 	}
 
-	if results[0].Status != ResultCompleted {
-		t.Errorf("expected completed, got %s (error: %v)", results[0].Status, results[0].Error)
+	// Both nodes should complete
+	for _, r := range results {
+		if r.Status != ResultCompleted {
+			t.Fatalf("node %s: expected completed, got %s (error: %v)", r.NodeID, r.Status, r.Error)
+		}
 	}
 
 	content, _ := os.ReadFile(target)
@@ -506,11 +511,13 @@ func TestEngineRunRenderCopyPipeline(t *testing.T) {
 		t.Errorf("expected 'Hello david!', got %q", string(content))
 	}
 
+	// The render node should have the source checksum
 	if results[0].SourceChecksum == "" {
-		t.Error("expected source checksum")
+		t.Error("expected source checksum on render node")
 	}
-	if results[0].TargetChecksum == "" {
-		t.Error("expected target checksum")
+	// The copy node should have the target checksum
+	if results[1].TargetChecksum == "" {
+		t.Error("expected target checksum on copy node")
 	}
 }
 
@@ -539,9 +546,16 @@ func TestEngineRunDecryptRenderCopyPipeline(t *testing.T) {
 			"Token":     "abc123",
 		},
 	})
+	// Chain: decrypt → render → copy
+	decryptNode := testNode(".secret:decrypt", "decrypt", source, "")
+	renderNode := testNode(".secret:render", "render", "", "")
+	copyNode := testNode(".secret", "copy", "", target)
+
 	graph := &Graph{
-		Nodes: []*Node{
-			testNode(".secret", []string{"decrypt", "render", "copy"}, source, target),
+		Nodes: []*Node{decryptNode, renderNode, copyNode},
+		Edges: []Edge{
+			{From: ".secret:decrypt", To: ".secret:render"},
+			{From: ".secret:render", To: ".secret"},
 		},
 	}
 
@@ -550,8 +564,11 @@ func TestEngineRunDecryptRenderCopyPipeline(t *testing.T) {
 		t.Fatalf("run: %v", err)
 	}
 
-	if results[0].Status != ResultCompleted {
-		t.Fatalf("expected completed, got %s (error: %v)", results[0].Status, results[0].Error)
+	// All three nodes should complete
+	for _, r := range results {
+		if r.Status != ResultCompleted {
+			t.Fatalf("node %s: expected completed, got %s (error: %v)", r.NodeID, r.Status, r.Error)
+		}
 	}
 
 	content, _ := os.ReadFile(target)
@@ -581,8 +598,8 @@ func TestEngineRunMultipleNodes(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode("tgt1.txt", []string{"link"}, source1, target1),
-			testNode("sub/tgt2.txt", []string{"link"}, source2, target2),
+			testNode("tgt1.txt", "link", source1, target1),
+			testNode("sub/tgt2.txt", "link", source2, target2),
 		},
 	}
 
@@ -606,7 +623,7 @@ func TestEngineRunUnknownOperation(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "test", Operations: []string{"unknown_op"}},
+			{ID: "test", Operation: "unknown_op"},
 		},
 	}
 
@@ -641,9 +658,9 @@ func TestEngineTopologicalSort(t *testing.T) {
 	// B depends on A, C depends on B
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode("c", []string{"link"}, srcC, filepath.Join(tmpDir, "out_c")),
-			testNode("a", []string{"link"}, srcA, filepath.Join(tmpDir, "out_a")),
-			testNode("b", []string{"link"}, srcB, filepath.Join(tmpDir, "out_b")),
+			testNode("c", "link", srcC, filepath.Join(tmpDir, "out_c")),
+			testNode("a", "link", srcA, filepath.Join(tmpDir, "out_a")),
+			testNode("b", "link", srcB, filepath.Join(tmpDir, "out_b")),
 		},
 		Edges: []Edge{
 			{From: "a", To: "b"},
@@ -682,7 +699,7 @@ func TestEngineDryRun(t *testing.T) {
 	engine := NewGraphExecutor(reg, ExecutorOptions{DryRun: true})
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode(".bashrc", []string{"link"}, source, target),
+			testNode(".bashrc", "link", source, target),
 		},
 	}
 
@@ -711,7 +728,7 @@ func TestPreflightNoConflict(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode("test", []string{"link"}, source, target),
+			testNode("test", "link", source, target),
 		},
 	}
 
@@ -737,7 +754,7 @@ func TestPreflightConflictRegularFile(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode("test", []string{"link"}, source, target),
+			testNode("test", "link", source, target),
 		},
 	}
 
@@ -763,7 +780,7 @@ func TestPreflightAlreadyDeployed(t *testing.T) {
 
 	graph := &Graph{
 		Nodes: []*Node{
-			testNode("test", []string{"link"}, source, target),
+			testNode("test", "link", source, target),
 		},
 	}
 
@@ -781,7 +798,7 @@ func TestPreflightPackagesManifest(t *testing.T) {
 	// The preflight should treat them as ready since there's no filesystem conflict
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "manifest", Operations: []string{"packages"}},
+			{ID: "manifest", Operation: "packages"},
 		},
 	}
 

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -112,7 +112,7 @@ func NewGraphExecutor(registry *OperationRegistry, opts ExecutorOptions) *GraphE
 
 // Run executes all nodes in the graph, respecting ordering constraints.
 // Nodes are processed in topological order when edges define dependencies.
-// Returns results for each node.
+// Content flows between chained nodes via an outputs map.
 func (e *GraphExecutor) Run(ctx context.Context, g *Graph) error {
 	if g.State != StatePending {
 		return fmt.Errorf("graph already executed (state: %s)", g.State)
@@ -127,9 +127,10 @@ func (e *GraphExecutor) Run(ctx context.Context, g *Graph) error {
 		Data:    e.options.Data,
 	}
 
+	outputs := make(map[string][]byte)
 	var results []*Result
 	for _, node := range ordered {
-		result := e.executeNode(execCtx, node)
+		result := e.executeNodeWithOutputs(execCtx, node, g.Edges, outputs)
 		results = append(results, result)
 
 		if result.Status == ResultFailed && e.options.ConflictResolution == ResolutionStop {
@@ -166,9 +167,10 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []Executable, edges 
 		Data:    e.options.Data,
 	}
 
+	outputs := make(map[string][]byte)
 	var results []*Result
 	for _, node := range ordered {
-		result := e.executeExecutable(execCtx, node)
+		result := e.executeExecutableWithOutputs(execCtx, node, edges, outputs)
 		results = append(results, result)
 
 		if result.Status == ResultFailed && e.options.ConflictResolution == ResolutionStop {
@@ -179,60 +181,75 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []Executable, edges 
 	return results, nil
 }
 
-// executeNode processes a single node through its operation pipeline.
-func (e *GraphExecutor) executeNode(ctx *Context, node *Node) *Result {
-	return e.executeExecutable(ctx, node)
+// executeNodeWithOutputs processes a single node, resolving upstream content from edges.
+func (e *GraphExecutor) executeNodeWithOutputs(ctx *Context, node *Node, edges []Edge, outputs map[string][]byte) *Result {
+	return e.executeExecutableWithOutputs(ctx, node, edges, outputs)
 }
 
-// executeExecutable processes any Executable through its operation pipeline.
-func (e *GraphExecutor) executeExecutable(ctx *Context, node Executable) *Result {
+// executeExecutableWithOutputs processes any Executable with single-op dispatch.
+// Content flows between chained nodes via the outputs map.
+func (e *GraphExecutor) executeExecutableWithOutputs(ctx *Context, node Executable, edges []Edge, outputs map[string][]byte) *Result {
+	opName := node.GetOperation()
+	if opName == "" {
+		return &Result{
+			NodeID: node.GetID(),
+			Status: ResultFailed,
+			Error:  fmt.Errorf("node %s has no operation", node.GetID()),
+		}
+	}
+
+	op, ok := e.registry.Get(opName)
+	if !ok {
+		return &Result{
+			NodeID: node.GetID(),
+			Status: ResultFailed,
+			Error:  fmt.Errorf("unknown operation: %s", opName),
+		}
+	}
+
 	var content []byte
 	var sourceChecksum, targetChecksum string
 
-	// Pre-read source content if pipeline needs it
-	source := node.GetSlot("source")
-	if source != "" && e.needsContent(node) {
-		var err error
-		content, err = os.ReadFile(source)
-		if err != nil {
-			return &Result{
-				NodeID: node.GetID(),
-				Status: ResultFailed,
-				Error:  fmt.Errorf("read source %s: %w", source, err),
+	// Resolve input content: check upstream chain first, then read source file
+	if upstream := findContentUpstream(node.GetID(), edges, outputs); upstream != nil {
+		content = upstream
+	} else if op.Category() != OpDirect {
+		source := node.GetSlot("source")
+		if source != "" {
+			var err error
+			content, err = os.ReadFile(source)
+			if err != nil {
+				return &Result{
+					NodeID: node.GetID(),
+					Status: ResultFailed,
+					Error:  fmt.Errorf("read source %s: %w", source, err),
+				}
 			}
+			sourceChecksum = ChecksumBytes(content)
 		}
-		sourceChecksum = ChecksumBytes(content)
 	}
 
-	// Execute operation pipeline
-	for _, opName := range node.GetOperations() {
-		op, ok := e.registry.Get(opName)
-		if !ok {
-			return &Result{
-				NodeID: node.GetID(),
-				Status: ResultFailed,
-				Error:  fmt.Errorf("unknown operation: %s", opName),
-			}
+	// Single operation dispatch
+	var err error
+	switch typed := op.(type) {
+	case Transform:
+		content, err = typed.Transform(ctx, node, content)
+		if err == nil {
+			outputs[node.GetID()] = content
 		}
+	case Writer:
+		targetChecksum, err = typed.Write(ctx, node, content)
+	case Direct:
+		err = typed.Execute(ctx, node)
+	default:
+		err = fmt.Errorf("operation %s does not implement Transform, Writer, or Direct", opName)
+	}
 
-		var err error
-		switch typed := op.(type) {
-		case Transform:
-			content, err = typed.Transform(ctx, node, content)
-		case Writer:
-			targetChecksum, err = typed.Write(ctx, node, content)
-		case Direct:
-			err = typed.Execute(ctx, node)
-		default:
-			err = fmt.Errorf("operation %s does not implement Transform, Writer, or Direct", opName)
-		}
-
-		if err != nil {
-			return &Result{
-				NodeID: node.GetID(),
-				Status: ResultFailed,
-				Error:  fmt.Errorf("%s: %w", opName, err),
-			}
+	if err != nil {
+		return &Result{
+			NodeID: node.GetID(),
+			Status: ResultFailed,
+			Error:  fmt.Errorf("%s: %w", opName, err),
 		}
 	}
 
@@ -244,19 +261,16 @@ func (e *GraphExecutor) executeExecutable(ctx *Context, node Executable) *Result
 	}
 }
 
-// needsContent returns true if the node's first operation requires pre-read
-// source content (transforms and writers, but not direct operations like link).
-func (e *GraphExecutor) needsContent(node Executable) bool {
-	ops := node.GetOperations()
-	if len(ops) == 0 {
-		return false
+// findContentUpstream walks incoming edges to find content from an upstream node.
+func findContentUpstream(nodeID string, edges []Edge, outputs map[string][]byte) []byte {
+	for _, edge := range edges {
+		if edge.To == nodeID {
+			if content, ok := outputs[edge.From]; ok {
+				return content
+			}
+		}
 	}
-	first := ops[0]
-	op, ok := e.registry.Get(first)
-	if !ok {
-		return false
-	}
-	return op.Category() != OpDirect
+	return nil
 }
 
 // orderNodes returns nodes in execution order.

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -139,8 +139,8 @@ type Node struct {
 	// ID is the unique identifier (typically relative target path or package name).
 	ID string `json:"id" yaml:"id"`
 
-	// Operations to perform: link, copy, expand, decrypt, install, etc.
-	Operations []string `json:"operations" yaml:"operations"`
+	// Operation to perform: link, copy, render, decrypt, install, etc.
+	Operation string `json:"operation" yaml:"operation"`
 
 	// Status of this node: pending, completed, skipped, failed.
 	Status NodeStatus `json:"status" yaml:"status"`
@@ -207,8 +207,8 @@ func (n *Node) SetSlotPromise(name, nodeRef, slot string) {
 // GetID returns the node's unique identifier.
 func (n *Node) GetID() string { return n.ID }
 
-// GetOperations returns the list of operations to perform.
-func (n *Node) GetOperations() []string { return n.Operations }
+// GetOperation returns the operation to perform.
+func (n *Node) GetOperation() string { return n.Operation }
 
 // GetProject returns the project name.
 func (n *Node) GetProject() string { return n.Project }
@@ -293,7 +293,7 @@ type Graph struct {
 // This interface is implemented by Node.
 type Executable interface {
 	GetID() string
-	GetOperations() []string
+	GetOperation() string
 	GetSlot(name string) string
 	GetProject() string
 	GetMode() os.FileMode
@@ -454,24 +454,22 @@ func (g *Graph) ComputeSummary() {
 			continue
 		}
 
-		// Determine primary operation
-		if len(n.Operations) > 0 {
-			switch n.Operations[0] {
-			case "link":
-				g.Summary.TotalFiles++
-				g.Summary.Links++
-			case "render":
-				g.Summary.TotalFiles++
-				g.Summary.Templates++
-			case "decrypt":
-				g.Summary.TotalFiles++
-				g.Summary.Secrets++
-			case "copy":
-				g.Summary.TotalFiles++
-				g.Summary.Copies++
-			case "package-install", "package-upgrade", "package-remove":
-				g.Summary.Packages++
-			}
+		// Count by operation type
+		switch n.Operation {
+		case "link":
+			g.Summary.TotalFiles++
+			g.Summary.Links++
+		case "render":
+			g.Summary.TotalFiles++
+			g.Summary.Templates++
+		case "decrypt":
+			g.Summary.TotalFiles++
+			g.Summary.Secrets++
+		case "copy":
+			g.Summary.TotalFiles++
+			g.Summary.Copies++
+		case "package-install", "package-upgrade", "package-remove":
+			g.Summary.Packages++
 		}
 
 		// Check for backup annotation

--- a/internal/execution/plan.go
+++ b/internal/execution/plan.go
@@ -66,10 +66,10 @@ func (p *Plan) Mkdir(path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("mkdir"),
-		Operations: []string{"mkdir"},
-		Project:    p.project,
-		Mode:       0755,
+		ID:        p.nextID("mkdir"),
+		Operation: "mkdir",
+		Project:   p.project,
+		Mode:      0755,
 	}
 	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -82,9 +82,9 @@ func (p *Plan) Link(source, path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("link"),
-		Operations: []string{"link"},
-		Project:    p.project,
+		ID:        p.nextID("link"),
+		Operation: "link",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", path)
@@ -92,23 +92,51 @@ func (p *Plan) Link(source, path string) *Node {
 	return node
 }
 
-// Copy adds a file copy operation. Transforms (decrypt, expand) can be
-// prepended to the pipeline.
+// Copy adds a file copy operation. Transforms (decrypt, render) create a chain
+// of nodes connected by edges, with content flowing between them.
 func (p *Plan) Copy(source, path string, transforms ...string) *Node {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	ops := append(transforms, "copy")
-	node := &Node{
-		ID:         p.nextID("copy"),
-		Operations: ops,
-		Project:    p.project,
-		Mode:       0644,
+	if len(transforms) == 0 {
+		node := &Node{
+			ID:        p.nextID("copy"),
+			Operation: "copy",
+			Project:   p.project,
+			Mode:      0644,
+		}
+		node.SetSlotImmediate("source", source)
+		node.SetSlotImmediate("path", path)
+		p.graph.Nodes = append(p.graph.Nodes, node)
+		return node
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", path)
-	p.graph.Nodes = append(p.graph.Nodes, node)
-	return node
+
+	// Chain: transform1 → transform2 → ... → copy
+	allOps := append(transforms, "copy")
+	var prevNode *Node
+	var lastNode *Node
+	for i, op := range allOps {
+		isLast := (i == len(allOps) - 1)
+		node := &Node{
+			ID:        p.nextID(op),
+			Operation: op,
+			Project:   p.project,
+		}
+		if i == 0 {
+			node.SetSlotImmediate("source", source)
+		}
+		if isLast {
+			node.SetSlotImmediate("path", path)
+			node.Mode = 0644
+		}
+		p.graph.Nodes = append(p.graph.Nodes, node)
+		if prevNode != nil {
+			p.graph.Edges = append(p.graph.Edges, Edge{From: prevNode.ID, To: node.ID})
+		}
+		prevNode = node
+		lastNode = node
+	}
+	return lastNode
 }
 
 // CopyWithMode adds a file copy operation with explicit permissions.
@@ -116,17 +144,45 @@ func (p *Plan) CopyWithMode(source, path string, mode os.FileMode, transforms ..
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	ops := append(transforms, "copy")
-	node := &Node{
-		ID:         p.nextID("copy"),
-		Operations: ops,
-		Project:    p.project,
-		Mode:       mode,
+	if len(transforms) == 0 {
+		node := &Node{
+			ID:        p.nextID("copy"),
+			Operation: "copy",
+			Project:   p.project,
+			Mode:      mode,
+		}
+		node.SetSlotImmediate("source", source)
+		node.SetSlotImmediate("path", path)
+		p.graph.Nodes = append(p.graph.Nodes, node)
+		return node
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", path)
-	p.graph.Nodes = append(p.graph.Nodes, node)
-	return node
+
+	// Chain: transform1 → transform2 → ... → copy
+	allOps := append(transforms, "copy")
+	var prevNode *Node
+	var lastNode *Node
+	for i, op := range allOps {
+		isLast := (i == len(allOps) - 1)
+		node := &Node{
+			ID:        p.nextID(op),
+			Operation: op,
+			Project:   p.project,
+		}
+		if i == 0 {
+			node.SetSlotImmediate("source", source)
+		}
+		if isLast {
+			node.SetSlotImmediate("path", path)
+			node.Mode = mode
+		}
+		p.graph.Nodes = append(p.graph.Nodes, node)
+		if prevNode != nil {
+			p.graph.Edges = append(p.graph.Edges, Edge{From: prevNode.ID, To: node.ID})
+		}
+		prevNode = node
+		lastNode = node
+	}
+	return lastNode
 }
 
 // Remove adds a file/directory removal operation.
@@ -135,9 +191,9 @@ func (p *Plan) Remove(path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("remove"),
-		Operations: []string{"remove"},
-		Project:    p.project,
+		ID:        p.nextID("remove"),
+		Operation: "remove",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -150,9 +206,9 @@ func (p *Plan) Unlink(path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("unlink"),
-		Operations: []string{"unlink"},
-		Project:    p.project,
+		ID:        p.nextID("unlink"),
+		Operation: "unlink",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -165,9 +221,9 @@ func (p *Plan) Backup(path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("backup"),
-		Operations: []string{"backup"},
-		Project:    p.project,
+		ID:        p.nextID("backup"),
+		Operation: "backup",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -180,9 +236,9 @@ func (p *Plan) Validate(check, message string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("validate"),
-		Operations: []string{"validate"},
-		Project:    p.project,
+		ID:        p.nextID("validate"),
+		Operation: "validate",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("check", check)
 	node.SetSlotImmediate("message", message)
@@ -196,9 +252,9 @@ func (p *Plan) Rename(source, path string) *Node {
 	defer p.mu.Unlock()
 
 	node := &Node{
-		ID:         p.nextID("move"),
-		Operations: []string{"move"},
-		Project:    p.project,
+		ID:        p.nextID("move"),
+		Operation: "move",
+		Project:   p.project,
 	}
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", path)

--- a/internal/execution/preflight.go
+++ b/internal/execution/preflight.go
@@ -70,19 +70,13 @@ func Preflight(graph *Graph) *PreflightResult {
 	return result
 }
 
-// nodeWritesToTarget returns true if the node's operations produce a file at
-// node's "path" slot (link, copy, or any pipeline ending in copy).
+// nodeWritesToTarget returns true if the node's operation produces a file at
+// node's "path" slot (link or copy).
 func nodeWritesToTarget(node *Node) bool {
 	if node.GetSlot("path") == "" {
 		return false
 	}
-	for _, op := range node.Operations {
-		switch op {
-		case "link", "copy":
-			return true
-		}
-	}
-	return false
+	return node.Operation == "link" || node.Operation == "copy"
 }
 
 // detectConflict checks if a target path has a conflict.

--- a/internal/execution/stateview.go
+++ b/internal/execution/stateview.go
@@ -34,8 +34,8 @@ type HistoryRecord struct {
 	// Tool is which tool created this record ("lore" or "writ").
 	Tool string `json:"tool" yaml:"tool"`
 
-	// Operations performed: link, expand, decrypt, install, verify, etc.
-	Operations []string `json:"operations" yaml:"operations"`
+	// Operation performed: link, copy, render, decrypt, install, etc.
+	Operation string `json:"operation" yaml:"operation"`
 
 	// Status of this operation: completed, skipped, failed.
 	Status NodeStatus `json:"status" yaml:"status"`
@@ -96,12 +96,7 @@ func (e *FileEntry) IsCopied() bool {
 	if last == nil {
 		return false
 	}
-	for _, op := range last.Operations {
-		if op == "render" || op == "decrypt" || op == "copy" {
-			return true
-		}
-	}
-	return false
+	return last.Operation == "copy"
 }
 
 // IsLinked returns true if the latest operation was a symlink.
@@ -110,7 +105,7 @@ func (e *FileEntry) IsLinked() bool {
 	if last == nil {
 		return false
 	}
-	return len(last.Operations) == 1 && last.Operations[0] == "link"
+	return last.Operation == "link"
 }
 
 // SourceChecksum returns the source checksum from the latest operation.
@@ -131,13 +126,13 @@ func (e *FileEntry) TargetChecksum() string {
 	return last.TargetChecksum
 }
 
-// Operations returns the operations from the latest deployment.
-func (e *FileEntry) Operations() []string {
+// LastOp returns the operation from the latest deployment.
+func (e *FileEntry) LastOp() string {
 	last := e.LastOperation()
 	if last == nil {
-		return nil
+		return ""
 	}
-	return last.Operations
+	return last.Operation
 }
 
 // FileTreeNode represents a node in the target filesystem tree.
@@ -438,13 +433,22 @@ func (b *StateViewBuilder) includeGraph(g *Graph) bool {
 	return true
 }
 
+// isTransformOnlyNode returns true if the node is an intermediate transform.
+func isTransformOnlyNode(node *Node) bool {
+	switch node.Operation {
+	case "render", "decrypt":
+		return true
+	}
+	return false
+}
+
 // processGraph adds nodes from a graph to the view.
 func (b *StateViewBuilder) processGraph(view *StateView, g *Graph) {
 	receiptName := g.Filename()
 
 	for _, node := range g.Nodes {
-		// Skip skipped nodes
-		if node.Status == StatusSkipped {
+		// Skip skipped nodes and intermediate transform nodes
+		if node.Status == StatusSkipped || isTransformOnlyNode(node) {
 			continue
 		}
 
@@ -452,7 +456,7 @@ func (b *StateViewBuilder) processGraph(view *StateView, g *Graph) {
 			Timestamp:      g.Timestamp,
 			Receipt:        receiptName,
 			Tool:           g.Tool,
-			Operations:     node.Operations,
+			Operation:      node.Operation,
 			Status:         node.Status,
 			SourceChecksum: node.SourceChecksum,
 			TargetChecksum: node.TargetChecksum,
@@ -469,12 +473,10 @@ func (b *StateViewBuilder) processGraph(view *StateView, g *Graph) {
 
 // isPackageNode determines if a node represents a package lifecycle operation.
 func (b *StateViewBuilder) isPackageNode(node *Node) bool {
-	// Package nodes have lifecycle operations
-	for _, op := range node.Operations {
-		switch op {
-		case "prepare", "install", "verify", "upgrade", "uninstall", "cleanup":
-			return true
-		}
+	switch node.Operation {
+	case "prepare", "install", "verify", "upgrade", "uninstall", "cleanup",
+		"package-install", "package-upgrade", "package-remove":
+		return true
 	}
 	return false
 }

--- a/internal/execution/stateview_test.go
+++ b/internal/execution/stateview_test.go
@@ -69,8 +69,8 @@ func TestFileEntryLastOperation(t *testing.T) {
 		e := &FileEntry{
 			Target: ".bashrc",
 			History: []HistoryRecord{
-				{Receipt: "old.yaml", Operations: []string{"link"}},
-				{Receipt: "new.yaml", Operations: []string{"render", "copy"}},
+				{Receipt: "old.yaml", Operation: "link"},
+				{Receipt: "new.yaml", Operation: "copy"},
 			},
 		}
 		last := e.LastOperation()
@@ -86,25 +86,21 @@ func TestFileEntryLastOperation(t *testing.T) {
 // TestFileEntryIsCopied tests FileEntry.IsCopied.
 func TestFileEntryIsCopied(t *testing.T) {
 	tests := []struct {
-		name       string
-		operations []string
-		want       bool
+		name      string
+		operation string
+		want      bool
 	}{
-		{"no history", nil, false},
-		{"link only", []string{"link"}, false},
-		{"copy operation", []string{"copy"}, true},
-		{"render operation", []string{"render"}, true},
-		{"decrypt operation", []string{"decrypt"}, true},
-		{"render+copy", []string{"render", "copy"}, true},
-		{"decrypt+render+copy", []string{"decrypt", "render", "copy"}, true},
+		{"no history", "", false},
+		{"link only", "link", false},
+		{"copy operation", "copy", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &FileEntry{Target: "test"}
-			if tt.operations != nil {
+			if tt.operation != "" {
 				e.History = []HistoryRecord{
-					{Operations: tt.operations},
+					{Operation: tt.operation},
 				}
 			}
 			if got := e.IsCopied(); got != tt.want {
@@ -117,23 +113,21 @@ func TestFileEntryIsCopied(t *testing.T) {
 // TestFileEntryIsLinked tests FileEntry.IsLinked.
 func TestFileEntryIsLinked(t *testing.T) {
 	tests := []struct {
-		name       string
-		operations []string
-		want       bool
+		name      string
+		operation string
+		want      bool
 	}{
-		{"no history", nil, false},
-		{"link only", []string{"link"}, true},
-		{"copy operation", []string{"copy"}, false},
-		{"render+copy", []string{"render", "copy"}, false},
-		{"link with extra ops", []string{"link", "something"}, false},
+		{"no history", "", false},
+		{"link only", "link", true},
+		{"copy operation", "copy", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &FileEntry{Target: "test"}
-			if tt.operations != nil {
+			if tt.operation != "" {
 				e.History = []HistoryRecord{
-					{Operations: tt.operations},
+					{Operation: tt.operation},
 				}
 			}
 			if got := e.IsLinked(); got != tt.want {
@@ -187,19 +181,19 @@ func TestFileTreeCopiedLinkedFiles(t *testing.T) {
 		Entries: map[string]*FileEntry{
 			".bashrc": {
 				Target:  ".bashrc",
-				History: []HistoryRecord{{Operations: []string{"link"}}},
+				History: []HistoryRecord{{Operation: "link"}},
 			},
 			".zshrc": {
 				Target:  ".zshrc",
-				History: []HistoryRecord{{Operations: []string{"link"}}},
+				History: []HistoryRecord{{Operation: "link"}},
 			},
 			".gitconfig": {
 				Target:  ".gitconfig",
-				History: []HistoryRecord{{Operations: []string{"render", "copy"}}},
+				History: []HistoryRecord{{Operation: "copy"}},
 			},
 			".ssh/config": {
 				Target:  ".ssh/config",
-				History: []HistoryRecord{{Operations: []string{"decrypt", "copy"}}},
+				History: []HistoryRecord{{Operation: "copy"}},
 			},
 		},
 	}
@@ -309,15 +303,15 @@ func TestStateViewSummary(t *testing.T) {
 			Entries: map[string]*FileEntry{
 				".bashrc": {
 					Target:  ".bashrc",
-					History: []HistoryRecord{{Operations: []string{"link"}}},
+					History: []HistoryRecord{{Operation: "link"}},
 				},
 				".zshrc": {
 					Target:  ".zshrc",
-					History: []HistoryRecord{{Operations: []string{"link"}}},
+					History: []HistoryRecord{{Operation: "link"}},
 				},
 				".gitconfig": {
 					Target:  ".gitconfig",
-					History: []HistoryRecord{{Operations: []string{"render", "copy"}}},
+					History: []HistoryRecord{{Operation: "copy"}},
 				},
 			},
 		},
@@ -341,13 +335,13 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 	earlier := now.Add(-time.Hour)
 
 	// Helper to create nodes with source slot
-	makeNode := func(id string, ops []string, source, project, layer string) *Node {
+	makeNode := func(id string, op string, source, project, layer string) *Node {
 		n := &Node{
-			ID:         id,
-			Operations: ops,
-			Project:    project,
-			Layer:      layer,
-			Status:     StatusCompleted,
+			ID:        id,
+			Operation: op,
+			Project:   project,
+			Layer:     layer,
+			Status:    StatusCompleted,
 		}
 		n.SetSlotImmediate("source", source)
 		return n
@@ -359,7 +353,7 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 			Timestamp: earlier,
 			Context:   GraphContext{TargetRoot: "/home/user"},
 			Nodes: []*Node{
-				makeNode(".bashrc", []string{"link"}, "/repo/.bashrc", "shell", "base"),
+				makeNode(".bashrc", "link", "/repo/.bashrc", "shell", "base"),
 			},
 		},
 		{
@@ -367,8 +361,8 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 			Timestamp: now,
 			Context:   GraphContext{TargetRoot: "/home/user"},
 			Nodes: []*Node{
-				makeNode(".bashrc", []string{"render", "copy"}, "/repo/.bashrc", "shell", "personal"),
-				makeNode(".gitconfig", []string{"link"}, "/repo/.gitconfig", "git", ""),
+				makeNode(".bashrc", "copy", "/repo/.bashrc", "shell", "personal"),
+				makeNode(".gitconfig", "link", "/repo/.gitconfig", "git", ""),
 			},
 		},
 	}
@@ -422,9 +416,9 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Timestamp: now.Add(-2 * time.Hour),
 			Nodes: []*Node{
 				{
-					ID:         "docker",
-					Operations: []string{"install"},
-					Status:     StatusCompleted,
+					ID:        "docker",
+					Operation: "install",
+					Status:    StatusCompleted,
 				},
 			},
 		},
@@ -433,14 +427,14 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Timestamp: now.Add(-time.Hour),
 			Nodes: []*Node{
 				{
-					ID:         "docker",
-					Operations: []string{"verify"},
-					Status:     StatusCompleted,
+					ID:        "docker",
+					Operation: "verify",
+					Status:    StatusCompleted,
 				},
 				{
-					ID:         "golang",
-					Operations: []string{"install"},
-					Status:     StatusCompleted,
+					ID:        "golang",
+					Operation: "install",
+					Status:    StatusCompleted,
 				},
 			},
 		},
@@ -449,9 +443,9 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Timestamp: now,
 			Nodes: []*Node{
 				{
-					ID:         "docker",
-					Operations: []string{"upgrade"},
-					Status:     StatusCompleted,
+					ID:        "docker",
+					Operation: "upgrade",
+					Status:    StatusCompleted,
 				},
 			},
 		},
@@ -474,14 +468,14 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 	}
 
 	// History should be ordered by time
-	if docker.History[0].Operations[0] != "install" {
-		t.Errorf("expected first operation 'install', got %q", docker.History[0].Operations[0])
+	if docker.History[0].Operation != "install" {
+		t.Errorf("expected first operation 'install', got %q", docker.History[0].Operation)
 	}
-	if docker.History[1].Operations[0] != "verify" {
-		t.Errorf("expected second operation 'verify', got %q", docker.History[1].Operations[0])
+	if docker.History[1].Operation != "verify" {
+		t.Errorf("expected second operation 'verify', got %q", docker.History[1].Operation)
 	}
-	if docker.History[2].Operations[0] != "upgrade" {
-		t.Errorf("expected third operation 'upgrade', got %q", docker.History[2].Operations[0])
+	if docker.History[2].Operation != "upgrade" {
+		t.Errorf("expected third operation 'upgrade', got %q", docker.History[2].Operation)
 	}
 
 	// golang should have 1 history record
@@ -499,10 +493,10 @@ func TestStateViewBuilderTimeFilter(t *testing.T) {
 	now := time.Now()
 
 	graphs := []*Graph{
-		{Tool: "writ", Timestamp: now.Add(-3 * time.Hour), Nodes: []*Node{{ID: "a", Operations: []string{"link"}, Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: "b", Operations: []string{"link"}, Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "c", Operations: []string{"link"}, Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: "d", Operations: []string{"link"}, Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-3 * time.Hour), Nodes: []*Node{{ID: "a", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: "b", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "c", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: "d", Operation: "link", Status: StatusCompleted}}},
 	}
 
 	// Filter to middle two
@@ -528,9 +522,9 @@ func TestStateViewBuilderToolFilter(t *testing.T) {
 	now := time.Now()
 
 	graphs := []*Graph{
-		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: ".bashrc", Operations: []string{"link"}, Status: StatusCompleted}}},
-		{Tool: "lore", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "docker", Operations: []string{"install"}, Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: ".zshrc", Operations: []string{"link"}, Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: ".bashrc", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "lore", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "docker", Operation: "install", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: ".zshrc", Operation: "link", Status: StatusCompleted}}},
 	}
 
 	t.Run("writ only", func(t *testing.T) {
@@ -573,9 +567,9 @@ func TestStateViewBuilderSkipsSkipped(t *testing.T) {
 			Tool:      "writ",
 			Timestamp: now,
 			Nodes: []*Node{
-				{ID: "a", Operations: []string{"link"}, Status: StatusCompleted},
-				{ID: "b", Operations: []string{"link"}, Status: StatusSkipped},
-				{ID: "c", Operations: []string{"link"}, Status: StatusFailed},
+				{ID: "a", Operation: "link", Status: StatusCompleted},
+				{ID: "b", Operation: "link", Status: StatusSkipped},
+				{ID: "c", Operation: "link", Status: StatusFailed},
 			},
 		},
 	}
@@ -618,7 +612,7 @@ func TestStateViewBuilderLoadReceipts(t *testing.T) {
 				State:     StateExecuted,
 				Context:   GraphContext{TargetRoot: "/home/user"},
 				Nodes: []*Node{
-					{ID: ".bashrc", Operations: []string{"link"}, Status: StatusCompleted},
+					{ID: ".bashrc", Operation: "link", Status: StatusCompleted},
 				},
 			},
 		},
@@ -631,7 +625,7 @@ func TestStateViewBuilderLoadReceipts(t *testing.T) {
 				State:     StateExecuted,
 				Context:   GraphContext{TargetRoot: "/home/user"},
 				Nodes: []*Node{
-					{ID: ".gitconfig", Operations: []string{"link"}, Status: StatusCompleted},
+					{ID: ".gitconfig", Operation: "link", Status: StatusCompleted},
 				},
 			},
 		},
@@ -689,27 +683,29 @@ func TestIsPackageNode(t *testing.T) {
 	builder := &StateViewBuilder{}
 
 	tests := []struct {
-		operations []string
-		want       bool
+		operation string
+		want      bool
 	}{
-		{[]string{"link"}, false},
-		{[]string{"copy"}, false},
-		{[]string{"render", "copy"}, false},
-		{[]string{"decrypt", "render", "copy"}, false},
-		{[]string{"install"}, true},
-		{[]string{"prepare"}, true},
-		{[]string{"verify"}, true},
-		{[]string{"upgrade"}, true},
-		{[]string{"uninstall"}, true},
-		{[]string{"cleanup"}, true},
-		{[]string{"prepare", "install", "verify"}, true},
+		{"link", false},
+		{"copy", false},
+		{"render", false},
+		{"decrypt", false},
+		{"install", true},
+		{"prepare", true},
+		{"verify", true},
+		{"upgrade", true},
+		{"uninstall", true},
+		{"cleanup", true},
+		{"package-install", true},
+		{"package-upgrade", true},
+		{"package-remove", true},
 	}
 
 	for _, tt := range tests {
-		node := &Node{Operations: tt.operations}
+		node := &Node{Operation: tt.operation}
 		got := builder.isPackageNode(node)
 		if got != tt.want {
-			t.Errorf("isPackageNode(%v) = %v, want %v", tt.operations, got, tt.want)
+			t.Errorf("isPackageNode(%q) = %v, want %v", tt.operation, got, tt.want)
 		}
 	}
 }

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -262,9 +262,9 @@ func addNativePMNodes(graph *execution.Graph, pkg *lorepackage.Release, action *
 
 	// Create the node with namespaced operation
 	node := &execution.Node{
-		ID:         fmt.Sprintf("%s-%s-%s", opName, pkg.Name, action.PhaseName),
-		Operations: []string{opName},
-		Project:    pkg.Name,
+		ID:        fmt.Sprintf("%s-%s-%s", opName, pkg.Name, action.PhaseName),
+		Operation: opName,
+		Project:   pkg.Name,
 	}
 	node.SetSlotImmediate("packages", strings.Join(action.Packages, ","))
 	node.SetSlotImmediate("phase", action.PhaseName)

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -49,7 +49,7 @@ func TestBuild_WithNativePMPackage(t *testing.T) {
 	// The first node should be a namespaced package-install operation
 	found := false
 	for _, node := range result.Graph.Nodes {
-		if len(node.Operations) > 0 && node.Operations[0] == "package-install" {
+		if node.Operation == "package-install" {
 			found = true
 			// Verify slot values
 			if node.GetSlot("packages") != "curl" {
@@ -97,7 +97,7 @@ func TestBuild_PlatformDetection(t *testing.T) {
 			// All platforms use the namespaced "package-install" operation
 			found := false
 			for _, node := range result.Graph.Nodes {
-				if len(node.Operations) > 0 && node.Operations[0] == "package-install" {
+				if node.Operation == "package-install" {
 					found = true
 					break
 				}
@@ -189,7 +189,7 @@ func TestEngineRunsPackageInstallOperations(t *testing.T) {
 	// Create a graph with a namespaced package-install node
 	node := &execution.Node{
 		ID:         "package-install-testpkg",
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 	}
 	node.SetSlotImmediate("packages", "testpkg")
 	graph := &execution.Graph{
@@ -228,7 +228,7 @@ func TestEngineRunsNamespacedPackageOps(t *testing.T) {
 		t.Run(opName, func(t *testing.T) {
 			node := &execution.Node{
 				ID:         "test-" + opName,
-				Operations: []string{opName},
+				Operation: opName,
 			}
 			if opName != "package-update" {
 				node.SetSlotImmediate("packages", "testpkg")
@@ -269,7 +269,7 @@ func TestNativePMNodeMetadata(t *testing.T) {
 	// Find the install node (uses namespaced "package-install" operation)
 	var installNode *execution.Node
 	for _, node := range result.Graph.Nodes {
-		if len(node.Operations) > 0 && node.Operations[0] == "package-install" {
+		if node.Operation == "package-install" {
 			installNode = node
 			break
 		}

--- a/internal/manifest/builder.go
+++ b/internal/manifest/builder.go
@@ -44,12 +44,13 @@ func (b *Builder) BuildSubgraph(ctx context.Context, manifestPath string, opts e
 // Entry point 2: Build from pre-parsed manifest (for callers who already have the data).
 func (b *Builder) BuildGraphFromManifest(ctx context.Context, manifest *PackagesManifest, opts execution.BuildOptions) (*execution.Graph, error) {
 	graph := &execution.Graph{
-		Nodes: make([]*execution.Node, 0, len(manifest.Packages)),
+		Nodes: make([]*execution.Node, 0, len(manifest.Packages)*4),
 	}
 
 	for _, pkg := range manifest.Packages {
-		node := b.buildPackageNode(pkg, opts)
-		graph.Nodes = append(graph.Nodes, node)
+		nodes, edges := b.buildPackageNodes(pkg, opts)
+		graph.Nodes = append(graph.Nodes, nodes...)
+		graph.Edges = append(graph.Edges, edges...)
 	}
 
 	// Add dependency edges between packages if needed
@@ -58,29 +59,50 @@ func (b *Builder) BuildGraphFromManifest(ctx context.Context, manifest *Packages
 	return graph, nil
 }
 
-// buildPackageNode creates an execution.Node for a single package entry.
-func (b *Builder) buildPackageNode(pkg PackageEntry, opts execution.BuildOptions) *execution.Node {
-	// Build the lore pipeline operations
-	// The four-phase lore pipeline: prepare → install → provision → verify
-	operations := []string{"prepare", "install", "provision", "verify"}
+// buildPackageNodes creates a chain of execution.Nodes for a single package entry.
+// The four-phase lore pipeline: prepare → install → provision → verify
+// Returns the nodes and edges for the chain.
+func (b *Builder) buildPackageNodes(pkg PackageEntry, opts execution.BuildOptions) ([]*execution.Node, []execution.Edge) {
+	phases := []string{"prepare", "install", "provision", "verify"}
 
-	node := &execution.Node{
-		ID:         pkg.Name,
-		Operations: operations,
-	}
+	var nodes []*execution.Node
+	var edges []execution.Edge
+	var prevNode *execution.Node
 
-	// Store package name for registry lookup
-	node.SetSlotImmediate("package", pkg.Name)
-
-	// Store enabled features
-	if len(pkg.With) > 0 {
-		for i, feature := range pkg.With {
-			node.SetSlotImmediate(fmt.Sprintf("feature.%d", i), feature)
+	for i, phase := range phases {
+		isLast := (i == len(phases) - 1)
+		nodeID := pkg.Name
+		if !isLast {
+			nodeID = pkg.Name + ":" + phase
 		}
-		node.SetSlotImmediate("feature_count", fmt.Sprintf("%d", len(pkg.With)))
+
+		node := &execution.Node{
+			ID:        nodeID,
+			Operation: phase,
+		}
+
+		// Store package name for registry lookup on all nodes
+		node.SetSlotImmediate("package", pkg.Name)
+
+		// Store enabled features on the first node
+		if i == 0 && len(pkg.With) > 0 {
+			for j, feature := range pkg.With {
+				node.SetSlotImmediate(fmt.Sprintf("feature.%d", j), feature)
+			}
+			node.SetSlotImmediate("feature_count", fmt.Sprintf("%d", len(pkg.With)))
+		}
+
+		nodes = append(nodes, node)
+
+		if prevNode != nil {
+			edges = append(edges, execution.Edge{
+				From: prevNode.ID, To: node.ID,
+			})
+		}
+		prevNode = node
 	}
 
-	return node
+	return nodes, edges
 }
 
 // Ensure Builder implements execution.SubgraphBuilder.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -310,40 +310,40 @@ func TestBuilder_BuildGraphFromManifest(t *testing.T) {
 		t.Fatalf("BuildGraphFromManifest failed: %v", err)
 	}
 
-	if len(graph.Nodes) != 3 {
-		t.Fatalf("expected 3 nodes, got %d", len(graph.Nodes))
+	// 3 packages × 4 phases = 12 nodes
+	if len(graph.Nodes) != 12 {
+		t.Fatalf("expected 12 nodes (3 packages × 4 phases), got %d", len(graph.Nodes))
+	}
+	// 3 packages × 3 edges per chain = 9 edges
+	if len(graph.Edges) != 9 {
+		t.Fatalf("expected 9 edges, got %d", len(graph.Edges))
 	}
 
-	// Check first node (simple package)
-	if graph.Nodes[0].ID != "gh" {
-		t.Errorf("nodes[0].ID: expected 'gh', got %q", graph.Nodes[0].ID)
-	}
-	if graph.Nodes[0].GetSlot("package") != "gh" {
-		t.Errorf("nodes[0] slot 'package': expected 'gh', got %q", graph.Nodes[0].GetSlot("package"))
-	}
-
-	// Check second node (with features)
-	if graph.Nodes[1].ID != "neovim" {
-		t.Errorf("nodes[1].ID: expected 'neovim', got %q", graph.Nodes[1].ID)
-	}
-	if graph.Nodes[1].GetSlot("feature_count") != "2" {
-		t.Errorf("nodes[1] slot 'feature_count': expected '2', got %q", graph.Nodes[1].GetSlot("feature_count"))
-	}
-	if graph.Nodes[1].GetSlot("feature.0") != "lsp" {
-		t.Errorf("nodes[1] slot 'feature.0': expected 'lsp', got %q", graph.Nodes[1].GetSlot("feature.0"))
-	}
-
-	// Check operations (four-phase pipeline)
-	expectedOps := []string{"prepare", "install", "provision", "verify"}
-	for i, node := range graph.Nodes {
-		if len(node.Operations) != 4 {
-			t.Errorf("nodes[%d].Operations: expected 4 ops, got %d", i, len(node.Operations))
+	// Check first package chain (gh): gh:prepare → gh:install → gh:provision → gh
+	expectedPhases := []string{"prepare", "install", "provision", "verify"}
+	expectedIDs := []string{"gh:prepare", "gh:install", "gh:provision", "gh"}
+	for i, id := range expectedIDs {
+		if graph.Nodes[i].ID != id {
+			t.Errorf("nodes[%d].ID: expected %q, got %q", i, id, graph.Nodes[i].ID)
 		}
-		for j, op := range node.Operations {
-			if op != expectedOps[j] {
-				t.Errorf("nodes[%d].Operations[%d]: expected %q, got %q", i, j, expectedOps[j], op)
-			}
+		if graph.Nodes[i].Operation != expectedPhases[i] {
+			t.Errorf("nodes[%d].Operation: expected %q, got %q", i, expectedPhases[i], graph.Nodes[i].Operation)
 		}
+		if graph.Nodes[i].GetSlot("package") != "gh" {
+			t.Errorf("nodes[%d] slot 'package': expected 'gh', got %q", i, graph.Nodes[i].GetSlot("package"))
+		}
+	}
+
+	// Check second package chain (neovim) — features on first node
+	neovimStart := 4
+	if graph.Nodes[neovimStart].ID != "neovim:prepare" {
+		t.Errorf("nodes[%d].ID: expected 'neovim:prepare', got %q", neovimStart, graph.Nodes[neovimStart].ID)
+	}
+	if graph.Nodes[neovimStart].GetSlot("feature_count") != "2" {
+		t.Errorf("nodes[%d] slot 'feature_count': expected '2', got %q", neovimStart, graph.Nodes[neovimStart].GetSlot("feature_count"))
+	}
+	if graph.Nodes[neovimStart].GetSlot("feature.0") != "lsp" {
+		t.Errorf("nodes[%d] slot 'feature.0': expected 'lsp', got %q", neovimStart, graph.Nodes[neovimStart].GetSlot("feature.0"))
 	}
 }
 
@@ -366,15 +366,18 @@ func TestBuilder_BuildGraph_FromFile(t *testing.T) {
 		t.Fatalf("BuildSubgraph failed: %v", err)
 	}
 
-	if len(graph.Nodes) != 2 {
-		t.Fatalf("expected 2 nodes, got %d", len(graph.Nodes))
+	// 2 packages × 4 phases = 8 nodes
+	if len(graph.Nodes) != 8 {
+		t.Fatalf("expected 8 nodes (2 packages × 4 phases), got %d", len(graph.Nodes))
 	}
 
-	if graph.Nodes[0].ID != "gh" {
-		t.Errorf("nodes[0].ID: expected 'gh', got %q", graph.Nodes[0].ID)
+	// Final node of first chain is "gh" (the verify phase)
+	if graph.Nodes[3].ID != "gh" {
+		t.Errorf("nodes[3].ID: expected 'gh', got %q", graph.Nodes[3].ID)
 	}
-	if graph.Nodes[1].ID != "neovim" {
-		t.Errorf("nodes[1].ID: expected 'neovim', got %q", graph.Nodes[1].ID)
+	// Final node of second chain is "neovim"
+	if graph.Nodes[7].ID != "neovim" {
+		t.Errorf("nodes[7].ID: expected 'neovim', got %q", graph.Nodes[7].ID)
 	}
 }
 

--- a/internal/starlark/plan.go
+++ b/internal/starlark/plan.go
@@ -66,7 +66,7 @@ func (p *planBindings) Project() string {
 func (p *planBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-install", packages...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -78,7 +78,7 @@ func (p *planBindings) PackageInstall(packages ...string) *execution.Node {
 func (p *planBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-upgrade", packages...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -90,7 +90,7 @@ func (p *planBindings) PackageUpgrade(packages ...string) *execution.Node {
 func (p *planBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-remove", packages...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -102,7 +102,7 @@ func (p *planBindings) PackageRemove(packages ...string) *execution.Node {
 func (p *planBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    p.project,
 	}
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -110,23 +110,37 @@ func (p *planBindings) PackageUpdate() *execution.Node {
 }
 
 // Configure adds a configuration file node (template expansion + copy).
+// Creates a render→copy chain with an edge between them.
 func (p *planBindings) Configure(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         generateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    p.project,
+	renderNode := &execution.Node{
+		ID:        generateNodeID("render"),
+		Operation: "render",
+		Project:   p.project,
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", p.host.ExpandPath(target))
-	p.graph.Nodes = append(p.graph.Nodes, node)
-	return node
+	renderNode.SetSlotImmediate("source", source)
+	p.graph.Nodes = append(p.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        generateNodeID("configure"),
+		Operation: "copy",
+		Project:   p.project,
+	}
+	copyNode.SetSlotImmediate("path", p.host.ExpandPath(target))
+	p.graph.Nodes = append(p.graph.Nodes, copyNode)
+
+	p.graph.Edges = append(p.graph.Edges, execution.Edge{
+		From: renderNode.ID,
+		To:   copyNode.ID,
+	})
+
+	return copyNode
 }
 
 // Link adds a symlink creation node.
 func (p *planBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -139,7 +153,7 @@ func (p *planBindings) Link(source, target string) *execution.Node {
 func (p *planBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -152,7 +166,7 @@ func (p *planBindings) Copy(source, target string) *execution.Node {
 func (p *planBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("path", p.host.ExpandPath(target))
@@ -165,7 +179,7 @@ func (p *planBindings) Write(target, content string) *execution.Node {
 func (p *planBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("remove"),
-		Operations: []string{"remove"},
+		Operation: "remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("path", p.host.ExpandPath(target))
@@ -177,7 +191,7 @@ func (p *planBindings) Remove(target string) *execution.Node {
 func (p *planBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("download"),
-		Operations: []string{"download"},
+		Operation: "download",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -190,7 +204,7 @@ func (p *planBindings) Download(url, target string) *execution.Node {
 func (p *planBindings) ArchiveExtract(archive, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("archive-extract"),
-		Operations: []string{"archive-extract"},
+		Operation: "archive-extract",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", p.host.ExpandPath(archive))
@@ -203,7 +217,7 @@ func (p *planBindings) ArchiveExtract(archive, target string) *execution.Node {
 func (p *planBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-clone"),
-		Operations: []string{"git-clone"},
+		Operation: "git-clone",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -216,7 +230,7 @@ func (p *planBindings) GitClone(url, target string) *execution.Node {
 func (p *planBindings) GitCheckout(ref string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-checkout"),
-		Operations: []string{"git-checkout"},
+		Operation: "git-checkout",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("ref", ref)
@@ -228,7 +242,7 @@ func (p *planBindings) GitCheckout(ref string) *execution.Node {
 func (p *planBindings) GitPull() *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-pull"),
-		Operations: []string{"git-pull"},
+		Operation: "git-pull",
 		Project:    p.project,
 	}
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -239,7 +253,7 @@ func (p *planBindings) GitPull() *execution.Node {
 func (p *planBindings) Service(name string, action ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("service", name, action.String()),
-		Operations: []string{"service"},
+		Operation: "service",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -252,7 +266,7 @@ func (p *planBindings) Service(name string, action ServiceAction) *execution.Nod
 func (p *planBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("shell"),
-		Operations: []string{"shell"},
+		Operation: "shell",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("command", command)

--- a/internal/starlark/plan_archive.go
+++ b/internal/starlark/plan_archive.go
@@ -65,7 +65,7 @@ func (a *ArchivePlan) extract(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:         generateNodeID("archive-extract"),
-		Operations: []string{"archive-extract"},
+		Operation: "archive-extract",
 		Project:    a.project,
 	}
 

--- a/internal/starlark/plan_file.go
+++ b/internal/starlark/plan_file.go
@@ -76,21 +76,32 @@ func (f *FilePlan) configure(_ *starlark.Thread, _ *starlark.Builtin, args starl
 		return nil, err
 	}
 
-	node := &execution.Node{
-		ID:         generateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    f.project,
+	renderNode := &execution.Node{
+		ID:        generateNodeID("render"),
+		Operation: "render",
+		Project:   f.project,
 	}
-
-	if err := FillSlot(node, f.graph, "source", source); err != nil {
+	if err := FillSlot(renderNode, f.graph, "source", source); err != nil {
 		return nil, fmt.Errorf("configure: source: %w", err)
 	}
-	if err := FillSlot(node, f.graph, "path", path); err != nil {
+	f.graph.Nodes = append(f.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        generateNodeID("configure"),
+		Operation: "copy",
+		Project:   f.project,
+	}
+	if err := FillSlot(copyNode, f.graph, "path", path); err != nil {
 		return nil, fmt.Errorf("configure: path: %w", err)
 	}
+	f.graph.Nodes = append(f.graph.Nodes, copyNode)
 
-	f.graph.Nodes = append(f.graph.Nodes, node)
-	return NewOutput(node, f.graph, ""), nil
+	f.graph.Edges = append(f.graph.Edges, execution.Edge{
+		From: renderNode.ID,
+		To:   copyNode.ID,
+	})
+
+	return NewOutput(copyNode, f.graph, ""), nil
 }
 
 // link adds a symlink creation node.
@@ -109,7 +120,7 @@ func (f *FilePlan) link(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:         generateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    f.project,
 	}
 
@@ -140,7 +151,7 @@ func (f *FilePlan) copy(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:         generateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    f.project,
 	}
 
@@ -171,7 +182,7 @@ func (f *FilePlan) write(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	node := &execution.Node{
 		ID:         generateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    f.project,
 	}
 
@@ -201,7 +212,7 @@ func (f *FilePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starlark
 
 	node := &execution.Node{
 		ID:         generateNodeID("remove"),
-		Operations: []string{"remove"},
+		Operation: "remove",
 		Project:    f.project,
 	}
 

--- a/internal/starlark/plan_git.go
+++ b/internal/starlark/plan_git.go
@@ -69,7 +69,7 @@ func (g *GitPlan) clone(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:         generateNodeID("git-clone"),
-		Operations: []string{"git-clone"},
+		Operation: "git-clone",
 		Project:    g.project,
 	}
 
@@ -100,7 +100,7 @@ func (g *GitPlan) checkout(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:         generateNodeID("git-checkout"),
-		Operations: []string{"git-checkout"},
+		Operation: "git-checkout",
 		Project:    g.project,
 	}
 
@@ -130,7 +130,7 @@ func (g *GitPlan) pull(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 
 	node := &execution.Node{
 		ID:         generateNodeID("git-pull"),
-		Operations: []string{"git-pull"},
+		Operation: "git-pull",
 		Project:    g.project,
 	}
 

--- a/internal/starlark/plan_package.go
+++ b/internal/starlark/plan_package.go
@@ -73,7 +73,7 @@ func (p *PackagePlan) install(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-install", packages...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -98,7 +98,7 @@ func (p *PackagePlan) upgrade(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-upgrade", packages...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -123,7 +123,7 @@ func (p *PackagePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-remove", packages...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -145,7 +145,7 @@ func (p *PackagePlan) update(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    p.project,
 	}
 

--- a/internal/starlark/plan_root.go
+++ b/internal/starlark/plan_root.go
@@ -99,7 +99,7 @@ func (p *PlanRoot) source(_ *starlark.Thread, _ *starlark.Builtin, args starlark
 
 	node := &execution.Node{
 		ID:         generateNodeID("source"),
-		Operations: []string{"source"},
+		Operation: "source",
 		Project:    p.project,
 	}
 
@@ -126,7 +126,7 @@ func (p *PlanRoot) literal(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:         generateNodeID("literal"),
-		Operations: []string{"literal"},
+		Operation: "literal",
 		Project:    p.project,
 	}
 
@@ -153,7 +153,7 @@ func (p *PlanRoot) download(_ *starlark.Thread, _ *starlark.Builtin, args starla
 
 	node := &execution.Node{
 		ID:         generateNodeID("download"),
-		Operations: []string{"download"},
+		Operation: "download",
 		Project:    p.project,
 	}
 
@@ -193,7 +193,7 @@ func (p *PlanRoot) service(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:         generateNodeID("service"),
-		Operations: []string{"service-" + actionStr},
+		Operation: "service-" + actionStr,
 		Project:    p.project,
 	}
 
@@ -223,7 +223,7 @@ func (p *PlanRoot) shell(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	node := &execution.Node{
 		ID:         generateNodeID("shell"),
-		Operations: []string{"shell"},
+		Operation: "shell",
 		Project:    p.project,
 	}
 

--- a/internal/starlark/platform/common.go
+++ b/internal/starlark/platform/common.go
@@ -89,7 +89,7 @@ func newBasePlanBindings(graph *execution.Graph, h host.Host, project string) *b
 func (b *basePlanBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("remove"),
-		Operations: []string{"remove"},
+		Operation: "remove",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("path", b.host.ExpandPath(target))
@@ -101,7 +101,7 @@ func (b *basePlanBindings) Remove(target string) *execution.Node {
 func (b *basePlanBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("download"),
-		Operations: []string{"download"},
+		Operation: "download",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -114,7 +114,7 @@ func (b *basePlanBindings) Download(url, target string) *execution.Node {
 func (b *basePlanBindings) ArchiveExtract(archive, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("archive-extract"),
-		Operations: []string{"archive-extract"},
+		Operation: "archive-extract",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("source", b.host.ExpandPath(archive))
@@ -127,7 +127,7 @@ func (b *basePlanBindings) ArchiveExtract(archive, target string) *execution.Nod
 func (b *basePlanBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-clone"),
-		Operations: []string{"git-clone"},
+		Operation: "git-clone",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -140,7 +140,7 @@ func (b *basePlanBindings) GitClone(url, target string) *execution.Node {
 func (b *basePlanBindings) GitCheckout(ref string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-checkout"),
-		Operations: []string{"git-checkout"},
+		Operation: "git-checkout",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("ref", ref)
@@ -152,7 +152,7 @@ func (b *basePlanBindings) GitCheckout(ref string) *execution.Node {
 func (b *basePlanBindings) GitPull() *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-pull"),
-		Operations: []string{"git-pull"},
+		Operation: "git-pull",
 		Project:    b.project,
 	}
 	b.graph.Nodes = append(b.graph.Nodes, node)

--- a/internal/starlark/platform/darwin.go
+++ b/internal/starlark/platform/darwin.go
@@ -172,7 +172,7 @@ func (d *DarwinPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starla
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -203,7 +203,7 @@ func (d *DarwinPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starla
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -234,7 +234,7 @@ func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlar
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -252,7 +252,7 @@ func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlar
 func (d *DarwinPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    d.project,
 	}
 	d.graph.Nodes = append(d.graph.Nodes, node)
@@ -265,21 +265,32 @@ func (d *DarwinPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Bu
 		return nil, err
 	}
 
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    d.project,
+	renderNode := &execution.Node{
+		ID:        darwinGenerateNodeID("render"),
+		Operation: "render",
+		Project:   d.project,
 	}
-
-	if err := loreStar.FillSlot(node, d.graph, "source", source); err != nil {
+	if err := loreStar.FillSlot(renderNode, d.graph, "source", source); err != nil {
 		return nil, fmt.Errorf("configure: source: %w", err)
 	}
-	if err := loreStar.FillSlot(node, d.graph, "path", path); err != nil {
+	d.graph.Nodes = append(d.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        darwinGenerateNodeID("configure"),
+		Operation: "copy",
+		Project:   d.project,
+	}
+	if err := loreStar.FillSlot(copyNode, d.graph, "path", path); err != nil {
 		return nil, fmt.Errorf("configure: path: %w", err)
 	}
+	d.graph.Nodes = append(d.graph.Nodes, copyNode)
 
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return loreStar.NewOutput(node, d.graph, ""), nil
+	d.graph.Edges = append(d.graph.Edges, execution.Edge{
+		From: renderNode.ID,
+		To:   copyNode.ID,
+	})
+
+	return loreStar.NewOutput(copyNode, d.graph, ""), nil
 }
 
 func (d *DarwinPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -290,7 +301,7 @@ func (d *DarwinPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    d.project,
 	}
 
@@ -313,7 +324,7 @@ func (d *DarwinPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    d.project,
 	}
 
@@ -336,7 +347,7 @@ func (d *DarwinPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builti
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    d.project,
 	}
 
@@ -371,7 +382,7 @@ func (d *DarwinPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Buil
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("launchd"),
-		Operations: []string{"launchd-" + actionStr},
+		Operation: "launchd-" + actionStr,
 		Project:    d.project,
 	}
 
@@ -394,7 +405,7 @@ func (d *DarwinPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builti
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("shell"),
-		Operations: []string{"shell"},
+		Operation: "shell",
 		Project:    d.project,
 	}
 
@@ -429,7 +440,7 @@ func (d *DarwinPlanBindings) PackageInstall(packages ...string) *execution.Node 
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -447,7 +458,7 @@ func (d *DarwinPlanBindings) PackageUpgrade(packages ...string) *execution.Node 
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -465,7 +476,7 @@ func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -482,7 +493,7 @@ func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
 func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    d.project,
 	}
 	d.graph.Nodes = append(d.graph.Nodes, node)
@@ -490,21 +501,34 @@ func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
 }
 
 func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         darwinGenerateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    d.project,
+	renderNode := &execution.Node{
+		ID:        darwinGenerateNodeID("render"),
+		Operation: "render",
+		Project:   d.project,
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", d.host.ExpandPath(target))
-	d.graph.Nodes = append(d.graph.Nodes, node)
-	return node
+	renderNode.SetSlotImmediate("source", source)
+	d.graph.Nodes = append(d.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        darwinGenerateNodeID("configure"),
+		Operation: "copy",
+		Project:   d.project,
+	}
+	copyNode.SetSlotImmediate("path", d.host.ExpandPath(target))
+	d.graph.Nodes = append(d.graph.Nodes, copyNode)
+
+	d.graph.Edges = append(d.graph.Edges, execution.Edge{
+		From: renderNode.ID,
+		To:   copyNode.ID,
+	})
+
+	return copyNode
 }
 
 func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -516,7 +540,7 @@ func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
 func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -528,7 +552,7 @@ func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
 func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -540,7 +564,7 @@ func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
 func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("launchd", name, action.String()),
-		Operations: []string{"launchd-" + action.String()},
+		Operation: "launchd-" + action.String(),
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -552,7 +576,7 @@ func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction)
 func (d *DarwinPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("shell"),
-		Operations: []string{"shell"},
+		Operation: "shell",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("command", command)

--- a/internal/starlark/platform/linux.go
+++ b/internal/starlark/platform/linux.go
@@ -97,7 +97,7 @@ func (l *LinuxPlanBindings) PackageManagerName() string {
 func (l *LinuxPlanBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-install", packages...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -109,7 +109,7 @@ func (l *LinuxPlanBindings) PackageInstall(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-upgrade", packages...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -121,7 +121,7 @@ func (l *LinuxPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-remove", packages...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -133,31 +133,44 @@ func (l *LinuxPlanBindings) PackageRemove(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    l.project,
 	}
 	l.graph.Nodes = append(l.graph.Nodes, node)
 	return node
 }
 
-// Configure adds a configuration file node.
+// Configure adds a configuration file node (render→copy chain).
 func (l *LinuxPlanBindings) Configure(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         linuxGenerateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    l.project,
+	renderNode := &execution.Node{
+		ID:        linuxGenerateNodeID("render"),
+		Operation: "render",
+		Project:   l.project,
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", l.host.ExpandPath(target))
-	l.graph.Nodes = append(l.graph.Nodes, node)
-	return node
+	renderNode.SetSlotImmediate("source", source)
+	l.graph.Nodes = append(l.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        linuxGenerateNodeID("configure"),
+		Operation: "copy",
+		Project:   l.project,
+	}
+	copyNode.SetSlotImmediate("path", l.host.ExpandPath(target))
+	l.graph.Nodes = append(l.graph.Nodes, copyNode)
+
+	l.graph.Edges = append(l.graph.Edges, execution.Edge{
+		From: renderNode.ID,
+		To:   copyNode.ID,
+	})
+
+	return copyNode
 }
 
 // Link adds a symlink creation node.
 func (l *LinuxPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -170,7 +183,7 @@ func (l *LinuxPlanBindings) Link(source, target string) *execution.Node {
 func (l *LinuxPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -183,7 +196,7 @@ func (l *LinuxPlanBindings) Copy(source, target string) *execution.Node {
 func (l *LinuxPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -196,7 +209,7 @@ func (l *LinuxPlanBindings) Write(target, content string) *execution.Node {
 func (l *LinuxPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("systemd", name, action.String()),
-		Operations: []string{"systemd-" + action.String()},
+		Operation: "systemd-" + action.String(),
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -209,7 +222,7 @@ func (l *LinuxPlanBindings) Service(name string, action loreStar.ServiceAction) 
 func (l *LinuxPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("shell"),
-		Operations: []string{"shell"},
+		Operation: "shell",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("command", command)
@@ -430,7 +443,7 @@ func (l *LinuxPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 	expandedOut := l.host.ExpandPath(out)
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", input.Path())

--- a/internal/starlark/platform/windows.go
+++ b/internal/starlark/platform/windows.go
@@ -55,7 +55,7 @@ func (w *WindowsPlanBindings) PackageManagerName() string {
 func (w *WindowsPlanBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-install", packages...),
-		Operations: []string{"package-install"},
+		Operation: "package-install",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -67,7 +67,7 @@ func (w *WindowsPlanBindings) PackageInstall(packages ...string) *execution.Node
 func (w *WindowsPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-upgrade", packages...),
-		Operations: []string{"package-upgrade"},
+		Operation: "package-upgrade",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -79,7 +79,7 @@ func (w *WindowsPlanBindings) PackageUpgrade(packages ...string) *execution.Node
 func (w *WindowsPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-remove", packages...),
-		Operations: []string{"package-remove"},
+		Operation: "package-remove",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -91,31 +91,43 @@ func (w *WindowsPlanBindings) PackageRemove(packages ...string) *execution.Node 
 func (w *WindowsPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-update"),
-		Operations: []string{"package-update"},
+		Operation: "package-update",
 		Project:    w.project,
 	}
 	w.graph.Nodes = append(w.graph.Nodes, node)
 	return node
 }
 
-// Configure adds a configuration file node.
+// Configure adds a render→copy chain for a configuration file.
 func (w *WindowsPlanBindings) Configure(source, target string) *execution.Node {
-	node := &execution.Node{
-		ID:         windowsGenerateNodeID("configure"),
-		Operations: []string{"render", "copy"},
-		Project:    w.project,
+	renderNode := &execution.Node{
+		ID:        windowsGenerateNodeID("render"),
+		Operation: "render",
+		Project:   w.project,
 	}
-	node.SetSlotImmediate("source", source)
-	node.SetSlotImmediate("path", w.host.ExpandPath(target))
-	w.graph.Nodes = append(w.graph.Nodes, node)
-	return node
+	renderNode.SetSlotImmediate("source", source)
+	w.graph.Nodes = append(w.graph.Nodes, renderNode)
+
+	copyNode := &execution.Node{
+		ID:        windowsGenerateNodeID("configure"),
+		Operation: "copy",
+		Project:   w.project,
+	}
+	copyNode.SetSlotImmediate("path", w.host.ExpandPath(target))
+	w.graph.Nodes = append(w.graph.Nodes, copyNode)
+
+	w.graph.Edges = append(w.graph.Edges, execution.Edge{
+		From: renderNode.ID, To: copyNode.ID,
+	})
+
+	return copyNode
 }
 
 // Link adds a symlink creation node (requires admin on Windows).
 func (w *WindowsPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("link"),
-		Operations: []string{"link"},
+		Operation: "link",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -129,7 +141,7 @@ func (w *WindowsPlanBindings) Link(source, target string) *execution.Node {
 func (w *WindowsPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("copy"),
-		Operations: []string{"copy"},
+		Operation: "copy",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -142,7 +154,7 @@ func (w *WindowsPlanBindings) Copy(source, target string) *execution.Node {
 func (w *WindowsPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -155,7 +167,7 @@ func (w *WindowsPlanBindings) Write(target, content string) *execution.Node {
 func (w *WindowsPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("winservice", name, action.String()),
-		Operations: []string{"winservice-" + action.String()},
+		Operation: "winservice-" + action.String(),
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -168,7 +180,7 @@ func (w *WindowsPlanBindings) Service(name string, action loreStar.ServiceAction
 func (w *WindowsPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("shell"),
-		Operations: []string{"powershell"},
+		Operation: "powershell",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("command", command)
@@ -392,7 +404,7 @@ func (w *WindowsPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Built
 	expandedOut := w.host.ExpandPath(out)
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("write"),
-		Operations: []string{"write"},
+		Operation: "write",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", input.Path())

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -485,16 +485,38 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 	}
 
 	target := filepath.Join(targetRoot, relTarget)
-	node := &execution.Node{
-		ID:         relTarget,
-		Operations: opStrings,
-		Project:    entry.Project,
-	}
-	node.SetSlotImmediate("source", entry.Source)
-	node.SetSlotImmediate("path", target)
+	hasDecrypt := hasDecryptOp(opStrings)
 
-	if hasDecryptOp(opStrings) {
-		node.Mode = 0600
+	// Build node chain for multi-op pipelines
+	var nodes []execution.Executable
+	var edges []execution.Edge
+	var prevNodeID string
+	for i, opName := range opStrings {
+		isLast := (i == len(opStrings) - 1)
+		nodeID := relTarget
+		if !isLast {
+			nodeID = relTarget + ":" + opName
+		}
+
+		node := &execution.Node{
+			ID:        nodeID,
+			Operation: opName,
+			Project:   entry.Project,
+		}
+		if i == 0 {
+			node.SetSlotImmediate("source", entry.Source)
+		}
+		if isLast {
+			node.SetSlotImmediate("path", target)
+			if hasDecrypt {
+				node.Mode = 0600
+			}
+		}
+		nodes = append(nodes, node)
+		if prevNodeID != "" {
+			edges = append(edges, execution.Edge{From: prevNodeID, To: nodeID})
+		}
+		prevNodeID = nodeID
 	}
 
 	reg := execution.NewOperationRegistry()
@@ -507,13 +529,13 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 		ConflictResolution: execution.ResolutionOverwrite,
 	})
 
-	results, runErr := eng.RunNodes(context.Background(), []execution.Executable{node}, nil)
+	results, runErr := eng.RunNodes(context.Background(), nodes, edges)
 	if runErr != nil {
 		cli.Error("%s: %v", relTarget, runErr)
 		return upgradeResultError
 	}
-	if len(results) > 0 && results[0].Status == execution.ResultFailed {
-		cli.Error("%s: %v", relTarget, results[0].Error)
+	if len(results) > 0 && results[len(results)-1].Status == execution.ResultFailed {
+		cli.Error("%s: %v", relTarget, results[len(results)-1].Error)
 		return upgradeResultError
 	}
 
@@ -680,18 +702,16 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 	report.ReceiptPath = cli.LatestReceiptPath("writ")
 
 	for _, n := range g.Nodes {
-		// Get primary operation
-		primaryOp := ""
-		if len(n.Operations) > 0 {
-			primaryOp = n.Operations[0]
-		}
-
 		// Skip non-file nodes and symlinks
-		if n.Status == execution.StatusSkipped || primaryOp == "delegate" || primaryOp == "backup" {
+		if n.Status == execution.StatusSkipped || n.Operation == "delegate" || n.Operation == "backup" {
 			continue
 		}
-		if primaryOp == "link" {
+		if n.Operation == "link" {
 			continue // Symlinks are found by scanning
+		}
+		// Skip intermediate transform nodes
+		if n.Operation == "render" || n.Operation == "decrypt" {
+			continue
 		}
 
 		var entry reconcile.Entry
@@ -703,7 +723,7 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 				Source:         source,
 				Target:         target,
 				Project:        n.Project,
-				Operations:     n.Operations,
+				Operation:      n.Operation,
 				SourceChecksum: n.SourceChecksum,
 				TargetChecksum: n.TargetChecksum,
 			}
@@ -730,11 +750,11 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 		} else {
 			// Just check if file exists
 			entry = reconcile.Entry{
-				RelTarget:  n.ID,
-				Source:     source,
-				Target:     target,
-				Project:    n.Project,
-				Operations: n.Operations,
+				RelTarget: n.ID,
+				Source:    source,
+				Target:    target,
+				Project:   n.Project,
+				Operation: n.Operation,
 			}
 			if _, err := os.Stat(target); os.IsNotExist(err) {
 				entry.State = reconcile.StateMissing
@@ -767,7 +787,7 @@ func reconcileFromView(view *execution.StateView, checkDrift bool) *reconcile.Re
 			Source:         entry.Source,
 			Target:         target,
 			Project:        entry.Project,
-			Operations:     entry.Operations(),
+			Operation:      entry.LastOp(),
 			SourceChecksum: entrySourceChecksum,
 			TargetChecksum: entryTargetChecksum,
 		}
@@ -850,13 +870,13 @@ func reconcileFromView(view *execution.StateView, checkDrift bool) *reconcile.Re
 // outputReconcileJSON outputs the reconcile report as JSON.
 func outputReconcileJSON(report *reconcile.Report) error {
 	type jsonEntry struct {
-		RelTarget  string   `json:"rel_target"`
-		Source     string   `json:"source"`
-		Target     string   `json:"target"`
-		State      string   `json:"state"`
-		Project    string   `json:"project"`
-		Operations []string `json:"operations"`
-		Message    string   `json:"message,omitempty"`
+		RelTarget string `json:"rel_target"`
+		Source    string `json:"source"`
+		Target   string `json:"target"`
+		State    string `json:"state"`
+		Project  string `json:"project"`
+		Operation string `json:"operation"`
+		Message  string `json:"message,omitempty"`
 	}
 
 	type jsonReport struct {
@@ -888,13 +908,13 @@ func outputReconcileJSON(report *reconcile.Report) error {
 
 	for _, e := range report.Entries {
 		jr.Entries = append(jr.Entries, jsonEntry{
-			RelTarget:  e.RelTarget,
-			Source:     e.Source,
-			Target:     e.Target,
-			State:      e.State.Label(),
-			Project:    e.Project,
-			Operations: e.Operations,
-			Message:    e.Message,
+			RelTarget: e.RelTarget,
+			Source:    e.Source,
+			Target:    e.Target,
+			State:     e.State.Label(),
+			Project:   e.Project,
+			Operation: e.Operation,
+			Message:   e.Message,
 		})
 	}
 

--- a/internal/writ/graph_builder.go
+++ b/internal/writ/graph_builder.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CurrentVersion is the graph format version.
-const CurrentVersion = "5"
+const CurrentVersion = "6"
 
 // GraphBuilder is the interface for all graph builders.
 type GraphBuilder interface {
@@ -57,19 +57,58 @@ func BuildTree(g *execution.Graph, cfg *Config) error {
 		return fmt.Errorf("build tree: %w", err)
 	}
 
-	// Convert file entries to graph nodes
+	// Convert file entries to graph nodes.
+	// Multi-op pipelines from tree (e.g., ["render", "copy"]) become node chains.
 	for _, f := range result.Files {
-		node := &execution.Node{
-			ID:         f.ID,
-			Operations: f.Operations,
-			Status:     execution.StatusPending,
-			Project:    f.Project,
-			Layer:      f.Layer,
-			Mode:       f.Mode,
+		ops := f.Operations
+
+		if len(ops) == 1 {
+			// Single operation — single node
+			node := &execution.Node{
+				ID:        f.ID,
+				Operation: ops[0],
+				Status:    execution.StatusPending,
+				Project:   f.Project,
+				Layer:     f.Layer,
+				Mode:      f.Mode,
+			}
+			node.SetSlotImmediate("source", f.Source)
+			node.SetSlotImmediate("path", f.Target)
+			g.Nodes = append(g.Nodes, node)
+		} else {
+			// Multi-op pipeline → node chain
+			var prevNode *execution.Node
+			for i, op := range ops {
+				isLast := (i == len(ops) - 1)
+				nodeID := f.ID
+				if !isLast {
+					nodeID = f.ID + ":" + op
+				}
+
+				node := &execution.Node{
+					ID:        nodeID,
+					Operation: op,
+					Status:    execution.StatusPending,
+					Project:   f.Project,
+					Layer:     f.Layer,
+					Mode:      f.Mode,
+				}
+				if i == 0 {
+					node.SetSlotImmediate("source", f.Source)
+				}
+				if isLast {
+					node.SetSlotImmediate("path", f.Target)
+				}
+				g.Nodes = append(g.Nodes, node)
+
+				if prevNode != nil {
+					g.Edges = append(g.Edges, execution.Edge{
+						From: prevNode.ID, To: node.ID,
+					})
+				}
+				prevNode = node
+			}
 		}
-		node.SetSlotImmediate("source", f.Source)
-		node.SetSlotImmediate("path", f.Target)
-		g.Nodes = append(g.Nodes, node)
 	}
 
 	// Record collisions
@@ -217,11 +256,11 @@ func (b *DecommissionGraphBuilder) Build() (*execution.Graph, error) {
 
 		target := filepath.Join(b.view.Files.Root, relTarget)
 		node := &execution.Node{
-			ID:         relTarget,
-			Operations: []string{op},
-			Status:     execution.StatusPending,
-			Project:    entry.Project,
-			Layer:      entry.Layer,
+			ID:        relTarget,
+			Operation: op,
+			Status:    execution.StatusPending,
+			Project:   entry.Project,
+			Layer:     entry.Layer,
 		}
 		node.SetSlotImmediate("source", entry.Source)
 		node.SetSlotImmediate("path", target)

--- a/internal/writ/graph_test.go
+++ b/internal/writ/graph_test.go
@@ -79,9 +79,9 @@ func TestNewGraph(t *testing.T) {
 func TestNode(t *testing.T) {
 	node := &execution.Node{
 		ID:         ".bashrc",
-		Operations: []string{"link"},
-		Status:     execution.StatusPending,
-		Project:    "all",
+		Operation: "link",
+		Status:    execution.StatusPending,
+		Project:   "all",
 	}
 	node.SetSlotImmediate("source", "/home/user/env/all/.bashrc")
 	node.SetSlotImmediate("path", "/home/user/.bashrc")
@@ -89,8 +89,8 @@ func TestNode(t *testing.T) {
 	if node.ID != ".bashrc" {
 		t.Errorf("expected ID '.bashrc', got %q", node.ID)
 	}
-	if len(node.Operations) != 1 || node.Operations[0] != "link" {
-		t.Errorf("expected operations ['link'], got %v", node.Operations)
+	if node.Operation != "link" {
+		t.Errorf("expected operation 'link', got %q", node.Operation)
 	}
 	if node.Status != execution.StatusPending {
 		t.Errorf("expected status 'pending', got %q", node.Status)
@@ -256,7 +256,7 @@ func TestGraphSerialize(t *testing.T) {
 		Nodes: []*execution.Node{
 			{
 				ID:         ".bashrc",
-				Operations: []string{"link"},
+				Operation: "link",
 				Status:     execution.StatusPending,
 			},
 		},
@@ -353,14 +353,14 @@ func TestRunGraphAlreadyExecuted(t *testing.T) {
 func TestComputeSummary(t *testing.T) {
 	g := &execution.Graph{
 		Nodes: []*execution.Node{
-			{ID: "1", Operations: []string{"link"}, Status: execution.StatusCompleted},
-			{ID: "2", Operations: []string{"link"}, Status: execution.StatusCompleted},
-			{ID: "3", Operations: []string{"render"}, Status: execution.StatusCompleted},
-			{ID: "4", Operations: []string{"decrypt"}, Status: execution.StatusCompleted},
-			{ID: "5", Operations: []string{"copy"}, Status: execution.StatusCompleted},
+			{ID: "1", Operation: "link", Status: execution.StatusCompleted},
+			{ID: "2", Operation: "link", Status: execution.StatusCompleted},
+			{ID: "3", Operation: "render", Status: execution.StatusCompleted},
+			{ID: "4", Operation: "decrypt", Status: execution.StatusCompleted},
+			{ID: "5", Operation: "copy", Status: execution.StatusCompleted},
 			{ID: "6", Status: execution.StatusSkipped},
-			{ID: "7", Operations: []string{"link"}, Status: execution.StatusFailed},
-			{ID: "8", Operations: []string{"link"}, Status: execution.StatusCompleted, Annotations: map[string]string{"backup": "/path/to/backup"}},
+			{ID: "7", Operation: "link", Status: execution.StatusFailed},
+			{ID: "8", Operation: "link", Status: execution.StatusCompleted, Annotations: map[string]string{"backup": "/path/to/backup"}},
 		},
 	}
 

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -34,11 +34,8 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 	// Find rename nodes in the graph
 	var renameNodes []*execution.Node
 	for _, node := range graph.Nodes {
-		for _, op := range node.Operations {
-			if op == "move" {
-				renameNodes = append(renameNodes, node)
-				break
-			}
+		if node.Operation == "move" {
+			renameNodes = append(renameNodes, node)
 		}
 	}
 
@@ -89,11 +86,8 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 func WriteMigratedMarker(sourceRoot string, graph *execution.Graph, analysis *MigrationAnalysis) error {
 	var renames []Rename
 	for _, node := range graph.Nodes {
-		for _, op := range node.Operations {
-			if op == "move" {
-				renames = append(renames, Rename{From: node.GetSlot("source"), To: node.GetSlot("path")})
-				break
-			}
+		if node.Operation == "move" {
+			renames = append(renames, Rename{From: node.GetSlot("source"), To: node.GetSlot("path")})
 		}
 	}
 

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -55,11 +55,11 @@ type graphContext struct {
 
 // nodeView represents a single node in the execution graph.
 type nodeView struct {
-	ID         string   `json:"id" yaml:"id"`
-	Operations []string `json:"operations" yaml:"operations"`
-	Source     string   `json:"source,omitempty" yaml:"source,omitempty"`
-	Target     string   `json:"target,omitempty" yaml:"target,omitempty"`
-	Status     string   `json:"status" yaml:"status"`
+	ID        string `json:"id" yaml:"id"`
+	Operation string `json:"operation" yaml:"operation"`
+	Source    string `json:"source,omitempty" yaml:"source,omitempty"`
+	Target    string `json:"target,omitempty" yaml:"target,omitempty"`
+	Status    string `json:"status" yaml:"status"`
 }
 
 // edgeView represents a dependency between nodes.
@@ -87,11 +87,11 @@ func buildMigrationView(graph *execution.Graph, analysis *MigrationAnalysis) *mi
 	var nodes []nodeView
 	for _, node := range graph.Nodes {
 		nodes = append(nodes, nodeView{
-			ID:         node.ID,
-			Operations: node.Operations,
-			Source:     node.GetSlot("source"),
-			Target:     node.GetSlot("path"),
-			Status:     string(node.Status),
+			ID:        node.ID,
+			Operation: node.Operation,
+			Source:    node.GetSlot("source"),
+			Target:    node.GetSlot("path"),
+			Status:    string(node.Status),
 		})
 	}
 
@@ -288,11 +288,8 @@ func formatRecommendations(w io.Writer, recommendations []string) {
 func filterNodesByOp(graph *execution.Graph, opName string) []*execution.Node {
 	var nodes []*execution.Node
 	for _, node := range graph.Nodes {
-		for _, op := range node.Operations {
-			if op == opName {
-				nodes = append(nodes, node)
-				break
-			}
+		if node.Operation == opName {
+			nodes = append(nodes, node)
 		}
 	}
 	return nodes

--- a/internal/writ/migrate/migrate_test.go
+++ b/internal/writ/migrate/migrate_test.go
@@ -262,7 +262,7 @@ func TestFormatMigrationViewJSON(t *testing.T) {
 			State   string `json:"state"`
 			Nodes   []struct {
 				ID         string   `json:"id"`
-				Operations []string `json:"operations"`
+				Operation string `json:"operation"`
 				Source     string   `json:"source"`
 				Target     string   `json:"target"`
 			} `json:"nodes"`

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -343,13 +343,11 @@ func (s *Session) formatGraphForPrompt() string {
 	var sb strings.Builder
 	sb.WriteString("Planned renames:\n")
 	for _, node := range s.graph.Nodes {
-		for _, op := range node.Operations {
-			if op == "move" {
-				// Show relative paths for readability
-				source := strings.TrimPrefix(node.GetSlot("source"), s.opts.SourceRoot+"/")
-				target := strings.TrimPrefix(node.GetSlot("path"), s.opts.SourceRoot+"/")
-				sb.WriteString(fmt.Sprintf("  %s -> %s\n", source, target))
-			}
+		if node.Operation == "move" {
+			// Show relative paths for readability
+			source := strings.TrimPrefix(node.GetSlot("source"), s.opts.SourceRoot+"/")
+			target := strings.TrimPrefix(node.GetSlot("path"), s.opts.SourceRoot+"/")
+			sb.WriteString(fmt.Sprintf("  %s -> %s\n", source, target))
 		}
 	}
 	return sb.String()

--- a/internal/writ/reconcile/reconcile.go
+++ b/internal/writ/reconcile/reconcile.go
@@ -12,9 +12,9 @@ import (
 	"github.com/NobleFactor/devlore-cli/internal/writ/tree"
 )
 
-// nodeIsDelegate returns true if the node's operations contain only "delegate".
-func nodeIsDelegate(ops []string) bool {
-	return len(ops) == 1 && ops[0] == "delegate"
+// nodeIsDelegate returns true if the node's operation is "delegate".
+func nodeIsDelegate(op string) bool {
+	return op == "delegate"
 }
 
 // State represents the status of a deployed file.
@@ -104,8 +104,8 @@ type Entry struct {
 	// Project is the project this belongs to
 	Project string
 
-	// Operations that were/should be performed
-	Operations []string
+	// Operation that was/should be performed
+	Operation string
 
 	// Message provides additional context (e.g., "points to wrong file")
 	Message string
@@ -172,10 +172,15 @@ func FromBuildResult(br *tree.BuildResult) *Report {
 	}
 
 	for _, f := range br.Files {
-		if nodeIsDelegate(f.Operations) {
+		// Use first operation from tree pipeline as the primary operation
+		op := ""
+		if len(f.Operations) > 0 {
+			op = f.Operations[len(f.Operations)-1] // final op (e.g., "copy" for render+copy)
+		}
+		if nodeIsDelegate(op) {
 			continue // Skip delegate nodes
 		}
-		entry := checkEntry(f.Source, f.Target, f.ID, f.Project, f.Operations)
+		entry := checkEntry(f.Source, f.Target, f.ID, f.Project, op)
 		report.Entries = append(report.Entries, entry)
 	}
 
@@ -183,13 +188,13 @@ func FromBuildResult(br *tree.BuildResult) *Report {
 }
 
 // checkEntry checks the status of a single file.
-func checkEntry(source, target, relTarget, project string, operations []string) Entry {
+func checkEntry(source, target, relTarget, project, operation string) Entry {
 	entry := Entry{
-		RelTarget:  relTarget,
+		RelTarget: relTarget,
 		Source:     source,
 		Target:     target,
 		Project:    project,
-		Operations: operations,
+		Operation:  operation,
 	}
 
 	// Check if target exists
@@ -212,7 +217,7 @@ func checkEntry(source, target, relTarget, project string, operations []string) 
 	}
 
 	// Determine expected operation type
-	isLink := len(operations) == 1 && operations[0] == "link"
+	isLink := operation == "link"
 
 	if isLink {
 		// Should be a symlink
@@ -333,11 +338,11 @@ func ScanTarget(targetRoot, sourceRoot string) *Report {
 		relTarget, _ := filepath.Rel(targetRoot, path)
 
 		entry := Entry{
-			RelTarget:  relTarget,
-			Source:     linkTarget,
-			Target:     path,
-			Project:    project,
-			Operations: []string{"link"},
+			RelTarget: relTarget,
+			Source:    linkTarget,
+			Target:    path,
+			Project:   project,
+			Operation: "link",
 		}
 
 		// Check if source exists

--- a/internal/writ/reconcile/reconcile_test.go
+++ b/internal/writ/reconcile/reconcile_test.go
@@ -35,7 +35,7 @@ func TestCheckEntry_LinkedCorrectly(t *testing.T) {
 	}
 
 	// Check entry
-	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", []string{"link"})
+	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", "link")
 
 	if entry.State != StateLinked {
 		t.Errorf("expected StateLinked, got %s (%s)", entry.State.Label(), entry.Message)
@@ -63,7 +63,7 @@ func TestCheckEntry_Missing(t *testing.T) {
 	targetFile := filepath.Join(targetDir, "test.txt")
 
 	// Check entry - target doesn't exist
-	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", []string{"link"})
+	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", "link")
 
 	if entry.State != StateMissing {
 		t.Errorf("expected StateMissing, got %s (%s)", entry.State.Label(), entry.Message)
@@ -95,7 +95,7 @@ func TestCheckEntry_Conflict(t *testing.T) {
 	}
 
 	// Check entry - should be conflict
-	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", []string{"link"})
+	entry := checkEntry(sourceFile, targetFile, "test.txt", "testproject", "link")
 
 	if entry.State != StateConflict {
 		t.Errorf("expected StateConflict, got %s (%s)", entry.State.Label(), entry.Message)
@@ -118,7 +118,7 @@ func TestCheckEntry_Orphan(t *testing.T) {
 	}
 
 	// Source also doesn't exist
-	entry := checkEntry(nonexistent, targetFile, "test.txt", "testproject", []string{"link"})
+	entry := checkEntry(nonexistent, targetFile, "test.txt", "testproject", "link")
 
 	if entry.State != StateOrphan {
 		t.Errorf("expected StateOrphan, got %s (%s)", entry.State.Label(), entry.Message)
@@ -150,7 +150,7 @@ func TestCheckEntry_CopiedFile(t *testing.T) {
 	}
 
 	// Check entry with copy operation
-	entry := checkEntry(sourceFile, targetFile, "config", "testproject", []string{"render", "copy"})
+	entry := checkEntry(sourceFile, targetFile, "config", "testproject", "copy")
 
 	if entry.State != StateCopied {
 		t.Errorf("expected StateCopied, got %s (%s)", entry.State.Label(), entry.Message)


### PR DESCRIPTION
## Summary

- Migrate `Node.Operations []string` to `Node.Operation string` — each node performs exactly one operation (prerequisite for code generation's 1:1 method-to-node mapping)
- Multi-op pipelines (render+copy, decrypt+render+copy) become node chains connected by edges, with content flowing via `outputs map[string][]byte` in the executor
- Graph version bumped 5 → 6
- Add "Typed Operation Results" section to GenReceiver plan (operations carry typed result objects instead of generic checksum fields on every node)
- Save phase-0 plan to `docs/plans/star-gen-receiver/phase-0.md`

## What the tests prove

- **Content flow through chains**: render→copy (2 nodes) and decrypt→render→copy (3 nodes) verify content passes between chained nodes via edges and the outputs map
- **Topological ordering**: chain tests verify Kahn's algorithm orders upstream transforms before downstream writers
- **Checksum attribution**: render gets SourceChecksum, copy gets TargetChecksum — right node in the chain
- **Pipeline decomposition**: 3 packages × 4 phases = 12 nodes + 9 edges in manifest builder
- **Single-op stateview**: IsCopied/IsLinked/isPackageNode work with single operation string
- **Reconcile**: checkEntry works with single operation string for all states

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] `go vet ./...` clean
- [ ] Manual: `writ deploy --dry-run` with a test repo containing templates