### PR TITLE
refactor(execution): rename Operation→Action with Do/Undo interface (Phase 1)

### DIFF
--- a/docs/plans/resource-provider/phase-1.md
+++ b/docs/plans/resource-provider/phase-1.md
@@ -1,0 +1,144 @@
+# Phase 1: Interface Rename
+
+## Context
+
+Phase 1 is a mechanical rename across the codebase. No structural changes, no
+new packages, no file moves (other than `operation.go` to `action.go`). The goal
+is to establish the Action interface with `Do`/`Undo` signatures so subsequent
+phases can build on the saga-ready contract.
+
+**Repo**: devlore-cli
+**Branch**: `feat/action-interface`
+
+## Changes
+
+### Core types (`internal/execution/action.go`)
+
+Rename `operation.go` to `action.go`. Replace the `Operation` interface with:
+
+```go
+type Result = any
+type UndoState = any
+
+type Action interface {
+    Name() string
+    Do(ctx *Context, node *Node) (Result, UndoState, error)
+    Undo(ctx *Context, node *Node, state UndoState) error
+}
+```
+
+All 20 existing op structs: rename `Execute` to `Do` (return `nil, nil, err`),
+add no-op `Undo` (return `nil`). This preserves current behavior while
+establishing the interface contract.
+
+### Registry (`internal/execution/registry.go`)
+
+- `OperationRegistry` to `ActionRegistry`
+- `NewOperationRegistry()` to `NewActionRegistry()`
+- Internal `operations` map to `actions` map
+
+### Node field (`internal/execution/graph.go`)
+
+- `Node.Operation` to `Node.Action` (JSON/YAML tag: `action`)
+- `GetOperation()` to `GetAction()` (or delete)
+- Add `Retry *RetryPolicy` field to Node
+- `Result` struct to `NodeResult` (avoids collision with new `Result` type alias)
+
+### Executor (`internal/execution/executor.go`)
+
+- Dispatch via `action.Do(ctx, node)` returning `(Result, UndoState, error)`
+- `Result` references to `NodeResult`
+
+### Registry catalog (`internal/execution/ops_registry.go`)
+
+- `AllOps()` to `AllActions()`
+- Delete `ValidateOp` (count drops from 21 to 20)
+
+### Generated ops (6 `ops_*_gen.go` files)
+
+Each file: rename `Execute` method to `Do` with triple return, add no-op `Undo`.
+
+### Plan receivers (`internal/execution/plan.go`, `internal/starlark/plan*.go`, `internal/starlark/platform/*.go`)
+
+All `Operation:` struct field initializers to `Action:`.
+
+### Callers (`internal/writ/`, `internal/lore/`, `internal/manifest/`, `internal/cli/`)
+
+- `execution.NewOperationRegistry()` to `execution.NewActionRegistry()`
+- `execution.AllOps()` to `execution.AllActions()`
+- `node.Operation` to `node.Action`
+- `Operation:` to `Action:` in Node struct literals
+
+### State view (`internal/execution/stateview.go`)
+
+- `HistoryRecord.Operation` to `HistoryRecord.Action`
+- `isPackageNode` and `isTransformOnlyNode` switch on `node.Action`
+
+## Exclusions
+
+These `Operation` references are in separate domains and must NOT be renamed:
+
+| Location | Field | Reason |
+|---|---|---|
+| `writ/reconcile/reconcile.go` | `Entry.Operation` | Reconcile package's own type |
+| `lorepackage/action.go` | `NativePMAction.Operation` | PMOperation type, not execution.Action |
+| `writ/tree/operation.go` | `Operation` type | Tree package's own type |
+| `writ/migrate/format.go` | `nodeView.Operation` | Serialization view struct field |
+
+## Files changed (40)
+
+| File | Change |
+|---|---|
+| `execution/action.go` | Renamed from `operation.go`; Action interface with Do/Undo |
+| `execution/registry.go` | ActionRegistry |
+| `execution/graph.go` | Node.Action, NodeResult, Retry field |
+| `execution/executor.go` | Dispatch via Do(), NodeResult |
+| `execution/builder.go` | node.Action |
+| `execution/preflight.go` | node.Action |
+| `execution/stateview.go` | HistoryRecord.Action, node.Action |
+| `execution/plan.go` | Action: in struct literals |
+| `execution/ops_registry.go` | AllActions(), ValidateOp deleted |
+| `execution/ops_file_gen.go` | Do/Undo |
+| `execution/ops_encryption_gen.go` | Do/Undo |
+| `execution/ops_package_gen.go` | Do/Undo |
+| `execution/ops_shell_gen.go` | Do/Undo |
+| `execution/ops_service_manager_gen.go` | Do/Undo |
+| `execution/execution_test.go` | All references |
+| `execution/phase_test.go` | All references, testRetryOp mock |
+| `execution/stateview_test.go` | All references |
+| `execution/dependencyview_test.go` | All references |
+| `starlark/plan.go` | Action: in struct literals |
+| `starlark/plan_file.go` | Action: in struct literals |
+| `starlark/plan_package.go` | Action: in struct literals |
+| `starlark/plan_root.go` | Action: in struct literals |
+| `starlark/plan_archive_gen.go` | Action: in struct literals |
+| `starlark/plan_git_gen.go` | Action: in struct literals |
+| `starlark/platform/common.go` | Action: in struct literals |
+| `starlark/platform/darwin.go` | Action: in struct literals |
+| `starlark/platform/linux.go` | Action: in struct literals |
+| `starlark/platform/windows.go` | Action: in struct literals |
+| `writ/graph_builder.go` | ActionRegistry, AllActions |
+| `writ/commands.go` | ActionRegistry, AllActions, node.Action |
+| `writ/graph_test.go` | All references |
+| `writ/migrate/session.go` | ActionRegistry, node.Action |
+| `writ/migrate/execute.go` | node.Action |
+| `writ/migrate/format.go` | node.Action (value only, not struct field) |
+| `lore/builder.go` | node.Action |
+| `lore/builder_test.go` | All references, NodeResult |
+| `lore/commands.go` | ActionRegistry, AllActions |
+| `manifest/builder.go` | Action: in struct literal |
+| `manifest/manifest_test.go` | node.Action |
+| `cli/receipts_test.go` | Action: in struct literal |
+
+## Verification
+
+```bash
+cd /path/to/devlore-cli.resource-provider
+
+go build ./...
+go test ./... -count=1
+go vet ./...
+
+# Confirm zero remaining Operation in execution package
+grep -rn '\bOperation\b' internal/execution/*.go  # expect 0 matches
+```

