### PR TITLE
feat(file): implement compensation for file provider (Phase 1)

### DIFF
--- a/docs/plans/compensation/phase-1.md
+++ b/docs/plans/compensation/phase-1.md
@@ -1,0 +1,85 @@
+---
+title: "Compensation Phase 1: File Provider"
+parent: compensation.md
+status: in-progress
+created: 2026-02-16
+updated: 2026-02-16
+---
+
+# Phase 1: File Provider (Reference Implementation)
+
+## Summary
+
+Add real compensation to the file provider — the largest provider (9 actions, 7
+compensable). Establishes the pattern for all subsequent providers.
+
+## Changes
+
+### provider.go — Forward Method Signature Changes
+
+7 compensable Forward methods gain a `map[string]any` state return:
+
+| Method | Current Return | New Return |
+|---|---|---|
+| `Link` | `error` | `(map[string]any, error)` |
+| `Copy` | `(string, error)` | `(string, map[string]any, error)` |
+| `Backup` | `(string, error)` | `(string, map[string]any, error)` |
+| `Unlink` | `error` | `(map[string]any, error)` |
+| `Remove` | `error` | `(map[string]any, error)` |
+| `Write` | `error` | `(map[string]any, error)` |
+| `Move` | `error` | `(map[string]any, error)` |
+
+Non-compensable methods (`Source`, `Mkdir`) unchanged.
+
+### provider.go — Backward Methods Added
+
+7 new `Compensate*` methods on `*Provider`:
+
+| Method | Compensation Logic |
+|---|---|
+| `CompensateLink` | Remove symlink if new; restore previous target if overwritten |
+| `CompensateCopy` | Remove file if new; restore previous content if overwritten |
+| `CompensateBackup` | Move backup file back to original path |
+| `CompensateUnlink` | Re-create symlink with saved target |
+| `CompensateRemove` | Re-create file with saved content and mode |
+| `CompensateWrite` | Remove file if new; restore previous content if overwritten |
+| `CompensateMove` | Move file back from destination to source |
+
+### provider.go — State Captured Per Method
+
+| Forward | State Keys |
+|---|---|
+| `Link` | `path`, `existed_before`, `previous_target?` |
+| `Copy` | `path`, `existed_before`, `previous_content?`, `previous_mode?` |
+| `Backup` | `original_path`, `backup_path` |
+| `Unlink` | `path`, `target` |
+| `Remove` | `path`, `content`, `mode` |
+| `Write` | `path`, `existed_before`, `previous_content?`, `previous_mode?` |
+| `Move` | `source`, `path` |
+
+### actions_gen.go — Do/Undo Wiring
+
+7 compensable actions updated:
+- `Do`: captures state from Forward's `map[string]any` return → UndoState
+- `Undo`: casts UndoState → `map[string]any`, delegates to `Impl.Compensate*(state)`
+
+2 non-compensable actions (`Source`, `Mkdir`) unchanged.
+
+### provider_test.go — Round-Trip Tests
+
+Per compensable method:
+1. Forward creates/modifies — verify state captured
+2. Backward restores — verify previous state restored
+
+Additional tests:
+- Forward on non-existent target: Backward removes created file
+- Forward on existing target: Backward restores original content
+- Nil state: Backward is no-op
+
+## Files
+
+| File | Action |
+|---|---|
+| `internal/execution/provider/file/provider.go` | Modify |
+| `internal/execution/provider/file/actions_gen.go` | Modify |
+| `internal/execution/provider/file/provider_test.go` | Create |

--- a/internal/execution/provider/file/actions_gen.go
+++ b/internal/execution/provider/file/actions_gen.go
@@ -23,11 +23,16 @@ func (o *Link) Do(ctx *execution.Context, slots map[string]any) (execution.Resul
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] link %v %v\n", source, path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Link(source, path)
+	state, err := o.Impl.Link(source, path)
+	return nil, state, err
 }
 
-func (o *Link) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Link) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateLink(s)
 }
 
 // Copy writes content to "path" slot (consumer: reads content from slot, checksums).
