### PR TITLE
feat(execution): add phase execution model with saga pattern

### DIFF
--- a/docs/architecture/devlore-phase-execution.md
+++ b/docs/architecture/devlore-phase-execution.md
@@ -1,0 +1,162 @@
+# Phase Execution Model for Lifecycle Pipelines
+
+## Status
+
+**Approved** — Implementation in progress.
+
+## Context
+
+The execution graph has no concept of "phase." Lifecycle pipelines
+(prepare → install → provision → verify) are a build-time concept — Starlark
+scripts emit nodes into a flat graph, and the executor runs them via topological
+sort. This means:
+
+- There is no error boundary between phases. A node failure is a graph failure.
+- There is no retry at the phase level. Transient failures abort the whole run.
+- There is no structured rollback. Partial success leaves the system in an
+  indeterminate state.
+
+This document describes **phases as first-class runtime concepts** in the
+execution graph, implementing the **Saga Pattern** as a transactional state
+machine. Each phase is a scoped transaction with a forward action, a compensating
+action, and the execution state needed to undo itself. The executor becomes a
+saga coordinator that walks phase boundaries, traps errors, retries, and unwinds.
+
+## The Saga Pattern
+
+Each lifecycle pipeline is a saga — a sequence of local transactions where each
+transaction has a compensating action. The executor is the saga coordinator:
+
+```
+prepare ──→ install ──→ provision ──→ verify
+   ↓            ↓            ↓
+cleanup    uninstall    unprovision
+(compensate) (compensate) (compensate)
+```
+
+On success: all phases complete, saga committed.
+On failure: completed phases are compensated in LIFO order.
+
+This is a **local saga** — the executor has full control of sequencing.
+Compensating actions run synchronously in reverse order. No distributed
+coordination, no eventual consistency.
+
+## Phase as (A, C, S) Tuple
+
+Each phase is defined by the tuple:
+
+| Component | Role | Example |
+|-----------|------|---------|
+| **A** (Action) | Forward operation | Install binary, link config |
+| **C** (Compensate) | Reverse operation | Remove binary, unlink config |
+| **S** (State) | Metadata captured during A that C needs | Installed version, created paths |
+
+A is obligated to populate S during forward execution. S is the receipt of A
+and the input to C. If A doesn't capture enough state, C can't undo the work.
+
+## Phase Boundary Nodes (Checkpoints)
+
+A phase is a **dual-method node** in the graph — a stateful controller that
+encapsulates both the forward and compensating actions. The executor recognizes
+phase nodes as boundaries.
+
+Phase node structure:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ID | string | Unique identifier (e.g., `"phase.install"`) |
+| Name | string | Phase name (e.g., `"install"`) |
+| Retry | *RetryPolicy | Max retries, backoff, timeout |
+| Status | PhaseStatus | pending, completed, failed, rolled_back, skipped |
+| NodeIDs | []string | IDs of inner nodes belonging to this phase |
+| Compensate | string | ID of compensating phase/action |
+| Attempts | []Attempt | Retry history |
+| State | map[string]any | Execution state captured during forward action (S) |
+
+## Recovery Pointer Stack
+
+When the executor enters a checkpoint phase, it pushes a **recovery pointer**
+onto a local stack. The stack tracks completed phases and their compensating
+actions:
+
+```
+Stack (LIFO):
+  [2] provision → unprovision (← top, most recent)
+  [1] install   → uninstall
+  [0] prepare   → cleanup
+```
+
+On failure after exhausting retries, the executor pops the stack and executes
+compensating actions in LIFO order until it reaches the bottom. Only phases
+that actually completed have entries on the stack — a phase that was never
+reached produces no entry.
+
+## Executor Loop
+
+The executor runs a **two-level loop**:
+
+**Outer loop**: walks phases in order (the saga coordinator)
+**Inner loop**: executes nodes within a phase (the current topological sort)
+
+```
+for each phase in pipeline:
+    push recovery pointer
+    result = phase.Execute(ctx)        // inner loop + retry
+    if result == success:
+        continue to next phase
+    else:
+        unwind(recovery_stack)         // LIFO compensating actions
+        return failure
+```
+
+## Inner Node Failure
+
+**Any inner node failure immediately fails the phase.** Inner nodes do not
+have independent retry. When a node within a phase errors, execution of
+that phase stops and the error bubbles to the phase boundary (the trap).
+
+The phase's retry policy then governs: retry the entire phase, or give up and
+trigger unwind.
+
+## Rollback (Unwind)
+
+When the executor decides to unwind:
+
+1. Pop the recovery stack
+2. For each entry (LIFO order): execute the compensating action
+3. Compensating action receives the phase's captured State (S)
+4. If a compensating action itself fails: log the error, continue unwinding
+5. Unwinding continues until the stack is empty
+
+## Retry Policy
+
+```go
+type RetryPolicy struct {
+    MaxAttempts  int
+    Backoff      BackoffStrategy  // none, linear, exponential
+    InitialDelay string           // duration string, e.g. "1s"
+    MaxDelay     string           // duration string, e.g. "30s"
+}
+```
+
+## Graph Integration
+
+The `Phases` field on `Graph` is optional. Graphs that don't use phases continue
+to work exactly as before. Lore lifecycle graphs populate `Phases` to enable
+phase-aware execution. The executor checks `graph.Phases != nil` and delegates
+to the phase-aware loop when present.
+
+## Starlark Integration (Future)
+
+Phase scripts will gain `forward()` / `compensate()` entry points.
+The phase `ctx` will expose a `state` dict for (S) capture.
+A `configure(phase)` hook will allow setting retry policy per-phase.
+
+## Files
+
+| File | Role |
+|------|------|
+| `internal/execution/phase.go` | Phase, PhaseStatus, Attempt, RetryPolicy types |
+| `internal/execution/recovery.go` | RecoveryStack, RecoveryEntry |
+| `internal/execution/executor.go` | RunPhased method on GraphExecutor |
+| `internal/execution/graph.go` | Phases field on Graph |

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ResultStatus represents the execution status of a node.
@@ -111,13 +112,24 @@ func NewGraphExecutor(registry *OperationRegistry, opts ExecutorOptions) *GraphE
 }
 
 // Run executes all nodes in the graph, respecting ordering constraints.
