### PR TITLE
feat(execution): typed slots with RequireStringSlot

### DIFF
--- a/docs/architecture/devlore-phase-execution.md
+++ b/docs/architecture/devlore-phase-execution.md
@@ -243,10 +243,124 @@ func (o *PackageInstallOp) Compensate(ctx *Context, node Executable, state map[s
 }
 ```
 
-This pattern extends to code generation. The Phase 2 `go.generate()` templates
-already produce operation structs with `Execute()`. Adding `Compensate()` to
-the graph operations template is a natural extension — the generator has the
-method descriptor and can produce both methods from the same source.
+### Implementation Struct Contract
+
+Today, operation structs (`PackageInstallOp`, `LinkOp`, etc.) have logic
+inline — `PackageInstallOp.Execute()` calls `pm.Install()` directly. There is
+no separate backing implementation. This conflates graph adaptation (slot
+reading, type conversion) with business logic (is the package installed?
+install it, record what we did).
+
+The implementation struct is a **backing Go struct** that:
+
+1. Is directly callable from Go (testable without the graph, nodes, or executor)
+2. Is the single source of truth for both forward and compensating logic
+3. Is the target that the auto-generated ops struct delegates to
+
+```
+Starlark script  → plan receiver  → creates Node in graph
+                                        ↓
+Graph executor   → ops struct     → reads slots, delegates to impl
+                   (auto-generated)     ↓
+                   impl struct    → actual logic (forward + compensate)
+                   (hand-written,   directly callable from Go)
+```
+
+The implementation struct's methods follow a convention:
+
+- **Forward**: `func(params...) (map[string]any, error)` — returns compensation
+  state (the receipt) and error. The state is the S in (A, C, S).
+- **Compensate**: `func(params..., state map[string]any) error` — receives the
+  state from the forward method and returns error.
+
+```go
+// Implementation struct — directly callable, testable without the graph.
+type PackageImpl struct {
+    pm host.PackageManager
+}
+
+// Forward: returns (state, error).
+func (p *PackageImpl) Install(packages []string) (map[string]any, error) {
+    already := p.pm.IsInstalled(packages[0])
+    if !already {
+        result := p.pm.Install(packages...)
+        if !result.OK {
+            return nil, fmt.Errorf("install failed: %s", result.Stderr)
+        }
+    }
+    return map[string]any{"already_installed": already}, nil
+}
+
+// Compensate: receives state from Install, returns error.
+func (p *PackageImpl) CompensateInstall(packages []string, state map[string]any) error {
+    if already, _ := state["already_installed"].(bool); already {
+        return nil // nothing to undo
+    }
+    result := p.pm.Remove(packages[0])
+    if !result.OK {
+        return fmt.Errorf("remove failed: %s", result.Stderr)
+    }
+    return nil
+}
+```
+
+The generated ops struct delegates to the implementation struct, handling the
+graph-level concerns (slot reading, state wiring, dry-run logging):
+
+```go
+// Generated — adapts the implementation to the graph execution model
+type PackageInstallOp struct{}
+
+func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
+    packages := parsePackages(node.GetSlot("packages"))
+    impl := &PackageImpl{pm: resolvePMForInstall(node.GetSlot("manager"))}
+
+    if ctx.DryRun {
+        fmt.Fprintf(ctx.Logger, "[dry-run] package-install %s\n", strings.Join(packages, " "))
+        return nil
+    }
+
+    state, err := impl.Install(packages)
+    if err != nil {
+        return err
+    }
+    for k, v := range state {
+        node.SetState(k, v)
+    }
+    return nil
+}
+
+func (o *PackageInstallOp) Compensate(ctx *Context, node Executable, state map[string]any) error {
+    packages := parsePackages(node.GetSlot("packages"))
+    impl := &PackageImpl{pm: resolvePMForInstall(node.GetSlot("manager"))}
+    return impl.CompensateInstall(packages, state)
+}
+```
+
+### Method Pairing for Code Generation
+
+The code generator inspects the implementation struct and pairs methods by
+naming convention:
+
+| Forward method | Compensate method |
+|---|---|
+| `Install(...)` | `CompensateInstall(...)` |
+| `Link(...)` | `CompensateLink(...)` |
+| `Copy(...)` | `CompensateCopy(...)` |
+
+Forward methods return `(map[string]any, error)`. Compensate methods accept
+the same parameters plus a `state map[string]any` and return `error`.
+
+Methods without a `Compensate` pair are not compensable. The code generator
+produces an ops struct with `Execute()` only — no `Compensate()` method.
+
+Gate validation for code generation:
+
+- **Gate 1** (existing): All parameter types must map to Starlark types
+- **Gate 2** (existing): Forward return must be `(map[string]any, error)`
+- **Gate 3** (new): If a `Compensate` pair exists, its return must be `error`
+  and its parameters must match the forward method's parameters plus
+  `state map[string]any`
 
 ### CompensableOperation Interface
 

--- a/internal/e2e/migrate_test.go
+++ b/internal/e2e/migrate_test.go
@@ -227,8 +227,10 @@ func evaluateMigrateCorrectness(analysis *migrate.MigrationAnalysis, graph *exec
 	if graph != nil {
 		for _, node := range graph.Nodes {
 			// Extract relative paths from source/target slots
-			source := filepath.Base(node.GetSlot("source"))
-			target := filepath.Base(node.GetSlot("target"))
+			src, _ := node.GetSlot("source").(string)
+			tgt, _ := node.GetSlot("path").(string)
+			source := filepath.Base(src)
+			target := filepath.Base(tgt)
 			actualRenames[source] = target
 		}
 	}

--- a/internal/execution/builder.go
+++ b/internal/execution/builder.go
@@ -3,7 +3,10 @@
 
 package execution
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // GraphBuilder is the interface for building execution graphs.
 // Implementations are provided by tools (writ, lore) and create graphs
@@ -54,7 +57,11 @@ func ExpandDelegates(ctx context.Context, graph *Graph, builder SubgraphBuilder,
 		}
 
 		// Build subgraph from the manifest file
-		sub, err := builder.BuildSubgraph(ctx, node.GetSlot("source"), opts)
+		source, err := node.RequireStringSlot("source")
+		if err != nil {
+			return fmt.Errorf("delegate node %s: %w", node.ID, err)
+		}
+		sub, err := builder.BuildSubgraph(ctx, source, opts)
 		if err != nil {
 			return err
 		}

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -1043,6 +1043,55 @@ func TestUnlinkOperationPrunesEmptyDirs(t *testing.T) {
 	}
 }
 
+func TestRequireStringSlot(t *testing.T) {
+	t.Run("correct value", func(t *testing.T) {
+		node := &Node{ID: "test"}
+		node.SetSlotImmediate("path", "hello")
+		val, err := node.RequireStringSlot("path")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != "hello" {
+			t.Errorf("expected %q, got %q", "hello", val)
+		}
+	})
+
+	t.Run("not set", func(t *testing.T) {
+		node := &Node{ID: "test"}
+		_, err := node.RequireStringSlot("path")
+		if err == nil {
+			t.Fatal("expected error for unset slot")
+		}
+		if !strings.Contains(err.Error(), "not set") {
+			t.Errorf("expected 'not set' in error, got: %v", err)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		node := &Node{ID: "test"}
+		node.SetSlotImmediate("count", 42)
+		_, err := node.RequireStringSlot("count")
+		if err == nil {
+			t.Fatal("expected error for wrong type")
+		}
+		if !strings.Contains(err.Error(), "expected string, got int") {
+			t.Errorf("expected 'expected string, got int' in error, got: %v", err)
+		}
+	})
+
+	t.Run("empty string is valid", func(t *testing.T) {
+		node := &Node{ID: "test"}
+		node.SetSlotImmediate("path", "")
+		val, err := node.RequireStringSlot("path")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != "" {
+			t.Errorf("expected empty string, got %q", val)
+		}
+	})
+}
+
 func TestRemoveNoPruneWithoutFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	nested := filepath.Join(tmpDir, "a", "b")

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -416,14 +416,17 @@ func (e *GraphExecutor) executeExecutableWithOutputs(ctx *Context, node Executab
 		}
 	}
 
+	// Fill unfilled slots from Context.Data
+	e.fillSlotsFromData(node)
+
 	var content []byte
 	var sourceChecksum, targetChecksum string
 
 	// Resolve input content: check upstream chain first, then read source file
 	if upstream := findContentUpstream(node.GetID(), edges, outputs); upstream != nil {
 		content = upstream
-	} else if op.Category() != OpDirect {
-		source := node.GetSlot("source")
+	} else if isContentOp(op) {
+		source, _ := node.GetSlot("source").(string)
 		if source != "" {
 			var err error
 			content, err = os.ReadFile(source)
@@ -621,8 +624,10 @@ func (e *GraphExecutor) sortNodesByDepth(nodes []*Node) []*Node {
 
 	for i := 0; i < len(sorted)-1; i++ {
 		for j := i + 1; j < len(sorted); j++ {
-			depthI := pathDepth(sorted[i].GetSlot("path"))
-			depthJ := pathDepth(sorted[j].GetSlot("path"))
+			pathI, _ := sorted[i].GetSlot("path").(string)
+			pathJ, _ := sorted[j].GetSlot("path").(string)
+			depthI := pathDepth(pathI)
+			depthJ := pathDepth(pathJ)
 			if depthI > depthJ {
 				sorted[i], sorted[j] = sorted[j], sorted[i]
 			}
@@ -639,8 +644,10 @@ func (e *GraphExecutor) sortByDepth(nodes []Executable) []Executable {
 
 	for i := 0; i < len(sorted)-1; i++ {
 		for j := i + 1; j < len(sorted); j++ {
-			depthI := pathDepth(sorted[i].GetSlot("path"))
-			depthJ := pathDepth(sorted[j].GetSlot("path"))
+			pathI, _ := sorted[i].GetSlot("path").(string)
+			pathJ, _ := sorted[j].GetSlot("path").(string)
+			depthI := pathDepth(pathI)
+			depthJ := pathDepth(pathJ)
 			if depthI > depthJ {
 				sorted[i], sorted[j] = sorted[j], sorted[i]
 			}
@@ -656,6 +663,29 @@ func pathDepth(path string) int {
 		return 0
 	}
 	return strings.Count(path, string(filepath.Separator))
+}
+
+// isContentOp returns true if the operation reads upstream content (Writer or Transform).
+func isContentOp(op Operation) bool {
+	switch op.(type) {
+	case Writer, Transform:
+		return true
+	}
+	return false
+}
+
+// fillSlotsFromData fills unfilled slots on the node from Context.Data.
+// Slots already set by the caller (Starlark plan or upstream node) are not overwritten.
+func (e *GraphExecutor) fillSlotsFromData(node Executable) {
+	n, ok := node.(*Node)
+	if !ok {
+		return
+	}
+	for key, value := range e.options.Data {
+		if _, exists := n.Slots[key]; !exists {
+			n.SetSlotImmediate(key, value)
+		}
+	}
 }
 
 // ChecksumBytes computes SHA256 of content and returns "sha256:<hex>".

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -176,8 +176,8 @@ type Node struct {
 }
 
 // GetSlot returns the resolved value of a slot.
-// If the slot is a promise, returns empty string (must be resolved by executor).
-func (n *Node) GetSlot(name string) string {
+// If the slot is a promise, returns nil (must be resolved by executor).
+func (n *Node) GetSlot(name string) any {
 	if n.Slots != nil {
 		if sv, ok := n.Slots[name]; ok {
 			if sv.IsImmediate() {
@@ -185,11 +185,26 @@ func (n *Node) GetSlot(name string) string {
 			}
 		}
 	}
-	return ""
+	return nil
+}
+
+// RequireStringSlot returns the string value of a required slot.
+// Returns an error if the slot is not set, or holds a non-string value.
+// An empty string is valid — use GetSlot for optional slots where zero value is acceptable.
+func (n *Node) RequireStringSlot(name string) (string, error) {
+	v := n.GetSlot(name)
+	if v == nil {
+		return "", fmt.Errorf("slot %q: not set", name)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("slot %q: expected string, got %T", name, v)
+	}
+	return s, nil
 }
 
 // SetSlotImmediate sets a slot to an immediate value.
-func (n *Node) SetSlotImmediate(name, value string) {
+func (n *Node) SetSlotImmediate(name string, value any) {
 	if n.Slots == nil {
 		n.Slots = make(map[string]SlotValue)
 	}
@@ -226,8 +241,8 @@ type Edge struct {
 // SlotValue represents a value that fills a slot in a node.
 // Either Immediate is set (direct value) or NodeRef is set (promise from upstream node).
 type SlotValue struct {
-	// Immediate is the direct value (string, used when known at analysis time).
-	Immediate string `json:"immediate,omitempty" yaml:"immediate,omitempty"`
+	// Immediate is the direct value (any type, known at analysis time).
+	Immediate any `json:"immediate,omitempty" yaml:"immediate,omitempty"`
 
 	// NodeRef is the ID of the node that produces this value (promise).
 	NodeRef string `json:"node_ref,omitempty" yaml:"node_ref,omitempty"`
@@ -243,7 +258,7 @@ func (s SlotValue) IsPromise() bool {
 
 // IsImmediate returns true if this slot value is an immediate value.
 func (s SlotValue) IsImmediate() bool {
-	return s.NodeRef == "" && s.Immediate != ""
+	return s.NodeRef == "" && s.Immediate != nil
 }
 
 // Graph represents an execution graph containing nodes and edges.
@@ -302,7 +317,8 @@ type Graph struct {
 type Executable interface {
 	GetID() string
 	GetOperation() string
-	GetSlot(name string) string
+	GetSlot(name string) any
+	RequireStringSlot(name string) (string, error)
 	GetProject() string
 	GetMode() os.FileMode
 }

--- a/internal/execution/operation.go
+++ b/internal/execution/operation.go
@@ -10,26 +10,9 @@ import (
 
 // Operation is the base interface for all executable actions.
 type Operation interface {
-	// Name returns the operation identifier (e.g., "link", "decrypt").
+	// Name returns the operation identifier (e.g., "file.link", "file.decrypt").
 	Name() string
-
-	// Category returns the operation category for pipeline validation.
-	Category() OpCategory
 }
-
-// OpCategory classifies operations by their data flow behavior.
-type OpCategory int
-
-const (
-	// OpTransform reads content, produces transformed content.
-	OpTransform OpCategory = iota
-
-	// OpWriter reads content, writes to filesystem, produces checksum.
-	OpWriter
-
-	// OpDirect manages its own I/O, no content flow.
-	OpDirect
-)
 
 // Transform operations read content and produce transformed content.
 // Used for: decrypt, expand.

--- a/internal/execution/ops.go
+++ b/internal/execution/ops.go
@@ -15,16 +15,15 @@ import (
 // LinkOp creates a symlink from node's "path" slot pointing to "source" slot.
 type LinkOp struct{}
 
-func (o *LinkOp) Name() string         { return "link" }
-func (o *LinkOp) Category() OpCategory { return OpDirect }
+func (o *LinkOp) Name() string { return "link" }
 
 func (o *LinkOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
 		return nil
 	}
 
-	target := node.GetSlot("path")
-	source := node.GetSlot("source")
+	target, _ := node.GetSlot("path").(string)
+	source, _ := node.GetSlot("source").(string)
 
 	// Idempotent: check if symlink already points correctly
 	if info, err := os.Lstat(target); err == nil {
@@ -50,15 +49,14 @@ func (o *LinkOp) Execute(ctx *Context, node Executable) error {
 // CopyOp writes content to node's "path" slot and returns the target checksum.
 type CopyOp struct{}
 
-func (o *CopyOp) Name() string         { return "copy" }
-func (o *CopyOp) Category() OpCategory { return OpWriter }
+func (o *CopyOp) Name() string { return "copy" }
 
 func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, error) {
 	if ctx.DryRun {
 		return ChecksumBytes(content), nil
 	}
 
-	target := node.GetSlot("path")
+	target, _ := node.GetSlot("path").(string)
 
 	// Remove existing file/symlink if present
 	if _, err := os.Lstat(target); err == nil {
@@ -87,8 +85,7 @@ func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, e
 // the template data. Returns the rendered content.
 type RenderOp struct{}
 
-func (o *RenderOp) Name() string         { return "render" }
-func (o *RenderOp) Category() OpCategory { return OpTransform }
+func (o *RenderOp) Name() string { return "render" }
 
 func (o *RenderOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
 	tmpl, err := template.New(node.GetID()).Parse(string(content))
@@ -118,8 +115,7 @@ func (o *RenderOp) Transform(ctx *Context, node Executable, content []byte) ([]b
 // configuration is expected in ctx.Data. Returns the decrypted content.
 type DecryptOp struct{}
 
-func (o *DecryptOp) Name() string         { return "decrypt" }
-func (o *DecryptOp) Category() OpCategory { return OpTransform }
+func (o *DecryptOp) Name() string { return "decrypt" }
 
 func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
 	decryptor, ok := ctx.Data["decryptor"]
@@ -139,7 +135,8 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 	if !ok {
 		return nil, fmt.Errorf("decryptor must be func(string, []byte) ([]byte, error)")
 	}
-	return decrypt(node.GetSlot("source"), content)
+	source, _ := node.GetSlot("source").(string)
+	return decrypt(source, content)
 }
 
 // NOTE: There is no DelegateOp. writ and lore share the same execution engine.
@@ -153,8 +150,7 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 // The backup path is stored in node.Annotations["backup_path"] after execution.
 type BackupOp struct{}
 
-func (o *BackupOp) Name() string         { return "backup" }
-func (o *BackupOp) Category() OpCategory { return OpDirect }
+func (o *BackupOp) Name() string { return "backup" }
 
 func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
@@ -168,7 +164,7 @@ func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 		}
 	}
 
-	target := node.GetSlot("path")
+	target, _ := node.GetSlot("path").(string)
 	timestamp := time.Now().Format("20060102-150405")
 	backupPath := target + suffix + "." + timestamp
 
@@ -191,15 +187,14 @@ func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 // empty parent directories are removed up to the boundary.
 type UnlinkOp struct{}
 
-func (o *UnlinkOp) Name() string         { return "unlink" }
-func (o *UnlinkOp) Category() OpCategory { return OpDirect }
+func (o *UnlinkOp) Name() string { return "unlink" }
 
 func (o *UnlinkOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
 		return nil
 	}
 
-	target := node.GetSlot("path")
+	target, _ := node.GetSlot("path").(string)
 
 	info, err := os.Lstat(target)
 	if os.IsNotExist(err) {
@@ -221,20 +216,19 @@ func (o *UnlinkOp) Execute(ctx *Context, node Executable) error {
 	return nil
 }
 
-// RemoveOp deletes the file at node.GetSlot("path").
+// RemoveOp deletes the file at node's "path" slot.
 // If ctx.Data["prune_empty_dirs"] is true and ctx.Data["prune_boundary"] is set,
 // empty parent directories are removed up to the boundary.
 type RemoveOp struct{}
 
-func (o *RemoveOp) Name() string         { return "remove" }
-func (o *RemoveOp) Category() OpCategory { return OpDirect }
+func (o *RemoveOp) Name() string { return "remove" }
 
 func (o *RemoveOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
 		return nil
 	}
 
-	target := node.GetSlot("path")
+	target, _ := node.GetSlot("path").(string)
 
 	if _, err := os.Lstat(target); os.IsNotExist(err) {
 		return nil // Already gone
@@ -298,11 +292,10 @@ func isSubpath(path, parent string) bool {
 // Used by plan.file.write() for writing inline content directly.
 type WriteOp struct{}
 
-func (o *WriteOp) Name() string         { return "write" }
-func (o *WriteOp) Category() OpCategory { return OpDirect }
+func (o *WriteOp) Name() string { return "write" }
 
 func (o *WriteOp) Execute(ctx *Context, node Executable) error {
-	content := node.GetSlot("content")
+	content, _ := node.GetSlot("content").(string)
 	if content == "" {
 		return fmt.Errorf("write: no content specified in node slots")
 	}
@@ -311,7 +304,7 @@ func (o *WriteOp) Execute(ctx *Context, node Executable) error {
 		return nil
 	}
 
-	target := node.GetSlot("path")
+	target, _ := node.GetSlot("path").(string)
 
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
@@ -327,14 +320,13 @@ func (o *WriteOp) Execute(ctx *Context, node Executable) error {
 }
 
 // ValidateOp checks a precondition and fails with a message if unmet.
-// The check function is retrieved from ctx.Data["validators"][node.GetSlot("check")].
+// The check function is retrieved from ctx.Data["validators"][node's "check" slot].
 type ValidateOp struct{}
 
-func (o *ValidateOp) Name() string         { return "validate" }
-func (o *ValidateOp) Category() OpCategory { return OpDirect }
+func (o *ValidateOp) Name() string { return "validate" }
 
 func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
-	checkName := node.GetSlot("check")
+	checkName, _ := node.GetSlot("check").(string)
 	if checkName == "" {
 		return fmt.Errorf("validate: no check specified in node slots")
 	}
@@ -350,7 +342,7 @@ func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
 	}
 
 	if err := validator(); err != nil {
-		message := node.GetSlot("message")
+		message, _ := node.GetSlot("message").(string)
 		if message != "" {
 			return fmt.Errorf("%s: %w", message, err)
 		}
@@ -364,16 +356,15 @@ func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
 // git mv when inside a git repository, falling back to os.Rename otherwise.
 type MoveOp struct{}
 
-func (o *MoveOp) Name() string         { return "move" }
-func (o *MoveOp) Category() OpCategory { return OpDirect }
+func (o *MoveOp) Name() string { return "move" }
 
 func (o *MoveOp) Execute(ctx *Context, node Executable) error {
 	if ctx.DryRun {
 		return nil
 	}
 
-	source := node.GetSlot("source")
-	target := node.GetSlot("path")
+	source, _ := node.GetSlot("source").(string)
+	target, _ := node.GetSlot("path").(string)
 
 	// Check if source exists
 	if _, err := os.Stat(source); err != nil {

--- a/internal/execution/ops_package.go
+++ b/internal/execution/ops_package.go
@@ -27,22 +27,24 @@ import (
 // PackageInstallOp installs packages using the platform's package manager.
 type PackageInstallOp struct{}
 
-func (o *PackageInstallOp) Name() string         { return "package-install" }
-func (o *PackageInstallOp) Category() OpCategory { return OpDirect }
+func (o *PackageInstallOp) Name() string { return "package-install" }
 
 func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
-	packages := parsePackages(node.GetSlot("packages"))
+	pkgList, _ := node.GetSlot("packages").(string)
+	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
 		return fmt.Errorf("package-install: no packages specified")
 	}
 
-	pm := resolvePMForInstall(node.GetSlot("manager"))
+	manager, _ := node.GetSlot("manager").(string)
+	pm := resolvePMForInstall(manager)
 	if pm == nil {
 		return fmt.Errorf("package-install: no package manager available")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := node.GetSlot("cask") == "true"
+	cask, _ := node.GetSlot("cask").(string)
+	isCask := cask == "true"
 
 	if ctx.DryRun {
 		if isCask {
@@ -73,23 +75,25 @@ func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
 // PackageUpgradeOp upgrades packages using the platform's package manager.
 type PackageUpgradeOp struct{}
 
-func (o *PackageUpgradeOp) Name() string         { return "package-upgrade" }
-func (o *PackageUpgradeOp) Category() OpCategory { return OpDirect }
+func (o *PackageUpgradeOp) Name() string { return "package-upgrade" }
 
 func (o *PackageUpgradeOp) Execute(ctx *Context, node Executable) error {
-	packages := parsePackages(node.GetSlot("packages"))
+	pkgList, _ := node.GetSlot("packages").(string)
+	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
 		return fmt.Errorf("package-upgrade: no packages specified")
 	}
 
 	// Use InstalledBy to determine which PM to upgrade with
-	pm := resolvePMForUpgrade(node.GetSlot("manager"), packages)
+	manager, _ := node.GetSlot("manager").(string)
+	pm := resolvePMForUpgrade(manager, packages)
 	if pm == nil {
 		return fmt.Errorf("package-upgrade: no package manager available")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := node.GetSlot("cask") == "true"
+	cask, _ := node.GetSlot("cask").(string)
+	isCask := cask == "true"
 
 	if ctx.DryRun {
 		if isCask {
@@ -122,18 +126,19 @@ func (o *PackageUpgradeOp) Execute(ctx *Context, node Executable) error {
 // PackageRemoveOp removes packages using the platform's package manager.
 type PackageRemoveOp struct{}
 
-func (o *PackageRemoveOp) Name() string         { return "package-remove" }
-func (o *PackageRemoveOp) Category() OpCategory { return OpDirect }
+func (o *PackageRemoveOp) Name() string { return "package-remove" }
 
 func (o *PackageRemoveOp) Execute(ctx *Context, node Executable) error {
-	packages := parsePackages(node.GetSlot("packages"))
+	pkgList, _ := node.GetSlot("packages").(string)
+	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
 		return fmt.Errorf("package-remove: no packages specified")
 	}
 
 	// Check if cask mode is enabled (for Homebrew Cask)
-	isCask := node.GetSlot("cask") == "true"
-	manager := node.GetSlot("manager")
+	cask, _ := node.GetSlot("cask").(string)
+	isCask := cask == "true"
+	manager, _ := node.GetSlot("manager").(string)
 
 	for _, pkg := range packages {
 		// Use InstalledBy to determine which PM to remove with
@@ -181,12 +186,12 @@ func (o *PackageRemoveOp) Execute(ctx *Context, node Executable) error {
 // PackageUpdateOp refreshes the package manager index.
 type PackageUpdateOp struct{}
 
-func (o *PackageUpdateOp) Name() string         { return "package-update" }
-func (o *PackageUpdateOp) Category() OpCategory { return OpDirect }
+func (o *PackageUpdateOp) Name() string { return "package-update" }
 
 func (o *PackageUpdateOp) Execute(ctx *Context, node Executable) error {
 	// Update uses preferred PM (not InstalledBy - we're updating the index, not a package)
-	pm := resolvePMForInstall(node.GetSlot("manager"))
+	manager, _ := node.GetSlot("manager").(string)
+	pm := resolvePMForInstall(manager)
 	if pm == nil {
 		return fmt.Errorf("package-update: no package manager available")
 	}
@@ -356,11 +361,10 @@ func runBrewCaskRemove(pkg string) host.Result {
 // ShellOp executes a shell command from node's "command" slot.
 type ShellOp struct{}
 
-func (o *ShellOp) Name() string         { return "shell" }
-func (o *ShellOp) Category() OpCategory { return OpDirect }
+func (o *ShellOp) Name() string { return "shell" }
 
 func (o *ShellOp) Execute(ctx *Context, node Executable) error {
-	command := node.GetSlot("command")
+	command, _ := node.GetSlot("command").(string)
 	if command == "" {
 		return fmt.Errorf("shell: no command specified")
 	}
@@ -380,11 +384,10 @@ func (o *ShellOp) Execute(ctx *Context, node Executable) error {
 // PowerShellOp executes a PowerShell command from node's "command" slot (Windows).
 type PowerShellOp struct{}
 
-func (o *PowerShellOp) Name() string         { return "powershell" }
-func (o *PowerShellOp) Category() OpCategory { return OpDirect }
+func (o *PowerShellOp) Name() string { return "powershell" }
 
 func (o *PowerShellOp) Execute(ctx *Context, node Executable) error {
-	command := node.GetSlot("command")
+	command, _ := node.GetSlot("command").(string)
 	if command == "" {
 		return fmt.Errorf("powershell: no command specified")
 	}

--- a/internal/execution/ops_service.go
+++ b/internal/execution/ops_service.go
@@ -24,11 +24,10 @@ import (
 // LaunchdStartOp starts a launchd service (macOS).
 type LaunchdStartOp struct{}
 
-func (o *LaunchdStartOp) Name() string         { return "launchd-start" }
-func (o *LaunchdStartOp) Category() OpCategory { return OpDirect }
+func (o *LaunchdStartOp) Name() string { return "launchd-start" }
 
 func (o *LaunchdStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-start: no service specified")
 	}
@@ -48,11 +47,10 @@ func (o *LaunchdStartOp) Execute(ctx *Context, node Executable) error {
 // LaunchdStopOp stops a launchd service (macOS).
 type LaunchdStopOp struct{}
 
-func (o *LaunchdStopOp) Name() string         { return "launchd-stop" }
-func (o *LaunchdStopOp) Category() OpCategory { return OpDirect }
+func (o *LaunchdStopOp) Name() string { return "launchd-stop" }
 
 func (o *LaunchdStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-stop: no service specified")
 	}
@@ -72,11 +70,10 @@ func (o *LaunchdStopOp) Execute(ctx *Context, node Executable) error {
 // LaunchdRestartOp restarts a launchd service (macOS).
 type LaunchdRestartOp struct{}
 
-func (o *LaunchdRestartOp) Name() string         { return "launchd-restart" }
-func (o *LaunchdRestartOp) Category() OpCategory { return OpDirect }
+func (o *LaunchdRestartOp) Name() string { return "launchd-restart" }
 
 func (o *LaunchdRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-restart: no service specified")
 	}
@@ -97,11 +94,10 @@ func (o *LaunchdRestartOp) Execute(ctx *Context, node Executable) error {
 // LaunchdEnableOp enables a launchd service at boot (macOS).
 type LaunchdEnableOp struct{}
 
-func (o *LaunchdEnableOp) Name() string         { return "launchd-enable" }
-func (o *LaunchdEnableOp) Category() OpCategory { return OpDirect }
+func (o *LaunchdEnableOp) Name() string { return "launchd-enable" }
 
 func (o *LaunchdEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-enable: no service specified")
 	}
@@ -121,11 +117,10 @@ func (o *LaunchdEnableOp) Execute(ctx *Context, node Executable) error {
 // LaunchdDisableOp disables a launchd service at boot (macOS).
 type LaunchdDisableOp struct{}
 
-func (o *LaunchdDisableOp) Name() string         { return "launchd-disable" }
-func (o *LaunchdDisableOp) Category() OpCategory { return OpDirect }
+func (o *LaunchdDisableOp) Name() string { return "launchd-disable" }
 
 func (o *LaunchdDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-disable: no service specified")
 	}
@@ -149,11 +144,10 @@ func (o *LaunchdDisableOp) Execute(ctx *Context, node Executable) error {
 // SystemdStartOp starts a systemd service (Linux).
 type SystemdStartOp struct{}
 
-func (o *SystemdStartOp) Name() string         { return "systemd-start" }
-func (o *SystemdStartOp) Category() OpCategory { return OpDirect }
+func (o *SystemdStartOp) Name() string { return "systemd-start" }
 
 func (o *SystemdStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-start: no service specified")
 	}
@@ -173,11 +167,10 @@ func (o *SystemdStartOp) Execute(ctx *Context, node Executable) error {
 // SystemdStopOp stops a systemd service (Linux).
 type SystemdStopOp struct{}
 
-func (o *SystemdStopOp) Name() string         { return "systemd-stop" }
-func (o *SystemdStopOp) Category() OpCategory { return OpDirect }
+func (o *SystemdStopOp) Name() string { return "systemd-stop" }
 
 func (o *SystemdStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-stop: no service specified")
 	}
@@ -197,11 +190,10 @@ func (o *SystemdStopOp) Execute(ctx *Context, node Executable) error {
 // SystemdRestartOp restarts a systemd service (Linux).
 type SystemdRestartOp struct{}
 
-func (o *SystemdRestartOp) Name() string         { return "systemd-restart" }
-func (o *SystemdRestartOp) Category() OpCategory { return OpDirect }
+func (o *SystemdRestartOp) Name() string { return "systemd-restart" }
 
 func (o *SystemdRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-restart: no service specified")
 	}
@@ -221,11 +213,10 @@ func (o *SystemdRestartOp) Execute(ctx *Context, node Executable) error {
 // SystemdEnableOp enables a systemd service at boot (Linux).
 type SystemdEnableOp struct{}
 
-func (o *SystemdEnableOp) Name() string         { return "systemd-enable" }
-func (o *SystemdEnableOp) Category() OpCategory { return OpDirect }
+func (o *SystemdEnableOp) Name() string { return "systemd-enable" }
 
 func (o *SystemdEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-enable: no service specified")
 	}
@@ -245,11 +236,10 @@ func (o *SystemdEnableOp) Execute(ctx *Context, node Executable) error {
 // SystemdDisableOp disables a systemd service at boot (Linux).
 type SystemdDisableOp struct{}
 
-func (o *SystemdDisableOp) Name() string         { return "systemd-disable" }
-func (o *SystemdDisableOp) Category() OpCategory { return OpDirect }
+func (o *SystemdDisableOp) Name() string { return "systemd-disable" }
 
 func (o *SystemdDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-disable: no service specified")
 	}
@@ -273,11 +263,10 @@ func (o *SystemdDisableOp) Execute(ctx *Context, node Executable) error {
 // WinServiceStartOp starts a Windows service.
 type WinServiceStartOp struct{}
 
-func (o *WinServiceStartOp) Name() string         { return "winservice-start" }
-func (o *WinServiceStartOp) Category() OpCategory { return OpDirect }
+func (o *WinServiceStartOp) Name() string { return "winservice-start" }
 
 func (o *WinServiceStartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-start: no service specified")
 	}
@@ -297,11 +286,10 @@ func (o *WinServiceStartOp) Execute(ctx *Context, node Executable) error {
 // WinServiceStopOp stops a Windows service.
 type WinServiceStopOp struct{}
 
-func (o *WinServiceStopOp) Name() string         { return "winservice-stop" }
-func (o *WinServiceStopOp) Category() OpCategory { return OpDirect }
+func (o *WinServiceStopOp) Name() string { return "winservice-stop" }
 
 func (o *WinServiceStopOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-stop: no service specified")
 	}
@@ -321,11 +309,10 @@ func (o *WinServiceStopOp) Execute(ctx *Context, node Executable) error {
 // WinServiceRestartOp restarts a Windows service (stop + start).
 type WinServiceRestartOp struct{}
 
-func (o *WinServiceRestartOp) Name() string         { return "winservice-restart" }
-func (o *WinServiceRestartOp) Category() OpCategory { return OpDirect }
+func (o *WinServiceRestartOp) Name() string { return "winservice-restart" }
 
 func (o *WinServiceRestartOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-restart: no service specified")
 	}
@@ -353,11 +340,10 @@ func (o *WinServiceRestartOp) Execute(ctx *Context, node Executable) error {
 // WinServiceEnableOp configures a Windows service to start automatically.
 type WinServiceEnableOp struct{}
 
-func (o *WinServiceEnableOp) Name() string         { return "winservice-enable" }
-func (o *WinServiceEnableOp) Category() OpCategory { return OpDirect }
+func (o *WinServiceEnableOp) Name() string { return "winservice-enable" }
 
 func (o *WinServiceEnableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-enable: no service specified")
 	}
@@ -377,11 +363,10 @@ func (o *WinServiceEnableOp) Execute(ctx *Context, node Executable) error {
 // WinServiceDisableOp configures a Windows service to be disabled.
 type WinServiceDisableOp struct{}
 
-func (o *WinServiceDisableOp) Name() string         { return "winservice-disable" }
-func (o *WinServiceDisableOp) Category() OpCategory { return OpDirect }
+func (o *WinServiceDisableOp) Name() string { return "winservice-disable" }
 
 func (o *WinServiceDisableOp) Execute(ctx *Context, node Executable) error {
-	service := node.GetSlot("name")
+	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-disable: no service specified")
 	}

--- a/internal/execution/phase_test.go
+++ b/internal/execution/phase_test.go
@@ -582,8 +582,7 @@ type testRetryOp struct {
 	fn   func(ctx *Context, node Executable) error
 }
 
-func (o *testRetryOp) Name() string          { return o.name }
-func (o *testRetryOp) Category() OpCategory   { return OpDirect }
+func (o *testRetryOp) Name() string { return o.name }
 func (o *testRetryOp) Execute(ctx *Context, node Executable) error {
 	return o.fn(ctx, node)
 }

--- a/internal/execution/preflight.go
+++ b/internal/execution/preflight.go
@@ -73,7 +73,8 @@ func Preflight(graph *Graph) *PreflightResult {
 // nodeWritesToTarget returns true if the node's operation produces a file at
 // node's "path" slot (link or copy).
 func nodeWritesToTarget(node *Node) bool {
-	if node.GetSlot("path") == "" {
+	path, _ := node.GetSlot("path").(string)
+	if path == "" {
 		return false
 	}
 	return node.Operation == "link" || node.Operation == "copy"
@@ -81,7 +82,7 @@ func nodeWritesToTarget(node *Node) bool {
 
 // detectConflict checks if a target path has a conflict.
 func detectConflict(node *Node) Conflict {
-	path := node.GetSlot("path")
+	path, _ := node.GetSlot("path").(string)
 	if path == "" {
 		return Conflict{Node: node, Type: ConflictNone}
 	}
@@ -116,7 +117,7 @@ func detectConflict(node *Node) Conflict {
 			}
 		}
 
-		source := node.GetSlot("source")
+		source, _ := node.GetSlot("source").(string)
 		if linkTarget == source {
 			return Conflict{
 				Node:         node,

--- a/internal/execution/stateview.go
+++ b/internal/execution/stateview.go
@@ -500,12 +500,13 @@ func (b *StateViewBuilder) addPackageRecord(view *StateView, node *Node, record 
 // addFileRecord adds a file deployment record to the view.
 func (b *StateViewBuilder) addFileRecord(view *StateView, node *Node, record HistoryRecord, g *Graph) {
 	relTarget := node.ID // Relative target path is the node ID
+	source, _ := node.GetSlot("source").(string)
 
 	entry, ok := view.Files.Entries[relTarget]
 	if !ok {
 		entry = &FileEntry{
 			Target:  relTarget,
-			Source:  node.GetSlot("source"),
+			Source:  source,
 			Project: node.Project,
 			Layer:   node.Layer,
 			History: make([]HistoryRecord, 0),
@@ -513,7 +514,7 @@ func (b *StateViewBuilder) addFileRecord(view *StateView, node *Node, record His
 		view.Files.Entries[relTarget] = entry
 	} else {
 		// Update source/project/layer from latest record
-		if source := node.GetSlot("source"); source != "" {
+		if source != "" {
 			entry.Source = source
 		}
 		if node.Project != "" {

--- a/internal/starlark/output.go
+++ b/internal/starlark/output.go
@@ -52,7 +52,7 @@ func (o *Output) Attr(name string) (starlark.Value, error) {
 		return starlark.String(o.slot), nil
 	default:
 		// Get the value from the node's slots
-		if value := o.node.GetSlot(name); value != "" {
+		if value, ok := o.node.GetSlot(name).(string); ok && value != "" {
 			return starlark.String(value), nil
 		}
 		return nil, starlark.NoSuchAttrError(fmt.Sprintf("Output has no attribute %q", name))
@@ -123,34 +123,37 @@ func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, val
 		return nil
 	}
 
-	// List: recurse for each element
+	// List: store as native []string (homogeneous) or []any (mixed)
 	if list, ok := value.(*starlark.List); ok {
-		iter := list.Iterate()
-		defer iter.Done()
-		var v starlark.Value
-		i := 0
-		for iter.Next(&v) {
-			subSlot := fmt.Sprintf("%s[%d]", slotName, i)
-			if err := FillSlot(node, graph, subSlot, v); err != nil {
-				return fmt.Errorf("list element %d: %w", i, err)
-			}
-			i++
+		result, err := starlarkListToSlice(list)
+		if err != nil {
+			return fmt.Errorf("slot %q: %w", slotName, err)
 		}
-		node.SetSlotImmediate(slotName+".len", fmt.Sprintf("%d", i))
+		node.SetSlotImmediate(slotName, result)
 		return nil
 	}
 
-	// Other immediate types
+	// Dict: store as native map[string]any
+	if dict, ok := value.(*starlark.Dict); ok {
+		result, err := starlarkDictToMap(dict)
+		if err != nil {
+			return fmt.Errorf("slot %q: %w", slotName, err)
+		}
+		node.SetSlotImmediate(slotName, result)
+		return nil
+	}
+
+	// Other immediate types — store as native Go types
 	switch v := value.(type) {
 	case starlark.Int:
 		i, _ := v.Int64()
-		node.SetSlotImmediate(slotName, fmt.Sprintf("%d", i))
+		node.SetSlotImmediate(slotName, int(i))
 		return nil
 	case starlark.Bool:
-		node.SetSlotImmediate(slotName, fmt.Sprintf("%t", v))
+		node.SetSlotImmediate(slotName, bool(v))
 		return nil
 	case starlark.Float:
-		node.SetSlotImmediate(slotName, fmt.Sprintf("%f", v))
+		node.SetSlotImmediate(slotName, float64(v))
 		return nil
 	case starlark.NoneType:
 		return nil
@@ -161,7 +164,8 @@ func FillSlot(node *execution.Node, graph *execution.Graph, slotName string, val
 
 // Path returns a path from the node's slots.
 func (o *Output) Path() string {
-	return o.node.GetSlot("path")
+	path, _ := o.node.GetSlot("path").(string)
+	return path
 }
 
 // DependOn creates an edge making the given node depend on this output's node.
@@ -179,6 +183,83 @@ func ResolveInput(value starlark.Value) (*Output, error) {
 		return output, nil
 	}
 	return nil, fmt.Errorf("expected Output, got %s", value.Type())
+}
+
+// starlarkValueToGo converts a Starlark value to a native Go value.
+func starlarkValueToGo(v starlark.Value) (any, error) {
+	switch val := v.(type) {
+	case starlark.String:
+		return string(val), nil
+	case starlark.Int:
+		i, _ := val.Int64()
+		return int(i), nil
+	case starlark.Bool:
+		return bool(val), nil
+	case starlark.Float:
+		return float64(val), nil
+	case starlark.NoneType:
+		return nil, nil
+	case *starlark.List:
+		return starlarkListToSlice(val)
+	case *starlark.Dict:
+		return starlarkDictToMap(val)
+	default:
+		return nil, fmt.Errorf("unsupported Starlark type %s", v.Type())
+	}
+}
+
+// starlarkListToSlice converts a Starlark list to a Go slice.
+// Returns []string if all elements are strings, []any otherwise.
+func starlarkListToSlice(list *starlark.List) (any, error) {
+	n := list.Len()
+	if n == 0 {
+		return []string{}, nil
+	}
+
+	// Try homogeneous []string first
+	allStrings := true
+	for i := 0; i < n; i++ {
+		if _, ok := list.Index(i).(starlark.String); !ok {
+			allStrings = false
+			break
+		}
+	}
+
+	if allStrings {
+		result := make([]string, n)
+		for i := 0; i < n; i++ {
+			result[i] = string(list.Index(i).(starlark.String))
+		}
+		return result, nil
+	}
+
+	// Mixed types: []any
+	result := make([]any, n)
+	for i := 0; i < n; i++ {
+		val, err := starlarkValueToGo(list.Index(i))
+		if err != nil {
+			return nil, fmt.Errorf("list element %d: %w", i, err)
+		}
+		result[i] = val
+	}
+	return result, nil
+}
+
+// starlarkDictToMap converts a Starlark dict to a Go map[string]any.
+func starlarkDictToMap(dict *starlark.Dict) (map[string]any, error) {
+	result := make(map[string]any, dict.Len())
+	for _, item := range dict.Items() {
+		key, ok := starlark.AsString(item[0])
+		if !ok {
+			return nil, fmt.Errorf("dict key must be string, got %s", item[0].Type())
+		}
+		val, err := starlarkValueToGo(item[1])
+		if err != nil {
+			return nil, fmt.Errorf("dict key %q: %w", key, err)
+		}
+		result[key] = val
+	}
+	return result, nil
 }
 
 // Gather represents a collection of outputs that can run in parallel.

--- a/internal/starlark/platform/linux.go
+++ b/internal/starlark/platform/linux.go
@@ -396,7 +396,7 @@ func (l *LinuxPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Bui
 	}
 	node := l.Configure(input.Path(), out)
 	input.DependOn(node)
-	return loreStar.NewOutput(node, l.graph, node.GetSlot("path")), nil
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path").(string)), nil
 }
 
 func (l *LinuxPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -411,7 +411,7 @@ func (l *LinuxPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin,
 	}
 	node := l.Link(input.Path(), out)
 	input.DependOn(node)
-	return loreStar.NewOutput(node, l.graph, node.GetSlot("path")), nil
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path").(string)), nil
 }
 
 func (l *LinuxPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -426,7 +426,7 @@ func (l *LinuxPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin,
 	}
 	node := l.Copy(input.Path(), out)
 	input.DependOn(node)
-	return loreStar.NewOutput(node, l.graph, node.GetSlot("path")), nil
+	return loreStar.NewOutput(node, l.graph, node.GetSlot("path").(string)), nil
 }
 
 func (l *LinuxPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -715,8 +715,8 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 		}
 
 		var entry reconcile.Entry
-		source := n.GetSlot("source")
-		target := n.GetSlot("path")
+		source, _ := n.GetSlot("source").(string)
+		target, _ := n.GetSlot("path").(string)
 		if checkDrift && n.SourceChecksum != "" {
 			entry = reconcile.Entry{
 				RelTarget:      n.ID,

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -48,7 +48,10 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 
 	// Verify no target conflicts before starting
 	for _, node := range renameNodes {
-		target := node.GetSlot("path")
+		target, err := node.RequireStringSlot("path")
+		if err != nil {
+			return fmt.Errorf("rename node %s: %w", node.ID, err)
+		}
 		if exists(target) {
 			return fmt.Errorf("target directory %q already exists; aborting", target)
 		}
@@ -57,8 +60,14 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 	// Perform renames
 	var renames []Rename
 	for _, node := range renameNodes {
-		source := node.GetSlot("source")
-		target := node.GetSlot("path")
+		source, err := node.RequireStringSlot("source")
+		if err != nil {
+			return fmt.Errorf("rename node %s: %w", node.ID, err)
+		}
+		target, err := node.RequireStringSlot("path")
+		if err != nil {
+			return fmt.Errorf("rename node %s: %w", node.ID, err)
+		}
 		if err := os.Rename(source, target); err != nil {
 			cli.Error("  %s -> %s", filepath.Base(source), filepath.Base(target))
 			return fmt.Errorf("rename %s -> %s: %w", source, target, err)
@@ -87,7 +96,9 @@ func WriteMigratedMarker(sourceRoot string, graph *execution.Graph, analysis *Mi
 	var renames []Rename
 	for _, node := range graph.Nodes {
 		if node.Operation == "move" {
-			renames = append(renames, Rename{From: node.GetSlot("source"), To: node.GetSlot("path")})
+			source, _ := node.GetSlot("source").(string)
+			target, _ := node.GetSlot("path").(string)
+			renames = append(renames, Rename{From: source, To: target})
 		}
 	}
 

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -86,11 +86,13 @@ func buildMigrationView(graph *execution.Graph, analysis *MigrationAnalysis) *mi
 	// Build nodes
 	var nodes []nodeView
 	for _, node := range graph.Nodes {
+		source, _ := node.GetSlot("source").(string)
+		target, _ := node.GetSlot("path").(string)
 		nodes = append(nodes, nodeView{
 			ID:        node.ID,
 			Operation: node.Operation,
-			Source:    node.GetSlot("source"),
-			Target:    node.GetSlot("path"),
+			Source:    source,
+			Target:    target,
 			Status:    string(node.Status),
 		})
 	}
@@ -182,14 +184,16 @@ func formatRenames(w io.Writer, graph *execution.Graph, sourceRoot string) {
 	_, _ = fmt.Fprintf(w, "Directory renames (%d):\n", len(renameNodes))
 	maxLen := 0
 	for _, node := range renameNodes {
-		source := node.GetSlot("source")
+		source, _ := node.GetSlot("source").(string)
 		if len(source) > maxLen {
 			maxLen = len(source)
 		}
 	}
 	for _, node := range renameNodes {
-		source := shortenPath(node.GetSlot("source"), sourceRoot)
-		target := shortenPath(node.GetSlot("path"), sourceRoot)
+		src, _ := node.GetSlot("source").(string)
+		tgt, _ := node.GetSlot("path").(string)
+		source := shortenPath(src, sourceRoot)
+		target := shortenPath(tgt, sourceRoot)
 		_, _ = fmt.Fprintf(w, "  %-*s  →  %s\n", maxLen-len(sourceRoot), source, target)
 	}
 	_, _ = fmt.Fprintln(w)

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -345,8 +345,10 @@ func (s *Session) formatGraphForPrompt() string {
 	for _, node := range s.graph.Nodes {
 		if node.Operation == "move" {
 			// Show relative paths for readability
-			source := strings.TrimPrefix(node.GetSlot("source"), s.opts.SourceRoot+"/")
-			target := strings.TrimPrefix(node.GetSlot("path"), s.opts.SourceRoot+"/")
+			src, _ := node.GetSlot("source").(string)
+			tgt, _ := node.GetSlot("path").(string)
+			source := strings.TrimPrefix(src, s.opts.SourceRoot+"/")
+			target := strings.TrimPrefix(tgt, s.opts.SourceRoot+"/")
 			sb.WriteString(fmt.Sprintf("  %s -> %s\n", source, target))
 		}
 	}
@@ -412,7 +414,8 @@ func (s *Session) addRenameToGraph(source, target string) {
 
 	// Check if this rename already exists
 	for _, node := range s.graph.Nodes {
-		if node.GetSlot("source") == source {
+		src, _ := node.GetSlot("source").(string)
+		if src == source {
 			// Update existing rename
 			node.SetSlotImmediate("path", target)
 			return
@@ -434,7 +437,8 @@ func (s *Session) removeRenameFromGraph(source string) {
 
 	// Find and remove the node
 	for i, node := range s.graph.Nodes {
-		if node.GetSlot("source") == source {
+		src, _ := node.GetSlot("source").(string)
+		if src == source {
 			s.graph.Nodes = append(s.graph.Nodes[:i], s.graph.Nodes[i+1:]...)
 			return
 		}


### PR DESCRIPTION
## Summary

- Phase 6 Steps 1+3: `GetSlot` returns `any`, all callers updated with type assertions
- `RequireStringSlot` added to `Node` and `Executable` interface for required-slot callers that cannot proceed with zero values
- 4 call sites across `builder.go` and `migrate/execute.go` upgraded to surface type mismatches as errors
- Fix: `e2e/migrate_test.go` was reading slot `"target"` instead of `"path"` (silent zero value)

## Test plan

- [x] `TestRequireStringSlot` — correct value, nil, wrong type, empty string
- [x] Full test suite passes (`go test ./...`, `go vet ./...`)
- [x] Verification checklist: no legacy/backward/compat/deprecated patterns