### PR TITLE
feat(star): derive impl_type automatically in ops generate

### DIFF
--- a/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
@@ -110,9 +110,6 @@ def run(ctx):
     if not category:
         category = to_snake(struct_short)
 
-    # Derive impl_type for graph_ops delegation (e.g., File → fileOps)
-    impl_type = struct_short[0].lower() + struct_short[1:] + "Ops"
-
     pkg_override = ctx.args.get("package", "")
 
     # Build method descriptors
@@ -159,7 +156,7 @@ def run(ctx):
             "category": category,
             "struct_name": struct_short,
             "namespace": namespace,
-            "impl_type": impl_type,
+            "impl_type": struct_name,
             "methods": method_descriptors,
         }
 

--- a/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright Noble Factor. All rights reserved.
 
-# generate.star - Generate receivers and operations from Go structs
+# generate.star - Generate receivers and operations from service structs
 #
-# Reads a Go implementation struct's methods via go.methods(), then calls
+# Reads a service struct's methods via go.methods(), then calls
 # go.generate() to produce plan receivers, graph operations, and real-time
 # receivers.
 
@@ -49,18 +49,18 @@ def to_snake(name):
     return "".join(result)
 
 def run(ctx):
-    """Generate receivers and operations from a Go struct."""
+    """Generate receivers and operations from a service struct."""
 
     # -------------------------------------------------------------------------
     # Validate required arguments
     # -------------------------------------------------------------------------
-    path = ctx.args.get("path", "")
-    struct_name = ctx.args.get("struct", "")
+    path = ctx.args.get("source", "")
+    struct_name = ctx.args.get("service", "")
 
     if not path:
-        fail("--path is required")
+        fail("--source is required")
     if not struct_name:
-        fail("--struct is required")
+        fail("--service is required")
 
     # -------------------------------------------------------------------------
     # Discover and filter methods

--- a/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
@@ -110,6 +110,9 @@ def run(ctx):
     if not category:
         category = to_snake(struct_short)
 
+    # Derive impl_type for graph_ops delegation (e.g., File → fileOps)
+    impl_type = struct_short[0].lower() + struct_short[1:] + "Ops"
+
     pkg_override = ctx.args.get("package", "")
 
     # Build method descriptors
@@ -156,6 +159,7 @@ def run(ctx):
             "category": category,
             "struct_name": struct_short,
             "namespace": namespace,
+            "impl_type": impl_type,
             "methods": method_descriptors,
         }
 

--- a/star/extensions/com.noblefactor.devlore.Ops/extension.yaml
+++ b/star/extensions/com.noblefactor.devlore.Ops/extension.yaml
@@ -19,14 +19,14 @@ commands:
     help: Generate boilerplate receivers and operations from a Go struct
     implementation: commands/generate.star
     flags:
-      - name: path
+      - name: source
         type: string
         default: ""
-        help: Path to the Go package containing the struct
-      - name: struct
+        help: Path to the Go package containing the service struct
+      - name: service
         type: string
         default: ""
-        help: Name of the Go struct to generate from
+        help: Name of the service struct to generate from
       - name: category
         type: string
         default: ""


### PR DESCRIPTION
## Summary

- Derive `impl_type` from the struct name automatically (e.g., `FileService` → `fileOps`)
- Set `impl_type` in the descriptor so graph_ops generates the ops interface and delegation instead of TODO stubs
- No flags added — the generator figures it out from `--struct`

## Test plan

- [ ] `star devlore ops generate --path ./internal/execution --struct FileService --templates graph_ops` produces an interface + delegation ops