@@ -58,16 +63,20 @@ func (o *Copy) Do(ctx *execution.Context, slots map[string]any) (execution.Resul
 		ctx.TargetChecksum = checksumBytes(content)
 		return nil, nil, nil
 	}
-	checksum, err := o.Impl.Copy(path, mode, content)
+	checksum, state, err := o.Impl.Copy(path, mode, content)
 	if err != nil {
 		return nil, nil, err
 	}
 	ctx.TargetChecksum = checksum
-	return nil, nil, nil
+	return nil, state, nil
 }
 
-func (o *Copy) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Copy) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateCopy(s)
 }
 
 // Backup moves the existing file at "path" slot to a timestamped backup.
@@ -84,15 +93,19 @@ func (o *Backup) Do(ctx *execution.Context, slots map[string]any) (execution.Res
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] backup %v\n", path)
 		return nil, nil, nil
 	}
-	backupPath, err := o.Impl.Backup(path, backupSuffix)
+	backupPath, state, err := o.Impl.Backup(path, backupSuffix)
 	if err != nil {
 		return nil, nil, err
 	}
-	return backupPath, nil, nil
+	return backupPath, state, nil
 }
 
-func (o *Backup) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Backup) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateBackup(s)
 }
 
 // Unlink removes a symlink at "path" slot.
@@ -109,11 +122,16 @@ func (o *Unlink) Do(ctx *execution.Context, slots map[string]any) (execution.Res
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] unlink %v\n", path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Unlink(path, prune, pruneBoundary)
+	state, err := o.Impl.Unlink(path, prune, pruneBoundary)
+	return nil, state, err
 }
 
-func (o *Unlink) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Unlink) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateUnlink(s)
 }
 
 // Remove deletes the file at "path" slot.
@@ -130,11 +148,16 @@ func (o *Remove) Do(ctx *execution.Context, slots map[string]any) (execution.Res
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] remove %v\n", path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Remove(path, prune, pruneBoundary)
+	state, err := o.Impl.Remove(path, prune, pruneBoundary)
+	return nil, state, err
 }
 
-func (o *Remove) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Remove) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateRemove(s)
 }
 
 // Write writes content from "content" slot to "path" slot.
@@ -151,11 +174,16 @@ func (o *Write) Do(ctx *execution.Context, slots map[string]any) (execution.Resu
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] write %v\n", path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Write(content, path, mode)
+	state, err := o.Impl.Write(content, path, mode)
+	return nil, state, err
 }
 
-func (o *Write) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Write) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateWrite(s)
 }
 
 // Move moves a file from "source" slot to "path" slot.
@@ -172,11 +200,16 @@ func (o *Move) Do(ctx *execution.Context, slots map[string]any) (execution.Resul
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] move %v %v\n", source, path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Move(gitMv, source, path)
+	state, err := o.Impl.Move(gitMv, source, path)
+	return nil, state, err
 }
 
-func (o *Move) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Move) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateMove(s)
 }
 
 // Mkdir creates a directory at "path" slot.

