### PR TITLE
refactor(starlark): rename execute receivers to _gen.go convention

### DIFF
--- a/internal/starlark/receiver_archive_gen.go
+++ b/internal/starlark/receiver_archive_gen.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
+// Code generated from gen-receiver templates; DO NOT EDIT.
+
 package starlark
 
 import (

--- a/internal/starlark/receiver_service_gen.go
+++ b/internal/starlark/receiver_service_gen.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
+// Code generated from gen-receiver templates; DO NOT EDIT.
+
 package starlark
 
 import (


### PR DESCRIPTION
## Summary

- Rename `receiver_archive.go` → `receiver_archive_gen.go` with generated code header
- Rename `receiver_service.go` → `receiver_service_gen.go` with generated code header
- Both already use `Receiver` embedding, `MakeAttr`, and `NoSuchAttrError`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/starlark/... -count=1` passes
- [x] `go vet ./...` clean