### PR TITLE
feat(lore): Starlark phase interface with forward/compensate/configure

### DIFF
--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -140,49 +140,209 @@ func BuildFromPackages(packages []string, plat string) (*BuildResult, error) {
 	})
 }
 
-// buildPackageNodes adds execution nodes for a package to the graph.
+// scriptResult holds metadata returned from executing a Starlark phase script.
+type scriptResult struct {
+	// HasCompensate is true if the script defines a compensate() function.
+	HasCompensate bool
+
+	// RetryPolicy from the configure() hook (nil if no configure function).
+	RetryPolicy *execution.RetryPolicy
+}
+
+// buildPackageNodes adds execution nodes and phases for a package to the graph.
+// Each lifecycle phase becomes a Phase entry in the graph. Phases that define
+// compensating actions get corresponding compensating Phase entries.
 func buildPackageNodes(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, plat string, cfg BuildConfig) error {
-	// Get phase actions for the install phase
 	op := lorepackage.OpDeploy
 	phases := lorepackage.PhaseOrder(op)
 
-	for _, phase := range phases {
-		actions := pkg.PhaseActions(plat, op, phase)
+	for _, phaseName := range phases {
+		actions := pkg.PhaseActions(plat, op, phaseName)
+		if len(actions) == 0 {
+			continue
+		}
+
+		phaseID := fmt.Sprintf("phase.%s.%s", pkg.Name, phaseName)
+		phase := &execution.Phase{
+			ID:     phaseID,
+			Name:   phaseName,
+			Status: execution.PhasePending,
+		}
+
+		// Snapshot current node count to track which nodes this phase adds.
+		nodesBefore := len(graph.Nodes)
+
+		// Track scripts that define compensate().
+		var compensateScripts []*lorepackage.ScriptAction
+
 		for _, action := range actions {
-			if err := buildActionNodes(graph, pkg, h, plat, action, cfg); err != nil {
-				return fmt.Errorf("phase %q: %w", phase, err)
+			switch a := action.(type) {
+			case *lorepackage.ScriptAction:
+				result, err := executeScriptAction(graph, pkg, h, plat, a, cfg)
+				if err != nil {
+					return fmt.Errorf("phase %q: %w", phaseName, err)
+				}
+				if result.HasCompensate {
+					compensateScripts = append(compensateScripts, a)
+				}
+				if result.RetryPolicy != nil && phase.Retry == nil {
+					phase.Retry = result.RetryPolicy
+				}
+			case *lorepackage.NativePMAction:
+				if err := addNativePMNodes(graph, pkg, a); err != nil {
+					return fmt.Errorf("phase %q: %w", phaseName, err)
+				}
+			default:
+				return fmt.Errorf("unknown action type: %T", action)
 			}
+		}
+
+		// Collect forward node IDs.
+		for i := nodesBefore; i < len(graph.Nodes); i++ {
+			phase.NodeIDs = append(phase.NodeIDs, graph.Nodes[i].ID)
+		}
+
+		// Create compensating phase if any script defines compensate().
+		if len(compensateScripts) > 0 {
+			compensatePhaseID := phaseID + ".compensate"
+			compensatePhase := &execution.Phase{
+				ID:     compensatePhaseID,
+				Name:   phaseName + ".compensate",
+				Status: execution.PhasePending,
+			}
+
+			compensateNodesBefore := len(graph.Nodes)
+			for _, script := range compensateScripts {
+				if err := executeCompensateScript(graph, pkg, h, plat, script, cfg); err != nil {
+					return fmt.Errorf("phase %q compensate: %w", phaseName, err)
+				}
+			}
+			for i := compensateNodesBefore; i < len(graph.Nodes); i++ {
+				compensatePhase.NodeIDs = append(compensatePhase.NodeIDs, graph.Nodes[i].ID)
+			}
+
+			phase.Compensate = compensatePhaseID
+			graph.Phases = append(graph.Phases, phase)
+			graph.Phases = append(graph.Phases, compensatePhase)
+		} else {
+			graph.Phases = append(graph.Phases, phase)
 		}
 	}
 
 	return nil
 }
 
-// buildActionNodes adds nodes for a single phase action.
-func buildActionNodes(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, plat string, action lorepackage.PhaseAction, cfg BuildConfig) error {
-	switch a := action.(type) {
-	case *lorepackage.ScriptAction:
-		return executeScriptAction(graph, pkg, h, plat, a, cfg)
-	case *lorepackage.NativePMAction:
-		return addNativePMNodes(graph, pkg, a)
-	default:
-		return fmt.Errorf("unknown action type: %T", action)
+// executeScriptAction runs a Starlark phase script's forward() function
+// and returns metadata about compensate() and configure() availability.
+func executeScriptAction(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, plat string, action *lorepackage.ScriptAction, cfg BuildConfig) (*scriptResult, error) {
+	thread, globals, pkgContext, systemBindings, planBindings, err := prepareScriptEnv(graph, pkg, h, action, cfg)
+	if err != nil {
+		return nil, err
 	}
+
+	data, err := os.ReadFile(action.Path)
+	if err != nil {
+		return nil, fmt.Errorf("reading script %s: %w", action.Path, err)
+	}
+
+	scriptGlobals, err := starlark.ExecFile(thread, action.Path, data, globals)
+	if err != nil {
+		return nil, fmt.Errorf("executing script: %w", err)
+	}
+
+	result := &scriptResult{}
+
+	// Call configure() hook if present.
+	if configureFn, ok := scriptGlobals["configure"]; ok {
+		if callable, ok := configureFn.(starlark.Callable); ok {
+			phaseConfig := loreStar.NewPhaseConfig()
+			_, err := starlark.Call(thread, callable, starlark.Tuple{phaseConfig.ToStarlark()}, nil)
+			if err != nil {
+				return nil, fmt.Errorf("calling configure(): %w", err)
+			}
+			result.RetryPolicy = phaseConfig.Retry
+		}
+	}
+
+	// Call forward() — the forward action.
+	fn, ok := scriptGlobals["forward"]
+	if !ok {
+		return nil, fmt.Errorf("function \"forward\" not found in script %s", action.Path)
+	}
+
+	callable, ok := fn.(starlark.Callable)
+	if !ok {
+		return nil, fmt.Errorf("\"forward\" is not callable in script %s", action.Path)
+	}
+
+	args := starlark.Tuple{
+		pkgContext.ToStarlark(),
+		systemBindings.ToStarlark(),
+		planBindings.ToStarlark(),
+	}
+	_, err = starlark.Call(thread, callable, args, nil)
+	if err != nil {
+		return nil, fmt.Errorf("calling forward(): %w", err)
+	}
+
+	// Check for compensate() function.
+	if _, ok := scriptGlobals["compensate"]; ok {
+		result.HasCompensate = true
+	}
+
+	return result, nil
 }
 
-// executeScriptAction runs a Starlark script to populate the graph.
-func executeScriptAction(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, plat string, action *lorepackage.ScriptAction, cfg BuildConfig) error {
-	// Read the script
+// executeCompensateScript runs a Starlark phase script's compensate() function
+// to collect compensating nodes into the graph at build time.
+func executeCompensateScript(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, plat string, action *lorepackage.ScriptAction, cfg BuildConfig) error {
+	thread, globals, pkgContext, systemBindings, planBindings, err := prepareScriptEnv(graph, pkg, h, action, cfg)
+	if err != nil {
+		return err
+	}
+	thread.Name = action.PhaseName + ".compensate"
+
 	data, err := os.ReadFile(action.Path)
 	if err != nil {
 		return fmt.Errorf("reading script %s: %w", action.Path, err)
 	}
 
-	// Create bindings
+	scriptGlobals, err := starlark.ExecFile(thread, action.Path, data, globals)
+	if err != nil {
+		return fmt.Errorf("executing script for compensate: %w", err)
+	}
+
+	fn, ok := scriptGlobals["compensate"]
+	if !ok {
+		return fmt.Errorf("function \"compensate\" not found in script %s", action.Path)
+	}
+
+	callable, ok := fn.(starlark.Callable)
+	if !ok {
+		return fmt.Errorf("\"compensate\" is not callable in script %s", action.Path)
+	}
+
+	args := starlark.Tuple{
+		pkgContext.ToStarlark(),
+		systemBindings.ToStarlark(),
+		planBindings.ToStarlark(),
+	}
+	_, err = starlark.Call(thread, callable, args, nil)
+	if err != nil {
+		return fmt.Errorf("calling compensate(): %w", err)
+	}
+
+	return nil
+}
+
+// prepareScriptEnv creates the Starlark thread, globals, and bindings
+// needed to execute a phase script. Shared by forward and compensate paths.
+func prepareScriptEnv(graph *execution.Graph, pkg *lorepackage.Release, h host.Host, action *lorepackage.ScriptAction, cfg BuildConfig) (
+	*starlark.Thread, starlark.StringDict, *loreStar.PackageContext, loreStar.SystemBindings, platform.PlatformPlanBindings, error,
+) {
 	systemBindings := loreStar.NewSystemBindings(h)
 	planBindings := platform.NewPlanBindings(graph, h, pkg.Name)
 
-	// Create package context
 	lifecycle := pkg.Lifecycle()
 	features := lifecycle.EnabledFeatures(cfg.Features)
 	settings := lifecycle.ResolvedSettings(cfg.Settings)
@@ -197,7 +357,6 @@ func executeScriptAction(graph *execution.Graph, pkg *lorepackage.Release, h hos
 		TargetRoot: h.HomeDir(),
 	}
 
-	// Create Starlark thread
 	thread := &starlark.Thread{
 		Name: action.PhaseName,
 		Print: func(_ *starlark.Thread, msg string) {
@@ -205,42 +364,13 @@ func executeScriptAction(graph *execution.Graph, pkg *lorepackage.Release, h hos
 		},
 	}
 
-	// Build globals with the three bindings
 	globals := starlark.StringDict{
 		"system":  systemBindings.ToStarlark(),
 		"package": pkgContext.ToStarlark(),
 		"plan":    planBindings.ToStarlark(),
 	}
 
-	// Execute the script
-	scriptGlobals, err := starlark.ExecFile(thread, action.Path, data, globals)
-	if err != nil {
-		return fmt.Errorf("executing script: %w", err)
-	}
-
-	// Call the phase function with arguments (package, system, plan)
-	fn, ok := scriptGlobals[action.PhaseName]
-	if !ok {
-		return fmt.Errorf("function %q not found in script", action.PhaseName)
-	}
-
-	callable, ok := fn.(starlark.Callable)
-	if !ok {
-		return fmt.Errorf("%q is not callable", action.PhaseName)
-	}
-
-	// Call with three arguments: package, system, plan
-	args := starlark.Tuple{
-		pkgContext.ToStarlark(),
-		systemBindings.ToStarlark(),
-		planBindings.ToStarlark(),
-	}
-	_, err = starlark.Call(thread, callable, args, nil)
-	if err != nil {
-		return fmt.Errorf("calling %s(): %w", action.PhaseName, err)
-	}
-
-	return nil
+	return thread, globals, pkgContext, systemBindings, planBindings, nil
 }
 
 // addNativePMNodes adds nodes for a native package manager operation.

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -520,7 +520,7 @@ def compensate(package, system, plan):
 `,
 		"Darwin/Deploy/provision.star": `
 def forward(package, system, plan):
-    plan.file.link(source="/opt/rg/completions/_rg", path="~/.zsh/completions/_rg")
+    plan.shell(command="ln -sf /opt/rg/completions/_rg ~/.zsh/completions/_rg")
 
 def compensate(package, system, plan):
     plan.shell(command="rm -f ~/.zsh/completions/_rg")

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -290,6 +290,321 @@ func TestNativePMNodeMetadata(t *testing.T) {
 	// The PM is determined at execution time by host.PackageManager()
 }
 
+// =============================================================================
+// Phase-aware builder tests
+// =============================================================================
+
+// createLorePackage creates a lore package fixture in a temp directory with
+// the given phase scripts. Returns the registry client and package name.
+func createLorePackage(t *testing.T, pkgName string, scripts map[string]string) *lorepackage.Registry {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	// Create package directory
+	pkgDir := filepath.Join(tmpDir, "packages", pkgName)
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write lifecycle.yaml
+	lifecycle := "name: " + pkgName + "\nversion: 1.0.0\nplatforms: [Darwin]\n"
+	if err := os.WriteFile(filepath.Join(pkgDir, "lifecycle.yaml"), []byte(lifecycle), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write phase scripts
+	for relPath, content := range scripts {
+		absPath := filepath.Join(pkgDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return lorepackage.New("test", nil, tmpDir)
+}
+
+func TestBuildPhased_NativePMCreatesPhases(t *testing.T) {
+	// Native PM packages should create Phase entries for each lifecycle phase
+	// that has actions.
+	tmpDir := t.TempDir()
+	client := lorepackage.New("test", nil, tmpDir)
+
+	result, err := Build(BuildConfig{
+		Packages:       []string{"curl"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Native PM only has the "install" phase (required phase for deploy).
+	if len(result.Graph.Phases) != 1 {
+		t.Fatalf("expected 1 phase, got %d", len(result.Graph.Phases))
+	}
+
+	phase := result.Graph.Phases[0]
+	if phase.Name != "install" {
+		t.Errorf("expected phase name 'install', got %q", phase.Name)
+	}
+	if phase.ID != "phase.curl.install" {
+		t.Errorf("expected phase ID 'phase.curl.install', got %q", phase.ID)
+	}
+	if phase.Status != execution.PhasePending {
+		t.Errorf("expected status pending, got %q", phase.Status)
+	}
+	if len(phase.NodeIDs) != 1 {
+		t.Errorf("expected 1 node ID, got %d", len(phase.NodeIDs))
+	}
+	if phase.Compensate != "" {
+		t.Errorf("native PM phase should not have compensate, got %q", phase.Compensate)
+	}
+}
+
+func TestBuildPhased_LorePackageForwardOnly(t *testing.T) {
+	// Lore package with only forward() — no compensate, no configure.
+	client := createLorePackage(t, "testpkg", map[string]string{
+		"Darwin/Deploy/install.star": `
+def forward(package, system, plan):
+    plan.package.install(package.name)
+`,
+	})
+
+	result, err := Build(BuildConfig{
+		Packages:       []string{"testpkg"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result.Graph.Phases) != 1 {
+		t.Fatalf("expected 1 phase, got %d", len(result.Graph.Phases))
+	}
+
+	phase := result.Graph.Phases[0]
+	if phase.Name != "install" {
+		t.Errorf("expected phase name 'install', got %q", phase.Name)
+	}
+	if len(phase.NodeIDs) == 0 {
+		t.Error("expected at least 1 node in phase")
+	}
+	if phase.Compensate != "" {
+		t.Errorf("expected no compensate, got %q", phase.Compensate)
+	}
+	if phase.Retry != nil {
+		t.Error("expected no retry policy")
+	}
+}
+
+func TestBuildPhased_LorePackageWithCompensate(t *testing.T) {
+	// Lore package with forward() and compensate() — should create a
+	// compensating phase with its own nodes.
+	client := createLorePackage(t, "testpkg", map[string]string{
+		"Darwin/Deploy/install.star": `
+def forward(package, system, plan):
+    plan.package.install(package.name)
+
+def compensate(package, system, plan):
+    plan.package.remove(package.name)
+`,
+	})
+
+	result, err := Build(BuildConfig{
+		Packages:       []string{"testpkg"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 2 phases: forward + compensate.
+	if len(result.Graph.Phases) != 2 {
+		t.Fatalf("expected 2 phases, got %d", len(result.Graph.Phases))
+	}
+
+	forward := result.Graph.Phases[0]
+	compensate := result.Graph.Phases[1]
+
+	if forward.Name != "install" {
+		t.Errorf("forward phase name = %q, want 'install'", forward.Name)
+	}
+	if forward.Compensate != compensate.ID {
+		t.Errorf("forward.Compensate = %q, want %q", forward.Compensate, compensate.ID)
+	}
+
+	if compensate.Name != "install.compensate" {
+		t.Errorf("compensate phase name = %q, want 'install.compensate'", compensate.Name)
+	}
+	if len(compensate.NodeIDs) == 0 {
+		t.Error("expected at least 1 node in compensate phase")
+	}
+
+	// Verify compensate phase has package-remove nodes.
+	nodeSet := make(map[string]bool)
+	for _, id := range compensate.NodeIDs {
+		nodeSet[id] = true
+	}
+	foundRemove := false
+	for _, n := range result.Graph.Nodes {
+		if nodeSet[n.ID] && n.Operation == "package-remove" {
+			foundRemove = true
+			break
+		}
+	}
+	if !foundRemove {
+		t.Error("expected package-remove node in compensate phase")
+	}
+}
+
+func TestBuildPhased_LorePackageWithConfigure(t *testing.T) {
+	// Lore package with configure() hook — should set retry policy on phase.
+	client := createLorePackage(t, "testpkg", map[string]string{
+		"Darwin/Deploy/install.star": `
+def configure(phase):
+    phase.retry(max_attempts=3, backoff="exponential", initial_delay="1s", max_delay="30s")
+
+def forward(package, system, plan):
+    plan.package.install(package.name)
+`,
+	})
+
+	result, err := Build(BuildConfig{
+		Packages:       []string{"testpkg"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result.Graph.Phases) != 1 {
+		t.Fatalf("expected 1 phase, got %d", len(result.Graph.Phases))
+	}
+
+	phase := result.Graph.Phases[0]
+	if phase.Retry == nil {
+		t.Fatal("expected retry policy")
+	}
+	if phase.Retry.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %d, want 3", phase.Retry.MaxAttempts)
+	}
+	if phase.Retry.Backoff != execution.BackoffExponential {
+		t.Errorf("Backoff = %q, want exponential", phase.Retry.Backoff)
+	}
+	if phase.Retry.InitialDelay != "1s" {
+		t.Errorf("InitialDelay = %q, want '1s'", phase.Retry.InitialDelay)
+	}
+	if phase.Retry.MaxDelay != "30s" {
+		t.Errorf("MaxDelay = %q, want '30s'", phase.Retry.MaxDelay)
+	}
+}
+
+func TestBuildPhased_LorePackageFullSaga(t *testing.T) {
+	// Full saga: forward + compensate + configure on multiple phases.
+	client := createLorePackage(t, "ripgrep", map[string]string{
+		"Darwin/Deploy/install.star": `
+def configure(phase):
+    phase.retry(max_attempts=2, backoff="linear", initial_delay="500ms")
+
+def forward(package, system, plan):
+    plan.package.install(package.name)
+
+def compensate(package, system, plan):
+    plan.package.remove(package.name)
+`,
+		"Darwin/Deploy/provision.star": `
+def forward(package, system, plan):
+    plan.file.link(source="/opt/rg/completions/_rg", path="~/.zsh/completions/_rg")
+
+def compensate(package, system, plan):
+    plan.shell(command="rm -f ~/.zsh/completions/_rg")
+`,
+	})
+
+	result, err := Build(BuildConfig{
+		Packages:       []string{"ripgrep"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 4 phases: install, install.compensate, provision, provision.compensate
+	if len(result.Graph.Phases) != 4 {
+		var names []string
+		for _, p := range result.Graph.Phases {
+			names = append(names, p.Name)
+		}
+		t.Fatalf("expected 4 phases, got %d: %v", len(result.Graph.Phases), names)
+	}
+
+	// Verify phase order and compensate references.
+	installPhase := result.Graph.Phases[0]
+	installComp := result.Graph.Phases[1]
+	provisionPhase := result.Graph.Phases[2]
+	provisionComp := result.Graph.Phases[3]
+
+	if installPhase.Name != "install" {
+		t.Errorf("phase[0] = %q, want 'install'", installPhase.Name)
+	}
+	if installPhase.Compensate != installComp.ID {
+		t.Errorf("install.Compensate = %q, want %q", installPhase.Compensate, installComp.ID)
+	}
+	if installPhase.Retry == nil || installPhase.Retry.MaxAttempts != 2 {
+		t.Error("install phase should have retry with max_attempts=2")
+	}
+
+	if provisionPhase.Name != "provision" {
+		t.Errorf("phase[2] = %q, want 'provision'", provisionPhase.Name)
+	}
+	if provisionPhase.Compensate != provisionComp.ID {
+		t.Errorf("provision.Compensate = %q, want %q", provisionPhase.Compensate, provisionComp.ID)
+	}
+	if provisionPhase.Retry != nil {
+		t.Error("provision phase should not have retry policy")
+	}
+
+	// Verify nodes are correctly assigned to phases.
+	if len(installPhase.NodeIDs) == 0 {
+		t.Error("install phase has no nodes")
+	}
+	if len(installComp.NodeIDs) == 0 {
+		t.Error("install.compensate phase has no nodes")
+	}
+	if len(provisionPhase.NodeIDs) == 0 {
+		t.Error("provision phase has no nodes")
+	}
+	if len(provisionComp.NodeIDs) == 0 {
+		t.Error("provision.compensate phase has no nodes")
+	}
+}
+
+func TestBuildPhased_MissingForwardFunction(t *testing.T) {
+	// Script without forward() should fail.
+	client := createLorePackage(t, "badpkg", map[string]string{
+		"Darwin/Deploy/install.star": `
+def install(package, system, plan):
+    plan.package.install(package.name)
+`,
+	})
+
+	_, err := Build(BuildConfig{
+		Packages:       []string{"badpkg"},
+		Platform:       "Darwin",
+		RegistryClient: client,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing forward() function")
+	}
+}
+
 func TestDarwinPackageManagerPrefix(t *testing.T) {
 	// Test that brew:, cask:, and port: prefixes are correctly parsed
 	// This tests the prefix parsing logic for macOS package managers

--- a/internal/starlark/phase_config.go
+++ b/internal/starlark/phase_config.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+)
+
+// PhaseConfig collects phase configuration from Starlark configure() hooks.
+// Passed to configure(phase) as the single argument.
+//
+// Starlark API:
+//
+//	def configure(phase):
+//	    phase.retry(max_attempts=3, backoff="exponential", initial_delay="1s")
+type PhaseConfig struct {
+	// Retry holds the retry policy configured by the script.
+	Retry *execution.RetryPolicy
+}
+
+// NewPhaseConfig creates a new PhaseConfig for collecting script configuration.
+func NewPhaseConfig() *PhaseConfig {
+	return &PhaseConfig{}
+}
+
+// ToStarlark returns a Starlark value exposing phase.retry().
+func (c *PhaseConfig) ToStarlark() starlark.Value {
+	return &starlarkPhaseConfig{config: c}
+}
+
+// starlarkPhaseConfig wraps PhaseConfig for Starlark exposure.
+type starlarkPhaseConfig struct {
+	config *PhaseConfig
+}
+
+func (s *starlarkPhaseConfig) String() string        { return "phase" }
+func (s *starlarkPhaseConfig) Type() string          { return "phase" }
+func (s *starlarkPhaseConfig) Freeze()               {}
+func (s *starlarkPhaseConfig) Truth() starlark.Bool  { return true }
+func (s *starlarkPhaseConfig) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: phase") }
+
+func (s *starlarkPhaseConfig) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "retry":
+		return starlark.NewBuiltin("phase.retry", s.retry), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("phase has no attribute %q", name))
+	}
+}
+
+func (s *starlarkPhaseConfig) AttrNames() []string {
+	return []string{"retry"}
+}
+
+// retry configures the retry policy for the phase.
+//
+// Usage:
+//
+//	phase.retry(max_attempts=3, backoff="exponential", initial_delay="1s", max_delay="30s")
+func (s *starlarkPhaseConfig) retry(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var maxAttempts int
+	var backoff, initialDelay, maxDelay string
+
+	if err := starlark.UnpackArgs("retry", args, kwargs,
+		"max_attempts", &maxAttempts,
+		"backoff?", &backoff,
+		"initial_delay?", &initialDelay,
+		"max_delay?", &maxDelay,
+	); err != nil {
+		return nil, err
+	}
+
+	if maxAttempts < 0 {
+		return nil, fmt.Errorf("retry: max_attempts must be non-negative, got %d", maxAttempts)
+	}
+
+	policy := &execution.RetryPolicy{
+		MaxAttempts: maxAttempts,
+	}
+
+	if backoff != "" {
+		switch backoff {
+		case "none":
+			policy.Backoff = execution.BackoffNone
+		case "linear":
+			policy.Backoff = execution.BackoffLinear
+		case "exponential":
+			policy.Backoff = execution.BackoffExponential
+		default:
+			return nil, fmt.Errorf("retry: unknown backoff %q (use none, linear, exponential)", backoff)
+		}
+	}
+
+	if initialDelay != "" {
+		policy.InitialDelay = initialDelay
+	}
+	if maxDelay != "" {
+		policy.MaxDelay = maxDelay
+	}
+
+	s.config.Retry = policy
+	return starlark.None, nil
+}


### PR DESCRIPTION
## Summary

- Phase scripts now use `forward()` as the entry point (replaces old phase-named function convention)
- Scripts can optionally define `compensate()` to emit rollback nodes into a compensating Phase
- Scripts can optionally define `configure(phase)` to set retry policy via `phase.retry()`
- Builder creates `Phase` entries in the execution graph, linking forward phases to their compensating phases
- New `PhaseConfig` Starlark bindings expose `phase.retry(max_attempts=, backoff=, initial_delay=, max_delay=)`
- Shared `prepareScriptEnv()` helper eliminates duplication between forward and compensate paths

Implements Steps 5-6 of the [Phase Execution Model plan](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/architecture/devlore-phase-execution.md). Builds on the core types and executor from PR #100.

## Test plan

- [x] `TestBuildPhased_NativePMCreatesPhases` — native PM packages get Phase entries
- [x] `TestBuildPhased_LorePackageForwardOnly` — script with only `forward()`, no compensate
- [x] `TestBuildPhased_LorePackageWithCompensate` — `forward()` + `compensate()` creates compensating phase
- [x] `TestBuildPhased_LorePackageWithConfigure` — `configure()` hook sets retry policy
- [x] `TestBuildPhased_LorePackageFullSaga` — multi-phase saga (install + provision) with compensate and configure
- [x] `TestBuildPhased_MissingForwardFunction` — script without `forward()` fails with error
- [x] All 22 existing test packages pass unchanged