### PR TITLE
feat(pkg): add compensation to package provider (Phase 3)

### DIFF
--- a/docs/plans/compensation/phase-3.md
+++ b/docs/plans/compensation/phase-3.md
@@ -1,0 +1,60 @@
+---
+title: "Compensation Phase 3: Package Provider"
+parent: compensation.md
+status: in-progress
+created: 2026-02-16
+updated: 2026-02-16
+---
+
+# Phase 3: Package Provider
+
+## Summary
+
+Add real compensation to the package provider. 3 compensable actions
+(Install, Upgrade, Remove) out of 4 total. Update is non-compensable
+(idempotent index refresh).
+
+## Changes
+
+### provider.go — Forward Method Signature Changes
+
+| Method | Current Return | New Return |
+|---|---|---|
+| `Install` | `error` | `(map[string]any, error)` |
+| `Upgrade` | `error` | `(map[string]any, error)` |
+| `Remove` | `error` | `(map[string]any, error)` |
+
+`Update` unchanged (non-compensable).
+
+### provider.go — Backward Methods Added
+
+| Method | Compensation Logic |
+|---|---|
+| `CompensateInstall` | Remove packages that weren't already installed |
+| `CompensateUpgrade` | No-op — captures previous versions for diagnostics but automatic downgrade is not reliable across package managers |
+| `CompensateRemove` | Reinstall the removed packages |
+
+### provider.go — State Captured Per Method
+
+| Forward | State Keys |
+|---|---|
+| `Install` | `packages`, `manager`, `cask`, `already_installed` |
+| `Upgrade` | `packages`, `manager`, `cask`, `previous_versions` |
+| `Remove` | `packages`, `manager`, `cask` |
+
+### Pre-Action State Queries
+
+Uses `host.PackageManager.Installed()` and `Version()` to query state
+before acting. Test hooks on Provider for mock-based testing.
+
+### actions_gen.go — Do/Undo Wiring
+
+3 compensable actions updated. Update unchanged.
+
+## Files
+
+| File | Action |
+|---|---|
+| `internal/execution/provider/pkg/provider.go` | Modify |
+| `internal/execution/provider/pkg/actions_gen.go` | Modify |
+| `internal/execution/provider/pkg/provider_test.go` | Create |

--- a/internal/execution/provider/pkg/actions_gen.go
+++ b/internal/execution/provider/pkg/actions_gen.go
@@ -24,11 +24,16 @@ func (o *Install) Do(ctx *execution.Context, slots map[string]any) (execution.Re
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-install %v\n", strings.Join(packages, " "))
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Install(packages, manager, cask)
+	state, err := o.Impl.Install(packages, manager, cask)
+	return nil, state, err
 }
 
-func (o *Install) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Install) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateInstall(s)
 }
 
 // Upgrade upgrades packages using the platform's package manager.
@@ -45,11 +50,16 @@ func (o *Upgrade) Do(ctx *execution.Context, slots map[string]any) (execution.Re
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-upgrade %v\n", strings.Join(packages, " "))
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Upgrade(packages, manager, cask)
+	state, err := o.Impl.Upgrade(packages, manager, cask)
+	return nil, state, err
 }
 
-func (o *Upgrade) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Upgrade) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateUpgrade(s)
 }
 
 // Remove removes packages using the platform's package manager.
@@ -66,11 +76,16 @@ func (o *Remove) Do(ctx *execution.Context, slots map[string]any) (execution.Res
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] package-remove %v\n", strings.Join(packages, " "))
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Remove(packages, manager, cask)
+	state, err := o.Impl.Remove(packages, manager, cask)
+	return nil, state, err
 }
 
-func (o *Remove) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Remove) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateRemove(s)
 }
 
 // Update refreshes the package manager index.

--- a/internal/execution/provider/pkg/provider.go
+++ b/internal/execution/provider/pkg/provider.go
@@ -7,12 +7,177 @@ import "fmt"
 
 // Provider provides platform-independent package management.
 // The package manager is resolved at runtime via host.PackageManager().
-type Provider struct{}
+//
+// Compensable Forward methods return (map[string]any, error).
+// The map is the compensation receipt — opaque to the executor,
+// meaningful only to the corresponding Compensate* Backward method.
+type Provider struct {
+	// Test hooks. Nil means use real host implementation.
+	isInstalledFn func(pkg, manager string) bool
+	getVersionFn  func(pkg, manager string) string
+	installFn     func(packages []string, manager string, cask bool) error
+	upgradeFn     func(packages []string, manager string, cask bool) error
+	removeFn      func(packages []string, manager string, cask bool) error
+}
 
 // Install installs packages using the platform's package manager.
