### PR TITLE
docs(architecture): compensation ownership model for phase execution

### DIFF
--- a/docs/architecture/devlore-phase-execution.md
+++ b/docs/architecture/devlore-phase-execution.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-**Approved** — Implementation in progress.
+**Approved** — Core types, executor, and Starlark integration implemented.
+Compensation ownership model under discussion.
 
 ## Context
 
@@ -146,11 +147,269 @@ to work exactly as before. Lore lifecycle graphs populate `Phases` to enable
 phase-aware execution. The executor checks `graph.Phases != nil` and delegates
 to the phase-aware loop when present.
 
-## Starlark Integration (Future)
+## Starlark Integration
 
-Phase scripts will gain `forward()` / `compensate()` entry points.
-The phase `ctx` will expose a `state` dict for (S) capture.
-A `configure(phase)` hook will allow setting retry policy per-phase.
+Phase scripts use three entry points:
+
+- **`forward(package, system, plan)`** — the forward action. Emits nodes into
+  the phase via plan receivers. Required.
+- **`compensate(package, system, plan)`** — the compensating action. Emits nodes
+  into a paired compensating phase. Optional.
+- **`configure(phase)`** — sets phase-level configuration (retry policy) before
+  forward execution. Optional.
+
+The builder calls `configure()` first (if present), then `forward()`, then
+checks for `compensate()`. If `compensate()` exists, the builder creates a
+paired compensating phase and executes `compensate()` to populate it.
+
+Scripts that only define `forward()` produce a phase with no compensation.
+This is appropriate for idempotent phases like `verify`.
+
+### Retry Policy from Scripts
+
+```python
+def configure(phase):
+    phase.retry(max_attempts=3, backoff="exponential",
+                initial_delay="1s", max_delay="30s")
+```
+
+## Compensation Ownership
+
+### The Problem
+
+Compensation is not the syntactic inverse of the forward action. It is the
+**semantic inverse**, which depends on what actually happened at runtime.
+
+Example: `plan.package.install("ripgrep")` creates a `package-install` node.
+At execution time:
+
+- If ripgrep was already installed → the operation is a no-op.
+- If ripgrep was NOT installed → the operation installs it.
+
+The compensating action depends on which case occurred:
+
+- If we installed it → remove it.
+- If it was already there → do nothing.
+
+The compensating action needs the **receipt** from the forward action — what did
+it actually do? That is the S in the (A, C, S) tuple. Without S, compensation
+is blind.
+
+### Return Signature: Result, State, Error
+
+An operation produces three distinct things:
+
+| Return | Consumer | Purpose |
+|--------|----------|---------|
+| **Result** | Executor | Outcome (status, checksums). Drives "continue or fail?" |
+| **State** | Compensate() | Compensation receipt. The S in (A, C, S) |
+| **Error** | Executor | Go error if the operation failed |
+
+Result tells the executor what happened. State tells the compensator what to
+undo. Error tells Go whether to propagate. These serve different consumers and
+must not be conflated.
+
+State is **opaque to the executor**. The executor saves it and hands it back
+during compensation. Only the operation knows what its own state means.
+`PackageInstallOp` writes `{"already_installed": true}` and reads it back;
+the executor never looks inside.
+
+### Where Compensation Resides
+
+Compensation lives on the **operation implementation struct** — the same struct
+that implements the forward action. The struct owns both directions because it
+understands its own semantics.
+
+```go
+// PackageInstallOp — forward and reverse on the same struct
+type PackageInstallOp struct{}
+
+func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
+    // Forward: check state, install if needed, write receipt
+    alreadyInstalled := pm.IsInstalled(pkg)
+    node.SetState("already_installed", alreadyInstalled)
+    if !alreadyInstalled {
+        pm.Install(pkg)
+    }
+    return nil
+}
+
+func (o *PackageInstallOp) Compensate(ctx *Context, node Executable, state map[string]any) error {
+    // Reverse: read receipt, undo only what we did
+    if alreadyInstalled, _ := state["already_installed"].(bool); alreadyInstalled {
+        return nil // we didn't install it — nothing to undo
+    }
+    return pm.Remove(pkg)
+}
+```
+
+This pattern extends to code generation. The Phase 2 `go.generate()` templates
+already produce operation structs with `Execute()`. Adding `Compensate()` to
+the graph operations template is a natural extension — the generator has the
+method descriptor and can produce both methods from the same source.
+
+### CompensableOperation Interface
+
+```go
+// CompensableOperation is implemented by operations that can undo their effects.
+// Orthogonal to the execution category (Transform, Writer, Direct).
+type CompensableOperation interface {
+    Operation
+    Compensate(ctx *Context, node Executable, state map[string]any) error
+}
+```
+
+Not all operations are compensable:
+
+| Operation | Compensable | Reason |
+|-----------|-------------|--------|
+| `package-install` | Yes | Can remove what was installed |
+| `link` | Yes | Can unlink what was linked |
+| `copy` | Yes | Can remove what was copied (with backup) |
+| `render` | Yes | Same as copy (output is a file) |
+| `decrypt` | No | Transform only — no side effects to undo |
+| `validate` | No | Read-only probe — nothing to undo |
+| `shell` | No | Arbitrary command — cannot auto-compensate |
+
+Shell operations are not compensable at Layer 1. If a script runs
+`plan.shell(command="...")`, the operation cannot know how to reverse an
+arbitrary command. Compensation for shell operations belongs at Layer 2
+(scripted phase-level compensation).
+
+### State Capture Mechanism
+
+Operations write state to the node during execution via `Executable`:
+
+```go
+type Executable interface {
+    GetID() string
+    GetOperation() string
+    GetSlot(name string) string
+    GetProject() string
+    GetMode() os.FileMode
+    SetState(key string, value any)   // new
+    GetState(key string) any          // new
+}
+```
+
+The executor reads state from the node after execution and stores it in the
+Result. This avoids changing the three operation interface signatures
+(Transform, Writer, Direct) — operations write state as a side effect of
+execution, not as a return value.
+
+`BackupOp` already does this by dirty-casting `node.(*Node)` to write
+`Annotations["backup_path"]`. The `SetState`/`GetState` API replaces that
+pattern with a clean interface.
+
+```go
+// Node gains a State field for compensation receipts
+type Node struct {
+    // ...existing fields...
+    State map[string]any `json:"state,omitempty" yaml:"state,omitempty"`
+}
+
+func (n *Node) SetState(key string, value any) {
+    if n.State == nil {
+        n.State = make(map[string]any)
+    }
+    n.State[key] = value
+}
+
+func (n *Node) GetState(key string) any {
+    if n.State == nil {
+        return nil
+    }
+    return n.State[key]
+}
+```
+
+Result gains a State field:
+
+```go
+type Result struct {
+    NodeID         string
+    Status         ResultStatus
+    Error          error
+    State          map[string]any  // compensation receipt from node
+    SourceChecksum string
+    TargetChecksum string
+}
+```
+
+### Executor State Flow
+
+```
+Forward execution:
+  1. executor allocates node
+  2. op.Execute(ctx, node)
+     → operation writes node.SetState("already_installed", false)
+  3. executor captures node.State into Result.State
+  4. Result.State pushed to recovery stack
+
+Compensation (on failure):
+  5. executor pops recovery stack (LIFO)
+  6. for each completed node (reverse order within phase):
+     → op.Compensate(ctx, node, savedState)
+     → operation reads state, decides what to undo
+```
+
+### Two Layers
+
+There are two distinct layers of compensation that serve different purposes.
+
+**Layer 1 — Operation-level (automatic, fine-grained)**
+
+Each operation knows its own inverse. The executor calls `Compensate()` on
+each completed node within a failed phase, in reverse order. No Starlark
+involvement. The operation is the single source of truth.
+
+During phase unwind, the executor:
+1. Iterates completed nodes in reverse order.
+2. Looks up the operation in the registry.
+3. If the operation implements `CompensableOperation`, calls `Compensate()`
+   with the node's saved state.
+4. If the operation does not implement `CompensableOperation`, skips it (logged).
+
+**Layer 2 — Phase-level (scripted, coarse-grained)**
+
+For orchestration logic beyond what individual operations provide: cleaning up
+temporary artifacts, sending notifications, restoring backups, coordinating
+multi-step rollback sequences that span concerns.
+
+This is where the Starlark `compensate()` function lives.
+
+**Layer interaction**: Layer 1 runs first (reverse-order node compensation
+within the phase). Layer 2 runs after (phase-level scripted compensation).
+Layer 2 does not subsume Layer 1 — they are complementary. A phase can have
+Layer 1 only, Layer 2 only, both, or neither.
+
+### Build Time vs Runtime
+
+The current implementation runs `compensate()` at build time to emit nodes
+into the graph. This gives dry-run visibility but cannot handle
+state-dependent compensation.
+
+Resolution:
+
+- **Build time (dry-run)**: The graph shows compensation **capability** — which
+  operations are compensable (interface check), which phases have scripted
+  compensation (compensate function exists). This is metadata, not a plan.
+- **Runtime**: The executor determines actual compensation from execution
+  state. Node results carry compensation receipts. The recovery stack carries
+  these receipts for unwind.
+- **Transition**: The builder's current `compensate()` call at build time
+  should be replaced with a compensation capability flag on the phase. The
+  Starlark `compensate()` function moves to runtime execution during unwind.
+
+### Open Questions
+
+1. **State serialization**: Node `State` is `map[string]any`, which serializes
+   to YAML/JSON for receipts. Should we constrain the value types (strings,
+   numbers, bools only) or allow arbitrary nesting?
+
+2. **Compensation validation**: Should the builder reject phases that require
+   compensation but contain non-compensable operations? Or warn at build time
+   and fail at runtime?
 
 ## Files
 
