### PR TITLE
feat(execution): delete dispatch interfaces, unify Operation

### DIFF
--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -11,13 +11,9 @@ import (
 	"testing"
 )
 
-// runGraph is a test helper that converts a Graph to Executable slice and calls RunNodes.
+// runGraph is a test helper that calls RunNodes with the graph's nodes and edges.
 func runGraph(ctx context.Context, e *GraphExecutor, g *Graph) ([]*Result, error) {
-	executables := make([]Executable, len(g.Nodes))
-	for i, n := range g.Nodes {
-		executables[i] = n
-	}
-	return e.RunNodes(ctx, executables, g.Edges)
+	return e.RunNodes(ctx, g.Nodes, g.Edges)
 }
 
 // testNode creates a node with source and path slots for testing.
@@ -116,16 +112,23 @@ func TestLinkOperationIdempotent(t *testing.T) {
 
 func TestCopyOperation(t *testing.T) {
 	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
 	target := filepath.Join(tmpDir, "output.txt")
 
-	op := &CopyOp{}
-	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test"}
-	node.SetSlotImmediate("path", target)
-	inputContent := []byte("file content")
+	if err := os.WriteFile(source, []byte("file content"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	checksum, err := op.Write(ctx, node, inputContent)
-	if err != nil {
+	op := &CopyOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Outputs: make(map[string][]byte),
+	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", target)
+
+	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
@@ -137,25 +140,33 @@ func TestCopyOperation(t *testing.T) {
 		t.Errorf("expected 'file content', got %q", string(content))
 	}
 
-	if checksum == "" {
+	if ctx.TargetChecksum == "" {
 		t.Error("expected target checksum to be set")
 	}
-	if !strings.HasPrefix(checksum, "sha256:") {
-		t.Errorf("expected sha256: prefix, got %q", checksum)
+	if !strings.HasPrefix(ctx.TargetChecksum, "sha256:") {
+		t.Errorf("expected sha256: prefix, got %q", ctx.TargetChecksum)
 	}
 }
 
 func TestCopyOperationCreatesParentDirs(t *testing.T) {
 	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.txt")
 	target := filepath.Join(tmpDir, "deep", "nested", "output.txt")
 
-	op := &CopyOp{}
-	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test"}
-	node.SetSlotImmediate("path", target)
-	inputContent := []byte("nested content")
+	if err := os.WriteFile(source, []byte("nested content"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	if _, err := op.Write(ctx, node, inputContent); err != nil {
+	op := &CopyOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Outputs: make(map[string][]byte),
+	}
+	node := &Node{ID: "test"}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", target)
+
+	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("copy with nested dirs: %v", err)
 	}
 
@@ -169,20 +180,27 @@ func TestCopyOperationCreatesParentDirs(t *testing.T) {
 }
 
 func TestRenderOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "template.txt")
+	templateContent := "# Shell: {{.Shell}}\n# User: {{.Username}}\n# Project: {{.Project}}"
+	if err := os.WriteFile(source, []byte(templateContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	op := &RenderOp{}
 	ctx := &Context{
 		Context: context.Background(),
 		Data:    map[string]any{"Username": "testuser", "Shell": "/bin/zsh"},
+		Outputs: make(map[string][]byte),
 	}
 	node := &Node{ID: ".bashrc", Project: "all"}
-	node.SetSlotImmediate("source", "/environment/all/.bashrc")
-	inputContent := []byte("# Shell: {{.Shell}}\n# User: {{.Username}}\n# Project: {{.Project}}")
+	node.SetSlotImmediate("source", source)
 
-	result, err := op.Transform(ctx, node, inputContent)
-	if err != nil {
-		t.Fatalf("expand: %v", err)
+	if err := op.Execute(ctx, node); err != nil {
+		t.Fatalf("render: %v", err)
 	}
 
+	result := ctx.Outputs[node.ID]
 	expected := "# Shell: /bin/zsh\n# User: testuser\n# Project: all"
 	if string(result) != expected {
 		t.Errorf("expected %q, got %q", expected, string(result))
@@ -190,6 +208,12 @@ func TestRenderOperation(t *testing.T) {
 }
 
 func TestDecryptOperation(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(source, []byte("encrypted-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	op := &DecryptOp{}
 
 	// Provide a mock decryptor
@@ -200,27 +224,38 @@ func TestDecryptOperation(t *testing.T) {
 	ctx := &Context{
 		Context: context.Background(),
 		Data:    map[string]any{"decryptor": mockDecrypt},
+		Outputs: make(map[string][]byte),
 	}
 	node := &Node{ID: "secret.txt"}
-	inputContent := []byte("encrypted-data")
+	node.SetSlotImmediate("source", source)
 
-	result, err := op.Transform(ctx, node, inputContent)
-	if err != nil {
+	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("decrypt: %v", err)
 	}
 
+	result := ctx.Outputs[node.ID]
 	if string(result) != "decrypted:encrypted-data" {
 		t.Errorf("unexpected content: %q", string(result))
 	}
 }
 
 func TestDecryptOperationNoDecryptor(t *testing.T) {
-	op := &DecryptOp{}
-	ctx := &Context{Context: context.Background(), Data: map[string]any{}}
-	node := &Node{ID: "secret.txt"}
-	inputContent := []byte("data")
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(source, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	if _, err := op.Transform(ctx, node, inputContent); err == nil {
+	op := &DecryptOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Data:    map[string]any{},
+		Outputs: make(map[string][]byte),
+	}
+	node := &Node{ID: "secret.txt"}
+	node.SetSlotImmediate("source", source)
+
+	if err := op.Execute(ctx, node); err == nil {
 		t.Error("expected error when no decryptor configured")
 	}
 }
@@ -229,10 +264,13 @@ func TestDecryptOperationNoDecryptor(t *testing.T) {
 // This is a critical test: we previously had a legacy signature fallback that accepted
 // func([]byte) ([]byte, error) which is a security issue since it doesn't track the source.
 func TestDecryptOperationInvalidSignature(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(source, []byte("encrypted-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	op := &DecryptOp{}
-	node := &Node{ID: "secret.txt"}
-	node.SetSlotImmediate("source", "/path/to/secret")
-	inputContent := []byte("encrypted-data")
 
 	tests := []struct {
 		name      string
@@ -279,12 +317,16 @@ func TestDecryptOperationInvalidSignature(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			node := &Node{ID: "secret.txt"}
+			node.SetSlotImmediate("source", source)
+
 			ctx := &Context{
 				Context: context.Background(),
 				Data:    map[string]any{"decryptor": tt.decryptor},
+				Outputs: make(map[string][]byte),
 			}
 
-			_, err := op.Transform(ctx, node, inputContent)
+			err := op.Execute(ctx, node)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error for %s, got nil", tt.name)
@@ -872,15 +914,23 @@ func TestBackupOperation(t *testing.T) {
 
 func TestCopyOperationWithMode(t *testing.T) {
 	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "source.sh")
 	target := filepath.Join(tmpDir, "script.sh")
 
-	op := &CopyOp{}
-	ctx := &Context{Context: context.Background()}
-	node := &Node{ID: "test", Mode: 0755}
-	node.SetSlotImmediate("path", target)
-	inputContent := []byte("#!/bin/sh\necho hello")
+	if err := os.WriteFile(source, []byte("#!/bin/sh\necho hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	if _, err := op.Write(ctx, node, inputContent); err != nil {
+	op := &CopyOp{}
+	ctx := &Context{
+		Context: context.Background(),
+		Outputs: make(map[string][]byte),
+	}
+	node := &Node{ID: "test", Mode: 0755}
+	node.SetSlotImmediate("source", source)
+	node.SetSlotImmediate("path", target)
+
+	if err := op.Execute(ctx, node); err != nil {
 		t.Fatalf("copy with mode: %v", err)
 	}
 

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -137,12 +137,13 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *Graph) error {
 		DryRun:  e.options.DryRun,
 		Logger:  e.options.Logger,
 		Data:    e.options.Data,
+		Edges:   g.Edges,
+		Outputs: make(map[string][]byte),
 	}
 
-	outputs := make(map[string][]byte)
 	var results []*Result
 	for _, node := range ordered {
-		result := e.executeNodeWithOutputs(execCtx, node, g.Edges, outputs)
+		result := e.executeNode(execCtx, node)
 		results = append(results, result)
 
 		if result.Status == ResultFailed && e.options.ConflictResolution == ResolutionStop {
@@ -363,23 +364,23 @@ func (e *GraphExecutor) unwindStack(ctx *Context, g *Graph, stack *RecoveryStack
 	return log
 }
 
-// RunNodes executes a slice of executables with the given edges.
+// RunNodes executes a slice of nodes with the given edges.
 // This is a lower-level API for callers that don't have a full Graph.
-func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []Executable, edges []Edge) ([]*Result, error) {
-	// Convert to internal node pointers for ordering
-	ordered := e.orderExecutables(nodes, edges)
+func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*Node, edges []Edge) ([]*Result, error) {
+	ordered := e.orderNodes(nodes, edges)
 
 	execCtx := &Context{
 		Context: ctx,
 		DryRun:  e.options.DryRun,
 		Logger:  e.options.Logger,
 		Data:    e.options.Data,
+		Edges:   edges,
+		Outputs: make(map[string][]byte),
 	}
 
-	outputs := make(map[string][]byte)
 	var results []*Result
 	for _, node := range ordered {
-		result := e.executeExecutableWithOutputs(execCtx, node, edges, outputs)
+		result := e.executeNode(execCtx, node)
 		results = append(results, result)
 
 		if result.Status == ResultFailed && e.options.ConflictResolution == ResolutionStop {
@@ -390,99 +391,44 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []Executable, edges 
 	return results, nil
 }
 
-// executeNodeWithOutputs processes a single node, resolving upstream content from edges.
-func (e *GraphExecutor) executeNodeWithOutputs(ctx *Context, node *Node, edges []Edge, outputs map[string][]byte) *Result {
-	return e.executeExecutableWithOutputs(ctx, node, edges, outputs)
-}
-
-// executeExecutableWithOutputs processes any Executable with single-op dispatch.
-// Content flows between chained nodes via the outputs map.
-func (e *GraphExecutor) executeExecutableWithOutputs(ctx *Context, node Executable, edges []Edge, outputs map[string][]byte) *Result {
-	opName := node.GetOperation()
+// executeNode processes a single node with uniform dispatch.
+func (e *GraphExecutor) executeNode(ctx *Context, node *Node) *Result {
+	opName := node.Operation
 	if opName == "" {
 		return &Result{
-			NodeID: node.GetID(),
+			NodeID: node.ID,
 			Status: ResultFailed,
-			Error:  fmt.Errorf("node %s has no operation", node.GetID()),
+			Error:  fmt.Errorf("node %s has no operation", node.ID),
 		}
 	}
 
 	op, ok := e.registry.Get(opName)
 	if !ok {
 		return &Result{
-			NodeID: node.GetID(),
+			NodeID: node.ID,
 			Status: ResultFailed,
 			Error:  fmt.Errorf("unknown operation: %s", opName),
 		}
 	}
 
-	// Fill unfilled slots from Context.Data
 	e.fillSlotsFromData(node)
+	ctx.SourceChecksum = ""
+	ctx.TargetChecksum = ""
 
-	var content []byte
-	var sourceChecksum, targetChecksum string
-
-	// Resolve input content: check upstream chain first, then read source file
-	if upstream := findContentUpstream(node.GetID(), edges, outputs); upstream != nil {
-		content = upstream
-	} else if isContentOp(op) {
-		source, _ := node.GetSlot("source").(string)
-		if source != "" {
-			var err error
-			content, err = os.ReadFile(source)
-			if err != nil {
-				return &Result{
-					NodeID: node.GetID(),
-					Status: ResultFailed,
-					Error:  fmt.Errorf("read source %s: %w", source, err),
-				}
-			}
-			sourceChecksum = ChecksumBytes(content)
-		}
-	}
-
-	// Single operation dispatch
-	var err error
-	switch typed := op.(type) {
-	case Transform:
-		content, err = typed.Transform(ctx, node, content)
-		if err == nil {
-			outputs[node.GetID()] = content
-		}
-	case Writer:
-		targetChecksum, err = typed.Write(ctx, node, content)
-	case Direct:
-		err = typed.Execute(ctx, node)
-	default:
-		err = fmt.Errorf("operation %s does not implement Transform, Writer, or Direct", opName)
-	}
-
-	if err != nil {
+	if err := op.Execute(ctx, node); err != nil {
 		return &Result{
-			NodeID: node.GetID(),
+			NodeID: node.ID,
 			Status: ResultFailed,
 			Error:  fmt.Errorf("%s: %w", opName, err),
 		}
 	}
 
 	return &Result{
-		NodeID:         node.GetID(),
+		NodeID:         node.ID,
 		Status:         ResultCompleted,
-		SourceChecksum: sourceChecksum,
-		TargetChecksum: targetChecksum,
+		SourceChecksum: ctx.SourceChecksum,
+		TargetChecksum: ctx.TargetChecksum,
 	}
-}
-
-// findContentUpstream walks incoming edges to find content from an upstream node.
-func findContentUpstream(nodeID string, edges []Edge, outputs map[string][]byte) []byte {
-	for _, edge := range edges {
-		if edge.To == nodeID {
-			if content, ok := outputs[edge.From]; ok {
-				return content
-			}
-		}
-	}
-	return nil
 }
 
 // orderNodes returns nodes in execution order.
@@ -491,14 +437,6 @@ func (e *GraphExecutor) orderNodes(nodes []*Node, edges []Edge) []*Node {
 		return e.topologicalSortNodes(nodes, edges)
 	}
 	return e.sortNodesByDepth(nodes)
-}
-
-// orderExecutables returns executables in execution order.
-func (e *GraphExecutor) orderExecutables(nodes []Executable, edges []Edge) []Executable {
-	if len(edges) > 0 {
-		return e.topologicalSort(nodes, edges)
-	}
-	return e.sortByDepth(nodes)
 }
 
 // topologicalSortNodes orders nodes respecting edge constraints (Kahn's algorithm).
@@ -559,87 +497,9 @@ func (e *GraphExecutor) topologicalSortNodes(nodes []*Node, edges []Edge) []*Nod
 	return sorted
 }
 
-// topologicalSort orders executables respecting edge constraints.
-func (e *GraphExecutor) topologicalSort(nodes []Executable, edges []Edge) []Executable {
-	nodeMap := make(map[string]Executable)
-	inDegree := make(map[string]int)
-	adj := make(map[string][]string)
-
-	for _, node := range nodes {
-		nodeMap[node.GetID()] = node
-		inDegree[node.GetID()] = 0
-	}
-
-	for _, edge := range edges {
-		if _, fromOK := nodeMap[edge.From]; !fromOK {
-			continue
-		}
-		if _, toOK := nodeMap[edge.To]; !toOK {
-			continue
-		}
-		adj[edge.From] = append(adj[edge.From], edge.To)
-		inDegree[edge.To]++
-	}
-
-	var queue []string
-	for _, node := range nodes {
-		if inDegree[node.GetID()] == 0 {
-			queue = append(queue, node.GetID())
-		}
-	}
-
-	var sorted []Executable
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-		sorted = append(sorted, nodeMap[id])
-
-		for _, neighbor := range adj[id] {
-			inDegree[neighbor]--
-			if inDegree[neighbor] == 0 {
-				queue = append(queue, neighbor)
-			}
-		}
-	}
-
-	if len(sorted) < len(nodes) {
-		visited := make(map[string]bool)
-		for _, node := range sorted {
-			visited[node.GetID()] = true
-		}
-		for _, node := range nodes {
-			if !visited[node.GetID()] {
-				sorted = append(sorted, node)
-			}
-		}
-	}
-
-	return sorted
-}
-
 // sortNodesByDepth sorts nodes by target path depth.
 func (e *GraphExecutor) sortNodesByDepth(nodes []*Node) []*Node {
 	sorted := make([]*Node, len(nodes))
-	copy(sorted, nodes)
-
-	for i := 0; i < len(sorted)-1; i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			pathI, _ := sorted[i].GetSlot("path").(string)
-			pathJ, _ := sorted[j].GetSlot("path").(string)
-			depthI := pathDepth(pathI)
-			depthJ := pathDepth(pathJ)
-			if depthI > depthJ {
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
-		}
-	}
-
-	return sorted
-}
-
-// sortByDepth sorts executables by target path depth.
-func (e *GraphExecutor) sortByDepth(nodes []Executable) []Executable {
-	sorted := make([]Executable, len(nodes))
 	copy(sorted, nodes)
 
 	for i := 0; i < len(sorted)-1; i++ {
@@ -665,25 +525,12 @@ func pathDepth(path string) int {
 	return strings.Count(path, string(filepath.Separator))
 }
 
-// isContentOp returns true if the operation reads upstream content (Writer or Transform).
-func isContentOp(op Operation) bool {
-	switch op.(type) {
-	case Writer, Transform:
-		return true
-	}
-	return false
-}
-
 // fillSlotsFromData fills unfilled slots on the node from Context.Data.
 // Slots already set by the caller (Starlark plan or upstream node) are not overwritten.
-func (e *GraphExecutor) fillSlotsFromData(node Executable) {
-	n, ok := node.(*Node)
-	if !ok {
-		return
-	}
+func (e *GraphExecutor) fillSlotsFromData(node *Node) {
 	for key, value := range e.options.Data {
-		if _, exists := n.Slots[key]; !exists {
-			n.SetSlotImmediate(key, value)
+		if _, exists := node.Slots[key]; !exists {
+			node.SetSlotImmediate(key, value)
 		}
 	}
 }

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -16,11 +16,10 @@
 //   - GraphExecutor: Runs graphs by executing operations on nodes
 //   - OperationRegistry: Maps operation names to implementations
 //
-// # Operation Categories
+// # Operations
 //
-//   - Transform: Read content, produce transformed content (decrypt, expand)
-//   - Writer: Read content, write to filesystem (copy)
-//   - Direct: Manage own I/O, no content flow (link, mkdir, install)
+// Each operation implements Operation.Execute(ctx, node). Content ops
+// use ctx.ContentFor(node) and ctx.StoreContent(node, data) internally.
 //
 // # Graph Lifecycle
 //
@@ -311,20 +310,6 @@ type Graph struct {
 	// Signature contains the cryptographic signature (optional).
 	Signature *Signature `json:"signature,omitempty" yaml:"signature,omitempty"`
 }
-
-// Executable represents a unit of work that can be executed.
-// This interface is implemented by Node.
-type Executable interface {
-	GetID() string
-	GetOperation() string
-	GetSlot(name string) any
-	RequireStringSlot(name string) (string, error)
-	GetProject() string
-	GetMode() os.FileMode
-}
-
-// Ensure Node implements Executable.
-var _ Executable = (*Node)(nil)
 
 // String returns a human-readable summary.
 func (s Summary) String() string {

--- a/internal/execution/operation.go
+++ b/internal/execution/operation.go
@@ -5,34 +5,20 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
 )
 
-// Operation is the base interface for all executable actions.
+// Operation is the interface for all executable actions.
+// Each operation is self-contained: it reads its own inputs via ctx and node,
+// performs its work, and stores any outputs back on ctx.
 type Operation interface {
 	// Name returns the operation identifier (e.g., "file.link", "file.decrypt").
 	Name() string
-}
 
-// Transform operations read content and produce transformed content.
-// Used for: decrypt, expand.
-type Transform interface {
-	Operation
-	Transform(ctx *Context, node Executable, content []byte) ([]byte, error)
-}
-
-// Writer operations read content and write to the filesystem.
-// Used for: copy.
-type Writer interface {
-	Operation
-	Write(ctx *Context, node Executable, content []byte) (targetChecksum string, err error)
-}
-
-// Direct operations manage their own I/O with no content flow.
-// Used for: link, mkdir, backup, unlink, remove, validate, rename, install.
-type Direct interface {
-	Operation
-	Execute(ctx *Context, node Executable) error
+	// Execute performs the operation using context and node state.
+	Execute(ctx *Context, node *Node) error
 }
 
 // Context provides execution context to operations.
@@ -49,4 +35,44 @@ type Context struct {
 	// identities, segment maps, etc. Each tool populates this before
 	// calling GraphExecutor.Run().
 	Data map[string]any
+
+	// Content pipeline (set by executor before each execution loop).
+	Edges   []Edge
+	Outputs map[string][]byte
+
+	// Per-node checksums (written by ops, read by executor).
+	SourceChecksum string
+	TargetChecksum string
+}
+
+// ContentFor resolves input content for a node. It checks the upstream
+// chain via edges first, then falls back to reading the source file.
+func (c *Context) ContentFor(node *Node) ([]byte, error) {
+	// Check upstream chain via edges
+	for _, edge := range c.Edges {
+		if edge.To == node.ID {
+			if content, ok := c.Outputs[edge.From]; ok {
+				return content, nil
+			}
+		}
+	}
+	// Read source file
+	source, _ := node.GetSlot("source").(string)
+	if source != "" {
+		content, err := os.ReadFile(source)
+		if err != nil {
+			return nil, fmt.Errorf("read source %s: %w", source, err)
+		}
+		c.SourceChecksum = ChecksumBytes(content)
+		return content, nil
+	}
+	return nil, nil
+}
+
+// StoreContent stores output content for a node so downstream nodes can read it.
+func (c *Context) StoreContent(node *Node, data []byte) {
+	if c.Outputs == nil {
+		c.Outputs = make(map[string][]byte)
+	}
+	c.Outputs[node.ID] = data
 }

--- a/internal/execution/ops.go
+++ b/internal/execution/ops.go
@@ -17,7 +17,7 @@ type LinkOp struct{}
 
 func (o *LinkOp) Name() string { return "link" }
 
-func (o *LinkOp) Execute(ctx *Context, node Executable) error {
+func (o *LinkOp) Execute(ctx *Context, node *Node) error {
 	if ctx.DryRun {
 		return nil
 	}
@@ -46,27 +46,34 @@ func (o *LinkOp) Execute(ctx *Context, node Executable) error {
 	return os.Symlink(source, target)
 }
 
-// CopyOp writes content to node's "path" slot and returns the target checksum.
+// CopyOp writes content to node's "path" slot. Content is resolved via
+// ctx.ContentFor (upstream chain or source file).
 type CopyOp struct{}
 
 func (o *CopyOp) Name() string { return "copy" }
 
-func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, error) {
-	if ctx.DryRun {
-		return ChecksumBytes(content), nil
+func (o *CopyOp) Execute(ctx *Context, node *Node) error {
+	content, err := ctx.ContentFor(node)
+	if err != nil {
+		return err
 	}
 
 	target, _ := node.GetSlot("path").(string)
 
+	if ctx.DryRun {
+		ctx.TargetChecksum = ChecksumBytes(content)
+		return nil
+	}
+
 	// Remove existing file/symlink if present
 	if _, err := os.Lstat(target); err == nil {
 		if err := os.Remove(target); err != nil {
-			return "", fmt.Errorf("remove existing: %w", err)
+			return fmt.Errorf("remove existing: %w", err)
 		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-		return "", fmt.Errorf("create parent dirs: %w", err)
+		return fmt.Errorf("create parent dirs: %w", err)
 	}
 
 	mode := node.GetMode()
@@ -75,22 +82,28 @@ func (o *CopyOp) Write(ctx *Context, node Executable, content []byte) (string, e
 	}
 
 	if err := os.WriteFile(target, content, mode); err != nil {
-		return "", err
+		return err
 	}
 
-	return ChecksumBytes(content), nil
+	ctx.TargetChecksum = ChecksumBytes(content)
+	return nil
 }
 
 // RenderOp processes content as a Go text/template with ctx.Data as
-// the template data. Returns the rendered content.
+// the template data. Stores the rendered content for downstream ops.
 type RenderOp struct{}
 
 func (o *RenderOp) Name() string { return "render" }
 
-func (o *RenderOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
-	tmpl, err := template.New(node.GetID()).Parse(string(content))
+func (o *RenderOp) Execute(ctx *Context, node *Node) error {
+	content, err := ctx.ContentFor(node)
 	if err != nil {
-		return nil, fmt.Errorf("parse template: %w", err)
+		return err
+	}
+
+	tmpl, err := template.New(node.ID).Parse(string(content))
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
 	}
 
 	// Build template data from context
@@ -105,22 +118,29 @@ func (o *RenderOp) Transform(ctx *Context, node Executable, content []byte) ([]b
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return nil, fmt.Errorf("execute template: %w", err)
+		return fmt.Errorf("execute template: %w", err)
 	}
 
-	return buf.Bytes(), nil
+	ctx.StoreContent(node, buf.Bytes())
+	return nil
 }
 
 // DecryptOp decrypts content using the SOPS API. The decryption
-// configuration is expected in ctx.Data. Returns the decrypted content.
+// configuration is expected in ctx.Data. Stores the decrypted content
+// for downstream ops.
 type DecryptOp struct{}
 
 func (o *DecryptOp) Name() string { return "decrypt" }
 
-func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]byte, error) {
+func (o *DecryptOp) Execute(ctx *Context, node *Node) error {
+	content, err := ctx.ContentFor(node)
+	if err != nil {
+		return err
+	}
+
 	decryptor, ok := ctx.Data["decryptor"]
 	if !ok {
-		return nil, fmt.Errorf("no decryptor configured in context")
+		return fmt.Errorf("no decryptor configured in context")
 	}
 
 	// The decryptor is a function that takes encrypted bytes and returns plaintext.
@@ -133,10 +153,16 @@ func (o *DecryptOp) Transform(ctx *Context, node Executable, content []byte) ([]
 
 	decrypt, ok := decryptor.(func(string, []byte) ([]byte, error))
 	if !ok {
-		return nil, fmt.Errorf("decryptor must be func(string, []byte) ([]byte, error)")
+		return fmt.Errorf("decryptor must be func(string, []byte) ([]byte, error)")
 	}
 	source, _ := node.GetSlot("source").(string)
-	return decrypt(source, content)
+	result, err := decrypt(source, content)
+	if err != nil {
+		return err
+	}
+
+	ctx.StoreContent(node, result)
+	return nil
 }
 
 // NOTE: There is no DelegateOp. writ and lore share the same execution engine.
@@ -152,7 +178,7 @@ type BackupOp struct{}
 
 func (o *BackupOp) Name() string { return "backup" }
 
-func (o *BackupOp) Execute(ctx *Context, node Executable) error {
+func (o *BackupOp) Execute(ctx *Context, node *Node) error {
 	if ctx.DryRun {
 		return nil
 	}
@@ -173,12 +199,10 @@ func (o *BackupOp) Execute(ctx *Context, node Executable) error {
 	}
 
 	// Store backup path in node annotations for receipt generation
-	if n, ok := node.(*Node); ok && n.Annotations == nil {
-		n.Annotations = make(map[string]string)
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
 	}
-	if n, ok := node.(*Node); ok {
-		n.Annotations["backup_path"] = backupPath
-	}
+	node.Annotations["backup_path"] = backupPath
 	return nil
 }
 
@@ -189,7 +213,7 @@ type UnlinkOp struct{}
 
 func (o *UnlinkOp) Name() string { return "unlink" }
 
-func (o *UnlinkOp) Execute(ctx *Context, node Executable) error {
+func (o *UnlinkOp) Execute(ctx *Context, node *Node) error {
 	if ctx.DryRun {
 		return nil
 	}
@@ -223,7 +247,7 @@ type RemoveOp struct{}
 
 func (o *RemoveOp) Name() string { return "remove" }
 
-func (o *RemoveOp) Execute(ctx *Context, node Executable) error {
+func (o *RemoveOp) Execute(ctx *Context, node *Node) error {
 	if ctx.DryRun {
 		return nil
 	}
@@ -294,7 +318,7 @@ type WriteOp struct{}
 
 func (o *WriteOp) Name() string { return "write" }
 
-func (o *WriteOp) Execute(ctx *Context, node Executable) error {
+func (o *WriteOp) Execute(ctx *Context, node *Node) error {
 	content, _ := node.GetSlot("content").(string)
 	if content == "" {
 		return fmt.Errorf("write: no content specified in node slots")
@@ -325,7 +349,7 @@ type ValidateOp struct{}
 
 func (o *ValidateOp) Name() string { return "validate" }
 
-func (o *ValidateOp) Execute(ctx *Context, node Executable) error {
+func (o *ValidateOp) Execute(ctx *Context, node *Node) error {
 	checkName, _ := node.GetSlot("check").(string)
 	if checkName == "" {
 		return fmt.Errorf("validate: no check specified in node slots")
@@ -358,7 +382,7 @@ type MoveOp struct{}
 
 func (o *MoveOp) Name() string { return "move" }
 
-func (o *MoveOp) Execute(ctx *Context, node Executable) error {
+func (o *MoveOp) Execute(ctx *Context, node *Node) error {
 	if ctx.DryRun {
 		return nil
 	}
@@ -389,25 +413,6 @@ func (o *MoveOp) Execute(ctx *Context, node Executable) error {
 }
 
 // FileOps returns all built-in file operations for registration.
-//
-// Transform operations (content in → content out):
-//   - decrypt: decrypts encrypted content via ctx.Data["decryptor"]
-//   - render: renders Go text/template content with ctx.Data
-//
-// Writer operations (content in → checksum out):
-//   - copy: writes content to node's "path" slot
-//
-// Direct operations (no content flow):
-//   - link: creates symlink from "path" → "source" slots
-//   - write: writes "content" slot to "path" slot
-//   - backup: moves "path" slot to timestamped backup
-//   - unlink: removes symlink at "path" slot
-//   - remove: deletes file at "path" slot
-//   - validate: checks precondition from ctx.Data["validators"]
-//   - move: moves "source" → "path" slots (git mv when possible)
-//
-// NOTE: Package operations (package-install, package-upgrade, package-remove,
-// package-update) are provided by ops_package.go.
 func FileOps() []Operation {
 	return []Operation{
 		&LinkOp{},

--- a/internal/execution/ops_package.go
+++ b/internal/execution/ops_package.go
@@ -29,7 +29,7 @@ type PackageInstallOp struct{}
 
 func (o *PackageInstallOp) Name() string { return "package-install" }
 
-func (o *PackageInstallOp) Execute(ctx *Context, node Executable) error {
+func (o *PackageInstallOp) Execute(ctx *Context, node *Node) error {
 	pkgList, _ := node.GetSlot("packages").(string)
 	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
@@ -77,7 +77,7 @@ type PackageUpgradeOp struct{}
 
 func (o *PackageUpgradeOp) Name() string { return "package-upgrade" }
 
-func (o *PackageUpgradeOp) Execute(ctx *Context, node Executable) error {
+func (o *PackageUpgradeOp) Execute(ctx *Context, node *Node) error {
 	pkgList, _ := node.GetSlot("packages").(string)
 	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
@@ -128,7 +128,7 @@ type PackageRemoveOp struct{}
 
 func (o *PackageRemoveOp) Name() string { return "package-remove" }
 
-func (o *PackageRemoveOp) Execute(ctx *Context, node Executable) error {
+func (o *PackageRemoveOp) Execute(ctx *Context, node *Node) error {
 	pkgList, _ := node.GetSlot("packages").(string)
 	packages := parsePackages(pkgList)
 	if len(packages) == 0 {
@@ -188,7 +188,7 @@ type PackageUpdateOp struct{}
 
 func (o *PackageUpdateOp) Name() string { return "package-update" }
 
-func (o *PackageUpdateOp) Execute(ctx *Context, node Executable) error {
+func (o *PackageUpdateOp) Execute(ctx *Context, node *Node) error {
 	// Update uses preferred PM (not InstalledBy - we're updating the index, not a package)
 	manager, _ := node.GetSlot("manager").(string)
 	pm := resolvePMForInstall(manager)
@@ -363,7 +363,7 @@ type ShellOp struct{}
 
 func (o *ShellOp) Name() string { return "shell" }
 
-func (o *ShellOp) Execute(ctx *Context, node Executable) error {
+func (o *ShellOp) Execute(ctx *Context, node *Node) error {
 	command, _ := node.GetSlot("command").(string)
 	if command == "" {
 		return fmt.Errorf("shell: no command specified")
@@ -386,7 +386,7 @@ type PowerShellOp struct{}
 
 func (o *PowerShellOp) Name() string { return "powershell" }
 
-func (o *PowerShellOp) Execute(ctx *Context, node Executable) error {
+func (o *PowerShellOp) Execute(ctx *Context, node *Node) error {
 	command, _ := node.GetSlot("command").(string)
 	if command == "" {
 		return fmt.Errorf("powershell: no command specified")

--- a/internal/execution/ops_service.go
+++ b/internal/execution/ops_service.go
@@ -26,7 +26,7 @@ type LaunchdStartOp struct{}
 
 func (o *LaunchdStartOp) Name() string { return "launchd-start" }
 
-func (o *LaunchdStartOp) Execute(ctx *Context, node Executable) error {
+func (o *LaunchdStartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-start: no service specified")
@@ -49,7 +49,7 @@ type LaunchdStopOp struct{}
 
 func (o *LaunchdStopOp) Name() string { return "launchd-stop" }
 
-func (o *LaunchdStopOp) Execute(ctx *Context, node Executable) error {
+func (o *LaunchdStopOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-stop: no service specified")
@@ -72,7 +72,7 @@ type LaunchdRestartOp struct{}
 
 func (o *LaunchdRestartOp) Name() string { return "launchd-restart" }
 
-func (o *LaunchdRestartOp) Execute(ctx *Context, node Executable) error {
+func (o *LaunchdRestartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-restart: no service specified")
@@ -96,7 +96,7 @@ type LaunchdEnableOp struct{}
 
 func (o *LaunchdEnableOp) Name() string { return "launchd-enable" }
 
-func (o *LaunchdEnableOp) Execute(ctx *Context, node Executable) error {
+func (o *LaunchdEnableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-enable: no service specified")
@@ -119,7 +119,7 @@ type LaunchdDisableOp struct{}
 
 func (o *LaunchdDisableOp) Name() string { return "launchd-disable" }
 
-func (o *LaunchdDisableOp) Execute(ctx *Context, node Executable) error {
+func (o *LaunchdDisableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("launchd-disable: no service specified")
@@ -146,7 +146,7 @@ type SystemdStartOp struct{}
 
 func (o *SystemdStartOp) Name() string { return "systemd-start" }
 
-func (o *SystemdStartOp) Execute(ctx *Context, node Executable) error {
+func (o *SystemdStartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-start: no service specified")
@@ -169,7 +169,7 @@ type SystemdStopOp struct{}
 
 func (o *SystemdStopOp) Name() string { return "systemd-stop" }
 
-func (o *SystemdStopOp) Execute(ctx *Context, node Executable) error {
+func (o *SystemdStopOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-stop: no service specified")
@@ -192,7 +192,7 @@ type SystemdRestartOp struct{}
 
 func (o *SystemdRestartOp) Name() string { return "systemd-restart" }
 
-func (o *SystemdRestartOp) Execute(ctx *Context, node Executable) error {
+func (o *SystemdRestartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-restart: no service specified")
@@ -215,7 +215,7 @@ type SystemdEnableOp struct{}
 
 func (o *SystemdEnableOp) Name() string { return "systemd-enable" }
 
-func (o *SystemdEnableOp) Execute(ctx *Context, node Executable) error {
+func (o *SystemdEnableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-enable: no service specified")
@@ -238,7 +238,7 @@ type SystemdDisableOp struct{}
 
 func (o *SystemdDisableOp) Name() string { return "systemd-disable" }
 
-func (o *SystemdDisableOp) Execute(ctx *Context, node Executable) error {
+func (o *SystemdDisableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("systemd-disable: no service specified")
@@ -265,7 +265,7 @@ type WinServiceStartOp struct{}
 
 func (o *WinServiceStartOp) Name() string { return "winservice-start" }
 
-func (o *WinServiceStartOp) Execute(ctx *Context, node Executable) error {
+func (o *WinServiceStartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-start: no service specified")
@@ -288,7 +288,7 @@ type WinServiceStopOp struct{}
 
 func (o *WinServiceStopOp) Name() string { return "winservice-stop" }
 
-func (o *WinServiceStopOp) Execute(ctx *Context, node Executable) error {
+func (o *WinServiceStopOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-stop: no service specified")
@@ -311,7 +311,7 @@ type WinServiceRestartOp struct{}
 
 func (o *WinServiceRestartOp) Name() string { return "winservice-restart" }
 
-func (o *WinServiceRestartOp) Execute(ctx *Context, node Executable) error {
+func (o *WinServiceRestartOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-restart: no service specified")
@@ -342,7 +342,7 @@ type WinServiceEnableOp struct{}
 
 func (o *WinServiceEnableOp) Name() string { return "winservice-enable" }
 
-func (o *WinServiceEnableOp) Execute(ctx *Context, node Executable) error {
+func (o *WinServiceEnableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-enable: no service specified")
@@ -365,7 +365,7 @@ type WinServiceDisableOp struct{}
 
 func (o *WinServiceDisableOp) Name() string { return "winservice-disable" }
 
-func (o *WinServiceDisableOp) Execute(ctx *Context, node Executable) error {
+func (o *WinServiceDisableOp) Execute(ctx *Context, node *Node) error {
 	service, _ := node.GetSlot("name").(string)
 	if service == "" {
 		return fmt.Errorf("winservice-disable: no service specified")

--- a/internal/execution/phase.go
+++ b/internal/execution/phase.go
@@ -188,10 +188,13 @@ func (e *GraphExecutor) ExecutePhaseInner(ctx *Context, g *Graph, phase *Phase) 
 	}
 
 	ordered := e.topologicalSortNodes(phaseNodes, phaseEdges)
-	outputs := make(map[string][]byte)
+
+	// Set content pipeline on context for this phase
+	ctx.Edges = phaseEdges
+	ctx.Outputs = make(map[string][]byte)
 
 	for _, node := range ordered {
-		result := e.executeNodeWithOutputs(ctx, node, phaseEdges, outputs)
+		result := e.executeNode(ctx, node)
 		if result.Status == ResultFailed {
 			// Apply this result to the node
 			node.Status = StatusFailed

--- a/internal/execution/phase_test.go
+++ b/internal/execution/phase_test.go
@@ -217,7 +217,7 @@ func TestPhasedExecutionFailureWithRollback(t *testing.T) {
 	// Phase 3 uses an operation that always fails
 	reg.Register(&testRetryOp{
 		name: "fail-provision",
-		fn: func(ctx *Context, node Executable) error {
+		fn: func(ctx *Context, node *Node) error {
 			return fmt.Errorf("permission denied")
 		},
 	})
@@ -344,10 +344,10 @@ func TestPhasedExecutionRetryThenSucceed(t *testing.T) {
 
 	reg := NewOperationRegistry()
 	reg.Register(&LinkOp{})
-	// Register a custom Direct op that creates the file on second attempt
+	// Register a custom op that creates the file on second attempt
 	reg.Register(&testRetryOp{
 		name: "retry-test",
-		fn: func(ctx *Context, node Executable) error {
+		fn: func(ctx *Context, node *Node) error {
 			attemptCount++
 			if attemptCount == 1 {
 				return fmt.Errorf("transient failure")
@@ -418,7 +418,7 @@ func TestPhasedExecutionRetryExhausted(t *testing.T) {
 	reg.Register(&LinkOp{})
 	reg.Register(&testRetryOp{
 		name: "always-fail",
-		fn: func(ctx *Context, node Executable) error {
+		fn: func(ctx *Context, node *Node) error {
 			return fmt.Errorf("permanent failure")
 		},
 	})
@@ -576,13 +576,13 @@ func TestPhaseByID(t *testing.T) {
 	}
 }
 
-// testRetryOp is a test-only Direct operation that executes a function.
+// testRetryOp is a test-only operation that executes a function.
 type testRetryOp struct {
 	name string
-	fn   func(ctx *Context, node Executable) error
+	fn   func(ctx *Context, node *Node) error
 }
 
 func (o *testRetryOp) Name() string { return o.name }
-func (o *testRetryOp) Execute(ctx *Context, node Executable) error {
+func (o *testRetryOp) Execute(ctx *Context, node *Node) error {
 	return o.fn(ctx, node)
 }

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -13,13 +13,9 @@ import (
 	"github.com/NobleFactor/devlore-cli/internal/lorepackage"
 )
 
-// runGraph is a test helper that converts an execution.Graph to Executable slice and calls RunNodes.
+// runGraph is a test helper that calls RunNodes with the graph's nodes and edges.
 func runGraph(ctx context.Context, eng *execution.GraphExecutor, g *execution.Graph) ([]*execution.Result, error) {
-	executables := make([]execution.Executable, len(g.Nodes))
-	for i, n := range g.Nodes {
-		executables[i] = n
-	}
-	return eng.RunNodes(ctx, executables, g.Edges)
+	return eng.RunNodes(ctx, g.Nodes, g.Edges)
 }
 
 func TestBuild_WithNativePMPackage(t *testing.T) {

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -267,13 +267,7 @@ func executeDeployments(ctx context.Context, resolved []resolvedPackage, cfg *lo
 			continue
 		}
 
-		// Convert nodes to executables and run
-		executables := make([]execution.Executable, len(buildResult.Graph.Nodes))
-		for i, n := range buildResult.Graph.Nodes {
-			executables[i] = n
-		}
-
-		results, err := executor.RunNodes(ctx, executables, buildResult.Graph.Edges)
+		results, err := executor.RunNodes(ctx, buildResult.Graph.Nodes, buildResult.Graph.Edges)
 		if err != nil {
 			cli.Error("Error deploying %q: %v", rp.pkg.Name, err)
 			lastErr = err

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -488,7 +488,7 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 	hasDecrypt := hasDecryptOp(opStrings)
 
 	// Build node chain for multi-op pipelines
-	var nodes []execution.Executable
+	var nodes []*execution.Node
 	var edges []execution.Edge
 	var prevNodeID string
 	for i, opName := range opStrings {

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -484,7 +484,7 @@ func (s *Session) executeStep() *console.Step {
 	eng := execution.NewGraphExecutor(reg, opts)
 
 	ctx := context.Background()
-	_, err := eng.RunNodes(ctx, toExecutables(s.graph.Nodes), s.graph.Edges)
+	_, err := eng.RunNodes(ctx, s.graph.Nodes, s.graph.Edges)
 	if err != nil {
 		s.err = fmt.Errorf("execution failed: %w", err)
 		s.state = StateError
@@ -623,11 +623,3 @@ func (s *Session) generateExplanation() string {
 	return buf.String()
 }
 
-// toExecutables converts nodes to executables.
-func toExecutables(nodes []*execution.Node) []execution.Executable {
-	executables := make([]execution.Executable, len(nodes))
-	for i, n := range nodes {
-		executables[i] = n
-	}
-	return executables
-}


### PR DESCRIPTION
## Summary

- Delete `Direct`, `Writer`, `Transform`, and `Executable` interfaces from the execution engine
- Unify on a single `Operation` interface with `Name()` and `Execute(ctx, node)` methods
- Content ops (CopyOp, RenderOp, DecryptOp) now use `ctx.ContentFor(node)` and `ctx.StoreContent(node, data)` internally
- Executor calls `op.Execute(ctx, node)` uniformly — no type-switch dispatch
- Remove all `[]Executable` conversion boilerplate from external callers (lore, writ, migrate)
- Net deletion: 13 files changed, -102 lines

## Context

Phase 0 of the [command tree plan](docs/plans/devlore-command-tree.md). Prerequisite for the code generator (`devlore.ops.generate`), which needs a single interface to target.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/execution/ -count=1` — all 55 tests pass
- [x] `go test ./internal/writ/... -count=1`
- [x] `go test ./internal/lore/... -count=1`
- [x] `go test ./internal/e2e/... -count=1`
- [x] `go vet ./...`
- [x] No remaining references to deleted interfaces