-func (p *Provider) Install(packages []string, manager string, cask bool) error {
+// Returns compensation state with pre-install status per package.
+func (p *Provider) Install(packages []string, manager string, cask bool) (map[string]any, error) {
 	if len(packages) == 0 {
-		return fmt.Errorf("no packages specified")
+		return nil, fmt.Errorf("no packages specified")
+	}
+
+	// Query which packages are already installed before acting
+	var alreadyInstalled []string
+	for _, pkg := range packages {
+		if p.isInstalled(pkg, manager) {
+			alreadyInstalled = append(alreadyInstalled, pkg)
+		}
+	}
+
+	if err := p.doInstall(packages, manager, cask); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"packages":          packages,
+		"manager":           manager,
+		"cask":              cask,
+		"already_installed": alreadyInstalled,
+	}, nil
+}
+
+// CompensateInstall undoes an Install by removing packages that weren't
+// already installed before the operation.
+func (p *Provider) CompensateInstall(state map[string]any) error {
+	packages, _ := state["packages"].([]string)
+	alreadyInstalled, _ := state["already_installed"].([]string)
+	manager, _ := state["manager"].(string)
+	cask, _ := state["cask"].(bool)
+
+	installed := make(map[string]bool)
+	for _, pkg := range alreadyInstalled {
+		installed[pkg] = true
+	}
+
+	var toRemove []string
+	for _, pkg := range packages {
+		if !installed[pkg] {
+			toRemove = append(toRemove, pkg)
+		}
+	}
+
+	if len(toRemove) == 0 {
+		return nil
+	}
+	return p.doRemove(toRemove, manager, cask)
+}
+
+// Upgrade upgrades packages using the platform's package manager.
+// Returns compensation state with pre-upgrade versions per package.
+func (p *Provider) Upgrade(packages []string, manager string, cask bool) (map[string]any, error) {
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("no packages specified")
+	}
+
+	// Capture current versions before upgrading
+	previousVersions := make(map[string]string)
+	for _, pkg := range packages {
+		if v := p.getVersion(pkg, manager); v != "" {
+			previousVersions[pkg] = v
+		}
+	}
+
+	if err := p.doUpgrade(packages, manager, cask); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"packages":          packages,
+		"manager":           manager,
+		"cask":              cask,
+		"previous_versions": previousVersions,
+	}, nil
+}
+
+// CompensateUpgrade is a diagnostic no-op. Previous versions are captured
+// in state for manual recovery, but automatic downgrade is not reliable
+// across package managers.
+func (p *Provider) CompensateUpgrade(_ map[string]any) error {
+	return nil
+}
+
+// Remove removes packages using the platform's package manager.
+// Returns compensation state for reinstallation.
+func (p *Provider) Remove(packages []string, manager string, cask bool) (map[string]any, error) {
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("no packages specified")
+	}
+
+	if err := p.doRemove(packages, manager, cask); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"packages": packages,
+		"manager":  manager,
+		"cask":     cask,
+	}, nil
+}
+
+// CompensateRemove undoes a Remove by reinstalling the removed packages.
+func (p *Provider) CompensateRemove(state map[string]any) error {
+	packages, _ := state["packages"].([]string)
+	manager, _ := state["manager"].(string)
+	cask, _ := state["cask"].(bool)
+
+	if len(packages) == 0 {
+		return nil
+	}
+	return p.doInstall(packages, manager, cask)
+}
+
+// Update refreshes the package manager index.
+func (p *Provider) Update(manager string) error {
+	pm := resolvePMForInstall(manager)
+	if pm == nil {
+		return fmt.Errorf("no package manager available")
+	}
+
+	result := pm.Update()
+	if !result.OK {
+		return fmt.Errorf("%s update failed: %s", pm.Name(), result.Stderr)
+	}
+	return nil
+}
+
+// --- Internal helpers ---
+
+func (p *Provider) isInstalled(pkg, manager string) bool {
+	if p.isInstalledFn != nil {
+		return p.isInstalledFn(pkg, manager)
+	}
+	pm := resolvePMForInstall(manager)
+	if pm == nil {
+		return false
+	}
+	return pm.Installed(pkg)
+}
+
+func (p *Provider) getVersion(pkg, manager string) string {
+	if p.getVersionFn != nil {
+		return p.getVersionFn(pkg, manager)
+	}
+	pm := resolvePMForInstall(manager)
+	if pm == nil {
+		return ""
+	}
+	return pm.Version(pkg)
+}
+
+func (p *Provider) doInstall(packages []string, manager string, cask bool) error {
+	if p.installFn != nil {
+		return p.installFn(packages, manager, cask)
 	}
 
 	pm := resolvePMForInstall(manager)
@@ -35,10 +200,9 @@ func (p *Provider) Install(packages []string, manager string, cask bool) error {
 	return nil
 }
 
-// Upgrade upgrades packages using the platform's package manager.
-func (p *Provider) Upgrade(packages []string, manager string, cask bool) error {
-	if len(packages) == 0 {
-		return fmt.Errorf("no packages specified")
+func (p *Provider) doUpgrade(packages []string, manager string, cask bool) error {
+	if p.upgradeFn != nil {
+		return p.upgradeFn(packages, manager, cask)
 	}
 
 	pm := resolvePMForUpgrade(manager, packages)
@@ -61,10 +225,9 @@ func (p *Provider) Upgrade(packages []string, manager string, cask bool) error {
 	return nil
 }
 
-// Remove removes packages using the platform's package manager.
-func (p *Provider) Remove(packages []string, manager string, cask bool) error {
-	if len(packages) == 0 {
-		return fmt.Errorf("no packages specified")
+func (p *Provider) doRemove(packages []string, manager string, cask bool) error {
+	if p.removeFn != nil {
+		return p.removeFn(packages, manager, cask)
 	}
 
 	for _, pkg := range packages {
@@ -84,20 +247,6 @@ func (p *Provider) Remove(packages []string, manager string, cask bool) error {
 				return fmt.Errorf("%s remove %s failed: %s", pm.Name(), pkg, result.Stderr)
 			}
 		}
-	}
-	return nil
-}
-
-// Update refreshes the package manager index.
-func (p *Provider) Update(manager string) error {
-	pm := resolvePMForInstall(manager)
-	if pm == nil {
-		return fmt.Errorf("no package manager available")
-	}
-
-	result := pm.Update()
-	if !result.OK {
-		return fmt.Errorf("%s update failed: %s", pm.Name(), result.Stderr)
 	}
 	return nil
 }

--- a/internal/execution/provider/pkg/provider_test.go
+++ b/internal/execution/provider/pkg/provider_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package pkg
+
+import (
+	"testing"
+)
+
+// mockProvider returns a Provider with test hooks that record calls
+// instead of executing real package manager commands.
+func mockProvider(installed map[string]bool, versions map[string]string) (*Provider, *[]string) {
+	var log []string
+	return &Provider{
+		isInstalledFn: func(pkg, _ string) bool {
+			return installed[pkg]
+		},
+		getVersionFn: func(pkg, _ string) string {
+			return versions[pkg]
+		},
+		installFn: func(packages []string, manager string, cask bool) error {
+			for _, p := range packages {
+				log = append(log, "install "+p)
+			}
+			return nil
+		},
+		upgradeFn: func(packages []string, manager string, cask bool) error {
+			for _, p := range packages {
+				log = append(log, "upgrade "+p)
+			}
+			return nil
+		},
+		removeFn: func(packages []string, manager string, cask bool) error {
+			for _, p := range packages {
+				log = append(log, "remove "+p)
+			}
+			return nil
+		},
+	}, &log
+}
+
+// --- Install ---
+
+func TestInstallNoneInstalled(t *testing.T) {
+	p, log := mockProvider(map[string]bool{}, nil)
+	state, err := p.Install([]string{"curl", "wget"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	already, _ := state["already_installed"].([]string)
+	if len(already) != 0 {
+		t.Errorf("expected no already_installed, got %v", already)
+	}
+
+	// Compensate: should remove both (neither was installed before)
+	if err := p.CompensateInstall(state); err != nil {
+		t.Fatalf("CompensateInstall: %v", err)
+	}
+	if len(*log) != 4 { // 2 install + 2 remove
+		t.Fatalf("expected 4 commands, got %d: %v", len(*log), *log)
+	}
+	if (*log)[2] != "remove curl" || (*log)[3] != "remove wget" {
+		t.Errorf("expected remove curl, remove wget; got %v", (*log)[2:])
+	}
+}
+
+func TestInstallSomeAlreadyInstalled(t *testing.T) {
+	p, log := mockProvider(map[string]bool{"curl": true}, nil)
+	state, err := p.Install([]string{"curl", "wget"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	already, _ := state["already_installed"].([]string)
+	if len(already) != 1 || already[0] != "curl" {
+		t.Errorf("expected already_installed=[curl], got %v", already)
+	}
+
+	// Compensate: should only remove wget (curl was already installed)
+	if err := p.CompensateInstall(state); err != nil {
+		t.Fatalf("CompensateInstall: %v", err)
+	}
+	if len(*log) != 3 { // 2 install + 1 remove
+		t.Fatalf("expected 3 commands, got %d: %v", len(*log), *log)
+	}
+	if (*log)[2] != "remove wget" {
+		t.Errorf("expected remove wget, got %q", (*log)[2])
+	}
+}
+
+func TestInstallAllAlreadyInstalled(t *testing.T) {
+	p, log := mockProvider(map[string]bool{"curl": true, "wget": true}, nil)
+	state, err := p.Install([]string{"curl", "wget"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Compensate: no-op (all were already installed)
+	if err := p.CompensateInstall(state); err != nil {
+		t.Fatalf("CompensateInstall: %v", err)
+	}
+	if len(*log) != 2 { // 2 install only, no removes
+		t.Errorf("expected 2 commands (install only), got %d: %v", len(*log), *log)
+	}
+}
+
+func TestInstallEmptyPackages(t *testing.T) {
+	p, _ := mockProvider(nil, nil)
+	_, err := p.Install(nil, "brew", false)
+	if err == nil {
+		t.Error("expected error for empty packages")
+	}
+}
+
+// --- Upgrade ---
+
+func TestUpgradeCapturesVersions(t *testing.T) {
+	p, _ := mockProvider(nil, map[string]string{"curl": "7.88", "wget": "1.21"})
+	state, err := p.Upgrade([]string{"curl", "wget"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+
+	versions, _ := state["previous_versions"].(map[string]string)
+	if versions["curl"] != "7.88" || versions["wget"] != "1.21" {
+		t.Errorf("expected previous versions, got %v", versions)
+	}
+}
+
+func TestUpgradeCompensateNoOp(t *testing.T) {
+	p, _ := mockProvider(nil, map[string]string{"curl": "7.88"})
+	state, err := p.Upgrade([]string{"curl"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+
+	// CompensateUpgrade is always a no-op
+	if err := p.CompensateUpgrade(state); err != nil {
+		t.Fatalf("CompensateUpgrade: %v", err)
+	}
+}
+
+func TestUpgradeEmptyPackages(t *testing.T) {
+	p, _ := mockProvider(nil, nil)
+	_, err := p.Upgrade(nil, "brew", false)
+	if err == nil {
+		t.Error("expected error for empty packages")
+	}
+}
+
+// --- Remove ---
+
+func TestRemoveCompensateReinstalls(t *testing.T) {
+	p, log := mockProvider(nil, nil)
+	state, err := p.Remove([]string{"curl", "wget"}, "brew", false)
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	packages, _ := state["packages"].([]string)
+	if len(packages) != 2 {
+		t.Errorf("expected 2 packages in state, got %v", packages)
+	}
+
+	// Compensate: should reinstall both
+	if err := p.CompensateRemove(state); err != nil {
+		t.Fatalf("CompensateRemove: %v", err)
+	}
+	if len(*log) != 4 { // 2 remove + 2 install
+		t.Fatalf("expected 4 commands, got %d: %v", len(*log), *log)
+	}
+	if (*log)[2] != "install curl" || (*log)[3] != "install wget" {
+		t.Errorf("expected install curl, install wget; got %v", (*log)[2:])
+	}
+}
+
+func TestRemoveEmptyPackages(t *testing.T) {
+	p, _ := mockProvider(nil, nil)
+	_, err := p.Remove(nil, "brew", false)
+	if err == nil {
+		t.Error("expected error for empty packages")
+	}
+}
+
+// --- Nil state safety ---
+
+func TestCompensateNilState(t *testing.T) {
+	p, _ := mockProvider(nil, nil)
+
+	if err := p.CompensateInstall(nil); err != nil {
+		t.Errorf("CompensateInstall(nil): %v", err)
+	}
+	if err := p.CompensateUpgrade(nil); err != nil {
+		t.Errorf("CompensateUpgrade(nil): %v", err)
+	}
+	if err := p.CompensateRemove(nil); err != nil {
+		t.Errorf("CompensateRemove(nil): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add real compensation to the package provider (3 compensable actions out of 4)
- Forward methods (Install, Upgrade, Remove) now return `map[string]any` state for undo
- CompensateInstall removes only newly installed packages (skips already-installed)
- CompensateUpgrade is diagnostic no-op (captures previous versions for manual recovery)
- CompensateRemove reinstalls the removed packages
- Update unchanged (non-compensable, idempotent index refresh)
- Test hooks on Provider for mock-based testing without real package managers
- 10 round-trip tests

## Test plan

- [x] `go test ./internal/execution/provider/pkg/...` — 10/10 pass
- [x] `go build ./...` — clean
- [ ] CI quality-gate passes