-// Nodes are processed in topological order when edges define dependencies.
-// Content flows between chained nodes via an outputs map.
+// When the graph has phases, execution is delegated to RunPhased which
+// implements the saga pattern with retry and rollback. Otherwise, nodes
+// are processed in topological order (flat execution).
 func (e *GraphExecutor) Run(ctx context.Context, g *Graph) error {
 	if g.State != StatePending {
 		return fmt.Errorf("graph already executed (state: %s)", g.State)
 	}
 
+	if len(g.Phases) > 0 {
+		return e.RunPhased(ctx, g)
+	}
+
+	return e.runFlat(ctx, g)
+}
+
+// runFlat executes all nodes in topological order without phase boundaries.
+// This is the original execution path for non-phased graphs.
+func (e *GraphExecutor) runFlat(ctx context.Context, g *Graph) error {
 	ordered := e.orderNodes(g.Nodes, g.Edges)
 
 	execCtx := &Context{
@@ -152,6 +164,203 @@ func (e *GraphExecutor) Run(ctx context.Context, g *Graph) error {
 	}
 
 	return nil
+}
+
+// RunPhased executes a phased graph using the saga pattern.
+// Phases are executed in order. Each phase runs its inner nodes via
+// topological sort. On failure, completed phases are compensated in
+// LIFO order (rollback).
+//
+// Phases referenced as compensating actions (via Compensate fields) are
+// skipped during the forward pass — they execute only during rollback.
+func (e *GraphExecutor) RunPhased(ctx context.Context, g *Graph) error {
+	execCtx := &Context{
+		Context: ctx,
+		DryRun:  e.options.DryRun,
+		Logger:  e.options.Logger,
+		Data:    e.options.Data,
+	}
+
+	// Collect compensating phase IDs so we skip them in the forward pass.
+	compensateIDs := make(map[string]bool)
+	for _, p := range g.Phases {
+		if p.Compensate != "" {
+			compensateIDs[p.Compensate] = true
+		}
+	}
+
+	// Build the forward phase list (excludes compensating phases).
+	var forwardPhases []*Phase
+	for _, p := range g.Phases {
+		if !compensateIDs[p.ID] {
+			forwardPhases = append(forwardPhases, p)
+		}
+	}
+
+	stack := &RecoveryStack{}
+	var rollbackLog []RollbackEntry
+
+	for _, phase := range forwardPhases {
+		err := e.executePhase(execCtx, g, phase, stack)
+		if err != nil {
+			// Phase failed after retries — unwind completed phases
+			phase.Status = PhaseFailed
+
+			// Mark remaining forward phases as skipped
+			started := false
+			for _, p := range forwardPhases {
+				if p.ID == phase.ID {
+					started = true
+					continue
+				}
+				if started && p.Status == PhasePending {
+					p.Status = PhaseSkipped
+				}
+			}
+
+			// Unwind the recovery stack
+			rollbackLog = e.unwindStack(execCtx, g, stack)
+
+			g.Rollback = rollbackLog
+			g.ComputeSummary()
+			g.State = StateFailed
+			return fmt.Errorf("phase %s failed: %w", phase.Name, err)
+		}
+	}
+
+	g.ComputeSummary()
+	g.State = StateExecuted
+	return nil
+}
+
+// executePhase runs a single phase with retry logic.
+// On success, pushes a recovery entry onto the stack.
+// On failure (retries exhausted), returns the error.
+func (e *GraphExecutor) executePhase(ctx *Context, g *Graph, phase *Phase, stack *RecoveryStack) error {
+	maxAttempts := 1
+	if phase.Retry != nil {
+		maxAttempts += phase.Retry.MaxAttempts
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		// Apply backoff delay before retries (not before first attempt)
+		if attempt > 0 && phase.Retry != nil {
+			delay := phase.Retry.ComputeDelay(attempt - 1)
+			if delay > 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(delay):
+				}
+			}
+		}
+
+		// Reset inner node statuses for retry
+		if attempt > 0 {
+			e.resetPhaseNodes(g, phase)
+		}
+
+		err := e.ExecutePhaseInner(ctx, g, phase)
+
+		attemptRecord := Attempt{
+			Number:    attempt + 1,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+
+		if err == nil {
+			attemptRecord.Status = "completed"
+			phase.Attempts = append(phase.Attempts, attemptRecord)
+			phase.Status = PhaseCompleted
+
+			// Push recovery entry if phase has a compensating action
+			if phase.Compensate != "" {
+				compensateID := phase.Compensate
+				phaseName := phase.Name
+				phaseState := phase.State
+
+				stack.Push(RecoveryEntry{
+					PhaseID:   phase.ID,
+					PhaseName: phaseName,
+					State:     phaseState,
+					Compensate: func(ctx *Context) error {
+						// Find the compensating phase in the graph
+						for _, p := range g.Phases {
+							if p.ID == compensateID {
+								return e.ExecutePhaseInner(ctx, g, p)
+							}
+						}
+						return fmt.Errorf("compensating phase %s not found", compensateID)
+					},
+				})
+			}
+
+			return nil
+		}
+
+		attemptRecord.Status = "failed"
+		attemptRecord.Error = err.Error()
+		phase.Attempts = append(phase.Attempts, attemptRecord)
+		lastErr = err
+	}
+
+	return lastErr
+}
+
+// resetPhaseNodes resets inner node statuses back to pending for retry.
+func (e *GraphExecutor) resetPhaseNodes(g *Graph, phase *Phase) {
+	nodeSet := make(map[string]bool, len(phase.NodeIDs))
+	for _, id := range phase.NodeIDs {
+		nodeSet[id] = true
+	}
+	for _, n := range g.Nodes {
+		if nodeSet[n.ID] {
+			n.Status = StatusPending
+			n.Error = ""
+			n.Timestamp = ""
+		}
+	}
+}
+
+// unwindStack pops the recovery stack and executes compensating actions in LIFO order.
+// Returns a log of rollback entries for the receipt.
+func (e *GraphExecutor) unwindStack(ctx *Context, g *Graph, stack *RecoveryStack) []RollbackEntry {
+	entries := stack.Entries()
+	var log []RollbackEntry
+
+	// Process in LIFO order (most recent first)
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		rollback := RollbackEntry{
+			Phase:      entry.PhaseName,
+			Compensate: entry.PhaseID + ".compensate",
+		}
+
+		if entry.Compensate == nil {
+			rollback.Status = "skipped"
+			log = append(log, rollback)
+			continue
+		}
+
+		if err := entry.Compensate(ctx); err != nil {
+			rollback.Status = "failed"
+			rollback.Error = err.Error()
+		} else {
+			rollback.Status = "completed"
+		}
+
+		// Mark the original phase as rolled back
+		for _, p := range g.Phases {
+			if p.ID == entry.PhaseID {
+				p.Status = PhaseRolledBack
+				break
+			}
+		}
+
+		log = append(log, rollback)
+	}
+
+	return log
 }
 
 // RunNodes executes a slice of executables with the given edges.

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -276,11 +276,19 @@ type Graph struct {
 	// Edges are the dependencies between nodes.
 	Edges []Edge `json:"edges,omitempty" yaml:"edges,omitempty"`
 
+	// Phases defines the ordered lifecycle phases (nil for non-phased graphs).
+	// When present, the executor uses phase-aware execution with retry and rollback.
+	// When nil, the executor falls back to flat node execution.
+	Phases []*Phase `json:"phases,omitempty" yaml:"phases,omitempty"`
+
 	// Collisions records source conflicts resolved during tree building (writ-specific).
 	Collisions []Collision `json:"collisions,omitempty" yaml:"collisions,omitempty"`
 
 	// Summary contains execution statistics (populated after Run).
 	Summary Summary `json:"summary,omitempty" yaml:"summary,omitempty"`
+
+	// Rollback records compensating actions executed during rollback (populated on failure).
+	Rollback []RollbackEntry `json:"rollback,omitempty" yaml:"rollback,omitempty"`
 
 	// Checksum is the git-style integrity hash.
 	Checksum string `json:"checksum,omitempty" yaml:"checksum,omitempty"`
@@ -389,6 +397,7 @@ func (g *Graph) CanonicalContent() ([]byte, error) {
 		State      GraphState   `yaml:"state"`
 		Platform   Platform     `yaml:"platform"`
 		Context    GraphContext `yaml:"context"`
+		Phases     []*Phase     `yaml:"phases,omitempty"`
 		Nodes      []*Node      `yaml:"nodes"`
 		Edges      []Edge       `yaml:"edges,omitempty"`
 		Collisions []Collision  `yaml:"collisions,omitempty"`
@@ -401,6 +410,7 @@ func (g *Graph) CanonicalContent() ([]byte, error) {
 		State:      g.State,
 		Platform:   g.Platform,
 		Context:    g.Context,
+		Phases:     g.Phases,
 		Nodes:      g.Nodes,
 		Edges:      g.Edges,
 		Collisions: g.Collisions,
@@ -437,6 +447,8 @@ func (g *Graph) ApplyResults(results []*Result) {
 }
 
 // ComputeSummary calculates summary statistics from nodes.
+// For phased graphs, node statuses reflect the phase execution outcome
+// (nodes in rolled-back phases may show as completed from before rollback).
 func (g *Graph) ComputeSummary() {
 	g.Summary = Summary{}
 
@@ -477,4 +489,14 @@ func (g *Graph) ComputeSummary() {
 			g.Summary.BackedUp++
 		}
 	}
+}
+
+// PhaseByID returns the phase with the given ID, or nil if not found.
+func (g *Graph) PhaseByID(id string) *Phase {
+	for _, p := range g.Phases {
+		if p.ID == id {
+			return p
+		}
+	}
+	return nil
 }

--- a/internal/execution/phase.go
+++ b/internal/execution/phase.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package execution
+
+import (
+	"fmt"
+	"time"
+)
+
+// PhaseStatus represents the execution state of a phase.
+type PhaseStatus string
+
+const (
+	PhasePending    PhaseStatus = "pending"
+	PhaseCompleted  PhaseStatus = "completed"
+	PhaseFailed     PhaseStatus = "failed"
+	PhaseRolledBack PhaseStatus = "rolled_back"
+	PhaseSkipped    PhaseStatus = "skipped"
+)
+
+// Phase represents a lifecycle phase in the execution graph.
+// Each phase owns a set of inner nodes and acts as an error boundary
+// with retry and compensating action support (the Saga Pattern).
+type Phase struct {
+	// ID is the unique identifier (e.g., "phase.install").
+	ID string `json:"id" yaml:"id"`
+
+	// Name is the phase name (e.g., "install").
+	Name string `json:"name" yaml:"name"`
+
+	// Status of this phase: pending, completed, failed, rolled_back, skipped.
+	Status PhaseStatus `json:"status" yaml:"status"`
+
+	// Retry governs retry behavior when inner nodes fail.
+	Retry *RetryPolicy `json:"retry,omitempty" yaml:"retry,omitempty"`
+
+	// NodeIDs lists the IDs of inner nodes belonging to this phase.
+	NodeIDs []string `json:"nodes,omitempty" yaml:"nodes,omitempty"`
+
+	// Compensate is the ID of the compensating action for rollback.
+	Compensate string `json:"compensate,omitempty" yaml:"compensate,omitempty"`
+
+	// Attempts records retry history (populated during execution).
+	Attempts []Attempt `json:"attempts,omitempty" yaml:"attempts,omitempty"`
+
+	// State holds execution metadata captured during the forward action.
+	// The compensating action reads this to know what to undo.
+	State map[string]any `json:"state,omitempty" yaml:"state,omitempty"`
+}
+
+// Attempt records one execution attempt of a phase.
+type Attempt struct {
+	// Number is the 1-based attempt number.
+	Number int `json:"number" yaml:"number"`
+
+	// Status is "completed" or "failed".
+	Status string `json:"status" yaml:"status"`
+
+	// Error is the error message if the attempt failed.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+
+	// Timestamp is when this attempt completed (RFC3339).
+	Timestamp string `json:"timestamp" yaml:"timestamp"`
+}
+
+// BackoffStrategy defines how delays increase between retries.
+type BackoffStrategy string
+
+const (
+	BackoffNone        BackoffStrategy = "none"
+	BackoffLinear      BackoffStrategy = "linear"
+	BackoffExponential BackoffStrategy = "exponential"
+)
+
+// RetryPolicy configures retry behavior for a phase.
+type RetryPolicy struct {
+	// MaxAttempts is the maximum number of retries (0 = no retry, fail immediately).
+	MaxAttempts int `json:"max_attempts" yaml:"max_attempts"`
+
+	// Backoff is the delay strategy: none, linear, exponential.
+	Backoff BackoffStrategy `json:"backoff" yaml:"backoff"`
+
+	// InitialDelay is the delay before the first retry (Go duration string, e.g. "1s").
+	InitialDelay string `json:"initial_delay,omitempty" yaml:"initial_delay,omitempty"`
+
+	// MaxDelay caps the delay between retries (Go duration string, e.g. "30s").
+	MaxDelay string `json:"max_delay,omitempty" yaml:"max_delay,omitempty"`
+}
+
+// ParseInitialDelay parses the InitialDelay string into a time.Duration.
+// Returns 0 if the string is empty or unparseable.
+func (r *RetryPolicy) ParseInitialDelay() time.Duration {
+	if r.InitialDelay == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(r.InitialDelay)
+	if err != nil {
+		return 0
+	}
+	return d
+}
+
+// ParseMaxDelay parses the MaxDelay string into a time.Duration.
+// Returns 0 if the string is empty or unparseable.
+func (r *RetryPolicy) ParseMaxDelay() time.Duration {
+	if r.MaxDelay == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(r.MaxDelay)
+	if err != nil {
+		return 0
+	}
+	return d
+}
+
+// ComputeDelay returns the delay for a given attempt number (0-based).
+func (r *RetryPolicy) ComputeDelay(attempt int) time.Duration {
+	initial := r.ParseInitialDelay()
+	if initial == 0 {
+		return 0
+	}
+
+	var delay time.Duration
+	switch r.Backoff {
+	case BackoffNone:
+		delay = initial
+	case BackoffLinear:
+		delay = initial * time.Duration(attempt+1)
+	case BackoffExponential:
+		delay = initial
+		for i := 0; i < attempt; i++ {
+			delay *= 2
+		}
+	default:
+		delay = initial
+	}
+
+	if maxDelay := r.ParseMaxDelay(); maxDelay > 0 && delay > maxDelay {
+		delay = maxDelay
+	}
+
+	return delay
+}
+
+// RollbackEntry records a compensating action executed during rollback.
+type RollbackEntry struct {
+	// Phase is the phase name that was rolled back.
+	Phase string `json:"phase" yaml:"phase"`
+
+	// Compensate is the ID of the compensating action.
+	Compensate string `json:"compensate" yaml:"compensate"`
+
+	// Status is "completed" or "failed".
+	Status string `json:"status" yaml:"status"`
+
+	// Error is the error message if the compensating action failed.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+// ExecutePhaseInner runs all inner nodes of a phase using the executor.
+// It extracts the phase's nodes from the graph and runs them in topological order.
+// Any node failure immediately fails the phase.
+func (e *GraphExecutor) ExecutePhaseInner(ctx *Context, g *Graph, phase *Phase) error {
+	// Collect the phase's inner nodes
+	nodeSet := make(map[string]bool, len(phase.NodeIDs))
+	for _, id := range phase.NodeIDs {
+		nodeSet[id] = true
+	}
+
+	var phaseNodes []*Node
+	for _, n := range g.Nodes {
+		if nodeSet[n.ID] {
+			phaseNodes = append(phaseNodes, n)
+		}
+	}
+
+	if len(phaseNodes) == 0 {
+		return nil
+	}
+
+	// Filter edges to only those between phase nodes
+	var phaseEdges []Edge
+	for _, edge := range g.Edges {
+		if nodeSet[edge.From] && nodeSet[edge.To] {
+			phaseEdges = append(phaseEdges, edge)
+		}
+	}
+
+	ordered := e.topologicalSortNodes(phaseNodes, phaseEdges)
+	outputs := make(map[string][]byte)
+
+	for _, node := range ordered {
+		result := e.executeNodeWithOutputs(ctx, node, phaseEdges, outputs)
+		if result.Status == ResultFailed {
+			// Apply this result to the node
+			node.Status = StatusFailed
+			if result.Error != nil {
+				node.Error = result.Error.Error()
+			}
+			node.Timestamp = time.Now().Format(time.RFC3339)
+			return fmt.Errorf("node %s failed: %w", node.ID, result.Error)
+		}
+
+		// Apply successful result
+		node.Status = StatusCompleted
+		node.Timestamp = time.Now().Format(time.RFC3339)
+		node.SourceChecksum = result.SourceChecksum
+		node.TargetChecksum = result.TargetChecksum
+	}
+
+	return nil
+}

--- a/internal/execution/phase_test.go
+++ b/internal/execution/phase_test.go
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package execution
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRetryPolicyComputeDelay tests backoff delay computation.
+func TestRetryPolicyComputeDelay(t *testing.T) {
+	t.Run("none backoff", func(t *testing.T) {
+		policy := &RetryPolicy{
+			MaxAttempts:  3,
+			Backoff:      BackoffNone,
+			InitialDelay: "100ms",
+		}
+		// All attempts get the same delay
+		for i := 0; i < 3; i++ {
+			d := policy.ComputeDelay(i)
+			if d != 100*time.Millisecond {
+				t.Errorf("attempt %d: expected 100ms, got %v", i, d)
+			}
+		}
+	})
+
+	t.Run("linear backoff", func(t *testing.T) {
+		policy := &RetryPolicy{
+			MaxAttempts:  3,
+			Backoff:      BackoffLinear,
+			InitialDelay: "100ms",
+		}
+		expected := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond}
+		for i, want := range expected {
+			d := policy.ComputeDelay(i)
+			if d != want {
+				t.Errorf("attempt %d: expected %v, got %v", i, want, d)
+			}
+		}
+	})
+
+	t.Run("exponential backoff", func(t *testing.T) {
+		policy := &RetryPolicy{
+			MaxAttempts:  3,
+			Backoff:      BackoffExponential,
+			InitialDelay: "100ms",
+		}
+		expected := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond}
+		for i, want := range expected {
+			d := policy.ComputeDelay(i)
+			if d != want {
+				t.Errorf("attempt %d: expected %v, got %v", i, want, d)
+			}
+		}
+	})
+
+	t.Run("max delay cap", func(t *testing.T) {
+		policy := &RetryPolicy{
+			MaxAttempts:  5,
+			Backoff:      BackoffExponential,
+			InitialDelay: "100ms",
+			MaxDelay:     "300ms",
+		}
+		d := policy.ComputeDelay(3) // Would be 800ms without cap
+		if d != 300*time.Millisecond {
+			t.Errorf("expected 300ms cap, got %v", d)
+		}
+	})
+
+	t.Run("empty initial delay", func(t *testing.T) {
+		policy := &RetryPolicy{Backoff: BackoffLinear}
+		if d := policy.ComputeDelay(0); d != 0 {
+			t.Errorf("expected 0 for empty initial delay, got %v", d)
+		}
+	})
+}
+
+// TestRetryPolicyParseDuration tests duration string parsing.
+func TestRetryPolicyParseDuration(t *testing.T) {
+	t.Run("valid initial delay", func(t *testing.T) {
+		p := &RetryPolicy{InitialDelay: "5s"}
+		if d := p.ParseInitialDelay(); d != 5*time.Second {
+			t.Errorf("expected 5s, got %v", d)
+		}
+	})
+
+	t.Run("valid max delay", func(t *testing.T) {
+		p := &RetryPolicy{MaxDelay: "1m30s"}
+		if d := p.ParseMaxDelay(); d != 90*time.Second {
+			t.Errorf("expected 1m30s, got %v", d)
+		}
+	})
+
+	t.Run("empty string returns 0", func(t *testing.T) {
+		p := &RetryPolicy{}
+		if d := p.ParseInitialDelay(); d != 0 {
+			t.Errorf("expected 0, got %v", d)
+		}
+	})
+
+	t.Run("invalid string returns 0", func(t *testing.T) {
+		p := &RetryPolicy{InitialDelay: "not-a-duration"}
+		if d := p.ParseInitialDelay(); d != 0 {
+			t.Errorf("expected 0 for invalid string, got %v", d)
+		}
+	})
+}
+
+// TestPhasedExecutionSuccess tests a 4-phase pipeline that succeeds.
+func TestPhasedExecutionSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create source files for link operations
+	sources := make(map[string]string)
+	for _, name := range []string{"probe.txt", "pkg.txt", "config.txt", "verify.txt"} {
+		path := filepath.Join(tmpDir, "src-"+name)
+		if err := os.WriteFile(path, []byte("content-"+name), 0644); err != nil {
+			t.Fatal(err)
+		}
+		sources[name] = path
+	}
+
+	reg := NewOperationRegistry()
+	reg.Register(&LinkOp{})
+
+	executor := NewGraphExecutor(reg, ExecutorOptions{})
+
+	graph := &Graph{
+		State: StatePending,
+		Phases: []*Phase{
+			{
+				ID:      "phase.prepare",
+				Name:    "prepare",
+				Status:  PhasePending,
+				NodeIDs: []string{"probe"},
+			},
+			{
+				ID:         "phase.install",
+				Name:       "install",
+				Status:     PhasePending,
+				NodeIDs:    []string{"pkg"},
+				Compensate: "phase.install.compensate",
+			},
+			{
+				ID:         "phase.provision",
+				Name:       "provision",
+				Status:     PhasePending,
+				NodeIDs:    []string{"config"},
+				Compensate: "phase.provision.compensate",
+			},
+			{
+				ID:      "phase.verify",
+				Name:    "verify",
+				Status:  PhasePending,
+				NodeIDs: []string{"check"},
+			},
+		},
+		Nodes: []*Node{
+			testNode("probe", "link", sources["probe.txt"], filepath.Join(tmpDir, "out-probe")),
+			testNode("pkg", "link", sources["pkg.txt"], filepath.Join(tmpDir, "out-pkg")),
+			testNode("config", "link", sources["config.txt"], filepath.Join(tmpDir, "out-config")),
+			testNode("check", "link", sources["verify.txt"], filepath.Join(tmpDir, "out-verify")),
+		},
+	}
+
+	err := executor.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+
+	if graph.State != StateExecuted {
+		t.Errorf("expected state executed, got %s", graph.State)
+	}
+
+	// All phases should be completed
+	for _, p := range graph.Phases {
+		if p.Status != PhaseCompleted {
+			t.Errorf("phase %s: expected completed, got %s", p.Name, p.Status)
+		}
+	}
+
+	// All nodes should be completed
+	for _, n := range graph.Nodes {
+		if n.Status != StatusCompleted {
+			t.Errorf("node %s: expected completed, got %s", n.ID, n.Status)
+		}
+	}
+}
+
+// TestPhasedExecutionFailureWithRollback tests failure at phase 3 with LIFO rollback.
+func TestPhasedExecutionFailureWithRollback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create source files for phases 1 and 2 (these succeed)
+	src1 := filepath.Join(tmpDir, "src1.txt")
+	src2 := filepath.Join(tmpDir, "src2.txt")
+	if err := os.WriteFile(src1, []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src2, []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	compensateSrc := filepath.Join(tmpDir, "compensate.txt")
+	if err := os.WriteFile(compensateSrc, []byte("c"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewOperationRegistry()
+	reg.Register(&LinkOp{})
+	// Phase 3 uses an operation that always fails
+	reg.Register(&testRetryOp{
+		name: "fail-provision",
+		fn: func(ctx *Context, node Executable) error {
+			return fmt.Errorf("permission denied")
+		},
+	})
+
+	executor := NewGraphExecutor(reg, ExecutorOptions{})
+
+	graph := &Graph{
+		State: StatePending,
+		Phases: []*Phase{
+			{
+				ID:         "phase.prepare",
+				Name:       "prepare",
+				Status:     PhasePending,
+				NodeIDs:    []string{"node-prepare"},
+				Compensate: "phase.prepare.compensate",
+			},
+			{
+				ID:         "phase.install",
+				Name:       "install",
+				Status:     PhasePending,
+				NodeIDs:    []string{"node-install"},
+				Compensate: "phase.install.compensate",
+			},
+			{
+				ID:         "phase.provision",
+				Name:       "provision",
+				Status:     PhasePending,
+				NodeIDs:    []string{"node-provision"},
+				Compensate: "phase.provision.compensate",
+			},
+			{
+				ID:      "phase.verify",
+				Name:    "verify",
+				Status:  PhasePending,
+				NodeIDs: []string{"node-verify"},
+			},
+			// Compensating phases
+			{
+				ID:      "phase.prepare.compensate",
+				Name:    "prepare.compensate",
+				Status:  PhasePending,
+				NodeIDs: []string{"comp-prepare"},
+			},
+			{
+				ID:      "phase.install.compensate",
+				Name:    "install.compensate",
+				Status:  PhasePending,
+				NodeIDs: []string{"comp-install"},
+			},
+			{
+				ID:      "phase.provision.compensate",
+				Name:    "provision.compensate",
+				Status:  PhasePending,
+				NodeIDs: []string{"comp-provision"},
+			},
+		},
+		Nodes: []*Node{
+			testNode("node-prepare", "link", src1, filepath.Join(tmpDir, "out1")),
+			testNode("node-install", "link", src2, filepath.Join(tmpDir, "out2")),
+			{ID: "node-provision", Operation: "fail-provision"},
+			testNode("node-verify", "link", src1, filepath.Join(tmpDir, "out4")),
+			testNode("comp-prepare", "link", compensateSrc, filepath.Join(tmpDir, "comp-out1")),
+			testNode("comp-install", "link", compensateSrc, filepath.Join(tmpDir, "comp-out2")),
+			testNode("comp-provision", "link", compensateSrc, filepath.Join(tmpDir, "comp-out3")),
+		},
+	}
+
+	err := executor.Run(context.Background(), graph)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(err.Error(), "phase provision failed") {
+		t.Errorf("expected provision failure, got: %v", err)
+	}
+
+	if graph.State != StateFailed {
+		t.Errorf("expected state failed, got %s", graph.State)
+	}
+
+	// Phases 1 and 2 should be rolled_back (they completed then were compensated)
+	prepare := graph.PhaseByID("phase.prepare")
+	install := graph.PhaseByID("phase.install")
+	provision := graph.PhaseByID("phase.provision")
+	verify := graph.PhaseByID("phase.verify")
+
+	if prepare.Status != PhaseRolledBack {
+		t.Errorf("prepare: expected rolled_back, got %s", prepare.Status)
+	}
+	if install.Status != PhaseRolledBack {
+		t.Errorf("install: expected rolled_back, got %s", install.Status)
+	}
+	if provision.Status != PhaseFailed {
+		t.Errorf("provision: expected failed, got %s", provision.Status)
+	}
+	if verify.Status != PhaseSkipped {
+		t.Errorf("verify: expected skipped, got %s", verify.Status)
+	}
+
+	// Rollback log should have 2 entries (install, prepare) in LIFO order
+	if len(graph.Rollback) != 2 {
+		t.Fatalf("expected 2 rollback entries, got %d", len(graph.Rollback))
+	}
+	if graph.Rollback[0].Phase != "install" {
+		t.Errorf("first rollback: expected install, got %s", graph.Rollback[0].Phase)
+	}
+	if graph.Rollback[1].Phase != "prepare" {
+		t.Errorf("second rollback: expected prepare, got %s", graph.Rollback[1].Phase)
+	}
+}
+
+// TestPhasedExecutionRetryThenSucceed tests that a phase retries and succeeds.
+func TestPhasedExecutionRetryThenSucceed(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src.txt")
+	if err := os.WriteFile(src, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 1's source will be created after first attempt
+	delayedSrc := filepath.Join(tmpDir, "delayed-src.txt")
+
+	attemptCount := 0
+
+	reg := NewOperationRegistry()
+	reg.Register(&LinkOp{})
+	// Register a custom Direct op that creates the file on second attempt
+	reg.Register(&testRetryOp{
+		name: "retry-test",
+		fn: func(ctx *Context, node Executable) error {
+			attemptCount++
+			if attemptCount == 1 {
+				return fmt.Errorf("transient failure")
+			}
+			// Create the file on retry
+			return os.WriteFile(delayedSrc, []byte("ok"), 0644)
+		},
+	})
+
+	executor := NewGraphExecutor(reg, ExecutorOptions{})
+
+	graph := &Graph{
+		State: StatePending,
+		Phases: []*Phase{
+			{
+				ID:      "phase.install",
+				Name:    "install",
+				Status:  PhasePending,
+				NodeIDs: []string{"retry-node"},
+				Retry: &RetryPolicy{
+					MaxAttempts:  2,
+					Backoff:      BackoffNone,
+					InitialDelay: "1ms", // Minimal delay for tests
+				},
+			},
+		},
+		Nodes: []*Node{
+			{ID: "retry-node", Operation: "retry-test"},
+		},
+	}
+
+	err := executor.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+
+	if graph.State != StateExecuted {
+		t.Errorf("expected executed, got %s", graph.State)
+	}
+
+	phase := graph.Phases[0]
+	if phase.Status != PhaseCompleted {
+		t.Errorf("expected completed, got %s", phase.Status)
+	}
+
+	// Should have 2 attempts: 1 failed, 1 completed
+	if len(phase.Attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", len(phase.Attempts))
+	}
+	if phase.Attempts[0].Status != "failed" {
+		t.Errorf("attempt 1: expected failed, got %s", phase.Attempts[0].Status)
+	}
+	if phase.Attempts[1].Status != "completed" {
+		t.Errorf("attempt 2: expected completed, got %s", phase.Attempts[1].Status)
+	}
+}
+
+// TestPhasedExecutionRetryExhausted tests that exhausted retries trigger rollback.
+func TestPhasedExecutionRetryExhausted(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src.txt")
+	if err := os.WriteFile(src, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewOperationRegistry()
+	reg.Register(&LinkOp{})
+	reg.Register(&testRetryOp{
+		name: "always-fail",
+		fn: func(ctx *Context, node Executable) error {
+			return fmt.Errorf("permanent failure")
+		},
+	})
+
+	executor := NewGraphExecutor(reg, ExecutorOptions{})
+
+	graph := &Graph{
+		State: StatePending,
+		Phases: []*Phase{
+			{
+				ID:      "phase.prepare",
+				Name:    "prepare",
+				Status:  PhasePending,
+				NodeIDs: []string{"prepare-node"},
+			},
+			{
+				ID:      "phase.install",
+				Name:    "install",
+				Status:  PhasePending,
+				NodeIDs: []string{"fail-node"},
+				Retry: &RetryPolicy{
+					MaxAttempts:  2,
+					Backoff:      BackoffNone,
+					InitialDelay: "1ms",
+				},
+			},
+		},
+		Nodes: []*Node{
+			testNode("prepare-node", "link", src, filepath.Join(tmpDir, "out1")),
+			{ID: "fail-node", Operation: "always-fail"},
+		},
+	}
+
+	err := executor.Run(context.Background(), graph)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+
+	phase := graph.PhaseByID("phase.install")
+	if phase.Status != PhaseFailed {
+		t.Errorf("expected failed, got %s", phase.Status)
+	}
+
+	// Should have 3 attempts (1 original + 2 retries)
+	if len(phase.Attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", len(phase.Attempts))
+	}
+	for _, a := range phase.Attempts {
+		if a.Status != "failed" {
+			t.Errorf("attempt %d: expected failed, got %s", a.Number, a.Status)
+		}
+	}
+}
+
+// TestNonPhasedGraphUnchanged verifies that graphs without phases still work.
+func TestNonPhasedGraphUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
+	target := filepath.Join(tmpDir, "target.txt")
+	if err := os.WriteFile(source, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewOperationRegistry()
+	reg.Register(&LinkOp{})
+
+	executor := NewGraphExecutor(reg, ExecutorOptions{})
+	graph := &Graph{
+		State: StatePending,
+		Nodes: []*Node{
+			testNode("test", "link", source, target),
+		},
+	}
+
+	err := executor.Run(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("non-phased run: %v", err)
+	}
+
+	if graph.State != StateExecuted {
+		t.Errorf("expected executed, got %s", graph.State)
+	}
+
+	linkTarget, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if linkTarget != source {
+		t.Errorf("expected symlink to %s, got %s", source, linkTarget)
+	}
+}
+
+// TestPhasedGraphSerialization tests that phased graphs round-trip through YAML.
+func TestPhasedGraphSerialization(t *testing.T) {
+	g := &Graph{
+		Version: "1",
+		Tool:    "lore",
+		State:   StatePending,
+		Phases: []*Phase{
+			{
+				ID:     "phase.install",
+				Name:   "install",
+				Status: PhasePending,
+				Retry: &RetryPolicy{
+					MaxAttempts:  3,
+					Backoff:      BackoffExponential,
+					InitialDelay: "1s",
+					MaxDelay:     "30s",
+				},
+				NodeIDs:    []string{"pkg-ripgrep"},
+				Compensate: "phase.install.compensate",
+			},
+			{
+				ID:     "phase.verify",
+				Name:   "verify",
+				Status: PhasePending,
+			},
+		},
+		Nodes: []*Node{
+			{ID: "pkg-ripgrep", Operation: "package-install"},
+		},
+	}
+
+	content, err := g.CanonicalContent()
+	if err != nil {
+		t.Fatalf("CanonicalContent: %v", err)
+	}
+
+	yaml := string(content)
+	if !strings.Contains(yaml, "phase.install") {
+		t.Error("expected phase.install in canonical content")
+	}
+	if !strings.Contains(yaml, "max_attempts: 3") {
+		t.Error("expected max_attempts in canonical content")
+	}
+	if !strings.Contains(yaml, "exponential") {
+		t.Error("expected backoff strategy in canonical content")
+	}
+}
+
+// TestPhaseByID tests Graph.PhaseByID lookup.
+func TestPhaseByID(t *testing.T) {
+	g := &Graph{
+		Phases: []*Phase{
+			{ID: "phase.prepare", Name: "prepare"},
+			{ID: "phase.install", Name: "install"},
+		},
+	}
+
+	if p := g.PhaseByID("phase.install"); p == nil || p.Name != "install" {
+		t.Error("expected to find phase.install")
+	}
+	if p := g.PhaseByID("nonexistent"); p != nil {
+		t.Error("expected nil for nonexistent phase")
+	}
+}
+
+// testRetryOp is a test-only Direct operation that executes a function.
+type testRetryOp struct {
+	name string
+	fn   func(ctx *Context, node Executable) error
+}
+
+func (o *testRetryOp) Name() string          { return o.name }
+func (o *testRetryOp) Category() OpCategory   { return OpDirect }
+func (o *testRetryOp) Execute(ctx *Context, node Executable) error {
+	return o.fn(ctx, node)
+}

--- a/internal/execution/recovery.go
+++ b/internal/execution/recovery.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package execution
+
+// RecoveryEntry represents a completed phase and its compensating action.
+// The executor pushes entries as phases complete successfully, and pops
+// them in LIFO order during rollback.
+type RecoveryEntry struct {
+	// PhaseID is the unique identifier of the completed phase.
+	PhaseID string
+
+	// PhaseName is the human-readable phase name.
+	PhaseName string
+
+	// Compensate is the function to execute for rollback.
+	// It receives the execution context and returns any error.
+	Compensate func(ctx *Context) error
+
+	// State holds the execution metadata captured during the forward action.
+	// Passed to the compensating action so it knows what to undo.
+	State map[string]any
+}
+
+// RecoveryStack is a LIFO stack of recovery entries.
+// The executor pushes entries as phases complete and unwinds
+// (pops + executes compensating actions) on failure.
+type RecoveryStack struct {
+	entries []RecoveryEntry
+}
+
+// Push adds a recovery entry to the top of the stack.
+func (s *RecoveryStack) Push(entry RecoveryEntry) {
+	s.entries = append(s.entries, entry)
+}
+
+// Len returns the number of entries on the stack.
+func (s *RecoveryStack) Len() int {
+	return len(s.entries)
+}
+
+// Unwind executes all compensating actions in LIFO order.
+// Returns a slice of errors from compensating actions that failed.
+// Compensating action failures do not stop the unwind — all entries
+// are processed regardless of individual failures.
+func (s *RecoveryStack) Unwind(ctx *Context) []error {
+	var errs []error
+
+	// Pop from top (most recent) to bottom (oldest)
+	for i := len(s.entries) - 1; i >= 0; i-- {
+		entry := s.entries[i]
+		if entry.Compensate == nil {
+			continue
+		}
+		if err := entry.Compensate(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Clear the stack
+	s.entries = nil
+
+	return errs
+}
+
+// Entries returns a copy of the stack entries (bottom to top).
+// Used for inspection and serialization.
+func (s *RecoveryStack) Entries() []RecoveryEntry {
+	result := make([]RecoveryEntry, len(s.entries))
+	copy(result, s.entries)
+	return result
+}

--- a/internal/execution/recovery_test.go
+++ b/internal/execution/recovery_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package execution
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestRecoveryStackPushLen(t *testing.T) {
+	s := &RecoveryStack{}
+
+	if s.Len() != 0 {
+		t.Errorf("expected empty stack, got len %d", s.Len())
+	}
+
+	s.Push(RecoveryEntry{PhaseID: "phase.prepare", PhaseName: "prepare"})
+	s.Push(RecoveryEntry{PhaseID: "phase.install", PhaseName: "install"})
+
+	if s.Len() != 2 {
+		t.Errorf("expected len 2, got %d", s.Len())
+	}
+}
+
+func TestRecoveryStackUnwindLIFO(t *testing.T) {
+	s := &RecoveryStack{}
+	var order []string
+
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.prepare",
+		PhaseName: "prepare",
+		Compensate: func(ctx *Context) error {
+			order = append(order, "prepare")
+			return nil
+		},
+	})
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.install",
+		PhaseName: "install",
+		Compensate: func(ctx *Context) error {
+			order = append(order, "install")
+			return nil
+		},
+	})
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.provision",
+		PhaseName: "provision",
+		Compensate: func(ctx *Context) error {
+			order = append(order, "provision")
+			return nil
+		},
+	})
+
+	ctx := &Context{Context: context.Background()}
+	errs := s.Unwind(ctx)
+
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// LIFO: provision, install, prepare
+	expected := []string{"provision", "install", "prepare"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d compensations, got %d", len(expected), len(order))
+	}
+	for i, name := range expected {
+		if order[i] != name {
+			t.Errorf("position %d: expected %q, got %q", i, name, order[i])
+		}
+	}
+
+	// Stack should be empty after unwind
+	if s.Len() != 0 {
+		t.Errorf("expected stack empty after unwind, got len %d", s.Len())
+	}
+}
+
+func TestRecoveryStackUnwindCompensateError(t *testing.T) {
+	s := &RecoveryStack{}
+
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.prepare",
+		PhaseName: "prepare",
+		Compensate: func(ctx *Context) error {
+			return nil
+		},
+	})
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.install",
+		PhaseName: "install",
+		Compensate: func(ctx *Context) error {
+			return fmt.Errorf("compensate install failed")
+		},
+	})
+	s.Push(RecoveryEntry{
+		PhaseID:   "phase.provision",
+		PhaseName: "provision",
+		Compensate: func(ctx *Context) error {
+			return nil
+		},
+	})
+
+	ctx := &Context{Context: context.Background()}
+	errs := s.Unwind(ctx)
+
+	// Should have 1 error but all three were executed
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error, got %d", len(errs))
+	}
+	if errs[0].Error() != "compensate install failed" {
+		t.Errorf("unexpected error: %v", errs[0])
+	}
+}
+
+func TestRecoveryStackUnwindNilCompensate(t *testing.T) {
+	s := &RecoveryStack{}
+
+	s.Push(RecoveryEntry{
+		PhaseID:    "phase.prepare",
+		PhaseName:  "prepare",
+		Compensate: nil, // No compensating action
+	})
+
+	ctx := &Context{Context: context.Background()}
+	errs := s.Unwind(ctx)
+
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for nil compensate, got %v", errs)
+	}
+}
+
+func TestRecoveryStackUnwindEmpty(t *testing.T) {
+	s := &RecoveryStack{}
+
+	ctx := &Context{Context: context.Background()}
+	errs := s.Unwind(ctx)
+
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for empty stack, got %v", errs)
+	}
+}
+
+func TestRecoveryStackEntries(t *testing.T) {
+	s := &RecoveryStack{}
+
+	s.Push(RecoveryEntry{PhaseID: "a", PhaseName: "first"})
+	s.Push(RecoveryEntry{PhaseID: "b", PhaseName: "second"})
+
+	entries := s.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].PhaseID != "a" {
+		t.Errorf("expected first entry 'a', got %q", entries[0].PhaseID)
+	}
+	if entries[1].PhaseID != "b" {
+		t.Errorf("expected second entry 'b', got %q", entries[1].PhaseID)
+	}
+
+	// Entries is a copy — original stack should be unaffected
+	entries[0].PhaseID = "modified"
+	original := s.Entries()
+	if original[0].PhaseID != "a" {
+		t.Error("Entries() did not return a copy")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement phases as first-class runtime concepts in the execution graph (the Saga Pattern)
- Each phase is a scoped transaction with forward action, compensating action, and retry policy
- The executor becomes a saga coordinator: walks phase boundaries, traps errors, retries, and unwinds via LIFO compensating actions on failure
- Non-phased graphs continue to use the existing flat execution path unchanged

## New types

`Phase`, `PhaseStatus`, `Attempt`, `RetryPolicy`, `BackoffStrategy`, `RollbackEntry` (phase.go)
`RecoveryStack`, `RecoveryEntry` (recovery.go)

## Changes

- `GraphExecutor.Run()` delegates to `RunPhased()` when `graph.Phases` is populated
- `Graph` gains `Phases` and `Rollback` fields; `CanonicalContent()` includes phases
- Compensating phases are automatically excluded from the forward execution pass
- 14 new tests covering retry policy, phased execution success/failure/retry, LIFO rollback, and serialization

## Scope

Steps 1–4 of the phase execution plan. Steps 5–6 (Starlark phase interface, lifecycle builder integration) are follow-up work.

## Test plan

- [x] `go test ./internal/execution/...` — all existing tests pass (non-phased graphs unchanged)
- [x] Unit tests for `RecoveryStack`: push, unwind LIFO, compensate error handling
- [x] Unit tests for `RetryPolicy`: none/linear/exponential backoff, max delay cap
- [x] Integration test: 4-phase pipeline success, all phases completed
- [x] Integration test: failure at phase 3, phases 1–2 compensated in reverse, phase 4 skipped
- [x] Integration test: retry succeeds on attempt 2, receipt records both attempts
- [x] Integration test: retry exhausted, receipt records all failed attempts
- [x] Serialization: phased graph CanonicalContent includes phases and retry policy
- [x] `go test ./...` — full project test suite passes (22 packages)