--- a/internal/execution/provider/file/provider.go
+++ b/internal/execution/provider/file/provider.go
@@ -12,43 +12,105 @@ import (
 
 // Provider provides file system operations. Each method receives all
 // inputs as parameters — no execution context, no node access.
+//
+// Compensable Forward methods return (result, map[string]any, error).
+// The map is the compensation receipt — opaque to the executor,
+// meaningful only to the corresponding Compensate* Backward method.
 type Provider struct{}
 
 // Link creates a symlink at path pointing to source. Idempotent: if the
-// symlink already points correctly, it's a no-op.
-func (p *Provider) Link(source, path string) error {
-	// Idempotent: check if symlink already points correctly
+// symlink already points correctly, it's a no-op (returns nil state).
+func (p *Provider) Link(source, path string) (map[string]any, error) {
+	var state map[string]any
+
 	if info, err := os.Lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
-			existing, err := os.Readlink(path)
-			if err == nil && existing == source {
-				return nil // Already correct
+			existing, readErr := os.Readlink(path)
+			if readErr == nil && existing == source {
+				return nil, nil // Already correct — no change
+			}
+			state = map[string]any{
+				"path":           path,
+				"existed_before": true,
+			}
+			if readErr == nil {
+				state["previous_target"] = existing
+			}
+		} else {
+			state = map[string]any{
+				"path":           path,
+				"existed_before": true,
 			}
 		}
 		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("remove existing: %w", err)
+			return nil, fmt.Errorf("remove existing: %w", err)
+		}
+	} else {
+		state = map[string]any{
+			"path":           path,
+			"existed_before": false,
 		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("create parent dirs: %w", err)
+		return nil, fmt.Errorf("create parent dirs: %w", err)
 	}
 
-	return os.Symlink(source, path)
+	if err := os.Symlink(source, path); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// CompensateLink undoes a Link operation using the captured state.
+func (p *Provider) CompensateLink(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	existed, _ := state["existed_before"].(bool)
+	if !existed {
+		return os.Remove(path)
+	}
+	prevTarget, ok := state["previous_target"].(string)
+	if !ok || prevTarget == "" {
+		// Was a non-symlink — can't restore, just remove the new symlink
+		return os.Remove(path)
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return os.Symlink(prevTarget, path)
 }
 
 // Copy writes content to path with the given mode. Returns the SHA256
-// checksum of the written content.
-func (p *Provider) Copy(path string, mode os.FileMode, content []byte) (string, error) {
-	// Remove existing file/symlink if present
-	if _, err := os.Lstat(path); err == nil {
+// checksum of the written content and compensation state.
+func (p *Provider) Copy(path string, mode os.FileMode, content []byte) (string, map[string]any, error) {
+	var state map[string]any
+
+	if info, err := os.Lstat(path); err == nil {
+		state = map[string]any{
+			"path":           path,
+			"existed_before": true,
+		}
+		if info.Mode().IsRegular() {
+			if prev, readErr := os.ReadFile(path); readErr == nil {
+				state["previous_content"] = prev
+				state["previous_mode"] = info.Mode().Perm()
+			}
+		}
 		if err := os.Remove(path); err != nil {
-			return "", fmt.Errorf("remove existing: %w", err)
+			return "", nil, fmt.Errorf("remove existing: %w", err)
+		}
+	} else {
+		state = map[string]any{
+			"path":           path,
+			"existed_before": false,
 		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return "", fmt.Errorf("create parent dirs: %w", err)
+		return "", nil, fmt.Errorf("create parent dirs: %w", err)
 	}
 
 	if mode == 0 {
@@ -56,15 +118,36 @@ func (p *Provider) Copy(path string, mode os.FileMode, content []byte) (string, 
 	}
 
 	if err := os.WriteFile(path, content, mode); err != nil {
-		return "", err
+		return "", nil, err
 	}
 
-	return checksumBytes(content), nil
+	return checksumBytes(content), state, nil
+}
+
+// CompensateCopy undoes a Copy operation using the captured state.
+func (p *Provider) CompensateCopy(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	existed, _ := state["existed_before"].(bool)
+	if !existed {
+		return os.Remove(path)
+	}
+	prev, ok := state["previous_content"].([]byte)
+	if !ok {
+		return nil // Can't restore without content
+	}
+	prevMode, _ := state["previous_mode"].(os.FileMode)
+	if prevMode == 0 {
+		prevMode = 0644
+	}
+	return os.WriteFile(path, prev, prevMode)
 }
 
 // Backup moves the file at path to a timestamped backup location.
-// Returns the backup path.
-func (p *Provider) Backup(path, backupSuffix string) (string, error) {
+// Returns the backup path and compensation state.
+func (p *Provider) Backup(path, backupSuffix string) (string, map[string]any, error) {
 	if backupSuffix == "" {
 		backupSuffix = ".writ-backup"
 	}
@@ -73,85 +156,223 @@ func (p *Provider) Backup(path, backupSuffix string) (string, error) {
 	backupPath := path + backupSuffix + "." + timestamp
 
 	if err := os.Rename(path, backupPath); err != nil {
-		return "", fmt.Errorf("backup %s → %s: %w", path, backupPath, err)
+		return "", nil, fmt.Errorf("backup %s → %s: %w", path, backupPath, err)
 	}
 
-	return backupPath, nil
+	state := map[string]any{
+		"original_path": path,
+		"backup_path":   backupPath,
+	}
+	return backupPath, state, nil
+}
+
+// CompensateBackup undoes a Backup by moving the backup back to the
+// original path.
+func (p *Provider) CompensateBackup(state map[string]any) error {
+	originalPath, _ := state["original_path"].(string)
+	backupPath, _ := state["backup_path"].(string)
+	if originalPath == "" || backupPath == "" {
+		return nil
+	}
+	return os.Rename(backupPath, originalPath)
 }
 
 // Unlink removes a symlink at path. If prune is true and pruneBoundary
 // is set, empty parent directories are removed up to the boundary.
-func (p *Provider) Unlink(path string, prune bool, pruneBoundary string) error {
+// Returns compensation state with the symlink target for re-creation.
+func (p *Provider) Unlink(path string, prune bool, pruneBoundary string) (map[string]any, error) {
 	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
-		return nil // Already gone
+		return nil, nil // Already gone — no change
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if info.Mode()&os.ModeSymlink == 0 {
-		return fmt.Errorf("%s is not a symlink", path)
+		return nil, fmt.Errorf("%s is not a symlink", path)
 	}
 
+	target, _ := os.Readlink(path)
+
 	if err := os.Remove(path); err != nil {
-		return err
+		return nil, err
 	}
 
 	pruneParents(path, prune, pruneBoundary)
-	return nil
+
+	state := map[string]any{
+		"path":   path,
+		"target": target,
+	}
+	return state, nil
+}
+
+// CompensateUnlink undoes an Unlink by re-creating the symlink.
+func (p *Provider) CompensateUnlink(state map[string]any) error {
+	path, _ := state["path"].(string)
+	target, _ := state["target"].(string)
+	if path == "" || target == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.Symlink(target, path)
 }
 
 // Remove deletes the file at path. If prune is true and pruneBoundary
 // is set, empty parent directories are removed up to the boundary.
-func (p *Provider) Remove(path string, prune bool, pruneBoundary string) error {
-	if _, err := os.Lstat(path); os.IsNotExist(err) {
-		return nil // Already gone
+// Returns compensation state with file content for re-creation.
+func (p *Provider) Remove(path string, prune bool, pruneBoundary string) (map[string]any, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, nil // Already gone — no change
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	state := map[string]any{"path": path}
+	if info.Mode().IsRegular() {
+		if content, readErr := os.ReadFile(path); readErr == nil {
+			state["content"] = content
+			state["mode"] = info.Mode().Perm()
+		}
 	}
 
 	if err := os.Remove(path); err != nil {
-		return err
+		return nil, err
 	}
 
 	pruneParents(path, prune, pruneBoundary)
-	return nil
+	return state, nil
+}
+
+// CompensateRemove undoes a Remove by re-creating the file with saved
+// content and mode.
+func (p *Provider) CompensateRemove(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	content, ok := state["content"].([]byte)
+	if !ok {
+		return nil // Can't restore without content
+	}
+	mode, _ := state["mode"].(os.FileMode)
+	if mode == 0 {
+		mode = 0644
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, mode)
 }
 
 // Write writes inline content to path with the given mode.
-func (p *Provider) Write(content, path string, mode os.FileMode) error {
+// Returns compensation state for undo.
+func (p *Provider) Write(content, path string, mode os.FileMode) (map[string]any, error) {
 	if content == "" {
-		return fmt.Errorf("write: no content specified")
+		return nil, fmt.Errorf("write: no content specified")
+	}
+
+	var state map[string]any
+	if info, err := os.Lstat(path); err == nil {
+		state = map[string]any{
+			"path":           path,
+			"existed_before": true,
+		}
+		if info.Mode().IsRegular() {
+			if prev, readErr := os.ReadFile(path); readErr == nil {
+				state["previous_content"] = prev
+				state["previous_mode"] = info.Mode().Perm()
+			}
+		}
+	} else {
+		state = map[string]any{
+			"path":           path,
+			"existed_before": false,
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("create parent dirs: %w", err)
+		return nil, fmt.Errorf("create parent dirs: %w", err)
 	}
 
 	if mode == 0 {
 		mode = 0644
 	}
 
-	return os.WriteFile(path, []byte(content), mode)
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// CompensateWrite undoes a Write operation using the captured state.
+func (p *Provider) CompensateWrite(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	existed, _ := state["existed_before"].(bool)
+	if !existed {
+		return os.Remove(path)
+	}
+	prev, ok := state["previous_content"].([]byte)
+	if !ok {
+		return nil // Can't restore without content
+	}
+	prevMode, _ := state["previous_mode"].(os.FileMode)
+	if prevMode == 0 {
+		prevMode = 0644
+	}
+	return os.WriteFile(path, prev, prevMode)
 }
 
 // Move moves a file from source to path. Uses gitMv if provided
 // (preserves git history), falling back to os.Rename.
-func (p *Provider) Move(gitMv func(src, dst string) error, source, path string) error {
+// Returns compensation state with paths for reverse move.
+func (p *Provider) Move(gitMv func(src, dst string) error, source, path string) (map[string]any, error) {
 	if _, err := os.Stat(source); err != nil {
-		return fmt.Errorf("source does not exist: %w", err)
+		return nil, fmt.Errorf("source does not exist: %w", err)
 	}
 
 	if gitMv != nil {
 		if err := gitMv(source, path); err == nil {
-			return nil
+			return map[string]any{
+				"source": source,
+				"path":   path,
+			}, nil
 		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("create parent dirs: %w", err)
+		return nil, fmt.Errorf("create parent dirs: %w", err)
 	}
 
-	return os.Rename(source, path)
+	if err := os.Rename(source, path); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"source": source,
+		"path":   path,
+	}, nil
+}
+
+// CompensateMove undoes a Move by moving the file back from path to
+// source.
+func (p *Provider) CompensateMove(state map[string]any) error {
+	source, _ := state["source"].(string)
+	path, _ := state["path"].(string)
+	if source == "" || path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(source), 0755); err != nil {
+		return err
+	}
+	return os.Rename(path, source)
 }
 
 // Source reads a file and returns its contents.

--- a/internal/execution/provider/file/provider_test.go
+++ b/internal/execution/provider/file/provider_test.go
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package file
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- Link ---
+
+func TestLinkNewSymlink(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	if err := os.WriteFile(source, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+
+	p := &Provider{}
+	state, err := p.Link(source, link)
+	if err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state for new symlink")
+	}
+
+	// Verify symlink created
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if target != source {
+		t.Errorf("target = %q, want %q", target, source)
+	}
+
+	// Compensate: should remove the new symlink
+	if err := p.CompensateLink(state); err != nil {
+		t.Fatalf("CompensateLink: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Error("symlink should be removed after compensation")
+	}
+}
+
+func TestLinkReplaceExistingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	oldTarget := filepath.Join(dir, "old.txt")
+	newTarget := filepath.Join(dir, "new.txt")
+	link := filepath.Join(dir, "link")
+
+	os.WriteFile(oldTarget, []byte("old"), 0644)
+	os.WriteFile(newTarget, []byte("new"), 0644)
+	os.Symlink(oldTarget, link)
+
+	p := &Provider{}
+	state, err := p.Link(newTarget, link)
+	if err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+
+	// Verify new symlink
+	target, _ := os.Readlink(link)
+	if target != newTarget {
+		t.Errorf("target = %q, want %q", target, newTarget)
+	}
+
+	// Compensate: should restore old symlink target
+	if err := p.CompensateLink(state); err != nil {
+		t.Fatalf("CompensateLink: %v", err)
+	}
+	target, _ = os.Readlink(link)
+	if target != oldTarget {
+		t.Errorf("restored target = %q, want %q", target, oldTarget)
+	}
+}
+
+func TestLinkIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	link := filepath.Join(dir, "link")
+
+	os.WriteFile(source, []byte("content"), 0644)
+	os.Symlink(source, link)
+
+	p := &Provider{}
+	state, err := p.Link(source, link)
+	if err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil state for idempotent no-op")
+	}
+}
+
+// --- Copy ---
+
+func TestCopyNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	content := []byte("hello world")
+
+	p := &Provider{}
+	checksum, state, err := p.Copy(path, 0644, content)
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if checksum == "" {
+		t.Error("expected non-empty checksum")
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	written, _ := os.ReadFile(path)
+	if !bytes.Equal(written, content) {
+		t.Error("file content mismatch")
+	}
+
+	// Compensate: should remove the new file
+	if err := p.CompensateCopy(state); err != nil {
+		t.Fatalf("CompensateCopy: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be removed after compensation")
+	}
+}
+
+func TestCopyOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	original := []byte("original content")
+	replacement := []byte("replacement content")
+
+	os.WriteFile(path, original, 0644)
+
+	p := &Provider{}
+	_, state, err := p.Copy(path, 0644, replacement)
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+
+	written, _ := os.ReadFile(path)
+	if !bytes.Equal(written, replacement) {
+		t.Error("file should contain replacement content")
+	}
+
+	// Compensate: should restore original content
+	if err := p.CompensateCopy(state); err != nil {
+		t.Fatalf("CompensateCopy: %v", err)
+	}
+	restored, _ := os.ReadFile(path)
+	if !bytes.Equal(restored, original) {
+		t.Errorf("restored content = %q, want %q", restored, original)
+	}
+}
+
+// --- Backup ---
+
+func TestBackupRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	content := []byte("important data")
+	os.WriteFile(path, content, 0644)
+
+	p := &Provider{}
+	backupPath, state, err := p.Backup(path, "")
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if backupPath == "" {
+		t.Error("expected non-empty backup path")
+	}
+
+	// Original should be gone, backup should exist
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("original file should be moved")
+	}
+	backupContent, _ := os.ReadFile(backupPath)
+	if !bytes.Equal(backupContent, content) {
+		t.Error("backup content mismatch")
+	}
+
+	// Compensate: should move backup back to original
+	if err := p.CompensateBackup(state); err != nil {
+		t.Fatalf("CompensateBackup: %v", err)
+	}
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Error("backup file should be gone after compensation")
+	}
+	restored, _ := os.ReadFile(path)
+	if !bytes.Equal(restored, content) {
+		t.Errorf("restored content mismatch")
+	}
+}
+
+// --- Unlink ---
+
+func TestUnlinkRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	link := filepath.Join(dir, "link")
+
+	os.WriteFile(source, []byte("content"), 0644)
+	os.Symlink(source, link)
+
+	p := &Provider{}
+	state, err := p.Unlink(link, false, "")
+	if err != nil {
+		t.Fatalf("Unlink: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	// Symlink should be gone
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Error("symlink should be removed")
+	}
+
+	// Compensate: should re-create the symlink
+	if err := p.CompensateUnlink(state); err != nil {
+		t.Fatalf("CompensateUnlink: %v", err)
+	}
+	target, _ := os.Readlink(link)
+	if target != source {
+		t.Errorf("restored target = %q, want %q", target, source)
+	}
+}
+
+func TestUnlinkAlreadyGone(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent")
+
+	p := &Provider{}
+	state, err := p.Unlink(path, false, "")
+	if err != nil {
+		t.Fatalf("Unlink: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil state for already-gone symlink")
+	}
+}
+
+// --- Remove ---
+
+func TestRemoveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	content := []byte("precious data")
+	os.WriteFile(path, content, 0600)
+
+	p := &Provider{}
+	state, err := p.Remove(path, false, "")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	// File should be gone
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be removed")
+	}
+
+	// Compensate: should re-create the file
+	if err := p.CompensateRemove(state); err != nil {
+		t.Fatalf("CompensateRemove: %v", err)
+	}
+	restored, _ := os.ReadFile(path)
+	if !bytes.Equal(restored, content) {
+		t.Error("restored content mismatch")
+	}
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("restored mode = %v, want %v", info.Mode().Perm(), os.FileMode(0600))
+	}
+}
+
+func TestRemoveAlreadyGone(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent")
+
+	p := &Provider{}
+	state, err := p.Remove(path, false, "")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil state for already-gone file")
+	}
+}
+
+// --- Write ---
+
+func TestWriteNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+
+	p := &Provider{}
+	state, err := p.Write("hello world", path, 0644)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	written, _ := os.ReadFile(path)
+	if string(written) != "hello world" {
+		t.Errorf("written = %q, want %q", written, "hello world")
+	}
+
+	// Compensate: should remove the new file
+	if err := p.CompensateWrite(state); err != nil {
+		t.Fatalf("CompensateWrite: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be removed after compensation")
+	}
+}
+
+func TestWriteOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	os.WriteFile(path, []byte("original"), 0644)
+
+	p := &Provider{}
+	state, err := p.Write("replacement", path, 0644)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	written, _ := os.ReadFile(path)
+	if string(written) != "replacement" {
+		t.Errorf("written = %q, want %q", written, "replacement")
+	}
+
+	// Compensate: should restore original content
+	if err := p.CompensateWrite(state); err != nil {
+		t.Fatalf("CompensateWrite: %v", err)
+	}
+	restored, _ := os.ReadFile(path)
+	if string(restored) != "original" {
+		t.Errorf("restored = %q, want %q", restored, "original")
+	}
+}
+
+// --- Move ---
+
+func TestMoveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	dest := filepath.Join(dir, "dest.txt")
+	content := []byte("movable data")
+	os.WriteFile(source, content, 0644)
+
+	p := &Provider{}
+	state, err := p.Move(nil, source, dest)
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	// Source should be gone, dest should exist
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Error("source should be gone after move")
+	}
+	moved, _ := os.ReadFile(dest)
+	if !bytes.Equal(moved, content) {
+		t.Error("moved content mismatch")
+	}
+
+	// Compensate: should move back from dest to source
+	if err := p.CompensateMove(state); err != nil {
+		t.Fatalf("CompensateMove: %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Error("dest should be gone after compensation")
+	}
+	restored, _ := os.ReadFile(source)
+	if !bytes.Equal(restored, content) {
+		t.Error("restored content mismatch")
+	}
+}
+
+// --- Nil state safety ---
+
+func TestCompensateNilState(t *testing.T) {
+	p := &Provider{}
+
+	// All Compensate methods must handle nil gracefully
+	if err := p.CompensateLink(nil); err != nil {
+		t.Errorf("CompensateLink(nil): %v", err)
+	}
+	if err := p.CompensateCopy(nil); err != nil {
+		t.Errorf("CompensateCopy(nil): %v", err)
+	}
+	if err := p.CompensateBackup(nil); err != nil {
+		t.Errorf("CompensateBackup(nil): %v", err)
+	}
+	if err := p.CompensateUnlink(nil); err != nil {
+		t.Errorf("CompensateUnlink(nil): %v", err)
+	}
+	if err := p.CompensateRemove(nil); err != nil {
+		t.Errorf("CompensateRemove(nil): %v", err)
+	}
+	if err := p.CompensateWrite(nil); err != nil {
+		t.Errorf("CompensateWrite(nil): %v", err)
+	}
+	if err := p.CompensateMove(nil); err != nil {
+		t.Errorf("CompensateMove(nil): %v", err)
+	}
+}
+
+// --- Non-compensable methods (unchanged) ---
+
+func TestSourceUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	content := []byte("read me")
+	os.WriteFile(path, content, 0644)
+
+	p := &Provider{}
+	result, err := p.Source(path)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	if !bytes.Equal(result, content) {
+		t.Error("Source content mismatch")
+	}
+}
+
+func TestMkdirUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "nested")
+
+	p := &Provider{}
+	if err := p.Mkdir(path, 0755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory")
+	}
+}


### PR DESCRIPTION
## Summary
- Add state capture to 7 compensable Forward methods on `file.Provider` (Link, Copy, Backup, Unlink, Remove, Write, Move)
- Add 7 `Compensate*` Backward methods for undo logic
- Wire action `Do` to capture state as `UndoState`, `Undo` to delegate to `Compensate*`
- Non-compensable actions (Source, Mkdir) unchanged
- 16 round-trip tests verify Forward+Backward per Activity pair

## Test plan
- [x] All 16 new provider tests pass (`go test ./internal/execution/provider/file/`)
- [x] All existing execution tests pass (`go test ./internal/execution/`)
- [x] Full repo builds clean (`go build ./...`)
- [x] No legacy/backward/compat/deprecated patterns