@@ -158,5 +417,10 @@ A `configure(phase)` hook will allow setting retry policy per-phase.
 |------|------|
 | `internal/execution/phase.go` | Phase, PhaseStatus, Attempt, RetryPolicy types |
 | `internal/execution/recovery.go` | RecoveryStack, RecoveryEntry |
-| `internal/execution/executor.go` | RunPhased method on GraphExecutor |
-| `internal/execution/graph.go` | Phases field on Graph |
+| `internal/execution/executor.go` | RunPhased, node compensation during unwind |
+| `internal/execution/graph.go` | Node.State, Result.State, Executable.SetState/GetState |
+| `internal/execution/operation.go` | CompensableOperation interface |
+| `internal/execution/ops.go` | Compensate() on file operations (link, copy, etc.) |
+| `internal/execution/ops_package.go` | Compensate() on package operations |
+| `internal/starlark/phase_config.go` | PhaseConfig Starlark bindings for configure() |
+| `internal/lore/builder.go` | Phase-aware graph builder |


### PR DESCRIPTION
## Summary

- Document the **(result, state, error)** return signature — three distinct outputs from an operation serving different consumers
- Define **CompensableOperation** interface — compensation lives on the operation implementation struct alongside the forward action
- Design **state capture mechanism** — `SetState`/`GetState` on `Executable`, replacing `BackupOp`'s dirty `node.(*Node)` cast pattern
- Specify **two-layer compensation model**: Layer 1 (operation-level, automatic) runs first, Layer 2 (phase-level, scripted) runs after
- Detail **executor state flow** from Execute → node.State → Result.State → recovery stack → Compensate
- Add **compensability table** classifying all current operations (install: yes, shell: no, etc.)

Resolves 3 of 4 original open questions from the phase execution architecture. Remaining: state serialization constraints and compensation validation timing.

## Test plan

- [x] Architecture document only — no code changes
- [x] Document reviewed for consistency with existing implementation