### PR TITLE
docs: command tree plan and service nomenclature

### DIFF
--- a/docs/architecture/devlore-typed-slots.md
+++ b/docs/architecture/devlore-typed-slots.md
@@ -12,10 +12,12 @@ structure and lifecycle.
 |---|---|---|
 | **Receiver** | Starlark | An object with methods. `file`, `plan.file`, `git` are receivers. Methods are bound to the receiver — `file.copy()` calls the `copy` method with `file` as the receiver. |
 | **Method** | Starlark/Python | A callable bound to a receiver. `file.copy()`, `plan.file.link()`, `git.clone()` are method calls. |
-| **Namespace** | Ours | The organizational grouping that ties together a receiver, its methods, and its operations. Derived from the struct name: `fileOps` → `file`. Appears in operation names (`file.link`), method paths (`plan.file.link()`), and error messages. |
-| **Plan receiver** | Ours | A receiver whose methods create graph nodes for later execution. `plan.file`, `plan.git`. |
-| **Real-time receiver** | Ours | A receiver whose methods execute immediately. `file`, `git`, `archive`. |
-| **Implementation struct** | Ours | The Go struct whose methods contain business logic. Source of truth for the generator. `fileOps`, `packageOps`. |
+| **Namespace** | Ours | The organizational grouping that ties together a service, its receivers, its methods, and its operations. Derived from the service struct name: `FileService` → `file`. Appears in operation names (`file.link`), method paths (`plan.file.link()`), and error messages. |
+| **Plan receiver** | Ours | A receiver whose methods create graph nodes for later execution. `plan.file`, `plan.git`. Generated from the service's method signatures. |
+| **Execute receiver** | Ours | A receiver whose methods execute immediately. `file`, `archive`, `service_manager`. Generated from the service's method signatures. |
+| **Service** | Ours | The hand-written Go struct whose methods contain business logic (activities). Source of truth for the generator. `FileService`, `PackageService`, `ServiceManagerService`. Named `*Service` by convention (or `*ManagerService` to avoid collision). |
+| **Ops interface** | Ours | Generated interface extracted from the service's method signatures. `fileOps`, `packageOps`, `serviceManagerOps`. Unexported — internal contract between the service and generated ops. |
+| **Activity** | Ours | A method on a service. Currently forward-only (execution). Will expand to include forward and backward (compensation) operations. |
 | **Slot** | Ours | A named, typed input on a graph node. Holds a value or a promise. |
 | **Promise** | Ours | A slot value that references another node's output, resolved at execution time. |
 
@@ -53,118 +55,87 @@ Plan receiver                Engine                   Op
 ## Slot Types
 
 `SlotValue.Immediate` is `any`. The type of each slot is determined by the
-implementation struct's method signature:
+service's method signature:
 
 ```go
-func (f *fileOps) Link(source, path string) error
-//                      string        string
-//                      slot:"source" slot:"path"
+func (f *FileService) Link(source, path string) error
+//                         string        string
+//                         slot:"source" slot:"path"
 
-func (f *fileOps) Render(templateData map[string]any, source string, content []byte) ([]byte, error)
-//                        map[string]any               string        []byte (framework)
-//                        slot:"template_data"         slot:"source"
+func (f *FileService) Render(templateData map[string]any, source string, content []byte) ([]byte, error)
+//                            map[string]any               string        []byte (framework)
+//                            slot:"template_data"         slot:"source"
 
-func (f *fileOps) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error)
-//                         func(...)                                        string        []byte (framework)
-//                         slot:"decryptor"                                 slot:"source"
+func (f *FileService) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error)
+//                             func(...)                                        string        []byte (framework)
+//                             slot:"decryptor"                                 slot:"source"
 ```
 
 Strings, bools, maps, functions — all just values in slots.
 
 ### Framework Content
 
-Writer and Transform operations receive content from the upstream pipeline
+Consumer and transformer operations receive content from the upstream pipeline
 (e.g., read source → decrypt → render → copy). This content is
 framework-provided — it is not a slot.
 
-The generator infers the operation interface from the implementation
-method's return signature:
+The generator infers the content model from the service method's return
+signature:
 
-| Return Signature | Interface | Content? |
+| Return Signature | Content Model | Content? |
 |---|---|---|
-| `error` | `Direct` | No content parameter |
-| `(string, error)` | `Writer` | Last `[]byte` param is content (string return is checksum) |
-| `([]byte, error)` | `Transform` | Last `[]byte` param is content ([]byte return is transformed content) |
+| `error` | No content | No content parameter |
+| `(string, error)` | Content consumer | Last `[]byte` param is content (string return is checksum) |
+| `([]byte, error)` | Content transformer | Last `[]byte` param is content ([]byte return is transformed content) |
 
 No annotation is needed. The method signature IS the specification. The
 generator validates at discovery time:
 
-- Direct methods return `error` only
-- Writer methods return `(string, error)` and have at least one `[]byte` param
-- Transform methods return `([]byte, error)` and have at least one `[]byte` param
+- No-content methods return `error` only
+- Consumer methods return `(string, error)` and have at least one `[]byte` param
+- Transformer methods return `([]byte, error)` and have at least one `[]byte` param
 - Any other return signature is rejected
-
-The executor dispatches via Go interface type switch — `case Transform`,
-`case Writer`, `case Direct`.
 
 Everything except the framework `[]byte` maps to a slot. The slot name is
 the snake_case form of the Go parameter name.
 
-## Operation Interfaces
+## Operation Interface
 
-Three interfaces define how the executor calls operations:
+One interface. Every generated op implements it:
 
 ```go
 type Operation interface {
     Name() string
-}
-
-type Direct interface {
-    Operation
-    Execute(ctx *Context, node Executable) error
-}
-
-type Writer interface {
-    Operation
-    Write(ctx *Context, node Executable, content []byte) (string, error)
-}
-
-type Transform interface {
-    Operation
-    Transform(ctx *Context, node Executable, content []byte) ([]byte, error)
+    Execute(ctx *Context, node *Node) error
 }
 ```
 
-The executor type-switches to dispatch:
-
-```go
-switch op := op.(type) {
-case Transform:
-    content, err = op.Transform(ctx, node, content)
-    outputs[node.GetID()] = content
-case Writer:
-    checksum, err = op.Write(ctx, node, content)
-case Direct:
-    err = op.Execute(ctx, node)
-}
-```
-
-Content sourcing: if the operation implements Writer or Transform, the
-executor reads the source file or chains from upstream content before
-calling the operation.
+The executor calls `op.Execute(ctx, node)` for every node. No type-switch.
+Each generated op is self-contained — it knows its own content model because
+the generator baked it in from the service method's return signature. The
+generated `Execute()` method handles content sourcing, slot assertions,
+dry-run logging, and delegation to the service internally.
 
 ## Namespace
 
-The namespace is the organizational grouping for a receiver, its methods,
-and the operations they produce. It is derived from the implementation
-struct name by stripping the suffix and normalizing to snake_case:
+The namespace is the organizational grouping for a service, its receivers,
+its methods, and the operations they produce. It is derived from the service
+struct name by stripping the `Service` suffix and normalizing to snake_case:
 
-| Struct | Strip suffix | Namespace |
+| Service | Strip suffix | Namespace |
 |---|---|---|
-| `fileOps` | strip "Ops" | `file` |
-| `packageOps` | strip "Ops" | `package` |
-| `serviceOps` | strip "Ops" | `service` |
-| `GitPlan` | strip "Plan" | `git` |
-| `ArchiveReceiver` | strip "Receiver" | `archive` |
+| `FileService` | strip "Service" | `file` |
+| `PackageService` | strip "Service" | `package` |
+| `ServiceManagerService` | strip "Service" | `service_manager` |
 
 The namespace appears in:
-- Operation names: `file.link`, `package.install`, `service.start`
-- Plan receiver methods: `plan.file.link()`, `plan.git.clone()`
-- Real-time receiver methods: `archive.extract()`, `git.clone()`
+- Operation names: `file.link`, `package.install`, `service_manager.start`
+- Plan receiver methods: `plan.file.link()`, `plan.package.install()`
+- Execute receiver methods: `file.copy()`, `archive.extract()`
 - Error messages: `file.link: slot "source" requires string`
+- Generated package names: `generated/fileops/`, `generated/packageops/`, `generated/servicemanagerops/`
 
-One struct family per namespace — `fileOps` + `FilePlan` + `FileReceiver`
-all share the `file` namespace. The namespace IS the receiver's identity.
+One service per namespace. The namespace IS the service's identity.
 
 ## Two Worlds
 
@@ -180,8 +151,8 @@ Starlark involvement.
 ## Starlark Type Mappings
 
 At plan time, Starlark values must be converted to Go types for slot