--- a/internal/cli/receipts_test.go
+++ b/internal/cli/receipts_test.go
@@ -17,7 +17,7 @@ import (
 func createTestGraph() *execution.Graph {
 	node := &execution.Node{
 		ID:         ".bashrc",
-		Operation: "link",
+		Action: "link",
 		Status:     execution.StatusCompleted,
 	}
 	node.SetSlotImmediate("source", "/home/user/env/.bashrc")

--- a/internal/execution/action.go
+++ b/internal/execution/action.go
@@ -10,25 +10,40 @@ import (
 	"os"
 )
 
-// Operation is the interface for all executable actions.
-// Each operation is self-contained: it reads its own inputs via ctx and node,
+// Result is data that flows to downstream nodes via edges (e.g., a checksum,
+// a rendered template, a query result). The executor stores this on the node
+// for edge-based slot resolution.
+type Result = any
+
+// UndoState is the state captured by Do and passed to Undo during saga
+// rollback. Each action defines its own state shape. Actions with no rollback
+// return nil from Do; their Undo ignores the state parameter.
+type UndoState = any
+
+// Action is the interface for all executable actions.
+// Each action is self-contained: it reads its own inputs via ctx and node,
 // performs its work, and stores any outputs back on ctx.
-type Operation interface {
-	// Name returns the operation identifier (e.g., "file.link", "file.decrypt").
+type Action interface {
+	// Name returns the action identifier (e.g., "link", "copy").
 	Name() string
 
-	// Execute performs the operation using context and node state.
-	Execute(ctx *Context, node *Node) error
+	// Do performs the forward action using context and node state.
+	// Returns a result (flows to downstream nodes) and undo state
+	// (stored on recovery stack for rollback).
+	Do(ctx *Context, node *Node) (Result, UndoState, error)
+
+	// Undo performs the compensating action using the state captured by Do.
+	Undo(ctx *Context, node *Node, state UndoState) error
 }
 
-// Context provides execution context to operations.
+// Context provides execution context to actions.
 type Context struct {
 	context.Context
 
 	// DryRun prevents filesystem modifications when true.
 	DryRun bool
 
-	// Logger receives operation output messages.
+	// Logger receives action output messages.
 	Logger io.Writer
 
 	// Data holds tool-provided context: template variables, SOPS config,
@@ -40,7 +55,7 @@ type Context struct {
 	Edges   []Edge
 	Outputs map[string][]byte
 
-	// Per-node checksums (written by ops, read by executor).
+	// Per-node checksums (written by actions, read by executor).
 	SourceChecksum string
 	TargetChecksum string
 }

--- a/internal/execution/builder.go
+++ b/internal/execution/builder.go
@@ -88,5 +88,5 @@ func ExpandDelegates(ctx context.Context, graph *Graph, builder SubgraphBuilder,
 
 // isDelegateNode returns true if the node is a pure delegate operation.
 func isDelegateNode(node *Node) bool {
-	return node.Operation == "delegate"
+	return node.Action == "delegate"
 }

--- a/internal/execution/dependencyview_test.go
+++ b/internal/execution/dependencyview_test.go
@@ -361,8 +361,8 @@ func TestDependencyViewSubgraph(t *testing.T) {
 func TestDependencyViewNode(t *testing.T) {
 	g := &Graph{
 		Nodes: []*Node{
-			{ID: "a", Operation: "link"},
-			{ID: "b", Operation: "copy"},
+			{ID: "a", Action: "link"},
+			{ID: "b", Action: "copy"},
 		},
 	}
 	v := NewDependencyView(g)
@@ -371,7 +371,7 @@ func TestDependencyViewNode(t *testing.T) {
 	if nodeA == nil {
 		t.Fatal("expected to find node a")
 	}
-	if nodeA.Operation != "link" {
+	if nodeA.Action != "link" {
 		t.Errorf("expected node a to have link operation")
 	}
 

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 // runGraph is a test helper that calls RunNodes with the graph's nodes and edges.
-func runGraph(ctx context.Context, e *GraphExecutor, g *Graph) ([]*Result, error) {
+func runGraph(ctx context.Context, e *GraphExecutor, g *Graph) ([]*NodeResult, error) {
 	return e.RunNodes(ctx, g.Nodes, g.Edges)
 }
 
 // testNode creates a node with source and path slots for testing.
 func testNode(id string, op string, source, path string) *Node {
-	node := &Node{ID: id, Operation: op}
+	node := &Node{ID: id, Action: op}
 	if source != "" {
 		node.SetSlotImmediate("source", source)
 	}
@@ -30,7 +30,7 @@ func testNode(id string, op string, source, path string) *Node {
 }
 
 func TestRegistryRegisterAndGet(t *testing.T) {
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 	reg.Register(&FileCopyOp{impl: &FileService{}})
 
@@ -49,7 +49,7 @@ func TestRegistryRegisterAndGet(t *testing.T) {
 }
 
 func TestRegistryNames(t *testing.T) {
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	for _, op := range FileOps(&FileService{}) {
 		reg.Register(op)
 	}
@@ -75,7 +75,7 @@ func TestLinkOperation(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("link: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestLinkOperationIdempotent(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("idempotent link: %v", err)
 	}
 }
@@ -129,7 +129,7 @@ func TestCopyOperation(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestCopyOperationCreatesParentDirs(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("copy with nested dirs: %v", err)
 	}
 
@@ -197,7 +197,7 @@ func TestRenderOperation(t *testing.T) {
 	node := &Node{ID: ".bashrc", Project: "all"}
 	node.SetSlotImmediate("source", source)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("render: %v", err)
 	}
 
@@ -230,7 +230,7 @@ func TestDecryptOperation(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("decryptor", mockDecrypt)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("decrypt: %v", err)
 	}
 
@@ -256,7 +256,7 @@ func TestDecryptOperationNoDecryptor(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	// No decryptor slot set
 
-	if err := op.Execute(ctx, node); err == nil {
+	if _, _, err := op.Do(ctx, node); err == nil {
 		t.Error("expected error when no decryptor configured")
 	}
 }
@@ -327,7 +327,7 @@ func TestDecryptOperationInvalidSignature(t *testing.T) {
 				Outputs: make(map[string][]byte),
 			}
 
-			err := op.Execute(ctx, node)
+			_, _, err := op.Do(ctx, node)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error for %s, got nil", tt.name)
@@ -365,7 +365,7 @@ func TestUnlinkOperation(t *testing.T) {
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("unlink: %v", err)
 	}
 
@@ -386,7 +386,7 @@ func TestRemoveOperation(t *testing.T) {
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 
@@ -406,7 +406,7 @@ func TestWriteOperation(t *testing.T) {
 	node.SetSlotImmediate("path", target)
 	node.SetSlotImmediate("content", content)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -430,7 +430,7 @@ func TestWriteCreatesParentDirs(t *testing.T) {
 	node.SetSlotImmediate("path", target)
 	node.SetSlotImmediate("content", content)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -449,7 +449,7 @@ func TestWriteRequiresContent(t *testing.T) {
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", "/tmp/test.txt")
 
-	err := op.Execute(ctx, node)
+	_, _, err := op.Do(ctx, node)
 	if err == nil {
 		t.Fatal("expected error when content is missing")
 	}
@@ -468,7 +468,7 @@ func TestWriteDryRun(t *testing.T) {
 	node.SetSlotImmediate("path", target)
 	node.SetSlotImmediate("content", "test")
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("write dry-run: %v", err)
 	}
 
@@ -485,7 +485,7 @@ func TestEngineRunLinkPipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
@@ -522,7 +522,7 @@ func TestEngineRunRenderCopyPipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileRenderOp{impl: &FileService{}})
 	reg.Register(&FileCopyOp{impl: &FileService{}})
 
@@ -578,7 +578,7 @@ func TestEngineRunDecryptRenderCopyPipeline(t *testing.T) {
 		return []byte(strings.TrimPrefix(string(ciphertext), "encrypted:")), nil
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&EncryptionDecryptOp{impl: &EncryptionService{}})
 	reg.Register(&FileRenderOp{impl: &FileService{}})
 	reg.Register(&FileCopyOp{impl: &FileService{}})
@@ -635,7 +635,7 @@ func TestEngineRunMultipleNodes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
@@ -662,11 +662,11 @@ func TestEngineRunMultipleNodes(t *testing.T) {
 }
 
 func TestEngineRunUnknownOperation(t *testing.T) {
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "test", Operation: "unknown_op"},
+			{ID: "test", Action: "unknown_op"},
 		},
 	}
 
@@ -693,7 +693,7 @@ func TestEngineTopologicalSort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{})
@@ -736,7 +736,7 @@ func TestEngineDryRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	engine := NewGraphExecutor(reg, ExecutorOptions{DryRun: true})
@@ -841,7 +841,7 @@ func TestPreflightPackagesManifest(t *testing.T) {
 	// The preflight should treat them as ready since there's no filesystem conflict
 	graph := &Graph{
 		Nodes: []*Node{
-			{ID: "manifest", Operation: "packages"},
+			{ID: "manifest", Action: "packages"},
 		},
 	}
 
@@ -854,10 +854,10 @@ func TestPreflightPackagesManifest(t *testing.T) {
 	}
 }
 
-func TestAllOpsCount(t *testing.T) {
-	ops := AllOps()
-	if len(ops) != 21 {
-		t.Errorf("expected 21 total ops, got %d", len(ops))
+func TestAllActionsCount(t *testing.T) {
+	ops := AllActions()
+	if len(ops) != 20 {
+		t.Errorf("expected 20 total actions, got %d", len(ops))
 	}
 
 	names := make(map[string]bool)
@@ -871,11 +871,10 @@ func TestAllOpsCount(t *testing.T) {
 		"package-install", "package-upgrade", "package-remove", "package-update",
 		"shell", "powershell",
 		"service-start", "service-stop", "service-restart", "service-enable", "service-disable",
-		"validate",
 	}
 	for _, name := range expected {
 		if !names[name] {
-			t.Errorf("expected operation %q in AllOps()", name)
+			t.Errorf("expected action %q in AllActions()", name)
 		}
 	}
 }
@@ -892,7 +891,7 @@ func TestBackupOperation(t *testing.T) {
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("backup: %v", err)
 	}
 
@@ -935,7 +934,7 @@ func TestCopyOperationWithMode(t *testing.T) {
 	node.SetSlotImmediate("source", source)
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("copy with mode: %v", err)
 	}
 
@@ -986,7 +985,7 @@ func TestRemoveOperationPrunesEmptyDirs(t *testing.T) {
 	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 
@@ -1029,7 +1028,7 @@ func TestRemoveOperationPruneStopsAtNonEmpty(t *testing.T) {
 	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 
@@ -1073,7 +1072,7 @@ func TestUnlinkOperationPrunesEmptyDirs(t *testing.T) {
 	node.SetSlotImmediate("prune", true)
 	node.SetSlotImmediate("prune_boundary", tmpDir)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("unlink: %v", err)
 	}
 
@@ -1152,7 +1151,7 @@ func TestRemoveNoPruneWithoutFlag(t *testing.T) {
 	node := &Node{ID: "test"}
 	node.SetSlotImmediate("path", target)
 
-	if err := op.Execute(ctx, node); err != nil {
+	if _, _, err := op.Do(ctx, node); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -49,8 +49,8 @@ func (s ResultStatus) String() string {
 	}
 }
 
-// Result represents the outcome of executing a single node.
-type Result struct {
+// NodeResult represents the outcome of executing a single node.
+type NodeResult struct {
 	NodeID         string
 	Status         ResultStatus
 	Error          error
@@ -78,7 +78,7 @@ type ExecutorOptions struct {
 	// DryRun prevents filesystem modifications.
 	DryRun bool
 
-	// Logger receives operation output.
+	// Logger receives action output.
 	Logger io.Writer
 
 	// Data holds tool-provided context (template vars, SOPS config, etc.).
@@ -91,14 +91,14 @@ type ExecutorOptions struct {
 	BackupSuffix string
 }
 
-// GraphExecutor executes operation graphs.
+// GraphExecutor executes action graphs.
 type GraphExecutor struct {
-	registry *OperationRegistry
+	registry *ActionRegistry
 	options  ExecutorOptions
 }
 
 // NewGraphExecutor creates an executor with the given registry and options.
-func NewGraphExecutor(registry *OperationRegistry, opts ExecutorOptions) *GraphExecutor {
+func NewGraphExecutor(registry *ActionRegistry, opts ExecutorOptions) *GraphExecutor {
 	if opts.Logger == nil {
 		opts.Logger = os.Stdout
 	}
@@ -141,7 +141,7 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *Graph) error {
 		Outputs: make(map[string][]byte),
 	}
 
-	var results []*Result
+	var results []*NodeResult
 	for _, node := range ordered {
 		result := e.executeNode(execCtx, node)
 		results = append(results, result)
@@ -366,7 +366,7 @@ func (e *GraphExecutor) unwindStack(ctx *Context, g *Graph, stack *RecoveryStack
 
 // RunNodes executes a slice of nodes with the given edges.
 // This is a lower-level API for callers that don't have a full Graph.
-func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*Node, edges []Edge) ([]*Result, error) {
+func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*Node, edges []Edge) ([]*NodeResult, error) {
 	ordered := e.orderNodes(nodes, edges)
 
 	execCtx := &Context{
@@ -378,7 +378,7 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*Node, edges []Edg
 		Outputs: make(map[string][]byte),
 	}
 
-	var results []*Result
+	var results []*NodeResult
 	for _, node := range ordered {
 		result := e.executeNode(execCtx, node)
 		results = append(results, result)
@@ -392,22 +392,22 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*Node, edges []Edg
 }
 
 // executeNode processes a single node with uniform dispatch.
-func (e *GraphExecutor) executeNode(ctx *Context, node *Node) *Result {
-	opName := node.Operation
-	if opName == "" {
-		return &Result{
+func (e *GraphExecutor) executeNode(ctx *Context, node *Node) *NodeResult {
+	actionName := node.Action
+	if actionName == "" {
+		return &NodeResult{
 			NodeID: node.ID,
 			Status: ResultFailed,
-			Error:  fmt.Errorf("node %s has no operation", node.ID),
+			Error:  fmt.Errorf("node %s has no action", node.ID),
 		}
 	}
 
-	op, ok := e.registry.Get(opName)
+	action, ok := e.registry.Get(actionName)
 	if !ok {
-		return &Result{
+		return &NodeResult{
 			NodeID: node.ID,
 			Status: ResultFailed,
-			Error:  fmt.Errorf("unknown operation: %s", opName),
+			Error:  fmt.Errorf("unknown action: %s", actionName),
 		}
 	}
 
@@ -415,15 +415,16 @@ func (e *GraphExecutor) executeNode(ctx *Context, node *Node) *Result {
 	ctx.SourceChecksum = ""
 	ctx.TargetChecksum = ""
 
-	if err := op.Execute(ctx, node); err != nil {
-		return &Result{
+	_, _, err := action.Do(ctx, node)
+	if err != nil {
+		return &NodeResult{
 			NodeID: node.ID,
 			Status: ResultFailed,
-			Error:  fmt.Errorf("%s: %w", opName, err),
+			Error:  fmt.Errorf("%s: %w", actionName, err),
 		}
 	}
 
-	return &Result{
+	return &NodeResult{
 		NodeID:         node.ID,
 		Status:         ResultCompleted,
 		SourceChecksum: ctx.SourceChecksum,

--- a/internal/execution/graph.go
+++ b/internal/execution/graph.go
@@ -7,19 +7,19 @@
 // # Core Types
 //
 //   - Graph: A directed graph of nodes and edges representing work to be done
-//   - Node: A single unit of work with operations to execute
+//   - Node: A single unit of work with an action to execute
 //   - Edge: A dependency relationship between nodes
 //
 // # Execution Model
 //
 //   - GraphBuilder: Interface for building graphs (implementations in tools)
-//   - GraphExecutor: Runs graphs by executing operations on nodes
-//   - OperationRegistry: Maps operation names to implementations
+//   - GraphExecutor: Runs graphs by executing actions on nodes
+//   - ActionRegistry: Maps action names to implementations
 //
-// # Operations
+// # Actions
 //
-// Each operation implements Operation.Execute(ctx, node). Content ops
-// use ctx.ContentFor(node) and ctx.StoreContent(node, data) internally.
+// Each action implements Action.Do(ctx, node) returning (Result, UndoState, error).
+// Content actions use ctx.ContentFor(node) and ctx.StoreContent(node, data) internally.
 //
 // # Graph Lifecycle
 //
@@ -138,8 +138,8 @@ type Node struct {
 	// ID is the unique identifier (typically relative target path or package name).
 	ID string `json:"id" yaml:"id"`
 
-	// Operation to perform: link, copy, render, decrypt, install, etc.
-	Operation string `json:"operation" yaml:"operation"`
+	// Action to perform: link, copy, render, decrypt, install, etc.
+	Action string `json:"action" yaml:"action"`
 
 	// Status of this node: pending, completed, skipped, failed.
 	Status NodeStatus `json:"status" yaml:"status"`
@@ -169,6 +169,9 @@ type Node struct {
 
 	// Error message if status is failed.
 	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+
+	// Retry is the retry policy for this node (nil = no retry).
+	Retry *RetryPolicy `json:"retry,omitempty" yaml:"retry,omitempty"`
 
 	// Annotations holds extensible metadata (serialized to receipts).
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
@@ -221,8 +224,8 @@ func (n *Node) SetSlotPromise(name, nodeRef, slot string) {
 // GetID returns the node's unique identifier.
 func (n *Node) GetID() string { return n.ID }
 
-// GetOperation returns the operation to perform.
-func (n *Node) GetOperation() string { return n.Operation }
+// GetAction returns the action to perform.
+func (n *Node) GetAction() string { return n.Action }
 
 // GetProject returns the project name.
 func (n *Node) GetProject() string { return n.Project }
@@ -284,7 +287,7 @@ type Graph struct {
 	// Context contains tool-specific metadata.
 	Context GraphContext `json:"context" yaml:"context"`
 
-	// Nodes are the operations to perform/performed.
+	// Nodes are the actions to perform/performed.
 	Nodes []*Node `json:"nodes" yaml:"nodes"`
 
 	// Edges are the dependencies between nodes.
@@ -421,8 +424,8 @@ func (g *Graph) CanonicalContent() ([]byte, error) {
 }
 
 // ApplyResults updates node states from execution results.
-func (g *Graph) ApplyResults(results []*Result) {
-	resultMap := make(map[string]*Result)
+func (g *Graph) ApplyResults(results []*NodeResult) {
+	resultMap := make(map[string]*NodeResult)
 	for _, r := range results {
 		resultMap[r.NodeID] = r
 	}
@@ -462,13 +465,13 @@ func (g *Graph) ComputeSummary() {
 			g.Summary.Failed++
 			continue
 		case StatusCompleted:
-			// Count by operation type below
+			// Count by action type below
 		default:
 			continue
 		}
 
-		// Count by operation type
-		switch n.Operation {
+		// Count by action type
+		switch n.Action {
 		case "link":
 			g.Summary.TotalFiles++
 			g.Summary.Links++

--- a/internal/execution/ops_encryption_gen.go
+++ b/internal/execution/ops_encryption_gen.go
@@ -13,29 +13,31 @@ type EncryptionDecryptOp struct{ impl *EncryptionService }
 
 func (o *EncryptionDecryptOp) Name() string { return "decrypt" }
 
-func (o *EncryptionDecryptOp) Execute(ctx *Context, node *Node) error {
+func (o *EncryptionDecryptOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	decryptor, _ := node.GetSlot("decryptor").(func(string, []byte) ([]byte, error))
 	source, _ := node.GetSlot("source").(string)
 	content, err := ctx.ContentFor(node)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] decrypt %v\n", source)
-		return nil
+		return nil, nil, nil
 	}
 	result, err := o.impl.Decrypt(decryptor, source, content)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	ctx.StoreContent(node, result)
-	return nil
+	return nil, nil, nil
 }
 
-// EncryptionOps returns all encryption operations backed by the given EncryptionService.
-func EncryptionOps(impl *EncryptionService) []Operation {
-	return []Operation{
+func (o *EncryptionDecryptOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
+
+// EncryptionOps returns all encryption actions backed by the given EncryptionService.
+func EncryptionOps(impl *EncryptionService) []Action {
+	return []Action{
 		&EncryptionDecryptOp{impl: impl},
 	}
 }

--- a/internal/execution/ops_file_gen.go
+++ b/internal/execution/ops_file_gen.go
@@ -12,49 +12,53 @@ type FileLinkOp struct{ impl *FileService }
 
 func (o *FileLinkOp) Name() string { return "link" }
 
-func (o *FileLinkOp) Execute(ctx *Context, node *Node) error {
+func (o *FileLinkOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	source := node.GetSlot("source").(string)
 	path := node.GetSlot("path").(string)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] link %v %v\n", source, path)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Link(source, path)
+	return nil, nil, o.impl.Link(source, path)
 }
+
+func (o *FileLinkOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileCopyOp writes content to node's "path" slot (consumer: reads content, checksums).
 type FileCopyOp struct{ impl *FileService }
 
 func (o *FileCopyOp) Name() string { return "copy" }
 
-func (o *FileCopyOp) Execute(ctx *Context, node *Node) error {
+func (o *FileCopyOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	path := node.GetSlot("path").(string)
 	mode := node.GetMode()
 	content, err := ctx.ContentFor(node)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] copy %v\n", path)
 		ctx.TargetChecksum = ChecksumBytes(content)
-		return nil
+		return nil, nil, nil
 	}
 	checksum, err := o.impl.Copy(path, mode, content)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	ctx.TargetChecksum = checksum
-	return nil
+	return nil, nil, nil
 }
+
+func (o *FileCopyOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileRenderOp processes content as a Go text/template (transformer: reads content, stores result).
 type FileRenderOp struct{ impl *FileService }
 
 func (o *FileRenderOp) Name() string { return "render" }
 
-func (o *FileRenderOp) Execute(ctx *Context, node *Node) error {
+func (o *FileRenderOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	source, _ := node.GetSlot("source").(string)
 	path, _ := node.GetSlot("path").(string)
 	project := node.GetProject()
@@ -64,20 +68,22 @@ func (o *FileRenderOp) Execute(ctx *Context, node *Node) error {
 	}
 	content, err := ctx.ContentFor(node)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] render %v %v\n", source, path)
-		return nil
+		return nil, nil, nil
 	}
 	result, err := o.impl.Render(templateData, source, path, project, content)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	ctx.StoreContent(node, result)
-	return nil
+	return nil, nil, nil
 }
+
+func (o *FileRenderOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileBackupOp moves the existing file at node's "path" slot to a timestamped backup.
 // The backup path is stored in node.Annotations["backup_path"] after execution.
@@ -85,96 +91,106 @@ type FileBackupOp struct{ impl *FileService }
 
 func (o *FileBackupOp) Name() string { return "backup" }
 
-func (o *FileBackupOp) Execute(ctx *Context, node *Node) error {
+func (o *FileBackupOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	path := node.GetSlot("path").(string)
 	backupSuffix, _ := node.GetSlot("backup_suffix").(string)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] backup %v\n", path)
-		return nil
+		return nil, nil, nil
 	}
 	backupPath, err := o.impl.Backup(path, backupSuffix)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
 	node.Annotations["backup_path"] = backupPath
-	return nil
+	return nil, nil, nil
 }
+
+func (o *FileBackupOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileUnlinkOp removes a symlink at node's "path" slot.
 type FileUnlinkOp struct{ impl *FileService }
 
 func (o *FileUnlinkOp) Name() string { return "unlink" }
 
-func (o *FileUnlinkOp) Execute(ctx *Context, node *Node) error {
+func (o *FileUnlinkOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	path := node.GetSlot("path").(string)
 	prune, _ := node.GetSlot("prune").(bool)
 	pruneBoundary, _ := node.GetSlot("prune_boundary").(string)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] unlink %v\n", path)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Unlink(path, prune, pruneBoundary)
+	return nil, nil, o.impl.Unlink(path, prune, pruneBoundary)
 }
+
+func (o *FileUnlinkOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileRemoveOp deletes the file at node's "path" slot.
 type FileRemoveOp struct{ impl *FileService }
 
 func (o *FileRemoveOp) Name() string { return "remove" }
 
-func (o *FileRemoveOp) Execute(ctx *Context, node *Node) error {
+func (o *FileRemoveOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	path := node.GetSlot("path").(string)
 	prune, _ := node.GetSlot("prune").(bool)
 	pruneBoundary, _ := node.GetSlot("prune_boundary").(string)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] remove %v\n", path)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Remove(path, prune, pruneBoundary)
+	return nil, nil, o.impl.Remove(path, prune, pruneBoundary)
 }
+
+func (o *FileRemoveOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileWriteOp writes content from node's "content" slot to node's "path" slot.
 type FileWriteOp struct{ impl *FileService }
 
 func (o *FileWriteOp) Name() string { return "write" }
 
-func (o *FileWriteOp) Execute(ctx *Context, node *Node) error {
+func (o *FileWriteOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	content, _ := node.GetSlot("content").(string)
 	path := node.GetSlot("path").(string)
 	mode := node.GetMode()
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] write %v\n", path)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Write(content, path, mode)
+	return nil, nil, o.impl.Write(content, path, mode)
 }
+
+func (o *FileWriteOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // FileMoveOp moves a file from node's "source" slot to "path" slot.
 type FileMoveOp struct{ impl *FileService }
 
 func (o *FileMoveOp) Name() string { return "move" }
 
-func (o *FileMoveOp) Execute(ctx *Context, node *Node) error {
+func (o *FileMoveOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	source := node.GetSlot("source").(string)
 	path := node.GetSlot("path").(string)
 	gitMv, _ := node.GetSlot("git_mv").(func(src, dst string) error)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] move %v %v\n", source, path)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Move(gitMv, source, path)
+	return nil, nil, o.impl.Move(gitMv, source, path)
 }
 
-// FileOps returns all file operations backed by the given FileService.
-func FileOps(impl *FileService) []Operation {
-	return []Operation{
+func (o *FileMoveOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
+
+// FileOps returns all file actions backed by the given FileService.
+func FileOps(impl *FileService) []Action {
+	return []Action{
 		&FileLinkOp{impl: impl},
 		&FileCopyOp{impl: impl},
 		&FileRenderOp{impl: impl},

--- a/internal/execution/ops_package_gen.go
+++ b/internal/execution/ops_package_gen.go
@@ -15,70 +15,78 @@ type PackageInstallOp struct{ impl *PackageService }
 
 func (o *PackageInstallOp) Name() string { return "package-install" }
 
-func (o *PackageInstallOp) Execute(ctx *Context, node *Node) error {
+func (o *PackageInstallOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	packages, _ := node.GetSlot("packages").([]string)
 	manager, _ := node.GetSlot("manager").(string)
 	cask, _ := node.GetSlot("cask").(bool)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-install %v\n", strings.Join(packages, " "))
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Install(packages, manager, cask)
+	return nil, nil, o.impl.Install(packages, manager, cask)
 }
+
+func (o *PackageInstallOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // PackageUpgradeOp upgrades packages using the platform's package manager.
 type PackageUpgradeOp struct{ impl *PackageService }
 
 func (o *PackageUpgradeOp) Name() string { return "package-upgrade" }
 
-func (o *PackageUpgradeOp) Execute(ctx *Context, node *Node) error {
+func (o *PackageUpgradeOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	packages, _ := node.GetSlot("packages").([]string)
 	manager, _ := node.GetSlot("manager").(string)
 	cask, _ := node.GetSlot("cask").(bool)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-upgrade %v\n", strings.Join(packages, " "))
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Upgrade(packages, manager, cask)
+	return nil, nil, o.impl.Upgrade(packages, manager, cask)
 }
+
+func (o *PackageUpgradeOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // PackageRemoveOp removes packages using the platform's package manager.
 type PackageRemoveOp struct{ impl *PackageService }
 
 func (o *PackageRemoveOp) Name() string { return "package-remove" }
 
-func (o *PackageRemoveOp) Execute(ctx *Context, node *Node) error {
+func (o *PackageRemoveOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	packages, _ := node.GetSlot("packages").([]string)
 	manager, _ := node.GetSlot("manager").(string)
 	cask, _ := node.GetSlot("cask").(bool)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-remove %v\n", strings.Join(packages, " "))
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Remove(packages, manager, cask)
+	return nil, nil, o.impl.Remove(packages, manager, cask)
 }
+
+func (o *PackageRemoveOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // PackageUpdateOp refreshes the package manager index.
 type PackageUpdateOp struct{ impl *PackageService }
 
 func (o *PackageUpdateOp) Name() string { return "package-update" }
 
-func (o *PackageUpdateOp) Execute(ctx *Context, node *Node) error {
+func (o *PackageUpdateOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	manager, _ := node.GetSlot("manager").(string)
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-update\n")
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Update(manager)
+	return nil, nil, o.impl.Update(manager)
 }
 
-// PackageOps returns all package operations backed by the given PackageService.
-func PackageOps(impl *PackageService) []Operation {
-	return []Operation{
+func (o *PackageUpdateOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
+
+// PackageOps returns all package actions backed by the given PackageService.
+func PackageOps(impl *PackageService) []Action {
+	return []Action{
 		&PackageInstallOp{impl: impl},
 		&PackageUpgradeOp{impl: impl},
 		&PackageRemoveOp{impl: impl},

--- a/internal/execution/ops_registry.go
+++ b/internal/execution/ops_registry.go
@@ -3,51 +3,14 @@
 
 package execution
 
-import "fmt"
-
-// ValidateOp checks a precondition and fails with a message if unmet.
-// The check function is retrieved from ctx.Data["validators"][node's "check" slot].
-type ValidateOp struct{}
-
-func (o *ValidateOp) Name() string { return "validate" }
-
-func (o *ValidateOp) Execute(ctx *Context, node *Node) error {
-	checkName, _ := node.GetSlot("check").(string)
-	if checkName == "" {
-		return fmt.Errorf("validate: no check specified in node slots")
-	}
-
-	validators, ok := ctx.Data["validators"].(map[string]func() error)
-	if !ok {
-		return fmt.Errorf("validate: no validators configured in context")
-	}
-
-	validator, ok := validators[checkName]
-	if !ok {
-		return fmt.Errorf("validate: unknown check %q", checkName)
-	}
-
-	if err := validator(); err != nil {
-		message, _ := node.GetSlot("message").(string)
-		if message != "" {
-			return fmt.Errorf("%s: %w", message, err)
-		}
-		return err
-	}
-
-	return nil
+// AllActions returns all actions for registration.
+// Both writ and lore use this to ensure the same actions are available.
+func AllActions() []Action {
+	var actions []Action
+	actions = append(actions, FileOps(&FileService{})...)
+	actions = append(actions, EncryptionOps(&EncryptionService{})...)
+	actions = append(actions, PackageOps(&PackageService{})...)
+	actions = append(actions, ShellOps(&ShellService{})...)
+	actions = append(actions, ServiceManagerOps(&ServiceManagerService{})...)
+	return actions
 }
-
-// AllOps returns all operations for registration.
-// Both writ and lore use this to ensure the same operations are available.
-func AllOps() []Operation {
-	var ops []Operation
-	ops = append(ops, FileOps(&FileService{})...)
-	ops = append(ops, EncryptionOps(&EncryptionService{})...)
-	ops = append(ops, PackageOps(&PackageService{})...)
-	ops = append(ops, ShellOps(&ShellService{})...)
-	ops = append(ops, ServiceManagerOps(&ServiceManagerService{})...)
-	ops = append(ops, &ValidateOp{})
-	return ops
-}
-

--- a/internal/execution/ops_service_manager_gen.go
+++ b/internal/execution/ops_service_manager_gen.go
@@ -12,94 +12,104 @@ type ServiceManagerStartOp struct{ impl *ServiceManagerService }
 
 func (o *ServiceManagerStartOp) Name() string { return "service-start" }
 
-func (o *ServiceManagerStartOp) Execute(ctx *Context, node *Node) error {
+func (o *ServiceManagerStartOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	name, _ := node.GetSlot("name").(string)
 	if name == "" {
-		return fmt.Errorf("service-start: no service specified")
+		return nil, nil, fmt.Errorf("service-start: no service specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] service-start %v\n", name)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Start(name, ctx.Logger)
+	return nil, nil, o.impl.Start(name, ctx.Logger)
 }
+
+func (o *ServiceManagerStartOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // ServiceManagerStopOp stops a service.
 type ServiceManagerStopOp struct{ impl *ServiceManagerService }
 
 func (o *ServiceManagerStopOp) Name() string { return "service-stop" }
 
-func (o *ServiceManagerStopOp) Execute(ctx *Context, node *Node) error {
+func (o *ServiceManagerStopOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	name, _ := node.GetSlot("name").(string)
 	if name == "" {
-		return fmt.Errorf("service-stop: no service specified")
+		return nil, nil, fmt.Errorf("service-stop: no service specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] service-stop %v\n", name)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Stop(name, ctx.Logger)
+	return nil, nil, o.impl.Stop(name, ctx.Logger)
 }
+
+func (o *ServiceManagerStopOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // ServiceManagerRestartOp restarts a service.
 type ServiceManagerRestartOp struct{ impl *ServiceManagerService }
 
 func (o *ServiceManagerRestartOp) Name() string { return "service-restart" }
 
-func (o *ServiceManagerRestartOp) Execute(ctx *Context, node *Node) error {
+func (o *ServiceManagerRestartOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	name, _ := node.GetSlot("name").(string)
 	if name == "" {
-		return fmt.Errorf("service-restart: no service specified")
+		return nil, nil, fmt.Errorf("service-restart: no service specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] service-restart %v\n", name)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Restart(name, ctx.Logger)
+	return nil, nil, o.impl.Restart(name, ctx.Logger)
 }
+
+func (o *ServiceManagerRestartOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // ServiceManagerEnableOp enables a service to start at boot.
 type ServiceManagerEnableOp struct{ impl *ServiceManagerService }
 
 func (o *ServiceManagerEnableOp) Name() string { return "service-enable" }
 
-func (o *ServiceManagerEnableOp) Execute(ctx *Context, node *Node) error {
+func (o *ServiceManagerEnableOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	name, _ := node.GetSlot("name").(string)
 	if name == "" {
-		return fmt.Errorf("service-enable: no service specified")
+		return nil, nil, fmt.Errorf("service-enable: no service specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] service-enable %v\n", name)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Enable(name, ctx.Logger)
+	return nil, nil, o.impl.Enable(name, ctx.Logger)
 }
+
+func (o *ServiceManagerEnableOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // ServiceManagerDisableOp disables a service from starting at boot.
 type ServiceManagerDisableOp struct{ impl *ServiceManagerService }
 
 func (o *ServiceManagerDisableOp) Name() string { return "service-disable" }
 
-func (o *ServiceManagerDisableOp) Execute(ctx *Context, node *Node) error {
+func (o *ServiceManagerDisableOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	name, _ := node.GetSlot("name").(string)
 	if name == "" {
-		return fmt.Errorf("service-disable: no service specified")
+		return nil, nil, fmt.Errorf("service-disable: no service specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] service-disable %v\n", name)
-		return nil
+		return nil, nil, nil
 	}
-	return o.impl.Disable(name, ctx.Logger)
+	return nil, nil, o.impl.Disable(name, ctx.Logger)
 }
 
-// ServiceManagerOps returns all service manager operations backed by the given ServiceManagerService.
-func ServiceManagerOps(impl *ServiceManagerService) []Operation {
-	return []Operation{
+func (o *ServiceManagerDisableOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
+
+// ServiceManagerOps returns all service manager actions backed by the given ServiceManagerService.
+func ServiceManagerOps(impl *ServiceManagerService) []Action {
+	return []Action{
 		&ServiceManagerStartOp{impl: impl},
 		&ServiceManagerStopOp{impl: impl},
 		&ServiceManagerRestartOp{impl: impl},

--- a/internal/execution/ops_shell_gen.go
+++ b/internal/execution/ops_shell_gen.go
@@ -12,42 +12,46 @@ type ShellOp struct{ impl *ShellService }
 
 func (o *ShellOp) Name() string { return "shell" }
 
-func (o *ShellOp) Execute(ctx *Context, node *Node) error {
+func (o *ShellOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	command, _ := node.GetSlot("command").(string)
 	if command == "" {
-		return fmt.Errorf("shell: no command specified")
+		return nil, nil, fmt.Errorf("shell: no command specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] shell %v\n", command)
-		return nil
+		return nil, nil, nil
 	}
 	_, _ = fmt.Fprintf(ctx.Logger, "[shell] %s\n", command)
-	return o.impl.Shell(command, ctx.Logger)
+	return nil, nil, o.impl.Shell(command, ctx.Logger)
 }
+
+func (o *ShellOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
 
 // PowerShellOp executes a PowerShell command from node's "command" slot (Windows).
 type PowerShellOp struct{ impl *ShellService }
 
 func (o *PowerShellOp) Name() string { return "powershell" }
 
-func (o *PowerShellOp) Execute(ctx *Context, node *Node) error {
+func (o *PowerShellOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
 	command, _ := node.GetSlot("command").(string)
 	if command == "" {
-		return fmt.Errorf("powershell: no command specified")
+		return nil, nil, fmt.Errorf("powershell: no command specified")
 	}
 
 	if ctx.DryRun {
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] powershell %v\n", command)
-		return nil
+		return nil, nil, nil
 	}
 	_, _ = fmt.Fprintf(ctx.Logger, "[powershell] %s\n", command)
-	return o.impl.PowerShell(command, ctx.Logger)
+	return nil, nil, o.impl.PowerShell(command, ctx.Logger)
 }
 
-// ShellOps returns all shell operations backed by the given ShellService.
-func ShellOps(impl *ShellService) []Operation {
-	return []Operation{
+func (o *PowerShellOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }
+
+// ShellOps returns all shell actions backed by the given ShellService.
+func ShellOps(impl *ShellService) []Action {
+	return []Action{
 		&ShellOp{impl: impl},
 		&PowerShellOp{impl: impl},
 	}

--- a/internal/execution/phase_test.go
+++ b/internal/execution/phase_test.go
@@ -126,7 +126,7 @@ func TestPhasedExecutionSuccess(t *testing.T) {
 		sources[name] = path
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	executor := NewGraphExecutor(reg, ExecutorOptions{})
@@ -212,7 +212,7 @@ func TestPhasedExecutionFailureWithRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 	// Phase 3 uses an operation that always fails
 	reg.Register(&testRetryOp{
@@ -277,7 +277,7 @@ func TestPhasedExecutionFailureWithRollback(t *testing.T) {
 		Nodes: []*Node{
 			testNode("node-prepare", "link", src1, filepath.Join(tmpDir, "out1")),
 			testNode("node-install", "link", src2, filepath.Join(tmpDir, "out2")),
-			{ID: "node-provision", Operation: "fail-provision"},
+			{ID: "node-provision", Action: "fail-provision"},
 			testNode("node-verify", "link", src1, filepath.Join(tmpDir, "out4")),
 			testNode("comp-prepare", "link", compensateSrc, filepath.Join(tmpDir, "comp-out1")),
 			testNode("comp-install", "link", compensateSrc, filepath.Join(tmpDir, "comp-out2")),
@@ -342,7 +342,7 @@ func TestPhasedExecutionRetryThenSucceed(t *testing.T) {
 
 	attemptCount := 0
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 	// Register a custom op that creates the file on second attempt
 	reg.Register(&testRetryOp{
@@ -375,7 +375,7 @@ func TestPhasedExecutionRetryThenSucceed(t *testing.T) {
 			},
 		},
 		Nodes: []*Node{
-			{ID: "retry-node", Operation: "retry-test"},
+			{ID: "retry-node", Action: "retry-test"},
 		},
 	}
 
@@ -414,7 +414,7 @@ func TestPhasedExecutionRetryExhausted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 	reg.Register(&testRetryOp{
 		name: "always-fail",
@@ -448,7 +448,7 @@ func TestPhasedExecutionRetryExhausted(t *testing.T) {
 		},
 		Nodes: []*Node{
 			testNode("prepare-node", "link", src, filepath.Join(tmpDir, "out1")),
-			{ID: "fail-node", Operation: "always-fail"},
+			{ID: "fail-node", Action: "always-fail"},
 		},
 	}
 
@@ -482,7 +482,7 @@ func TestNonPhasedGraphUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg := NewOperationRegistry()
+	reg := NewActionRegistry()
 	reg.Register(&FileLinkOp{impl: &FileService{}})
 
 	executor := NewGraphExecutor(reg, ExecutorOptions{})
@@ -538,7 +538,7 @@ func TestPhasedGraphSerialization(t *testing.T) {
 			},
 		},
 		Nodes: []*Node{
-			{ID: "pkg-ripgrep", Operation: "package-install"},
+			{ID: "pkg-ripgrep", Action: "package-install"},
 		},
 	}
 
@@ -576,13 +576,14 @@ func TestPhaseByID(t *testing.T) {
 	}
 }
 
-// testRetryOp is a test-only operation that executes a function.
+// testRetryOp is a test-only action that executes a function.
 type testRetryOp struct {
 	name string
 	fn   func(ctx *Context, node *Node) error
 }
 
 func (o *testRetryOp) Name() string { return o.name }
-func (o *testRetryOp) Execute(ctx *Context, node *Node) error {
-	return o.fn(ctx, node)
+func (o *testRetryOp) Do(ctx *Context, node *Node) (Result, UndoState, error) {
+	return nil, nil, o.fn(ctx, node)
 }
+func (o *testRetryOp) Undo(_ *Context, _ *Node, _ UndoState) error { return nil }

--- a/internal/execution/plan.go
+++ b/internal/execution/plan.go
@@ -67,7 +67,7 @@ func (p *Plan) Mkdir(path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("mkdir"),
-		Operation: "mkdir",
+		Action: "mkdir",
 		Project:   p.project,
 		Mode:      0755,
 	}
@@ -83,7 +83,7 @@ func (p *Plan) Link(source, path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -101,7 +101,7 @@ func (p *Plan) Copy(source, path string, transforms ...string) *Node {
 	if len(transforms) == 0 {
 		node := &Node{
 			ID:        p.nextID("copy"),
-			Operation: "copy",
+			Action: "copy",
 			Project:   p.project,
 			Mode:      0644,
 		}
@@ -119,7 +119,7 @@ func (p *Plan) Copy(source, path string, transforms ...string) *Node {
 		isLast := (i == len(allOps) - 1)
 		node := &Node{
 			ID:        p.nextID(op),
-			Operation: op,
+			Action: op,
 			Project:   p.project,
 		}
 		if i == 0 {
@@ -147,7 +147,7 @@ func (p *Plan) CopyWithMode(source, path string, mode os.FileMode, transforms ..
 	if len(transforms) == 0 {
 		node := &Node{
 			ID:        p.nextID("copy"),
-			Operation: "copy",
+			Action: "copy",
 			Project:   p.project,
 			Mode:      mode,
 		}
@@ -165,7 +165,7 @@ func (p *Plan) CopyWithMode(source, path string, mode os.FileMode, transforms ..
 		isLast := (i == len(allOps) - 1)
 		node := &Node{
 			ID:        p.nextID(op),
-			Operation: op,
+			Action: op,
 			Project:   p.project,
 		}
 		if i == 0 {
@@ -192,7 +192,7 @@ func (p *Plan) Remove(path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("remove"),
-		Operation: "remove",
+		Action: "remove",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
@@ -207,7 +207,7 @@ func (p *Plan) Unlink(path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("unlink"),
-		Operation: "unlink",
+		Action: "unlink",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
@@ -222,7 +222,7 @@ func (p *Plan) Backup(path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("backup"),
-		Operation: "backup",
+		Action: "backup",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("path", path)
@@ -237,7 +237,7 @@ func (p *Plan) Validate(check, message string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("validate"),
-		Operation: "validate",
+		Action: "validate",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("check", check)
@@ -253,7 +253,7 @@ func (p *Plan) Rename(source, path string) *Node {
 
 	node := &Node{
 		ID:        p.nextID("move"),
-		Operation: "move",
+		Action: "move",
 		Project:   p.project,
 	}
 	node.SetSlotImmediate("source", source)

--- a/internal/execution/preflight.go
+++ b/internal/execution/preflight.go
@@ -77,7 +77,7 @@ func nodeWritesToTarget(node *Node) bool {
 	if path == "" {
 		return false
 	}
-	return node.Operation == "link" || node.Operation == "copy"
+	return node.Action == "link" || node.Action == "copy"
 }
 
 // detectConflict checks if a target path has a conflict.

--- a/internal/execution/registry.go
+++ b/internal/execution/registry.go
@@ -3,33 +3,33 @@
 
 package execution
 
-// OperationRegistry maps operation names to their implementations.
-// Each tool registers its operations before calling GraphExecutor.Run().
-type OperationRegistry struct {
-	ops map[string]Operation
+// ActionRegistry maps action names to their implementations.
+// Each tool registers its actions before calling GraphExecutor.Run().
+type ActionRegistry struct {
+	actions map[string]Action
 }
 
-// NewOperationRegistry creates an empty operation registry.
-func NewOperationRegistry() *OperationRegistry {
-	return &OperationRegistry{ops: make(map[string]Operation)}
+// NewActionRegistry creates an empty action registry.
+func NewActionRegistry() *ActionRegistry {
+	return &ActionRegistry{actions: make(map[string]Action)}
 }
 
-// Register adds an operation to the registry. If an operation with the same
+// Register adds an action to the registry. If an action with the same
 // name already exists, it is replaced.
-func (r *OperationRegistry) Register(op Operation) {
-	r.ops[op.Name()] = op
+func (r *ActionRegistry) Register(action Action) {
+	r.actions[action.Name()] = action
 }
 
-// Get returns the operation registered under the given name.
-func (r *OperationRegistry) Get(name string) (Operation, bool) {
-	op, ok := r.ops[name]
-	return op, ok
+// Get returns the action registered under the given name.
+func (r *ActionRegistry) Get(name string) (Action, bool) {
+	action, ok := r.actions[name]
+	return action, ok
 }
 
-// Names returns all registered operation names.
-func (r *OperationRegistry) Names() []string {
-	names := make([]string, 0, len(r.ops))
-	for name := range r.ops {
+// Names returns all registered action names.
+func (r *ActionRegistry) Names() []string {
+	names := make([]string, 0, len(r.actions))
+	for name := range r.actions {
 		names = append(names, name)
 	}
 	return names

--- a/internal/execution/stateview.go
+++ b/internal/execution/stateview.go
@@ -34,8 +34,8 @@ type HistoryRecord struct {
 	// Tool is which tool created this record ("lore" or "writ").
 	Tool string `json:"tool" yaml:"tool"`
 
-	// Operation performed: link, copy, render, decrypt, install, etc.
-	Operation string `json:"operation" yaml:"operation"`
+	// Action performed: link, copy, render, decrypt, install, etc.
+	Action string `json:"action" yaml:"action"`
 
 	// Status of this operation: completed, skipped, failed.
 	Status NodeStatus `json:"status" yaml:"status"`
@@ -96,7 +96,7 @@ func (e *FileEntry) IsCopied() bool {
 	if last == nil {
 		return false
 	}
-	return last.Operation == "copy"
+	return last.Action == "copy"
 }
 
 // IsLinked returns true if the latest operation was a symlink.
@@ -105,7 +105,7 @@ func (e *FileEntry) IsLinked() bool {
 	if last == nil {
 		return false
 	}
-	return last.Operation == "link"
+	return last.Action == "link"
 }
 
 // SourceChecksum returns the source checksum from the latest operation.
@@ -132,7 +132,7 @@ func (e *FileEntry) LastOp() string {
 	if last == nil {
 		return ""
 	}
-	return last.Operation
+	return last.Action
 }
 
 // FileTreeNode represents a node in the target filesystem tree.
@@ -435,7 +435,7 @@ func (b *StateViewBuilder) includeGraph(g *Graph) bool {
 
 // isTransformOnlyNode returns true if the node is an intermediate transform.
 func isTransformOnlyNode(node *Node) bool {
-	switch node.Operation {
+	switch node.Action {
 	case "render", "decrypt":
 		return true
 	}
@@ -456,7 +456,7 @@ func (b *StateViewBuilder) processGraph(view *StateView, g *Graph) {
 			Timestamp:      g.Timestamp,
 			Receipt:        receiptName,
 			Tool:           g.Tool,
-			Operation:      node.Operation,
+			Action:         node.Action,
 			Status:         node.Status,
 			SourceChecksum: node.SourceChecksum,
 			TargetChecksum: node.TargetChecksum,
@@ -473,7 +473,7 @@ func (b *StateViewBuilder) processGraph(view *StateView, g *Graph) {
 
 // isPackageNode determines if a node represents a package lifecycle operation.
 func (b *StateViewBuilder) isPackageNode(node *Node) bool {
-	switch node.Operation {
+	switch node.Action {
 	case "prepare", "install", "verify", "upgrade", "uninstall", "cleanup",
 		"package-install", "package-upgrade", "package-remove":
 		return true

--- a/internal/execution/stateview_test.go
+++ b/internal/execution/stateview_test.go
@@ -69,8 +69,8 @@ func TestFileEntryLastOperation(t *testing.T) {
 		e := &FileEntry{
 			Target: ".bashrc",
 			History: []HistoryRecord{
-				{Receipt: "old.yaml", Operation: "link"},
-				{Receipt: "new.yaml", Operation: "copy"},
+				{Receipt: "old.yaml", Action: "link"},
+				{Receipt: "new.yaml", Action: "copy"},
 			},
 		}
 		last := e.LastOperation()
@@ -100,7 +100,7 @@ func TestFileEntryIsCopied(t *testing.T) {
 			e := &FileEntry{Target: "test"}
 			if tt.operation != "" {
 				e.History = []HistoryRecord{
-					{Operation: tt.operation},
+					{Action: tt.operation},
 				}
 			}
 			if got := e.IsCopied(); got != tt.want {
@@ -127,7 +127,7 @@ func TestFileEntryIsLinked(t *testing.T) {
 			e := &FileEntry{Target: "test"}
 			if tt.operation != "" {
 				e.History = []HistoryRecord{
-					{Operation: tt.operation},
+					{Action: tt.operation},
 				}
 			}
 			if got := e.IsLinked(); got != tt.want {
@@ -181,19 +181,19 @@ func TestFileTreeCopiedLinkedFiles(t *testing.T) {
 		Entries: map[string]*FileEntry{
 			".bashrc": {
 				Target:  ".bashrc",
-				History: []HistoryRecord{{Operation: "link"}},
+				History: []HistoryRecord{{Action: "link"}},
 			},
 			".zshrc": {
 				Target:  ".zshrc",
-				History: []HistoryRecord{{Operation: "link"}},
+				History: []HistoryRecord{{Action: "link"}},
 			},
 			".gitconfig": {
 				Target:  ".gitconfig",
-				History: []HistoryRecord{{Operation: "copy"}},
+				History: []HistoryRecord{{Action: "copy"}},
 			},
 			".ssh/config": {
 				Target:  ".ssh/config",
-				History: []HistoryRecord{{Operation: "copy"}},
+				History: []HistoryRecord{{Action: "copy"}},
 			},
 		},
 	}
@@ -303,15 +303,15 @@ func TestStateViewSummary(t *testing.T) {
 			Entries: map[string]*FileEntry{
 				".bashrc": {
 					Target:  ".bashrc",
-					History: []HistoryRecord{{Operation: "link"}},
+					History: []HistoryRecord{{Action: "link"}},
 				},
 				".zshrc": {
 					Target:  ".zshrc",
-					History: []HistoryRecord{{Operation: "link"}},
+					History: []HistoryRecord{{Action: "link"}},
 				},
 				".gitconfig": {
 					Target:  ".gitconfig",
-					History: []HistoryRecord{{Operation: "copy"}},
+					History: []HistoryRecord{{Action: "copy"}},
 				},
 			},
 		},
@@ -338,7 +338,7 @@ func TestStateViewBuilderBuildFrom(t *testing.T) {
 	makeNode := func(id string, op string, source, project, layer string) *Node {
 		n := &Node{
 			ID:        id,
-			Operation: op,
+			Action: op,
 			Project:   project,
 			Layer:     layer,
 			Status:    StatusCompleted,
@@ -417,7 +417,7 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Nodes: []*Node{
 				{
 					ID:        "docker",
-					Operation: "install",
+					Action: "install",
 					Status:    StatusCompleted,
 				},
 			},
@@ -428,12 +428,12 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Nodes: []*Node{
 				{
 					ID:        "docker",
-					Operation: "verify",
+					Action: "verify",
 					Status:    StatusCompleted,
 				},
 				{
 					ID:        "golang",
-					Operation: "install",
+					Action: "install",
 					Status:    StatusCompleted,
 				},
 			},
@@ -444,7 +444,7 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 			Nodes: []*Node{
 				{
 					ID:        "docker",
-					Operation: "upgrade",
+					Action: "upgrade",
 					Status:    StatusCompleted,
 				},
 			},
@@ -468,14 +468,14 @@ func TestStateViewBuilderPackageNodes(t *testing.T) {
 	}
 
 	// History should be ordered by time
-	if docker.History[0].Operation != "install" {
-		t.Errorf("expected first operation 'install', got %q", docker.History[0].Operation)
+	if docker.History[0].Action != "install" {
+		t.Errorf("expected first operation 'install', got %q", docker.History[0].Action)
 	}
-	if docker.History[1].Operation != "verify" {
-		t.Errorf("expected second operation 'verify', got %q", docker.History[1].Operation)
+	if docker.History[1].Action != "verify" {
+		t.Errorf("expected second operation 'verify', got %q", docker.History[1].Action)
 	}
-	if docker.History[2].Operation != "upgrade" {
-		t.Errorf("expected third operation 'upgrade', got %q", docker.History[2].Operation)
+	if docker.History[2].Action != "upgrade" {
+		t.Errorf("expected third operation 'upgrade', got %q", docker.History[2].Action)
 	}
 
 	// golang should have 1 history record
@@ -493,10 +493,10 @@ func TestStateViewBuilderTimeFilter(t *testing.T) {
 	now := time.Now()
 
 	graphs := []*Graph{
-		{Tool: "writ", Timestamp: now.Add(-3 * time.Hour), Nodes: []*Node{{ID: "a", Operation: "link", Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: "b", Operation: "link", Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "c", Operation: "link", Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: "d", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-3 * time.Hour), Nodes: []*Node{{ID: "a", Action: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: "b", Action: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "c", Action: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: "d", Action: "link", Status: StatusCompleted}}},
 	}
 
 	// Filter to middle two
@@ -522,9 +522,9 @@ func TestStateViewBuilderToolFilter(t *testing.T) {
 	now := time.Now()
 
 	graphs := []*Graph{
-		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: ".bashrc", Operation: "link", Status: StatusCompleted}}},
-		{Tool: "lore", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "docker", Operation: "install", Status: StatusCompleted}}},
-		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: ".zshrc", Operation: "link", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now.Add(-2 * time.Hour), Nodes: []*Node{{ID: ".bashrc", Action: "link", Status: StatusCompleted}}},
+		{Tool: "lore", Timestamp: now.Add(-1 * time.Hour), Nodes: []*Node{{ID: "docker", Action: "install", Status: StatusCompleted}}},
+		{Tool: "writ", Timestamp: now, Nodes: []*Node{{ID: ".zshrc", Action: "link", Status: StatusCompleted}}},
 	}
 
 	t.Run("writ only", func(t *testing.T) {
@@ -567,9 +567,9 @@ func TestStateViewBuilderSkipsSkipped(t *testing.T) {
 			Tool:      "writ",
 			Timestamp: now,
 			Nodes: []*Node{
-				{ID: "a", Operation: "link", Status: StatusCompleted},
-				{ID: "b", Operation: "link", Status: StatusSkipped},
-				{ID: "c", Operation: "link", Status: StatusFailed},
+				{ID: "a", Action: "link", Status: StatusCompleted},
+				{ID: "b", Action: "link", Status: StatusSkipped},
+				{ID: "c", Action: "link", Status: StatusFailed},
 			},
 		},
 	}
@@ -612,7 +612,7 @@ func TestStateViewBuilderLoadReceipts(t *testing.T) {
 				State:     StateExecuted,
 				Context:   GraphContext{TargetRoot: "/home/user"},
 				Nodes: []*Node{
-					{ID: ".bashrc", Operation: "link", Status: StatusCompleted},
+					{ID: ".bashrc", Action: "link", Status: StatusCompleted},
 				},
 			},
 		},
@@ -625,7 +625,7 @@ func TestStateViewBuilderLoadReceipts(t *testing.T) {
 				State:     StateExecuted,
 				Context:   GraphContext{TargetRoot: "/home/user"},
 				Nodes: []*Node{
-					{ID: ".gitconfig", Operation: "link", Status: StatusCompleted},
+					{ID: ".gitconfig", Action: "link", Status: StatusCompleted},
 				},
 			},
 		},
@@ -702,7 +702,7 @@ func TestIsPackageNode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		node := &Node{Operation: tt.operation}
+		node := &Node{Action: tt.operation}
 		got := builder.isPackageNode(node)
 		if got != tt.want {
 			t.Errorf("isPackageNode(%q) = %v, want %v", tt.operation, got, tt.want)

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -393,7 +393,7 @@ func addNativePMNodes(graph *execution.Graph, pkg *lorepackage.Release, action *
 	// Create the node with namespaced operation
 	node := &execution.Node{
 		ID:        fmt.Sprintf("%s-%s-%s", opName, pkg.Name, action.PhaseName),
-		Operation: opName,
+		Action: opName,
 		Project:   pkg.Name,
 	}
 	node.SetSlotImmediate("packages", strings.Join(action.Packages, ","))

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // runGraph is a test helper that calls RunNodes with the graph's nodes and edges.
-func runGraph(ctx context.Context, eng *execution.GraphExecutor, g *execution.Graph) ([]*execution.Result, error) {
+func runGraph(ctx context.Context, eng *execution.GraphExecutor, g *execution.Graph) ([]*execution.NodeResult, error) {
 	return eng.RunNodes(ctx, g.Nodes, g.Edges)
 }
 
@@ -45,7 +45,7 @@ func TestBuild_WithNativePMPackage(t *testing.T) {
 	// The first node should be a namespaced package-install operation
 	found := false
 	for _, node := range result.Graph.Nodes {
-		if node.Operation == "package-install" {
+		if node.Action == "package-install" {
 			found = true
 			// Verify slot values
 			if node.GetSlot("packages") != "curl" {
@@ -93,7 +93,7 @@ func TestBuild_PlatformDetection(t *testing.T) {
 			// All platforms use the namespaced "package-install" operation
 			found := false
 			for _, node := range result.Graph.Nodes {
-				if node.Operation == "package-install" {
+				if node.Action == "package-install" {
 					found = true
 					break
 				}
@@ -173,10 +173,10 @@ func TestBuild_MutuallyExclusiveConfig(t *testing.T) {
 
 func TestEngineRunsPackageInstallOperations(t *testing.T) {
 	// Integration test: build graph and run through engine with DryRun
-	reg := execution.NewOperationRegistry()
+	reg := execution.NewActionRegistry()
 
 	// Register all operations (file + package)
-	for _, op := range execution.AllOps() {
+	for _, op := range execution.AllActions() {
 		reg.Register(op)
 	}
 
@@ -185,7 +185,7 @@ func TestEngineRunsPackageInstallOperations(t *testing.T) {
 	// Create a graph with a namespaced package-install node
 	node := &execution.Node{
 		ID:         "package-install-testpkg",
-		Operation: "package-install",
+		Action: "package-install",
 	}
 	node.SetSlotImmediate("packages", "testpkg")
 	graph := &execution.Graph{
@@ -208,8 +208,8 @@ func TestEngineRunsPackageInstallOperations(t *testing.T) {
 
 func TestEngineRunsNamespacedPackageOps(t *testing.T) {
 	// Test that all namespaced package operations can execute in dry-run mode
-	reg := execution.NewOperationRegistry()
-	for _, op := range execution.AllOps() {
+	reg := execution.NewActionRegistry()
+	for _, op := range execution.AllActions() {
 		reg.Register(op)
 	}
 
@@ -224,7 +224,7 @@ func TestEngineRunsNamespacedPackageOps(t *testing.T) {
 		t.Run(opName, func(t *testing.T) {
 			node := &execution.Node{
 				ID:         "test-" + opName,
-				Operation: opName,
+				Action: opName,
 			}
 			if opName != "package-update" {
 				node.SetSlotImmediate("packages", "testpkg")
@@ -265,7 +265,7 @@ func TestNativePMNodeMetadata(t *testing.T) {
 	// Find the install node (uses namespaced "package-install" operation)
 	var installNode *execution.Node
 	for _, node := range result.Graph.Nodes {
-		if node.Operation == "package-install" {
+		if node.Action == "package-install" {
 			installNode = node
 			break
 		}
@@ -448,7 +448,7 @@ def compensate(package, system, plan):
 	}
 	foundRemove := false
 	for _, n := range result.Graph.Nodes {
-		if nodeSet[n.ID] && n.Operation == "package-remove" {
+		if nodeSet[n.ID] && n.Action == "package-remove" {
 			foundRemove = true
 			break
 		}

--- a/internal/lore/commands.go
+++ b/internal/lore/commands.go
@@ -234,8 +234,8 @@ func executeDeployments(ctx context.Context, resolved []resolvedPackage, cfg *lo
 	fmt.Println("\nDeploying packages...")
 
 	// Create operation registry and executor
-	registry := execution.NewOperationRegistry()
-	for _, op := range execution.AllOps() {
+	registry := execution.NewActionRegistry()
+	for _, op := range execution.AllActions() {
 		registry.Register(op)
 	}
 	executor := execution.NewGraphExecutor(registry, execution.ExecutorOptions{

--- a/internal/manifest/builder.go
+++ b/internal/manifest/builder.go
@@ -78,7 +78,7 @@ func (b *Builder) buildPackageNodes(pkg PackageEntry, opts execution.BuildOption
 
 		node := &execution.Node{
 			ID:        nodeID,
-			Operation: phase,
+			Action: phase,
 		}
 
 		// Store package name for registry lookup on all nodes

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -326,8 +326,8 @@ func TestBuilder_BuildGraphFromManifest(t *testing.T) {
 		if graph.Nodes[i].ID != id {
 			t.Errorf("nodes[%d].ID: expected %q, got %q", i, id, graph.Nodes[i].ID)
 		}
-		if graph.Nodes[i].Operation != expectedPhases[i] {
-			t.Errorf("nodes[%d].Operation: expected %q, got %q", i, expectedPhases[i], graph.Nodes[i].Operation)
+		if graph.Nodes[i].Action != expectedPhases[i] {
+			t.Errorf("nodes[%d].Action: expected %q, got %q", i, expectedPhases[i], graph.Nodes[i].Action)
 		}
 		if graph.Nodes[i].GetSlot("package") != "gh" {
 			t.Errorf("nodes[%d] slot 'package': expected 'gh', got %q", i, graph.Nodes[i].GetSlot("package"))

--- a/internal/starlark/plan.go
+++ b/internal/starlark/plan.go
@@ -66,7 +66,7 @@ func (p *planBindings) Project() string {
 func (p *planBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-install", packages...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -78,7 +78,7 @@ func (p *planBindings) PackageInstall(packages ...string) *execution.Node {
 func (p *planBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-upgrade", packages...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -90,7 +90,7 @@ func (p *planBindings) PackageUpgrade(packages ...string) *execution.Node {
 func (p *planBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-remove", packages...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -102,7 +102,7 @@ func (p *planBindings) PackageRemove(packages ...string) *execution.Node {
 func (p *planBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    p.project,
 	}
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -114,7 +114,7 @@ func (p *planBindings) PackageUpdate() *execution.Node {
 func (p *planBindings) Configure(source, target string) *execution.Node {
 	renderNode := &execution.Node{
 		ID:        generateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   p.project,
 	}
 	renderNode.SetSlotImmediate("source", source)
@@ -122,7 +122,7 @@ func (p *planBindings) Configure(source, target string) *execution.Node {
 
 	copyNode := &execution.Node{
 		ID:        generateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   p.project,
 	}
 	copyNode.SetSlotImmediate("path", p.host.ExpandPath(target))
@@ -140,7 +140,7 @@ func (p *planBindings) Configure(source, target string) *execution.Node {
 func (p *planBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -153,7 +153,7 @@ func (p *planBindings) Link(source, target string) *execution.Node {
 func (p *planBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -166,7 +166,7 @@ func (p *planBindings) Copy(source, target string) *execution.Node {
 func (p *planBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("path", p.host.ExpandPath(target))
@@ -179,7 +179,7 @@ func (p *planBindings) Write(target, content string) *execution.Node {
 func (p *planBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("remove"),
-		Operation: "remove",
+		Action: "remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("path", p.host.ExpandPath(target))
@@ -191,7 +191,7 @@ func (p *planBindings) Remove(target string) *execution.Node {
 func (p *planBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("download"),
-		Operation: "download",
+		Action: "download",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -204,7 +204,7 @@ func (p *planBindings) Download(url, target string) *execution.Node {
 func (p *planBindings) ArchiveExtract(archive, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("archive-extract"),
-		Operation: "archive-extract",
+		Action: "archive-extract",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("source", p.host.ExpandPath(archive))
@@ -217,7 +217,7 @@ func (p *planBindings) ArchiveExtract(archive, target string) *execution.Node {
 func (p *planBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-clone"),
-		Operation: "git-clone",
+		Action: "git-clone",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -230,7 +230,7 @@ func (p *planBindings) GitClone(url, target string) *execution.Node {
 func (p *planBindings) GitCheckout(ref string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-checkout"),
-		Operation: "git-checkout",
+		Action: "git-checkout",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("ref", ref)
@@ -242,7 +242,7 @@ func (p *planBindings) GitCheckout(ref string) *execution.Node {
 func (p *planBindings) GitPull() *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("git-pull"),
-		Operation: "git-pull",
+		Action: "git-pull",
 		Project:    p.project,
 	}
 	p.graph.Nodes = append(p.graph.Nodes, node)
@@ -253,7 +253,7 @@ func (p *planBindings) GitPull() *execution.Node {
 func (p *planBindings) Service(name string, action ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("service", name, action.String()),
-		Operation: "service",
+		Action: "service",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -266,7 +266,7 @@ func (p *planBindings) Service(name string, action ServiceAction) *execution.Nod
 func (p *planBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         generateNodeID("shell"),
-		Operation: "shell",
+		Action: "shell",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("command", command)

--- a/internal/starlark/plan_archive_gen.go
+++ b/internal/starlark/plan_archive_gen.go
@@ -55,7 +55,7 @@ func (a *ArchivePlan) extract(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:        generateNodeID("archive-extract"),
-		Operation: "archive-extract",
+		Action: "archive-extract",
 		Project:   a.project,
 	}
 

--- a/internal/starlark/plan_file.go
+++ b/internal/starlark/plan_file.go
@@ -78,7 +78,7 @@ func (f *FilePlan) configure(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	renderNode := &execution.Node{
 		ID:        generateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   f.project,
 	}
 	if err := FillSlot(renderNode, f.graph, "source", source); err != nil {
@@ -88,7 +88,7 @@ func (f *FilePlan) configure(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	copyNode := &execution.Node{
 		ID:        generateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   f.project,
 	}
 	if err := FillSlot(copyNode, f.graph, "path", path); err != nil {
@@ -120,7 +120,7 @@ func (f *FilePlan) link(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:         generateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    f.project,
 	}
 
@@ -151,7 +151,7 @@ func (f *FilePlan) copy(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:         generateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    f.project,
 	}
 
@@ -182,7 +182,7 @@ func (f *FilePlan) write(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	node := &execution.Node{
 		ID:         generateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    f.project,
 	}
 
@@ -212,7 +212,7 @@ func (f *FilePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starlark
 
 	node := &execution.Node{
 		ID:         generateNodeID("remove"),
-		Operation: "remove",
+		Action: "remove",
 		Project:    f.project,
 	}
 

--- a/internal/starlark/plan_git_gen.go
+++ b/internal/starlark/plan_git_gen.go
@@ -59,7 +59,7 @@ func (g *GitPlan) checkout(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:        generateNodeID("git-checkout"),
-		Operation: "git-checkout",
+		Action: "git-checkout",
 		Project:   g.project,
 	}
 
@@ -82,7 +82,7 @@ func (g *GitPlan) clone(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 
 	node := &execution.Node{
 		ID:        generateNodeID("git-clone"),
-		Operation: "git-clone",
+		Action: "git-clone",
 		Project:   g.project,
 	}
 
@@ -105,7 +105,7 @@ func (g *GitPlan) pull(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 
 	node := &execution.Node{
 		ID:        generateNodeID("git-pull"),
-		Operation: "git-pull",
+		Action: "git-pull",
 		Project:   g.project,
 	}
 

--- a/internal/starlark/plan_package.go
+++ b/internal/starlark/plan_package.go
@@ -73,7 +73,7 @@ func (p *PackagePlan) install(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-install", packages...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -98,7 +98,7 @@ func (p *PackagePlan) upgrade(_ *starlark.Thread, _ *starlark.Builtin, args star
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-upgrade", packages...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -123,7 +123,7 @@ func (p *PackagePlan) remove(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-remove", packages...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    p.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -145,7 +145,7 @@ func (p *PackagePlan) update(_ *starlark.Thread, _ *starlark.Builtin, args starl
 
 	node := &execution.Node{
 		ID:         generateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    p.project,
 	}
 

--- a/internal/starlark/plan_root.go
+++ b/internal/starlark/plan_root.go
@@ -99,7 +99,7 @@ func (p *PlanRoot) source(_ *starlark.Thread, _ *starlark.Builtin, args starlark
 
 	node := &execution.Node{
 		ID:         generateNodeID("source"),
-		Operation: "source",
+		Action: "source",
 		Project:    p.project,
 	}
 
@@ -126,7 +126,7 @@ func (p *PlanRoot) literal(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:         generateNodeID("literal"),
-		Operation: "literal",
+		Action: "literal",
 		Project:    p.project,
 	}
 
@@ -153,7 +153,7 @@ func (p *PlanRoot) download(_ *starlark.Thread, _ *starlark.Builtin, args starla
 
 	node := &execution.Node{
 		ID:         generateNodeID("download"),
-		Operation: "download",
+		Action: "download",
 		Project:    p.project,
 	}
 
@@ -193,7 +193,7 @@ func (p *PlanRoot) service(_ *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	node := &execution.Node{
 		ID:         generateNodeID("service"),
-		Operation: "service-" + actionStr,
+		Action: "service-" + actionStr,
 		Project:    p.project,
 	}
 
@@ -223,7 +223,7 @@ func (p *PlanRoot) shell(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	node := &execution.Node{
 		ID:         generateNodeID("shell"),
-		Operation: "shell",
+		Action: "shell",
 		Project:    p.project,
 	}
 

--- a/internal/starlark/platform/common.go
+++ b/internal/starlark/platform/common.go
@@ -89,7 +89,7 @@ func newBasePlanBindings(graph *execution.Graph, h host.Host, project string) *b
 func (b *basePlanBindings) Remove(target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("remove"),
-		Operation: "remove",
+		Action: "remove",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("path", b.host.ExpandPath(target))
@@ -101,7 +101,7 @@ func (b *basePlanBindings) Remove(target string) *execution.Node {
 func (b *basePlanBindings) Download(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("download"),
-		Operation: "download",
+		Action: "download",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -114,7 +114,7 @@ func (b *basePlanBindings) Download(url, target string) *execution.Node {
 func (b *basePlanBindings) ArchiveExtract(archive, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("archive-extract"),
-		Operation: "archive-extract",
+		Action: "archive-extract",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("source", b.host.ExpandPath(archive))
@@ -127,7 +127,7 @@ func (b *basePlanBindings) ArchiveExtract(archive, target string) *execution.Nod
 func (b *basePlanBindings) GitClone(url, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-clone"),
-		Operation: "git-clone",
+		Action: "git-clone",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("url", url)
@@ -140,7 +140,7 @@ func (b *basePlanBindings) GitClone(url, target string) *execution.Node {
 func (b *basePlanBindings) GitCheckout(ref string) *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-checkout"),
-		Operation: "git-checkout",
+		Action: "git-checkout",
 		Project:    b.project,
 	}
 	node.SetSlotImmediate("ref", ref)
@@ -152,7 +152,7 @@ func (b *basePlanBindings) GitCheckout(ref string) *execution.Node {
 func (b *basePlanBindings) GitPull() *execution.Node {
 	node := &execution.Node{
 		ID:         baseGenerateNodeID("git-pull"),
-		Operation: "git-pull",
+		Action: "git-pull",
 		Project:    b.project,
 	}
 	b.graph.Nodes = append(b.graph.Nodes, node)

--- a/internal/starlark/platform/darwin.go
+++ b/internal/starlark/platform/darwin.go
@@ -172,7 +172,7 @@ func (d *DarwinPlanBindings) packageInstallBuiltin(_ *starlark.Thread, _ *starla
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -203,7 +203,7 @@ func (d *DarwinPlanBindings) packageUpgradeBuiltin(_ *starlark.Thread, _ *starla
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -234,7 +234,7 @@ func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlar
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -252,7 +252,7 @@ func (d *DarwinPlanBindings) packageRemoveBuiltin(_ *starlark.Thread, _ *starlar
 func (d *DarwinPlanBindings) packageUpdateBuiltin(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    d.project,
 	}
 	d.graph.Nodes = append(d.graph.Nodes, node)
@@ -267,7 +267,7 @@ func (d *DarwinPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Bu
 
 	renderNode := &execution.Node{
 		ID:        darwinGenerateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   d.project,
 	}
 	if err := loreStar.FillSlot(renderNode, d.graph, "source", source); err != nil {
@@ -277,7 +277,7 @@ func (d *DarwinPlanBindings) configureBuiltin(_ *starlark.Thread, _ *starlark.Bu
 
 	copyNode := &execution.Node{
 		ID:        darwinGenerateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   d.project,
 	}
 	if err := loreStar.FillSlot(copyNode, d.graph, "path", path); err != nil {
@@ -301,7 +301,7 @@ func (d *DarwinPlanBindings) linkBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    d.project,
 	}
 
@@ -324,7 +324,7 @@ func (d *DarwinPlanBindings) copyBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    d.project,
 	}
 
@@ -347,7 +347,7 @@ func (d *DarwinPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builti
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    d.project,
 	}
 
@@ -382,7 +382,7 @@ func (d *DarwinPlanBindings) serviceBuiltin(_ *starlark.Thread, _ *starlark.Buil
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("launchd"),
-		Operation: "launchd-" + actionStr,
+		Action: "launchd-" + actionStr,
 		Project:    d.project,
 	}
 
@@ -405,7 +405,7 @@ func (d *DarwinPlanBindings) shellBuiltin(_ *starlark.Thread, _ *starlark.Builti
 
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("shell"),
-		Operation: "shell",
+		Action: "shell",
 		Project:    d.project,
 	}
 
@@ -440,7 +440,7 @@ func (d *DarwinPlanBindings) PackageInstall(packages ...string) *execution.Node 
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-install", cleanPkgs...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -458,7 +458,7 @@ func (d *DarwinPlanBindings) PackageUpgrade(packages ...string) *execution.Node 
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-upgrade", cleanPkgs...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -476,7 +476,7 @@ func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	cleanPkgs, manager, isCask := parsePackagesWithPrefix(packages)
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-remove", cleanPkgs...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(cleanPkgs, ","))
@@ -493,7 +493,7 @@ func (d *DarwinPlanBindings) PackageRemove(packages ...string) *execution.Node {
 func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    d.project,
 	}
 	d.graph.Nodes = append(d.graph.Nodes, node)
@@ -503,7 +503,7 @@ func (d *DarwinPlanBindings) PackageUpdate() *execution.Node {
 func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
 	renderNode := &execution.Node{
 		ID:        darwinGenerateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   d.project,
 	}
 	renderNode.SetSlotImmediate("source", source)
@@ -511,7 +511,7 @@ func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
 
 	copyNode := &execution.Node{
 		ID:        darwinGenerateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   d.project,
 	}
 	copyNode.SetSlotImmediate("path", d.host.ExpandPath(target))
@@ -528,7 +528,7 @@ func (d *DarwinPlanBindings) Configure(source, target string) *execution.Node {
 func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -540,7 +540,7 @@ func (d *DarwinPlanBindings) Link(source, target string) *execution.Node {
 func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -552,7 +552,7 @@ func (d *DarwinPlanBindings) Copy(source, target string) *execution.Node {
 func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -564,7 +564,7 @@ func (d *DarwinPlanBindings) Write(target, content string) *execution.Node {
 func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("launchd", name, action.String()),
-		Operation: "launchd-" + action.String(),
+		Action: "launchd-" + action.String(),
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -576,7 +576,7 @@ func (d *DarwinPlanBindings) Service(name string, action loreStar.ServiceAction)
 func (d *DarwinPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         darwinGenerateNodeID("shell"),
-		Operation: "shell",
+		Action: "shell",
 		Project:    d.project,
 	}
 	node.SetSlotImmediate("command", command)

--- a/internal/starlark/platform/linux.go
+++ b/internal/starlark/platform/linux.go
@@ -97,7 +97,7 @@ func (l *LinuxPlanBindings) PackageManagerName() string {
 func (l *LinuxPlanBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-install", packages...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -109,7 +109,7 @@ func (l *LinuxPlanBindings) PackageInstall(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-upgrade", packages...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -121,7 +121,7 @@ func (l *LinuxPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-remove", packages...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -133,7 +133,7 @@ func (l *LinuxPlanBindings) PackageRemove(packages ...string) *execution.Node {
 func (l *LinuxPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    l.project,
 	}
 	l.graph.Nodes = append(l.graph.Nodes, node)
@@ -144,7 +144,7 @@ func (l *LinuxPlanBindings) PackageUpdate() *execution.Node {
 func (l *LinuxPlanBindings) Configure(source, target string) *execution.Node {
 	renderNode := &execution.Node{
 		ID:        linuxGenerateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   l.project,
 	}
 	renderNode.SetSlotImmediate("source", source)
@@ -152,7 +152,7 @@ func (l *LinuxPlanBindings) Configure(source, target string) *execution.Node {
 
 	copyNode := &execution.Node{
 		ID:        linuxGenerateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   l.project,
 	}
 	copyNode.SetSlotImmediate("path", l.host.ExpandPath(target))
@@ -170,7 +170,7 @@ func (l *LinuxPlanBindings) Configure(source, target string) *execution.Node {
 func (l *LinuxPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -183,7 +183,7 @@ func (l *LinuxPlanBindings) Link(source, target string) *execution.Node {
 func (l *LinuxPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -196,7 +196,7 @@ func (l *LinuxPlanBindings) Copy(source, target string) *execution.Node {
 func (l *LinuxPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -209,7 +209,7 @@ func (l *LinuxPlanBindings) Write(target, content string) *execution.Node {
 func (l *LinuxPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("systemd", name, action.String()),
-		Operation: "systemd-" + action.String(),
+		Action: "systemd-" + action.String(),
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -222,7 +222,7 @@ func (l *LinuxPlanBindings) Service(name string, action loreStar.ServiceAction) 
 func (l *LinuxPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("shell"),
-		Operation: "shell",
+		Action: "shell",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("command", command)
@@ -443,7 +443,7 @@ func (l *LinuxPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Builtin
 	expandedOut := l.host.ExpandPath(out)
 	node := &execution.Node{
 		ID:         linuxGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    l.project,
 	}
 	node.SetSlotImmediate("source", input.Path())

--- a/internal/starlark/platform/windows.go
+++ b/internal/starlark/platform/windows.go
@@ -55,7 +55,7 @@ func (w *WindowsPlanBindings) PackageManagerName() string {
 func (w *WindowsPlanBindings) PackageInstall(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-install", packages...),
-		Operation: "package-install",
+		Action: "package-install",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -67,7 +67,7 @@ func (w *WindowsPlanBindings) PackageInstall(packages ...string) *execution.Node
 func (w *WindowsPlanBindings) PackageUpgrade(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-upgrade", packages...),
-		Operation: "package-upgrade",
+		Action: "package-upgrade",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -79,7 +79,7 @@ func (w *WindowsPlanBindings) PackageUpgrade(packages ...string) *execution.Node
 func (w *WindowsPlanBindings) PackageRemove(packages ...string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-remove", packages...),
-		Operation: "package-remove",
+		Action: "package-remove",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("packages", strings.Join(packages, ","))
@@ -91,7 +91,7 @@ func (w *WindowsPlanBindings) PackageRemove(packages ...string) *execution.Node 
 func (w *WindowsPlanBindings) PackageUpdate() *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("package-update"),
-		Operation: "package-update",
+		Action: "package-update",
 		Project:    w.project,
 	}
 	w.graph.Nodes = append(w.graph.Nodes, node)
@@ -102,7 +102,7 @@ func (w *WindowsPlanBindings) PackageUpdate() *execution.Node {
 func (w *WindowsPlanBindings) Configure(source, target string) *execution.Node {
 	renderNode := &execution.Node{
 		ID:        windowsGenerateNodeID("render"),
-		Operation: "render",
+		Action: "render",
 		Project:   w.project,
 	}
 	renderNode.SetSlotImmediate("source", source)
@@ -110,7 +110,7 @@ func (w *WindowsPlanBindings) Configure(source, target string) *execution.Node {
 
 	copyNode := &execution.Node{
 		ID:        windowsGenerateNodeID("configure"),
-		Operation: "copy",
+		Action: "copy",
 		Project:   w.project,
 	}
 	copyNode.SetSlotImmediate("path", w.host.ExpandPath(target))
@@ -127,7 +127,7 @@ func (w *WindowsPlanBindings) Configure(source, target string) *execution.Node {
 func (w *WindowsPlanBindings) Link(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("link"),
-		Operation: "link",
+		Action: "link",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -141,7 +141,7 @@ func (w *WindowsPlanBindings) Link(source, target string) *execution.Node {
 func (w *WindowsPlanBindings) Copy(source, target string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("copy"),
-		Operation: "copy",
+		Action: "copy",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", source)
@@ -154,7 +154,7 @@ func (w *WindowsPlanBindings) Copy(source, target string) *execution.Node {
 func (w *WindowsPlanBindings) Write(target, content string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("content", content)
@@ -167,7 +167,7 @@ func (w *WindowsPlanBindings) Write(target, content string) *execution.Node {
 func (w *WindowsPlanBindings) Service(name string, action loreStar.ServiceAction) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("winservice", name, action.String()),
-		Operation: "winservice-" + action.String(),
+		Action: "winservice-" + action.String(),
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("name", name)
@@ -180,7 +180,7 @@ func (w *WindowsPlanBindings) Service(name string, action loreStar.ServiceAction
 func (w *WindowsPlanBindings) Shell(command string) *execution.Node {
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("shell"),
-		Operation: "powershell",
+		Action: "powershell",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("command", command)
@@ -404,7 +404,7 @@ func (w *WindowsPlanBindings) writeBuiltin(_ *starlark.Thread, _ *starlark.Built
 	expandedOut := w.host.ExpandPath(out)
 	node := &execution.Node{
 		ID:         windowsGenerateNodeID("write"),
-		Operation: "write",
+		Action: "write",
 		Project:    w.project,
 	}
 	node.SetSlotImmediate("source", input.Path())

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -500,7 +500,7 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 
 		node := &execution.Node{
 			ID:        nodeID,
-			Operation: opName,
+			Action: opName,
 			Project:   entry.Project,
 		}
 		if i == 0 {
@@ -519,8 +519,8 @@ func upgradeFile(cfg *UpgradeConfig, view *execution.StateView, relTarget string
 		prevNodeID = nodeID
 	}
 
-	reg := execution.NewOperationRegistry()
-	for _, op := range execution.AllOps() {
+	reg := execution.NewActionRegistry()
+	for _, op := range execution.AllActions() {
 		reg.Register(op)
 	}
 	eng := execution.NewGraphExecutor(reg, execution.ExecutorOptions{
@@ -703,14 +703,14 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 
 	for _, n := range g.Nodes {
 		// Skip non-file nodes and symlinks
-		if n.Status == execution.StatusSkipped || n.Operation == "delegate" || n.Operation == "backup" {
+		if n.Status == execution.StatusSkipped || n.Action == "delegate" || n.Action == "backup" {
 			continue
 		}
-		if n.Operation == "link" {
+		if n.Action == "link" {
 			continue // Symlinks are found by scanning
 		}
 		// Skip intermediate transform nodes
-		if n.Operation == "render" || n.Operation == "decrypt" {
+		if n.Action == "render" || n.Action == "decrypt" {
 			continue
 		}
 
@@ -723,7 +723,7 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 				Source:         source,
 				Target:         target,
 				Project:        n.Project,
-				Operation:      n.Operation,
+				Operation:      n.Action,
 				SourceChecksum: n.SourceChecksum,
 				TargetChecksum: n.TargetChecksum,
 			}
@@ -754,7 +754,7 @@ func addCopiedFilesFromGraph(report *reconcile.Report, g *execution.Graph, check
 				Source:    source,
 				Target:    target,
 				Project:   n.Project,
-				Operation: n.Operation,
+				Operation: n.Action,
 			}
 			if _, err := os.Stat(target); os.IsNotExist(err) {
 				entry.State = reconcile.StateMissing

--- a/internal/writ/graph_builder.go
+++ b/internal/writ/graph_builder.go
@@ -66,7 +66,7 @@ func BuildTree(g *execution.Graph, cfg *Config) error {
 			// Single operation — single node
 			node := &execution.Node{
 				ID:        f.ID,
-				Operation: ops[0],
+				Action: ops[0],
 				Status:    execution.StatusPending,
 				Project:   f.Project,
 				Layer:     f.Layer,
@@ -87,7 +87,7 @@ func BuildTree(g *execution.Graph, cfg *Config) error {
 
 				node := &execution.Node{
 					ID:        nodeID,
-					Operation: op,
+					Action: op,
 					Status:    execution.StatusPending,
 					Project:   f.Project,
 					Layer:     f.Layer,
@@ -142,8 +142,8 @@ func ConfigureEngine(cfg *Config) (*execution.GraphExecutor, error) {
 	}
 
 	// Create registry and register all operations
-	registry := execution.NewOperationRegistry()
-	for _, op := range execution.AllOps() {
+	registry := execution.NewActionRegistry()
+	for _, op := range execution.AllActions() {
 		registry.Register(op)
 	}
 
@@ -257,7 +257,7 @@ func (b *DecommissionGraphBuilder) Build() (*execution.Graph, error) {
 		target := filepath.Join(b.view.Files.Root, relTarget)
 		node := &execution.Node{
 			ID:        relTarget,
-			Operation: op,
+			Action: op,
 			Status:    execution.StatusPending,
 			Project:   entry.Project,
 			Layer:     entry.Layer,

--- a/internal/writ/graph_test.go
+++ b/internal/writ/graph_test.go
@@ -79,7 +79,7 @@ func TestNewGraph(t *testing.T) {
 func TestNode(t *testing.T) {
 	node := &execution.Node{
 		ID:         ".bashrc",
-		Operation: "link",
+		Action: "link",
 		Status:    execution.StatusPending,
 		Project:   "all",
 	}
@@ -89,8 +89,8 @@ func TestNode(t *testing.T) {
 	if node.ID != ".bashrc" {
 		t.Errorf("expected ID '.bashrc', got %q", node.ID)
 	}
-	if node.Operation != "link" {
-		t.Errorf("expected operation 'link', got %q", node.Operation)
+	if node.Action != "link" {
+		t.Errorf("expected operation 'link', got %q", node.Action)
 	}
 	if node.Status != execution.StatusPending {
 		t.Errorf("expected status 'pending', got %q", node.Status)
@@ -256,7 +256,7 @@ func TestGraphSerialize(t *testing.T) {
 		Nodes: []*execution.Node{
 			{
 				ID:         ".bashrc",
-				Operation: "link",
+				Action: "link",
 				Status:     execution.StatusPending,
 			},
 		},
@@ -338,7 +338,7 @@ func TestRunGraphAlreadyExecuted(t *testing.T) {
 	}
 
 	// Create a minimal executor for the test
-	reg := execution.NewOperationRegistry()
+	reg := execution.NewActionRegistry()
 	executor := execution.NewGraphExecutor(reg, execution.ExecutorOptions{DryRun: true})
 
 	err := executor.Run(context.Background(), g)
@@ -353,14 +353,14 @@ func TestRunGraphAlreadyExecuted(t *testing.T) {
 func TestComputeSummary(t *testing.T) {
 	g := &execution.Graph{
 		Nodes: []*execution.Node{
-			{ID: "1", Operation: "link", Status: execution.StatusCompleted},
-			{ID: "2", Operation: "link", Status: execution.StatusCompleted},
-			{ID: "3", Operation: "render", Status: execution.StatusCompleted},
-			{ID: "4", Operation: "decrypt", Status: execution.StatusCompleted},
-			{ID: "5", Operation: "copy", Status: execution.StatusCompleted},
+			{ID: "1", Action: "link", Status: execution.StatusCompleted},
+			{ID: "2", Action: "link", Status: execution.StatusCompleted},
+			{ID: "3", Action: "render", Status: execution.StatusCompleted},
+			{ID: "4", Action: "decrypt", Status: execution.StatusCompleted},
+			{ID: "5", Action: "copy", Status: execution.StatusCompleted},
 			{ID: "6", Status: execution.StatusSkipped},
-			{ID: "7", Operation: "link", Status: execution.StatusFailed},
-			{ID: "8", Operation: "link", Status: execution.StatusCompleted, Annotations: map[string]string{"backup": "/path/to/backup"}},
+			{ID: "7", Action: "link", Status: execution.StatusFailed},
+			{ID: "8", Action: "link", Status: execution.StatusCompleted, Annotations: map[string]string{"backup": "/path/to/backup"}},
 		},
 	}
 

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -34,7 +34,7 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 	// Find rename nodes in the graph
 	var renameNodes []*execution.Node
 	for _, node := range graph.Nodes {
-		if node.Operation == "move" {
+		if node.Action == "move" {
 			renameNodes = append(renameNodes, node)
 		}
 	}
@@ -95,7 +95,7 @@ func Execute(graph *execution.Graph, analysis *MigrationAnalysis) error {
 func WriteMigratedMarker(sourceRoot string, graph *execution.Graph, analysis *MigrationAnalysis) error {
 	var renames []Rename
 	for _, node := range graph.Nodes {
-		if node.Operation == "move" {
+		if node.Action == "move" {
 			source, _ := node.GetSlot("source").(string)
 			target, _ := node.GetSlot("path").(string)
 			renames = append(renames, Rename{From: source, To: target})

--- a/internal/writ/migrate/format.go
+++ b/internal/writ/migrate/format.go
@@ -90,7 +90,7 @@ func buildMigrationView(graph *execution.Graph, analysis *MigrationAnalysis) *mi
 		target, _ := node.GetSlot("path").(string)
 		nodes = append(nodes, nodeView{
 			ID:        node.ID,
-			Operation: node.Operation,
+			Operation: node.Action,
 			Source:    source,
 			Target:    target,
 			Status:    string(node.Status),
@@ -292,7 +292,7 @@ func formatRecommendations(w io.Writer, recommendations []string) {
 func filterNodesByOp(graph *execution.Graph, opName string) []*execution.Node {
 	var nodes []*execution.Node
 	for _, node := range graph.Nodes {
-		if node.Operation == opName {
+		if node.Action == opName {
 			nodes = append(nodes, node)
 		}
 	}

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -343,7 +343,7 @@ func (s *Session) formatGraphForPrompt() string {
 	var sb strings.Builder
 	sb.WriteString("Planned renames:\n")
 	for _, node := range s.graph.Nodes {
-		if node.Operation == "move" {
+		if node.Action == "move" {
 			// Show relative paths for readability
 			src, _ := node.GetSlot("source").(string)
 			tgt, _ := node.GetSlot("path").(string)
@@ -479,7 +479,7 @@ func (s *Session) processPlanResponse(input string) error {
 // executeStep runs the execution graph.
 func (s *Session) executeStep() *console.Step {
 	// Execute the graph
-	reg := execution.NewOperationRegistry()
+	reg := execution.NewActionRegistry()
 	opts := execution.ExecutorOptions{DryRun: false}
 	eng := execution.NewGraphExecutor(reg, opts)
 


### PR DESCRIPTION
## Summary

- Rename `Operation` interface to `Action` with `Do(ctx, node) (Result, UndoState, error)` and `Undo(ctx, node, state) error` methods across 40 files
- Rename `OperationRegistry` → `ActionRegistry`, `AllOps()` → `AllActions()`, `Node.Operation` → `Node.Action`, `Result` → `NodeResult`
- Add `Result` and `UndoState` type aliases for saga rollback support
- Delete `ValidateOp` (20 actions, down from 21)
- Add Phase 1 plan document at `docs/plans/resource-provider/phase-1.md`

This is Phase 1 of the [resource-provider plan](docs/plans/resource-provider.md). Mechanical rename only — no structural changes, no new packages.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (27 packages, 0 failures)
- [x] Zero remaining `Operation` references in `internal/execution/`
- [x] Domain-specific `Operation` fields preserved (`reconcile.Entry`, `NativePMAction`, `nodeView`, `writ/tree`)