### PR TITLE
fix(execution): rename prune_empty_dirs key to prune

### DIFF
--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -983,7 +983,7 @@ func TestRemoveOperationPrunesEmptyDirs(t *testing.T) {
 	ctx := &Context{Context: context.Background()}
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
-	node.SetSlotImmediate("prune_empty_dirs", true)
+	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
 	if err := op.Execute(ctx, node); err != nil {
@@ -1026,7 +1026,7 @@ func TestRemoveOperationPruneStopsAtNonEmpty(t *testing.T) {
 	ctx := &Context{Context: context.Background()}
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
-	node.SetSlotImmediate("prune_empty_dirs", true)
+	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
 	if err := op.Execute(ctx, node); err != nil {
@@ -1070,7 +1070,7 @@ func TestUnlinkOperationPrunesEmptyDirs(t *testing.T) {
 	ctx := &Context{Context: context.Background()}
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
-	node.SetSlotImmediate("prune_empty_dirs", true)
+	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
 	if err := op.Execute(ctx, node); err != nil {

--- a/internal/execution/ops_file_gen.go
+++ b/internal/execution/ops_file_gen.go
@@ -111,7 +111,7 @@ func (o *FileUnlinkOp) Name() string { return "unlink" }
 
 func (o *FileUnlinkOp) Execute(ctx *Context, node *Node) error {
 	path := node.GetSlot("path").(string)
-	prune, _ := node.GetSlot("prune_empty_dirs").(bool)
+	prune, _ := node.GetSlot("prune").(bool)
 	pruneBoundary, _ := node.GetSlot("prune_boundary").(string)
 
 	if ctx.DryRun {
@@ -128,7 +128,7 @@ func (o *FileRemoveOp) Name() string { return "remove" }
 
 func (o *FileRemoveOp) Execute(ctx *Context, node *Node) error {
 	path := node.GetSlot("path").(string)
-	prune, _ := node.GetSlot("prune_empty_dirs").(bool)
+	prune, _ := node.GetSlot("prune").(bool)
 	pruneBoundary, _ := node.GetSlot("prune_boundary").(string)
 
 	if ctx.DryRun {

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -234,7 +234,7 @@ func runDecommission(cmd *cobra.Command, args []string) error {
 	// If --prune is set, enable directory cleanup: after each file removal,
 	// empty parent directories are removed up to the target root boundary.
 	if cfg.Prune {
-		cfg.TemplateData["prune_empty_dirs"] = true
+		cfg.TemplateData["prune"] = true
 		cfg.TemplateData["prune_boundary"] = view.Files.Root
 	}
 


### PR DESCRIPTION
## Summary

- Rename Context.Data key `prune_empty_dirs` → `prune` to match `FileService.Unlink`/`Remove` parameter name
- Updated in `commands.go` (setter), `ops_file_gen.go` (slot readers), and tests

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/execution/... ./internal/writ/... -count=1` passes
- [x] `go vet ./...` clean
- [x] No stale `prune_empty_dirs` references in code (only in plan doc describing the rename)