### PR TITLE
chore(ci): rename sync-knowledge workflow to knowledge-extract

### DIFF
--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: SSPL-1.0
-# Sync knowledge base to devlore-registry when source code changes.
+# Extract knowledge base to devlore-registry when source code changes.
 # This keeps the LLM context accurate for package generation and migrations.
-name: Sync Knowledge Base
+name: Knowledge Extract
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - 'release/*'
 
 jobs:
-  sync-knowledge:
+  knowledge-extract:
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token


### PR DESCRIPTION
## Summary
- Rename `sync-knowledge.yaml` → `knowledge-extract.yaml`
- Rename workflow name to "Knowledge Extract" and job name to `knowledge-extract`
- Aligns CI check names with the actual command: `star devlore knowledge extract`