-filling. The type mappings are determined from the implementation struct's
-method signatures:
+filling. The type mappings are determined from the service's method
+signatures:
 
 | Go Type | Starlark Type | Notes |
 |---|---|---|
@@ -243,53 +214,53 @@ data := map[string]any{
 Key naming convention: snake_case. This aligns with Starlark conventions
 and the generator's parameter name → slot name mapping.
 
-## Implementation Structs
+## Services
 
-Implementation structs are the source of truth for business logic. The
-generator reads their method signatures to produce graph operations,
-plan receivers, and real-time receivers.
+Services are the hand-written source of truth. The generator reads their
+method signatures to produce everything else: ops interface, graph
+operations, plan receivers, execute receivers, and Starlark type mappings.
 
 ```go
-// impl_file.go — hand-written, survives regeneration
-type fileOps struct{}
+// file_service.go — hand-written, survives regeneration
+type FileService struct{}
 
-func (f *fileOps) Link(source, path string) error {
+func (f *FileService) Link(source, path string) error {
     // idempotent symlink
 }
 
-func (f *fileOps) Copy(path string, mode os.FileMode, content []byte) (string, error) {
+func (f *FileService) Copy(path string, mode os.FileMode, content []byte) (string, error) {
     // write file, return checksum
 }
 
-func (f *fileOps) Render(templateData map[string]any, source, path, project string, content []byte) ([]byte, error) {
+func (f *FileService) Render(templateData map[string]any, source, path, project string, content []byte) ([]byte, error) {
     // execute Go text/template with templateData
 }
 
-func (f *fileOps) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error) {
+func (f *FileService) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error) {
     return decryptor(source, content)
 }
 
-func (f *fileOps) Backup(path, backupSuffix string) error {
+func (f *FileService) Backup(path, backupSuffix string) error {
     // timestamped backup using backupSuffix
 }
 
-func (f *fileOps) Unlink(path string, prune bool, pruneBoundary string) error {
+func (f *FileService) Unlink(path string, prune bool, pruneBoundary string) error {
     // remove symlink, optionally prune empty parents
 }
 
-func (f *fileOps) Remove(path string, prune bool, pruneBoundary string) error {
+func (f *FileService) Remove(path string, prune bool, pruneBoundary string) error {
     // delete file, optionally prune empty parents
 }
 
-func (f *fileOps) Write(content, path string, mode os.FileMode) error {
+func (f *FileService) Write(content, path string, mode os.FileMode) error {
     // write inline content
 }
 
-func (f *fileOps) Validate(validators map[string]func() error, check, message string) error {
+func (f *FileService) Validate(validators map[string]func() error, check, message string) error {
     // look up and run named validator
 }
 
-func (f *fileOps) Move(gitMv func(src, dst string) error, source, path string) error {
+func (f *FileService) Move(gitMv func(src, dst string) error, source, path string) error {
     // git mv with os.Rename fallback
 }
 ```
@@ -298,19 +269,47 @@ Every parameter except the framework `content []byte` maps to a slot. The
 slot value comes from the resolution chain: caller-provided first, then
 Context.Data fallback.
 
-## Generated Graph Ops
+## Generated Code
 
-The generator reads the implementation struct's methods and produces
-graph operations that read slots, validate types, handle dry-run, and
-delegate to the implementation:
+The generator reads the service's methods and produces all infrastructure
+in a subpackage (`internal/execution/generated/fileops/`). Everything below
+is generated — nuke-safe, never hand-edited.
+
+### Ops Interface
+
+The generated interface extracted from the service's method signatures:
 
 ```go
-// ops_file_gen.go — generated, nuke-safe
-type FileLinkOp struct{ impl *fileOps }
+// generated/fileops/ops.go — generated, nuke-safe
+type fileOps interface {
+    Link(source, path string) error
+    Copy(path string, mode os.FileMode, content []byte) (string, error)
+    Render(templateData map[string]any, source, path, project string, content []byte) ([]byte, error)
+    Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error)
+    Backup(path, backupSuffix string) error
+    Unlink(path string, prune bool, pruneBoundary string) error
+    Remove(path string, prune bool, pruneBoundary string) error
+    Write(content, path string, mode os.FileMode) error
+    Validate(validators map[string]func() error, check, message string) error
+    Move(gitMv func(src, dst string) error, source, path string) error
+}
+```
+
+`FileService` satisfies this interface. The ops reference `fileOps`, not
+the concrete `FileService` — the interface is the contract boundary.
+
+### Graph Operations
+
+Each generated op implements the single `Operation` interface. The content
+model (no content, consumer, transformer) is baked in by the generator:
+
+```go
+// generated/fileops/ops.go — generated, nuke-safe
+type FileLinkOp struct{ impl fileOps }
 
 func (o *FileLinkOp) Name() string { return "file.link" }
 
-func (o *FileLinkOp) Execute(ctx *Context, node Executable) error {
+func (o *FileLinkOp) Execute(ctx *Context, node *Node) error {
     source, ok := node.GetSlot("source").(string)
     if !ok {
         return fmt.Errorf("file.link: slot \"source\" requires string")
@@ -327,36 +326,42 @@ func (o *FileLinkOp) Execute(ctx *Context, node Executable) error {
 }
 ```
 
-For a Transform operation with a function-valued slot:
+A content-transformer op handles its own content sourcing internally:
 
 ```go
-type FileDecryptOp struct{ impl *fileOps }
+type FileDecryptOp struct{ impl fileOps }
 
 func (o *FileDecryptOp) Name() string { return "file.decrypt" }
 
-func (o *FileDecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
+func (o *FileDecryptOp) Execute(ctx *Context, node *Node) error {
     decryptor, ok := node.GetSlot("decryptor").(func(string, []byte) ([]byte, error))
     if !ok {
-        return nil, fmt.Errorf("file.decrypt: slot \"decryptor\" requires func")
+        return fmt.Errorf("file.decrypt: slot \"decryptor\" requires func")
     }
     source, ok := node.GetSlot("source").(string)
     if !ok {
-        return nil, fmt.Errorf("file.decrypt: slot \"source\" requires string")
+        return fmt.Errorf("file.decrypt: slot \"source\" requires string")
     }
+    content := ctx.ContentFor(node)
     if ctx.DryRun {
-        return content, nil
+        ctx.StoreContent(node, content)
+        return nil
     }
-    return o.impl.Decrypt(decryptor, source, content)
+    result, err := o.impl.Decrypt(decryptor, source, content)
+    if err != nil {
+        return err
+    }
+    ctx.StoreContent(node, result)
+    return nil
 }
 ```
 
-No ctx.Data access. All inputs come through typed slots.
+No type-switch in the executor. Every op is self-contained.
 
-## Registration
+### Registration
 
 ```go
-func FileOps() []Operation {
-    impl := &fileOps{}
+func Ops(impl fileOps) []Operation {
     return []Operation{
         &FileLinkOp{impl: impl},
         &FileCopyOp{impl: impl},
@@ -372,8 +377,9 @@ func FileOps() []Operation {
 }
 ```
 
-The implementation struct has no fields — it is a method namespace. All
-inputs come through typed slots. Registration is stateless.
+The parent package wires it: `fileops.Ops(&FileService{})`. The service
+has no fields — it is a method namespace. All inputs come through typed
+slots. Registration is stateless.
 
 ## Engine Slot Filling
 
@@ -423,14 +429,14 @@ A slot's name, type, and Starlark type mapping must be discoverable by
 extension authors, plan writers, and error messages.
 
 - **Names**: Derived from Go parameter names (snake_case). The canonical
-  list of slot names for an operation is its implementation method
-  signature. Available via `go.methods()` in the generator, and listed
-  by each receiver's methods at plan time.
+  list of slot names for an operation is its service method signature.
+  Available via `go.methods()` in the generator, and listed by each
+  receiver's methods at plan time.
 
-- **Types**: Determined by the implementation method signature. The
-  generator knows the Go type of each slot and the corresponding Starlark
-  type for plan receiver method arguments. The type mapping table
-  (string↔String, bool↔Bool, etc.) must be documented and consistent.
+- **Types**: Determined by the service method signature. The generator
+  knows the Go type of each slot and the corresponding Starlark type for
+  plan receiver method arguments. The type mapping table (string↔String,
+  bool↔Bool, etc.) must be documented and consistent.
 
 - **Introspection**: Operations should be able to report their expected
   slots — names and types — for tooling, help text, and error messages.

--- a/docs/plans/devlore-command-tree.md
+++ b/docs/plans/devlore-command-tree.md
@@ -1,0 +1,263 @@
+---
+title: "Devlore Command Tree Restructuring"
+status: draft
+created: 2026-02-13
+updated: 2026-02-13
+---
+
+# Plan: Devlore Command Tree Restructuring
+
+## Summary
+
+Restructure the `devlore.*` command tree from a single monolithic Knowledge extension
+into four extensions organized by target: knowledge, package, ops, and model. Move the
+GenReceiver extension from noblefactor-ops to devlore-cli and rename it to follow the
+`com.noblefactor.devlore.*` convention with `devlore.<noun>.<verb>` command naming.
+
+## Goals
+
+1. **Four-node command tree.** `devlore.knowledge`, `devlore.package`, `devlore.ops`,
+   `devlore.model` — each classified by what the commands target.
+2. **Correct extension placement.** All devlore extensions live in
+   `devlore-cli/star/extensions/`, not noblefactor-ops.
+3. **Noun/verb naming.** Every command follows `devlore.<noun>.<verb>` — nouns are
+   the target domain, verbs are the action.
+4. **No functional changes.** The Starlark implementations (`.star` files) are moved
+   and renamed but not rewritten. Flags and behavior stay identical.
+
+## Current State
+
+### com.noblefactor.devlore.Knowledge (devlore-cli)
+
+One extension containing 8 commands that span four concerns:
+
+| Command | Target | Proposed Home |
+|---|---|---|
+| `devlore.knowledge.extract` | Knowledge artifacts | knowledge |
+| `devlore.knowledge.build.modelfile` | Ollama config | model |
+| `devlore.knowledge.index.domains` | Knowledge artifacts | knowledge |
+| `devlore.knowledge.index.packages` | Lore packages | package |
+| `devlore.knowledge.sign.index` | Knowledge artifacts | knowledge |
+| `devlore.knowledge.sign.package` | Lore packages | package |
+| `devlore.knowledge.validate` | Knowledge + packages | Split: knowledge + package |
+| `devlore.knowledge.api` | Ops API surface | Split: ops.validate + ops.generate docs |
+
+### com.noblefactor.star.GenReceiver (noblefactor-ops)
+
+One extension in the wrong repo with the wrong naming convention:
+
+| Command | Target | Proposed Home |
+|---|---|---|
+| `gen.receiver` | Graph ops + plan receivers | ops |
+
+## Target Command Tree
+
+```
+devlore
+├── knowledge
+│   ├── extract          — extract knowledge artifacts from source (--domain)
+│   ├── index            — generate domain indexes
+│   ├── sign             — sign knowledge index
+│   └── validate         — validate knowledge artifacts
+├── package
+│   ├── index            — generate package indexes + cross-references
+│   ├── sign             — sign a lore package
+│   └── validate         — validate lore packages
+├── ops
+│   ├── generate         — generate graph operations + plan receivers + docs
+│   └── validate         — validate API contract (Attr vs StringDict, etc.)
+└── model
+    └── build            — generate Ollama Modelfile from knowledge domain
+```
+
+## Command Mapping
+
+| Current | New | Notes |
+|---|---|---|
+| `devlore.knowledge.extract` | `devlore.knowledge.extract` | Add `--domain ops` for mapping artifact |
+| `devlore.knowledge.index.domains` | `devlore.knowledge.index` | Shortened — only one index verb for knowledge |
+| `devlore.knowledge.index.packages` | `devlore.package.index` | Moved to package node |
+| `devlore.knowledge.sign.index` | `devlore.knowledge.sign` | Shortened — only one sign verb for knowledge |
+| `devlore.knowledge.sign.package` | `devlore.package.sign` | Moved to package node |
+| `devlore.knowledge.validate` | `devlore.knowledge.validate` + `devlore.package.validate` | Split by target |
+| `devlore.knowledge.api` (contract check) | `devlore.ops.validate` | Contract validation is ops concern |
+| `devlore.knowledge.api` (doc generation) | `devlore.ops.generate` | Docs generated alongside code |
+| `devlore.knowledge.build.modelfile` | `devlore.model.build` | Moved to model node |
+| `gen.receiver` (noblefactor-ops) | `devlore.ops.generate` | Moved to devlore-cli, renamed |
+
+## Implementation Phases
+
+### Phase 0: Delete Dispatch Interfaces
+
+Delete `Direct`, `Writer`, `Transform` from `internal/execution/operation.go`.
+Delete `Executable`. Replace with a single `Operation` interface:
+
+```go
+type Operation interface {
+    Name() string
+    Execute(ctx *Context, node *Node) error
+}
+```
+
+Update the executor to call `op.Execute(ctx, node)` uniformly — no type-switch.
+Update all 31 existing ops to implement the single interface. Each op handles
+its own content sourcing internally.
+
+- [ ] Delete `Direct`, `Writer`, `Transform`, `Executable` interfaces from `operation.go`
+- [ ] Add `Execute(ctx *Context, node *Node) error` to `Operation` interface
+- [ ] Update executor dispatch — remove type-switch, call `op.Execute()` uniformly
+- [ ] Update all ops in `ops.go`, `ops_package.go`, `ops_service.go` to implement single interface
+- [ ] Update all tests
+
+**Files**:
+
+| File | Repo | Action |
+|---|---|---|
+| `internal/execution/operation.go` | devlore-cli | Delete Direct/Writer/Transform/Executable, single Operation |
+| `internal/execution/executor.go` | devlore-cli | Remove type-switch dispatch |
+| `internal/execution/ops.go` | devlore-cli | All ops implement single Execute |
+| `internal/execution/ops_package.go` | devlore-cli | All ops implement single Execute |
+| `internal/execution/ops_service.go` | devlore-cli | All ops implement single Execute |
+| `internal/execution/graph.go` | devlore-cli | Remove Executable interface |
+| `internal/execution/*_test.go` | devlore-cli | Update tests |
+
+### Phase 1: Create Four Extensions
+
+Create the extension directories and `extension.yaml` files. Move `.star`
+implementations from the monolithic Knowledge extension into the correct
+extension directories.
+
+- [ ] Create `com.noblefactor.devlore.Knowledge` (slimmed — 4 commands)
+- [ ] Create `com.noblefactor.devlore.Package` (3 commands)
+- [ ] Create `com.noblefactor.devlore.Ops` (2 commands)
+- [ ] Create `com.noblefactor.devlore.Model` (1 command)
+- [ ] Move `gen-receiver.star` from noblefactor-ops to devlore-cli
+- [ ] Split `validate.star` into knowledge and package variants
+- [ ] Split `api.star` into ops.validate (contract) and merge doc generation into ops.generate
+
+**Files**:
+
+| File | Repo | Action |
+|---|---|---|
+| `star/extensions/com.noblefactor.devlore.Knowledge/extension.yaml` | devlore-cli | Modify (remove moved commands) |
+| `star/extensions/com.noblefactor.devlore.Knowledge/commands/build-modelfile.star` | devlore-cli | Delete (moves to Model) |
+| `star/extensions/com.noblefactor.devlore.Knowledge/commands/index-packages.star` | devlore-cli | Delete (moves to Package) |
+| `star/extensions/com.noblefactor.devlore.Knowledge/commands/sign-package.star` | devlore-cli | Delete (moves to Package) |
+| `star/extensions/com.noblefactor.devlore.Knowledge/commands/api.star` | devlore-cli | Delete (splits to Ops) |
+| `star/extensions/com.noblefactor.devlore.Package/extension.yaml` | devlore-cli | Create |
+| `star/extensions/com.noblefactor.devlore.Package/commands/index.star` | devlore-cli | Create (from index-packages.star) |
+| `star/extensions/com.noblefactor.devlore.Package/commands/sign.star` | devlore-cli | Create (from sign-package.star) |
+| `star/extensions/com.noblefactor.devlore.Package/commands/validate.star` | devlore-cli | Create (package validation from validate.star) |
+| `star/extensions/com.noblefactor.devlore.Ops/extension.yaml` | devlore-cli | Create |
+| `star/extensions/com.noblefactor.devlore.Ops/commands/generate.star` | devlore-cli | Create (from gen-receiver.star + doc generation from api.star) |
+| `star/extensions/com.noblefactor.devlore.Ops/commands/validate.star` | devlore-cli | Create (contract validation from api.star) |
+| `star/extensions/com.noblefactor.devlore.Model/extension.yaml` | devlore-cli | Create |
+| `star/extensions/com.noblefactor.devlore.Model/commands/build.star` | devlore-cli | Create (from build-modelfile.star) |
+
+### Phase 2: Remove GenReceiver from noblefactor-ops
+
+Delete the extension from noblefactor-ops after it has been moved to devlore-cli.
+
+- [ ] Delete `star/extensions/com.noblefactor.star.GenReceiver/` directory
+
+**Files**:
+
+| File | Repo | Action |
+|---|---|---|
+| `star/extensions/com.noblefactor.star.GenReceiver/extension.yaml` | noblefactor-ops | Delete |
+| `star/extensions/com.noblefactor.star.GenReceiver/commands/gen-receiver.star` | noblefactor-ops | Delete |
+
+### Phase 3: Update ops.generate for Domain Extraction
+
+Fold the `--domain ops` mapping artifact generation into `devlore.knowledge.extract`.
+This extends the existing extract command rather than adding a new command.
+
+- [ ] Add `ops` domain to extract.star
+- [ ] Wire `go.mapping()` call for ops domain
+- [ ] Write mapping artifacts to knowledge root
+
+**Files**:
+
+| File | Repo | Action |
+|---|---|---|
+| `star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star` | devlore-cli | Modify (add ops domain) |
+
+## Migration Path
+
+1. All commands get new names. Old names stop working immediately — there are no
+   legacy users.
+2. GenReceiver moves repos. The `go` and `file` receivers it depends on are builtins
+   in the star runtime (noblefactor-ops), so they remain available regardless of
+   which repo hosts the extension.
+3. The noblefactor-ops Phase 6 verification commands (`star gen.receiver ...`) become
+   `star devlore ops generate ...` with equivalent flags.
+
+## Generation Model
+
+The generator reads hand-written **services** (`FileService`, `PackageService`,
+`ServiceManagerService`) and produces all infrastructure code. Services are the
+only hand-written code; everything else is generated and nuke-safe.
+
+### What We Write
+
+| Artifact | File | Example |
+|---|---|---|
+| Service | `internal/execution/file_service.go` | `FileService` |
+
+### What the Generator Produces
+
+| Artifact | Location | Example |
+|---|---|---|
+| Ops interface | `internal/execution/generated/fileops/` | `fileOps` (unexported) |
+| Graph operations | `internal/execution/generated/fileops/` | `FileLinkOp`, `FileCopyOp` |
+| Plan receiver | `internal/execution/generated/fileops/` | Starlark `plan.file.*` bindings |
+| Execute receiver | `internal/execution/generated/fileops/` | Starlark `file.*` bindings |
+| Starlark type mappings | `internal/execution/generated/fileops/` | Slot assertions, UnpackArgs |
+| Registration | `internal/execution/generated/fileops/` | `Ops(impl fileOps) []Operation` |
+
+### Single Operation Interface
+
+```go
+type Operation interface {
+    Name() string
+    Execute(ctx *Context, node *Node) error
+}
+```
+
+No `Direct`, `Writer`, `Transform` interfaces. The content model (no content,
+consumer, transformer) is baked into each generated op's `Execute()` method by
+the generator, based on the service method's return signature. The executor
+calls `op.Execute(ctx, node)` uniformly for every node.
+
+### Command Flags
+
+`devlore.ops.generate` has one optional flag:
+
+- `--implementation <name>` — generate only for this service (default: discover
+  all `*Service` structs and generate everything)
+
+Namespace is derived from the service name (`FileService` → `file`,
+`ServiceManagerService` → `service_manager`). Path is known
+(`internal/execution/`). All methods are included by default.
+
+## Resolved Questions
+
+- **`--category` flag**: Removed. Namespace derived from service name.
+- **7 flags reduced to 1.** `--implementation` is optional. Without it, the
+  generator discovers all `*Service` structs and generates everything.
+- **`validate.star` split**: Two standalone implementations, no `--type` flag.
+  `devlore.knowledge.validate` validates knowledge artifacts (domains, indexes).
+  `devlore.package.validate` validates lore packages (manifests, lifecycles).
+  Each knows its own schema set.
+- **No dispatch interfaces.** `Direct`, `Writer`, `Transform` are deleted.
+  One `Operation` interface with `Name()` and `Execute()`. Each generated op
+  is self-contained — the generator bakes the content model into `Execute()`.
+- **Service naming.** Hand-written structs named `*Service` (`FileService`,
+  `PackageService`, `ServiceManagerService`). Methods are activities — currently
+  forward-only, will expand to forward + backward (compensation).
+
+## Related Documents
+
+- [phase-6.md](star-gen-receiver/phase-6.md) — Typed slots and full generation
+- [star-gen-receiver.md](star-gen-receiver.md) — Overall generator plan
+- GitHub issue #71 — `star tree` builtin command

--- a/docs/plans/star-gen-receiver/phase-6.md
+++ b/docs/plans/star-gen-receiver/phase-6.md
@@ -13,30 +13,37 @@ Key architectural decisions that change the approach:
 |---|---|
 | `GetSlot` returns `string` | `GetSlot` returns `any` |
 | `SlotValue.Immediate` is `string` | `SlotValue.Immediate` is `any` |
-| Impl methods take `ctx *Context` first | Impl methods are stateless — no ctx param |
+| Impl methods take `ctx *Context` first | Service methods are stateless — no ctx param |
 | Ops access `ctx.Data` directly | Engine fills unfilled slots from Context.Data |
-| `Category() OpCategory` on every op | Removed; dispatch by interface type switch |
-| `op_category` in descriptor | Return signature determines interface |
-| `--category` flag required | Namespace derived from struct name |
+| `Category() OpCategory` on every op | Removed — no OpCategory |
+| `Direct`/`Writer`/`Transform` interfaces | Removed — single `Operation` interface |
+| `Executable` interface | Removed — ops receive `*Node` directly |
+| `op_category` in descriptor | Return signature determines content model |
+| `--category` flag required | Namespace derived from service name |
+| Impl structs named `fileOps` | Services named `FileService` (hand-written) |
+| Generated ops in same package | Generated code in subpackages (`generated/fileops/`) |
 
 **Repos**: noblefactor-ops (template changes), devlore-cli (infrastructure + restructure)
 
 ## Goals
 
 1. **Typed slots.** `SlotValue.Immediate` is `any`. Slot types are determined
-   by the implementation method's signature. No string-only slots.
+   by the service method's signature. No string-only slots.
 2. **Slot resolution chain.** Caller-provided first, then engine fills unfilled
    slots from Context.Data. Operations never access ctx.Data directly.
-3. **No OpCategory.** The executor dispatches via interface type switch
-   (Direct/Writer/Transform). The `Category()` method and `OpCategory` enum
-   are removed.
-4. **Return signature is the spec.** The generator infers Direct/Writer/Transform
-   from the impl method's return type. No annotation needed.
-5. **Stateless impl structs.** Implementation methods receive all inputs as
-   parameters. No ctx, no state, no side-channel data.
-6. **All Starlark infrastructure is generated.** Plan receivers, graph ops,
-   and real-time receivers are generated from implementation struct signatures.
-7. **Nuke-safe.** Delete any `_gen.go`, re-run the generator, get it back.
+3. **Single Operation interface.** `Direct`, `Writer`, `Transform`, `Executable`
+   are deleted. One interface: `Operation` with `Name()` and `Execute()`. Each
+   generated op is self-contained — the content model is baked in by the generator.
+4. **Return signature is the spec.** The generator infers the content model
+   (no content, consumer, transformer) from the service method's return type.
+   No annotation needed.
+5. **Services are the source of truth.** Hand-written `FileService`,
+   `PackageService`, `ServiceManagerService`. The generator reads their method
+   signatures to produce everything else.
+6. **All infrastructure is generated.** Ops interface, graph operations, plan
+   receivers, execute receivers, Starlark type mappings, registration — all
+   generated from service signatures.
+7. **Nuke-safe.** Delete any generated subpackage, re-run the generator, get it back.
 
 ## Current State
 
@@ -44,16 +51,18 @@ Key architectural decisions that change the approach:
 |---|---|---|
 | `SlotValue.Immediate` | `string` | `any` |
 | `GetSlot` return type | `string` | `any` |
-| `Executable.GetSlot` | `string` | `any` |
+| `Executable` interface | Present | Deleted — ops receive `*Node` |
 | `FillSlot` | Converts all to string | Stores native Go types |
-| `OpCategory` enum | Present, used by executor | Removed |
-| `Category()` on ops | Present on all 31 current ops | Removed |
+| `OpCategory` enum | Present, used by executor | Deleted |
+| `Category()` on ops | Present on all 31 current ops | Deleted |
+| `Direct`/`Writer`/`Transform` | Present, executor type-switches | Deleted — single `Operation` |
 | Engine slot filling | Not implemented | Fills unfilled from Context.Data |
 | Ops ctx.Data access | 8 ops read ctx.Data directly | Zero — all through slots |
-| Impl structs | Don't exist | Source of truth for generation |
-| Generated graph ops | Don't exist | All 21 ops generated |
+| Services | Don't exist | `FileService`, `PackageService`, `ServiceManagerService` |
+| Generated ops interface | Doesn't exist | `fileOps`, `packageOps`, `serviceManagerOps` |
+| Generated graph ops | Don't exist | All ops generated in subpackages |
 | Generated plan receivers | Don't exist | GitPlan, ArchivePlan generated |
-| Generated real-time receivers | Don't exist | ArchiveReceiver, ServiceReceiver generated |
+| Generated execute receivers | Don't exist | Archive, ServiceManager generated |
 
 ## Step 1: Typed Slot Infrastructure (devlore-cli)
 
@@ -62,7 +71,6 @@ Changes to `internal/execution/graph.go`.
 ### 1a: SlotValue.Immediate → any
 
 ```go
-// graph.go line 230
 type SlotValue struct {
     Immediate any    `json:"immediate,omitempty" yaml:"immediate,omitempty"`
     NodeRef   string `json:"node_ref,omitempty" yaml:"node_ref,omitempty"`
@@ -75,7 +83,6 @@ type SlotValue struct {
 ### 1b: GetSlot → returns any
 
 ```go
-// graph.go line 180
 func (n *Node) GetSlot(name string) any {
     if n.Slots != nil {
         if sv, ok := n.Slots[name]; ok {
@@ -91,7 +98,6 @@ func (n *Node) GetSlot(name string) any {
 ### 1c: SetSlotImmediate → takes any
 
 ```go
-// graph.go line 192
 func (n *Node) SetSlotImmediate(name string, value any) {
     if n.Slots == nil {
         n.Slots = make(map[string]SlotValue)
@@ -100,30 +106,22 @@ func (n *Node) SetSlotImmediate(name string, value any) {
 }
 ```
 
-### 1d: Executable interface
+### 1d: Delete Executable interface
 
-```go
-// graph.go line 302
-type Executable interface {
-    GetID() string
-    GetOperation() string
-    GetSlot(name string) any
-    GetProject() string
-    GetMode() os.FileMode
-}
-```
+Remove the `Executable` interface entirely. All code that references
+`Executable` changes to `*Node`.
 
 ### 1e: Cascade fixes
 
 All callers of `GetSlot` that expect `string` must type-assert:
 
-- `executor.go` lines 624, 636: `sortNodesByDepth` and `sortByDepth` use
-  `node.GetSlot("path")` for depth sorting → `path, _ := node.GetSlot("path").(string)`
-- `executor.go` line 426: source file reading →
+- `executor.go`: `sortNodesByDepth`, `sortByDepth` use
+  `node.GetSlot("path")` → `path, _ := node.GetSlot("path").(string)`
+- `executor.go`: source file reading →
   `source, _ := node.GetSlot("source").(string)`
-- `output.go` line 55: `Output.Attr` returns slot value to Starlark →
+- `output.go`: `Output.Attr` returns slot value to Starlark →
   type-switch to convert `any` back to `starlark.Value`
-- `output.go` line 163: `Output.Path()` → `o.node.GetSlot("path").(string)`
+- `output.go`: `Output.Path()` → `o.node.GetSlot("path").(string)`
 - All 31 existing ops that call `node.GetSlot("x")` and use the result as
   string → add `.(string)` assertions. (These ops are replaced in Step 5,
   so the temporary assertions are short-lived.)
@@ -162,49 +160,39 @@ not immediate values.
 go test ./internal/starlark/ -count=1
 ```
 
-## Step 3: Remove OpCategory (devlore-cli)
+## Step 3: Delete Dispatch Interfaces (devlore-cli)
 
-### 3a: Delete OpCategory from operation.go
+### 3a: Delete from operation.go
 
-Remove `OpCategory` type, constants (`OpTransform`, `OpWriter`, `OpDirect`),
-and `Category() OpCategory` from the `Operation` interface. The interface becomes:
+Remove `Direct`, `Writer`, `Transform` interfaces. Remove `OpCategory` type
+and constants. The file becomes:
 
 ```go
 type Operation interface {
     Name() string
+    Execute(ctx *Context, node *Node) error
 }
 ```
 
-### 3b: Update executor content sourcing
+### 3b: Update executor
 
-`executor.go` line 425 uses `op.Category() != OpDirect` to decide whether to
-read source content. Replace with interface type check:
+Remove the type-switch dispatch (`case Transform`, `case Writer`, `case Direct`).
+The executor calls `op.Execute(ctx, node)` uniformly for every node. Content
+sourcing moves into the ops themselves (temporarily for hand-written ops,
+permanently for generated ops).
+
+### 3c: Update all 31 ops
+
+Every op implements the single `Execute(ctx *Context, node *Node) error` method.
+Ops that previously implemented `Transform` or `Writer` now handle their own
+content sourcing inside `Execute()`.
+
+### 3d: Add content helpers to Context
 
 ```go
-// Before
-} else if op.Category() != OpDirect {
-
-// After
-} else if isContentOp(op) {
+func (ctx *Context) ContentFor(node *Node) []byte  // read from upstream or source file
+func (ctx *Context) StoreContent(node *Node, content []byte)  // store for downstream
 ```
-
-Where `isContentOp` checks `Writer` or `Transform`:
-
-```go
-func isContentOp(op Operation) bool {
-    switch op.(type) {
-    case Writer, Transform:
-        return true
-    }
-    return false
-}
-```
-
-### 3c: Remove Category() from all ops
-
-Delete the `Category() OpCategory` method from every op struct in `ops.go`,
-`ops_package.go`, `ops_service.go` (31 current ops; reduced to 21 after
-service unification in Step 5).
 
 ### Verification
 
@@ -221,15 +209,10 @@ fill any slot that the caller didn't provide.
 ### 4a: Add fillSlotsFromData to GraphExecutor
 
 ```go
-// executor.go
-func (e *GraphExecutor) fillSlotsFromData(node Executable) {
-    n, ok := node.(*Node)
-    if !ok {
-        return
-    }
+func (e *GraphExecutor) fillSlotsFromData(node *Node) {
     for key, value := range e.options.Data {
-        if _, exists := n.Slots[key]; !exists {
-            n.SetSlotImmediate(key, value)
+        if _, exists := node.Slots[key]; !exists {
+            node.SetSlotImmediate(key, value)
         }
     }
 }
@@ -237,8 +220,8 @@ func (e *GraphExecutor) fillSlotsFromData(node Executable) {
 
 ### 4b: Call before dispatch
 
-In `executeExecutableWithOutputs`, call `e.fillSlotsFromData(node)` before
-the content sourcing and dispatch logic.
+In the executor's node loop, call `e.fillSlotsFromData(node)` before
+`op.Execute(ctx, node)`.
 
 ### 4c: Verify existing ops still work
 
@@ -259,46 +242,47 @@ This is a transitional step. Step 5 removes the ctx.Data reads from ops.
 go test ./internal/execution/ -count=1
 ```
 
-## Step 5: Implementation Struct Extraction (devlore-cli)
+## Step 5: Service Extraction (devlore-cli)
 
-Extract business logic into stateless implementation structs. Each method
-receives all inputs as parameters — no ctx, no ctx.Data access.
+Extract business logic into hand-written services. Each method receives all
+inputs as parameters — no ctx, no ctx.Data access. Services are named
+`*Service` by convention.
 
-### 5a: impl_file.go
+### 5a: file_service.go
 
 ```go
-type fileOps struct{}
+type FileService struct{}
 
-func (f *fileOps) Link(source, path string) error
-func (f *fileOps) Copy(path string, mode os.FileMode, content []byte) (string, error)
-func (f *fileOps) Render(templateData map[string]any, source, path, project string, content []byte) ([]byte, error)
-func (f *fileOps) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error)
-func (f *fileOps) Backup(path, backupSuffix string) error
-func (f *fileOps) Unlink(path string, prune bool, pruneBoundary string) error
-func (f *fileOps) Remove(path string, prune bool, pruneBoundary string) error
-func (f *fileOps) Write(content, path string, mode os.FileMode) error
-func (f *fileOps) Validate(validators map[string]func() error, check, message string) error
-func (f *fileOps) Move(gitMv func(src, dst string) error, source, path string) error
+func (f *FileService) Link(source, path string) error
+func (f *FileService) Copy(path string, mode os.FileMode, content []byte) (string, error)
+func (f *FileService) Render(templateData map[string]any, source, path, project string, content []byte) ([]byte, error)
+func (f *FileService) Decrypt(decryptor func(string, []byte) ([]byte, error), source string, content []byte) ([]byte, error)
+func (f *FileService) Backup(path, backupSuffix string) error
+func (f *FileService) Unlink(path string, prune bool, pruneBoundary string) error
+func (f *FileService) Remove(path string, prune bool, pruneBoundary string) error
+func (f *FileService) Write(content, path string, mode os.FileMode) error
+func (f *FileService) Validate(validators map[string]func() error, check, message string) error
+func (f *FileService) Move(gitMv func(src, dst string) error, source, path string) error
 ```
 
 Every parameter except the framework `content []byte` (last param on
-Writer/Transform methods) maps to a slot. Parameters like `decryptor`,
+consumer/transformer methods) maps to a slot. Parameters like `decryptor`,
 `validators`, `templateData`, `backupSuffix`, `prune`, `pruneBoundary`,
 `gitMv` come from Context.Data via engine slot filling.
 
 Helper functions (`pruneEmptyParents`, `isSubpath`) move to this file.
 
-### 5b: impl_package.go
+### 5b: package_service.go
 
 ```go
-type packageOps struct{}
+type PackageService struct{}
 
-func (p *packageOps) Install(packages []string, manager string, cask bool) error
-func (p *packageOps) Upgrade(packages []string, manager string, cask bool) error
-func (p *packageOps) Remove(packages []string, manager string, cask bool) error
-func (p *packageOps) Update(manager string) error
-func (p *packageOps) Shell(command string) error
-func (p *packageOps) PowerShell(command string) error
+func (p *PackageService) Install(packages []string, manager string, cask bool) error
+func (p *PackageService) Upgrade(packages []string, manager string, cask bool) error
+func (p *PackageService) Remove(packages []string, manager string, cask bool) error
+func (p *PackageService) Update(manager string) error
+func (p *PackageService) Shell(command string) error
+func (p *PackageService) PowerShell(command string) error
 ```
 
 Helper functions (`resolvePMForInstall`, `resolvePMForUpgrade`,
@@ -308,30 +292,30 @@ Helper functions (`resolvePMForInstall`, `resolvePMForUpgrade`,
 `parsePackages` helper (comma-separated string splitting) is removed.
 `FillSlot` handles `*starlark.List` → `[]string` conversion at plan time.
 
-### 5c: impl_service.go
+### 5c: service_manager_service.go
 
 Platform-agnostic service operations. Same pattern as package: the caller
-says `service.start("foo")` and the impl handles platform dispatch internally.
-15 platform-specific ops collapse to 5.
+says `service_manager.start("foo")` and the service handles platform dispatch
+internally. 15 platform-specific ops collapse to 5.
 
 ```go
-type serviceOps struct{}
+type ServiceManagerService struct{}
 
-func (s *serviceOps) Start(name string) error
-func (s *serviceOps) Stop(name string) error
-func (s *serviceOps) Restart(name string) error
-func (s *serviceOps) Enable(name string) error
-func (s *serviceOps) Disable(name string) error
+func (s *ServiceManagerService) Start(name string) error
+func (s *ServiceManagerService) Stop(name string) error
+func (s *ServiceManagerService) Restart(name string) error
+func (s *ServiceManagerService) Enable(name string) error
+func (s *ServiceManagerService) Disable(name string) error
 ```
 
 Each method detects the platform at runtime (`runtime.GOOS`) and dispatches
 to the appropriate service manager (launchd on darwin, systemd on linux,
 sc on windows). The 15 current ops (`LaunchdStartOp`, `SystemdStartOp`,
-`WinServiceStartOp`, etc.) are replaced by 5 ops (`ServiceStartOp`, etc.).
+`WinServiceStartOp`, etc.) are replaced by 5 ops.
 
 ### Verification
 
-Impl structs compile standalone. No tests yet — they're exercised through
+Services compile standalone. No tests yet — they're exercised through
 the generated ops in Step 7.
 
 ```bash
@@ -340,99 +324,55 @@ go build ./internal/execution/...
 
 ## Step 6: Generator Template Updates (noblefactor-ops)
 
-### 6a: Remove op_category from descriptor
+### 6a: Single Operation interface in templates
 
-Delete `OpCategory` field from `methodInfo`. Delete `op_category` handling
-from `methodInfoFromValue`. Add `Interface` field (inferred from return type):
+All generated ops implement `Operation` with `Name()` and `Execute()`.
+No `Direct`, `Writer`, `Transform` in generated code. The content model
+is baked into each op's `Execute()` method based on the service method's
+return signature.
+
+### 6b: Generate ops interface
+
+The generator produces an unexported interface from the service's method
+signatures:
+
+```go
+// generated/fileops/ops.go
+type fileOps interface {
+    Link(source, path string) error
+    Copy(path string, mode os.FileMode, content []byte) (string, error)
+    // ...
+}
+```
+
+### 6c: Content model inference from return signature
 
 ```go
 type methodInfo struct {
-    GoName    string
-    SnakeName string
-    Params    []paramInfo
-    ReturnType string
-    Interface  string // "Direct", "Writer", "Transform"
-    Doc        string
+    GoName       string
+    SnakeName    string
+    Params       []paramInfo
+    ReturnType   string
+    ContentModel string // "none", "consumer", "transformer"
+    Doc          string
 }
 ```
 
-In `descriptorFromValue` or `goGenerate`, after `validateReturnSignature`
-extracts the value type:
-
-```go
-switch valueType {
-case "string":
-    m.Interface = "Writer"
-case "[]byte":
-    m.Interface = "Transform"
-default:
-    m.Interface = "Direct"
-}
-```
-
-For methods that return `error` only (not `(T, error)`), the gate validation
-needs a new path. Currently `validateReturnSignature` rejects bare `error`.
-Add support:
-
-```go
-if returns == "error" {
-    return "", nil  // empty valueType signals Direct
-}
-```
-
-### 6b: Graph ops template — remove Category(), typed assertions
-
-Replace `{{if eq .OpCategory "OpWriter"}}` with `{{if eq .Interface "Writer"}}`.
-
-Remove all `Category() OpCategory` lines.
-
-Replace `tplSlotReaders` with typed assertion code:
-
-```go
-// For string params:
-source, ok := node.GetSlot("source").(string)
-if !ok {
-    return fmt.Errorf("{{$.Category}}.{{.SnakeName}}: slot \"source\" requires string")
-}
-
-// For bool params:
-prune, _ := node.GetSlot("prune").(bool)
-
-// For function params:
-decryptor, ok := node.GetSlot("decryptor").(func(string, []byte) ([]byte, error))
-if !ok {
-    return nil, fmt.Errorf("{{$.Category}}.{{.SnakeName}}: slot \"decryptor\" requires func")
-}
-```
-
-The assertion pattern depends on the Go type. Required params (string, func)
-use `ok` check with error. Optional/defaultable params (bool, int) use
-zero-value fallback.
-
-### 6c: Graph ops template — delegation without ctx
-
-Impl methods don't take ctx. The delegation call passes only slot values:
-
-```go
-return o.impl.{{.GoName}}({{implArgs .Params}})           // Direct
-return o.impl.{{.GoName}}({{implArgs .Params}}, content)  // Writer/Transform
-```
-
-### 6d: Namespace from struct name
-
-Add a `namespaceFromStruct` function that strips known suffixes and converts
-to snake_case:
-
-| Struct | Strip Suffix | Namespace |
+| Return Signature | Content Model | Generated Execute() |
 |---|---|---|
-| `fileOps` | `Ops` | `file` |
-| `packageOps` | `Ops` | `package` |
-| `serviceOps` | `Ops` | `service` |
-| `GitPlan` | `Plan` | `git` |
-| `ArchiveReceiver` | `Receiver` | `archive` |
+| `error` | `none` | Read slots, delegate, return error |
+| `(string, error)` | `consumer` | Read content + slots, delegate, store checksum |
+| `([]byte, error)` | `transformer` | Read content + slots, delegate, store output content |
 
-The `category` field in the descriptor is derived from this — no `--category`
-CLI flag needed.
+### 6d: Namespace from service name
+
+Strip `Service` suffix, snake_case:
+
+| Service | Namespace |
+|---|---|
+| `FileService` | `file` |
+| `PackageService` | `package` |
+| `ServiceManagerService` | `service_manager` |
 
 ### 6e: Expand type mappings
 
@@ -455,7 +395,7 @@ from Context.Data at runtime. The generator skips them in plan receiver template
 
 The generator must distinguish slot params from framework params. Convention:
 
-- **Framework content**: The last `[]byte` param on Writer/Transform methods.
+- **Framework content**: The last `[]byte` param on consumer/transformer methods.
   Identified by: method returns `(string, error)` or `([]byte, error)`, AND
   the last param's type is `[]byte`. This param is NOT a slot — it's the
   content pipeline.
@@ -463,25 +403,49 @@ The generator must distinguish slot params from framework params. Convention:
 
 No annotation needed. The method signature IS the specification.
 
-### 6g: Tests
+### 6g: Generate into subpackages
+
+The generator produces code in `generated/<namespace>ops/`:
+
+```
+internal/execution/generated/
+├── fileops/
+│   └── ops.go       # fileOps interface, FileLinkOp, ..., Ops() registration
+├── packageops/
+│   └── ops.go       # packageOps interface, PackageInstallOp, ..., Ops()
+└── servicemanagerops/
+    └── ops.go       # serviceManagerOps interface, ServiceManagerStartOp, ..., Ops()
+```
+
+Registration function accepts the interface:
+
+```go
+func Ops(impl fileOps) []Operation { ... }
+```
+
+Parent package wires it: `fileops.Ops(&FileService{})`.
+
+### 6h: Tests
 
 Update existing tests, add new tests:
 
+- `TestGenerateOpsInterface`: Verify generated interface matches service methods
 - `TestGenerateGraphOpsTypedSlots`: Verify typed assertion code for string,
-  bool, func params.
-- `TestGenerateGraphOpsWriterInferred`: Method with `(string, error)` return
-  generates `Write()` without explicit op_category.
-- `TestGenerateGraphOpsTransformInferred`: Method with `([]byte, error)` return
-  generates `Transform()`.
-- `TestGenerateGraphOpsDirectInferred`: Method with `error` return generates
-  `Execute()`.
-- `TestGenerateGraphOpsNoCategory`: Verify no `Category()` method in output.
-- `TestNamespaceFromStruct`: Verify suffix stripping and snake_case.
+  bool, func params
+- `TestGenerateConsumerInferred`: Method with `(string, error)` return generates
+  content consumer Execute()
+- `TestGenerateTransformerInferred`: Method with `([]byte, error)` return generates
+  content transformer Execute()
+- `TestGenerateNoContentInferred`: Method with `error` return generates
+  no-content Execute()
+- `TestGenerateNoDispatchInterfaces`: Verify no `Direct`, `Writer`, `Transform`
+  in output
+- `TestNamespaceFromService`: Verify suffix stripping and snake_case
 
 ### Verification
 
 ```bash
-cd /Users/david-noble/Workspace/NobleFactor/noblefactor-ops
+cd /path/to/noblefactor-ops
 go test ./internal/starlark/ -run TestGenerate -count=1
 go test ./internal/starlark/ -count=1
 go build ./... && go vet ./internal/starlark/
@@ -489,33 +453,43 @@ go build ./... && go vet ./internal/starlark/
 
 ## Step 7: Generate and Replace Graph Ops (devlore-cli)
 
-### 7a: Generate ops_file_gen.go
+### 7a: Generate generated/fileops/
 
-Run the generator against `fileOps`. The generated file contains:
+Run the generator against `FileService`. The generated subpackage contains:
 
-- `FileLinkOp` (Direct), `FileCopyOp` (Writer), `FileRenderOp` (Transform),
-  `FileDecryptOp` (Transform), `FileBackupOp` (Direct), `FileUnlinkOp` (Direct),
-  `FileRemoveOp` (Direct), `FileWriteOp` (Direct), `FileValidateOp` (Direct),
-  `FileMoveOp` (Direct)
-- Each op: struct with `impl *fileOps`, `Name()`, Execute/Write/Transform
-  with typed slot assertions + dry-run + delegation
-- `FileOps() []Operation` registration function
+- `fileOps` interface (unexported)
+- `FileLinkOp`, `FileCopyOp`, `FileRenderOp`, `FileDecryptOp`, `FileBackupOp`,
+  `FileUnlinkOp`, `FileRemoveOp`, `FileWriteOp`, `FileValidateOp`, `FileMoveOp`
+- Each op: struct with `impl fileOps`, `Name()`, `Execute()` with typed slot
+  assertions + dry-run + content handling + delegation
+- `Ops(impl fileOps) []Operation` registration function
 
-### 7b: Generate ops_package_gen.go
+### 7b: Generate generated/packageops/
 
-From `packageOps`. 6 ops (Install, Upgrade, Remove, Update, Shell, PowerShell).
+From `PackageService`. 6 ops (Install, Upgrade, Remove, Update, Shell, PowerShell).
 
-### 7c: Generate ops_service_gen.go
+### 7c: Generate generated/servicemanagerops/
 
-From `serviceOps`. 5 platform-agnostic ops (Start, Stop, Restart, Enable,
-Disable). Operation names: `service.start`, `service.stop`, etc.
+From `ServiceManagerService`. 5 platform-agnostic ops (Start, Stop, Restart,
+Enable, Disable). Operation names: `service_manager.start`,
+`service_manager.stop`, etc.
 
 ### 7d: Delete hand-written ops
 
 Remove `ops.go` (file ops + AllOps), `ops_package.go`, `ops_service.go`.
 
-Move `AllOps()` to a new small wiring file or into one of the generated files.
-`AllOps` calls `FileOps()`, `PackageOps()`, `ServiceOps()`.
+Create a small wiring file that imports generated subpackages and registers:
+
+```go
+// ops_registry.go
+func AllOps() []Operation {
+    var ops []Operation
+    ops = append(ops, fileops.Ops(&FileService{})...)
+    ops = append(ops, packageops.Ops(&PackageService{})...)
+    ops = append(ops, servicemanagerops.Ops(&ServiceManagerService{})...)
+    return ops
+}
+```
 
 ### Verification
 
@@ -524,15 +498,15 @@ go build ./internal/execution/...
 go test ./internal/execution/ -count=1
 
 # Nuke and regenerate
-rm internal/execution/ops_*_gen.go
-# Run generator for each impl struct
+rm -rf internal/execution/generated/
+star devlore ops generate
 go build ./internal/execution/...
 go test ./internal/execution/ -count=1
 ```
 
 ## Step 8: Generate Plan Receivers (devlore-cli)
 
-### 8a: Generate plan_git_gen.go
+### 8a: Generate plan_git in generated/
 
 From GitPlan's 3 methods (clone, checkout, pull). Delete `plan_git.go`.
 
@@ -545,7 +519,7 @@ The generated plan receiver:
 - Operation names: `git.clone`, `git.checkout`, `git.pull`
 - Node IDs: `generateNodeID("git.clone")`
 
-### 8b: Generate plan_archive_gen.go
+### 8b: Generate plan_archive in generated/
 
 From ArchivePlan's 1 method (extract). Delete `plan_archive.go`.
 
@@ -557,12 +531,6 @@ From ArchivePlan's 1 method (extract). Delete `plan_archive.go`.
   from standard `UnpackArgs`.
 - `plan_root.go`: Top-level orchestration methods.
 
-### 8d: Update plan_root.go constructors
-
-If generated plan receiver constructors changed signature (they shouldn't —
-`NewGitPlan(graph, host, project)` matches the template output), verify
-`plan_root.go` still compiles.
-
 ### Verification
 
 ```bash
@@ -570,18 +538,18 @@ go build ./internal/starlark/...
 go test ./internal/starlark/ -count=1
 ```
 
-## Step 9: Generate Real-Time Receivers (devlore-cli)
+## Step 9: Generate Execute Receivers (devlore-cli)
 
 ### 9a: Typed receivers → generated
 
-- `receiver_archive_gen.go` from ArchiveReceiver's typed params (extract).
+- Archive execute receiver from ArchiveService's typed params (extract).
   Delete `receiver_archive.go`.
-- `receiver_service_gen.go` from ServiceReceiver's typed params.
+- ServiceManager execute receiver from ServiceManagerService's typed params.
   Delete `receiver_service.go`.
 
-### 9b: Hand-written receivers stay
+### 9b: Hand-written execute receivers stay
 
-| Receiver | Reason |
+| File | Reason |
 |---|---|
 | `receiver_git.go` | kwargs passthrough (CLI wrapper) |
 | `receiver_npm.go` | kwargs passthrough |
@@ -638,7 +606,7 @@ resolution. User-authored templates reference them. No rename.
 
 In `commands.go`, the undeploy command sets `cfg.TemplateData["prune_empty_dirs"]`.
 Rename to `"prune"` to match the slot name on
-`fileOps.Unlink(path string, prune bool, ...)`.
+`FileService.Unlink(path string, prune bool, ...)`.
 
 ### Verification
 
@@ -652,33 +620,34 @@ go test ./... -count=1
 ```
 Step 1 (typed slots)
   → Step 2 (FillSlot typed conversions)
-  → Step 3 (remove OpCategory)
+  → Step 3 (delete dispatch interfaces)
   → Step 4 (engine slot filling)
-  → Step 5 (impl struct extraction)
+  → Step 5 (service extraction)
   → Step 7 (generate graph ops)
 
 Step 6 (template updates, noblefactor-ops) — parallel with Steps 1-5
 
 Step 7 (generate graph ops) requires Steps 5 + 6
 Step 8 (generate plan receivers) requires Step 6
-Step 9 (generate real-time receivers) requires Step 6
+Step 9 (generate execute receivers) requires Step 6
 Step 10 (key normalization) — can run anytime after Step 4
 ```
 
-Steps 1-4 are infrastructure. Step 5 extracts impl structs. Step 6 updates
+Steps 1-4 are infrastructure. Step 5 extracts services. Step 6 updates
 templates. Steps 7-9 generate and replace. Step 10 normalizes keys.
 
 ## Scope Boundaries
 
 | Pattern | Generated | Hand-Written |
 |---|---|---|
+| Ops interface (unexported) | All | - |
 | Graph ops (typed slot assertions + delegation) | All 21 | - |
 | Plan receivers (standard 1:1 method → node) | GitPlan, ArchivePlan | FilePlan, PackagePlan |
-| Real-time receivers (typed params) | Archive, Service | Git/Npm/Docker/Shell/Env/HTTP/Log/Package |
+| Execute receivers (typed params) | Archive, ServiceManager | Git/Npm/Docker/Shell/Env/HTTP/Log/Package |
 | Receiver embedding + MakeAttr + AttrNames | All generated | All hand-written use same pattern |
 | Slot readers + dry-run logging | All generated | - |
-| Registration functions with impl | All generated | - |
-| Implementation bodies | - | impl structs (source of truth) |
+| Registration functions | All generated | - |
+| Service implementations | - | Services (source of truth) |
 | Multi-node methods (configure) | - | Required |
 | Variadic args pattern (PackagePlan) | - | Required |
 | kwargs passthrough (CLI wrappers) | - | Required |
@@ -691,52 +660,42 @@ templates. Steps 7-9 generate and replace. Step 10 normalizes keys.
 
 | File | Action | Purpose |
 |---|---|---|
-| `internal/execution/graph.go` | Modify | Typed slots (any), GetSlot returns any |
-| `internal/execution/operation.go` | Modify | Remove OpCategory |
-| `internal/execution/executor.go` | Modify | Type-switch content sourcing, engine slot filling |
+| `internal/execution/graph.go` | Modify | Typed slots (any), delete Executable |
+| `internal/execution/operation.go` | Modify | Delete Direct/Writer/Transform, single Operation |
+| `internal/execution/executor.go` | Modify | Uniform op.Execute(), engine slot filling |
 | `internal/starlark/output.go` | Modify | FillSlot stores native Go types |
-| `internal/execution/impl_file.go` | Create | fileOps implementation struct |
-| `internal/execution/impl_package.go` | Create | packageOps implementation struct |
-| `internal/execution/impl_service.go` | Create | serviceOps implementation struct |
-| `internal/execution/ops_file_gen.go` | Create | Generated file ops |
-| `internal/execution/ops_package_gen.go` | Create | Generated package ops |
-| `internal/execution/ops_service_gen.go` | Create | Generated service ops |
-| `internal/execution/ops.go` | Delete | Replaced by impl_file.go + ops_file_gen.go |
-| `internal/execution/ops_package.go` | Delete | Replaced by impl_package.go + ops_package_gen.go |
-| `internal/execution/ops_service.go` | Delete | Replaced by impl_service.go + ops_service_gen.go |
-| `internal/starlark/plan_git_gen.go` | Create | Generated GitPlan |
-| `internal/starlark/plan_archive_gen.go` | Create | Generated ArchivePlan |
-| `internal/starlark/plan_git.go` | Delete | Replaced by plan_git_gen.go |
-| `internal/starlark/plan_archive.go` | Delete | Replaced by plan_archive_gen.go |
-| `internal/starlark/receiver_archive_gen.go` | Create | Generated ArchiveReceiver |
-| `internal/starlark/receiver_service_gen.go` | Create | Generated ServiceReceiver |
-| `internal/starlark/receiver_archive.go` | Delete | Replaced by receiver_archive_gen.go |
-| `internal/starlark/receiver_service.go` | Delete | Replaced by receiver_service_gen.go |
+| `internal/execution/file_service.go` | Create | FileService (hand-written) |
+| `internal/execution/package_service.go` | Create | PackageService (hand-written) |
+| `internal/execution/service_manager_service.go` | Create | ServiceManagerService (hand-written) |
+| `internal/execution/ops_registry.go` | Create | AllOps() wiring |
+| `internal/execution/generated/fileops/ops.go` | Create | Generated: fileOps interface + ops |
+| `internal/execution/generated/packageops/ops.go` | Create | Generated: packageOps interface + ops |
+| `internal/execution/generated/servicemanagerops/ops.go` | Create | Generated: serviceManagerOps interface + ops |
+| `internal/execution/ops.go` | Delete | Replaced by service + generated subpackage |
+| `internal/execution/ops_package.go` | Delete | Replaced by service + generated subpackage |
+| `internal/execution/ops_service.go` | Delete | Replaced by service + generated subpackage |
+| `internal/starlark/plan_git.go` | Delete | Replaced by generated |
+| `internal/starlark/plan_archive.go` | Delete | Replaced by generated |
+| `internal/starlark/receiver_archive.go` | Delete | Replaced by generated |
+| `internal/starlark/receiver_service.go` | Delete | Replaced by generated |
 | `internal/writ/commands.go` | Modify | Rename `prune_empty_dirs` key to `prune` |
 
 ### noblefactor-ops
 
 | File | Action | Purpose |
 |---|---|---|
-| `internal/starlark/receiver_go_gen.go` | Modify | Remove op_category, typed assertions, return-type inference, namespace from struct |
+| `internal/starlark/receiver_go_gen.go` | Modify | Single Operation, ops interface, content model inference, namespace from service |
 
 ## Verification
 
 After all steps, validate the nuke-and-regenerate workflow:
 
 ```bash
-# Delete all generated files
-rm internal/execution/ops_*_gen.go
-rm internal/starlark/plan_*_gen.go
-rm internal/starlark/receiver_*_gen.go
+# Delete all generated subpackages
+rm -rf internal/execution/generated/
 
 # Regenerate all
-star gen.receiver --struct fileOps --path ./internal/execution --templates graph_ops --write
-star gen.receiver --struct packageOps --path ./internal/execution --templates graph_ops --write
-star gen.receiver --struct serviceOps --path ./internal/execution --templates graph_ops --write
-star gen.receiver --struct GitPlan --path ./internal/starlark --templates plan_receiver --write
-star gen.receiver --struct ArchivePlan --path ./internal/starlark --templates plan_receiver --write
-# ... real-time receivers
+star devlore ops generate
 
 # Everything compiles and tests pass
 go build ./...
@@ -747,6 +706,7 @@ go test ./...
 
 - [devlore-typed-slots.md](../../architecture/devlore-typed-slots.md) — Typed slots architecture
 - [devlore-execution-graph.md](../../architecture/devlore-execution-graph.md) — Graph structure and lifecycle
+- [devlore-command-tree.md](../devlore-command-tree.md) — Command tree restructuring
 - [phase-5.md](phase-5.md) — Previous plan (superseded by this document)
 - Phases 0-4 — Generator pipeline (merged)
 
@@ -760,3 +720,13 @@ go test ./...
 - **`packages` slot type**: `[]string` natively. Remove comma-separated string.
   `FillSlot` converts `*starlark.List` → `[]string`.
 - **Phase 5**: Superseded by this document. Note added to phase-5.md.
+- **Dispatch interfaces**: `Direct`, `Writer`, `Transform` deleted. Single
+  `Operation` interface with `Name()` and `Execute()`. Content model baked
+  into each generated op by the generator.
+- **Service naming**: Hand-written structs named `*Service` (`FileService`,
+  `PackageService`, `ServiceManagerService`). Generated ops interface named
+  `*Ops` (unexported: `fileOps`, `packageOps`, `serviceManagerOps`).
+- **Namespace derivation**: Strip `Service` suffix, snake_case the remainder.
+  `FileService` → `file`. `ServiceManagerService` → `service_manager`.
+- **Generated code location**: Subpackages under `internal/execution/generated/`.
+  Each namespace gets its own package (`fileops/`, `packageops/`, `servicemanagerops/`).


### PR DESCRIPTION
## Summary

- Add devlore command tree restructuring plan with four extension nodes: knowledge, package, ops, model
- Update typed-slots architecture to use service nomenclature (FileService, PackageService, ServiceManagerService)
- Update Phase 6 plan to align with service model and single Operation interface
- Delete Direct/Writer/Transform dispatch interfaces in favor of single Operation with Name() and Execute()

## Documents

| File | Change |
|---|---|
| `docs/plans/devlore-command-tree.md` | New plan: four-node command tree, command mapping, implementation phases |
| `docs/architecture/devlore-typed-slots.md` | Service nomenclature, Activity term, Execute receiver, Ops interface |
| `docs/plans/star-gen-receiver/phase-6.md` | FileService/PackageService/ServiceManagerService, service_manager namespace |

## Test plan

- [ ] Review terminology table in typed-slots architecture doc
- [ ] Verify consistent use of "Service" (not "Receiver") for hand-written implementation structs
- [ ] Verify consistent use of "Activity" for service methods
- [ ] Verify namespace derivation: strip "Service" suffix, snake_case remainder