### PR TITLE
feat(providers): add compensation to net, archive, git providers (Phase 4)

### DIFF
--- a/docs/plans/compensation/phase-4.md
+++ b/docs/plans/compensation/phase-4.md
@@ -1,0 +1,84 @@
+---
+title: "Compensation Phase 4: Remaining Providers (Net, Archive, Git)"
+parent: compensation.md
+status: in-progress
+created: 2026-02-16
+updated: 2026-02-16
+---
+
+# Phase 4: Remaining Providers (Net, Archive, Git)
+
+## Summary
+
+Add real compensation to the 3 remaining providers. 1 compensable action each.
+Small scope — straightforward state capture and cleanup.
+
+## Changes
+
+### Net Provider — Download
+
+Current `Download(url)` returns `([]byte, error)` — raw bytes. The file write
+happens in the action's `Do` (when `path` slot is set). Compensation removes
+the downloaded file.
+
+| Method | Change |
+|---|---|
+| `Download` | Unchanged — returns raw bytes |
+| `CompensateDownload` | New — removes file at `state["path"]` |
+
+State capture happens in the action `Do` (since the file write is there).
+`Undo` delegates to `CompensateDownload`. In-memory downloads (no path) are
+not compensable — UndoState is nil.
+
+### Archive Provider — Extract
+
+Current `Extract(source, prefix)` returns `error`. Changed to return
+`(map[string]any, error)` with created file list for compensation.
+
+| Method | Current Return | New Return |
+|---|---|---|
+| `Extract` | `error` | `(map[string]any, error)` |
+
+| Method | Compensation Logic |
+|---|---|
+| `CompensateExtract` | Remove created files in reverse order, then empty dirs |
+
+State: `{"dest": prefix, "created_files": [...]}`
+
+The internal extract helpers (`extractTarGz`, `extractZip`) are modified to
+collect and return created file paths.
+
+### Git Provider — Clone
+
+Current `Clone(url, path, output)` returns `error`. Changed to return
+`(map[string]any, error)`.
+
+| Method | Current Return | New Return |
+|---|---|---|
+| `Clone` | `error` | `(map[string]any, error)` |
+
+| Method | Compensation Logic |
+|---|---|
+| `CompensateClone` | `os.RemoveAll(path)` |
+
+State: `{"path": path}`
+
+Non-compensable: `Checkout`, `Pull` (unchanged).
+
+### actions_gen.go — Do/Undo Wiring
+
+3 actions updated across 3 packages.
+
+## Files
+
+| File | Action |
+|---|---|
+| `internal/execution/provider/net/provider.go` | Modify |
+| `internal/execution/provider/net/actions_gen.go` | Modify |
+| `internal/execution/provider/net/provider_test.go` | Create |
+| `internal/execution/provider/archive/provider.go` | Modify |
+| `internal/execution/provider/archive/actions_gen.go` | Modify |
+| `internal/execution/provider/archive/provider_test.go` | Create |
+| `internal/execution/provider/git/provider.go` | Modify |
+| `internal/execution/provider/git/actions_gen.go` | Modify |
+| `internal/execution/provider/git/provider_test.go` | Create |

--- a/internal/execution/provider/archive/actions_gen.go
+++ b/internal/execution/provider/archive/actions_gen.go
@@ -37,11 +37,16 @@ func (o *Extract) Do(ctx *execution.Context, slots map[string]any) (execution.Re
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] archive-extract %v \u2192 %v\n", source, prefix)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Extract(source, prefix)
+	state, err := o.Impl.Extract(source, prefix)
+	return nil, state, err
 }
 
-func (o *Extract) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Extract) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateExtract(s)
 }
 
 // Register registers all archive actions with the given registry.

--- a/internal/execution/provider/archive/provider.go
+++ b/internal/execution/provider/archive/provider.go
@@ -15,39 +15,87 @@ import (
 )
 
 // Provider provides archive extraction operations.
+//
+// Compensable Forward methods return (map[string]any, error).
+// The map is the compensation receipt — opaque to the executor,
+// meaningful only to the corresponding Compensate* Backward method.
 type Provider struct{}
 
 // Extract extracts an archive (tar.gz or zip) from source into the prefix directory.
 // The archive format is detected from the file extension.
-func (p *Provider) Extract(source, prefix string) error {
+// Returns compensation state with the list of created files.
+func (p *Provider) Extract(source, prefix string) (map[string]any, error) {
 	if err := os.MkdirAll(prefix, 0755); err != nil {
-		return fmt.Errorf("create prefix dir: %w", err)
+		return nil, fmt.Errorf("create prefix dir: %w", err)
 	}
+
+	var created []string
+	var err error
 
 	lower := strings.ToLower(source)
 	switch {
 	case strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz"):
-		return extractTarGz(source, prefix)
+		created, err = extractTarGz(source, prefix)
 	case strings.HasSuffix(lower, ".zip"):
-		return extractZip(source, prefix)
+		created, err = extractZip(source, prefix)
 	default:
-		return fmt.Errorf("unsupported archive format: %s", source)
+		return nil, fmt.Errorf("unsupported archive format: %s", source)
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"dest":          prefix,
+		"created_files": created,
+	}, nil
 }
 
-func extractTarGz(source, prefix string) error {
+// CompensateExtract removes files created during extraction, then cleans up
+// empty directories under dest.
+func (p *Provider) CompensateExtract(state map[string]any) error {
+	created, _ := state["created_files"].([]string)
+
+	// Remove files in reverse order (deepest first)
+	for i := len(created) - 1; i >= 0; i-- {
+		os.Remove(created[i])
+	}
+
+	// Clean up empty directories under dest
+	dest, _ := state["dest"].(string)
+	if dest != "" {
+		removeEmptyDirs(dest)
+	}
+	return nil
+}
+
+// removeEmptyDirs walks dest bottom-up removing empty directories.
+func removeEmptyDirs(root string) {
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || !info.IsDir() {
+			return nil
+		}
+		// Try to remove — fails silently if non-empty
+		os.Remove(path)
+		return nil
+	})
+}
+
+func extractTarGz(source, prefix string) ([]string, error) {
 	f, err := os.Open(source)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer f.Close()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
-		return fmt.Errorf("gzip: %w", err)
+		return nil, fmt.Errorf("gzip: %w", err)
 	}
 	defer gz.Close()
 
+	var created []string
 	tr := tar.NewReader(gz)
 	for {
 		hdr, err := tr.Next()
@@ -55,7 +103,7 @@ func extractTarGz(source, prefix string) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("tar: %w", err)
+			return created, fmt.Errorf("tar: %w", err)
 		}
 
 		target := filepath.Join(prefix, filepath.Clean(hdr.Name))
@@ -66,33 +114,35 @@ func extractTarGz(source, prefix string) error {
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
-				return err
+				return created, err
 			}
 		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-				return err
+				return created, err
 			}
 			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
 			if err != nil {
-				return err
+				return created, err
 			}
 			if _, err := io.Copy(out, tr); err != nil {
 				out.Close()
-				return err
+				return created, err
 			}
 			out.Close()
+			created = append(created, target)
 		}
 	}
-	return nil
+	return created, nil
 }
 
-func extractZip(source, prefix string) error {
+func extractZip(source, prefix string) ([]string, error) {
 	r, err := zip.OpenReader(source)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer r.Close()
 
+	var created []string
 	for _, f := range r.File {
 		target := filepath.Join(prefix, filepath.Clean(f.Name))
 		if !strings.HasPrefix(target, filepath.Clean(prefix)+string(os.PathSeparator)) {
@@ -101,33 +151,34 @@ func extractZip(source, prefix string) error {
 
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, f.Mode()); err != nil {
-				return err
+				return created, err
 			}
 			continue
 		}
 
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
+			return created, err
 		}
 
 		rc, err := f.Open()
 		if err != nil {
-			return err
+			return created, err
 		}
 
 		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		if err != nil {
 			rc.Close()
-			return err
+			return created, err
 		}
 
 		if _, err := io.Copy(out, rc); err != nil {
 			out.Close()
 			rc.Close()
-			return err
+			return created, err
 		}
 		out.Close()
 		rc.Close()
+		created = append(created, target)
 	}
-	return nil
+	return created, nil
 }

--- a/internal/execution/provider/archive/provider_test.go
+++ b/internal/execution/provider/archive/provider_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// createTarGz creates a .tar.gz with the given file entries (name → content).
+func createTarGz(t *testing.T, dir string, files map[string]string) string {
+	t.Helper()
+	path := filepath.Join(dir, "test.tar.gz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tw.Close()
+	gw.Close()
+	return path
+}
+
+// createZip creates a .zip with the given file entries (name → content).
+func createZip(t *testing.T, dir string, files map[string]string) string {
+	t.Helper()
+	path := filepath.Join(dir, "test.zip")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	for name, content := range files {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w.Close()
+	return path
+}
+
+func TestExtractTarGzAndCompensate(t *testing.T) {
+	dir := t.TempDir()
+	archive := createTarGz(t, dir, map[string]string{
+		"a.txt": "alpha",
+		"b.txt": "bravo",
+	})
+
+	dest := filepath.Join(dir, "out")
+	p := &Provider{}
+	state, err := p.Extract(archive, dest)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	created, _ := state["created_files"].([]string)
+	if len(created) != 2 {
+		t.Fatalf("expected 2 created files, got %d: %v", len(created), created)
+	}
+
+	// Verify files exist
+	for _, f := range created {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %s to exist: %v", f, err)
+		}
+	}
+
+	// Compensate: removes created files
+	if err := p.CompensateExtract(state); err != nil {
+		t.Fatalf("CompensateExtract: %v", err)
+	}
+
+	for _, f := range created {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("file %s should have been removed", f)
+		}
+	}
+}
+
+func TestExtractZipAndCompensate(t *testing.T) {
+	dir := t.TempDir()
+	archive := createZip(t, dir, map[string]string{
+		"x.txt": "xray",
+		"y.txt": "yankee",
+	})
+
+	dest := filepath.Join(dir, "out")
+	p := &Provider{}
+	state, err := p.Extract(archive, dest)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	created, _ := state["created_files"].([]string)
+	if len(created) != 2 {
+		t.Fatalf("expected 2 created files, got %d: %v", len(created), created)
+	}
+
+	// Compensate
+	if err := p.CompensateExtract(state); err != nil {
+		t.Fatalf("CompensateExtract: %v", err)
+	}
+
+	for _, f := range created {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("file %s should have been removed", f)
+		}
+	}
+}
+
+func TestCompensateExtractNilState(t *testing.T) {
+	p := &Provider{}
+	if err := p.CompensateExtract(nil); err != nil {
+		t.Errorf("CompensateExtract(nil): %v", err)
+	}
+}

--- a/internal/execution/provider/git/actions_gen.go
+++ b/internal/execution/provider/git/actions_gen.go
@@ -28,11 +28,16 @@ func (o *Clone) Do(ctx *execution.Context, slots map[string]any) (execution.Resu
 		_, _ = fmt.Fprintf(ctx.Logger, "[dry-run] git-clone %v \u2192 %v\n", url, path)
 		return nil, nil, nil
 	}
-	return nil, nil, o.Impl.Clone(url, path, ctx.Logger)
+	state, err := o.Impl.Clone(url, path, ctx.Logger)
+	return nil, state, err
 }
 
-func (o *Clone) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Clone) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateClone(s)
 }
 
 // Checkout checks out a git ref.

--- a/internal/execution/provider/git/provider.go
+++ b/internal/execution/provider/git/provider.go
@@ -5,18 +5,36 @@ package git
 
 import (
 	"io"
+	"os"
 	"os/exec"
 )
 
 // Provider provides git operations.
-type Provider struct{}
+//
+// Compensable Forward methods return (map[string]any, error).
+// The map is the compensation receipt — opaque to the executor,
+// meaningful only to the corresponding Compensate* Backward method.
+type Provider struct {
+	// Test hooks. Nil means use real git commands.
+	cloneFn func(url, path string, output io.Writer) error
+}
 
 // Clone clones a repository from url into path.
-func (p *Provider) Clone(url, path string, output io.Writer) error {
-	cmd := exec.Command("git", "clone", url, path)
-	cmd.Stdout = output
-	cmd.Stderr = output
-	return cmd.Run()
+// Returns compensation state with the cloned path.
+func (p *Provider) Clone(url, path string, output io.Writer) (map[string]any, error) {
+	if err := p.doClone(url, path, output); err != nil {
+		return nil, err
+	}
+	return map[string]any{"path": path}, nil
+}
+
+// CompensateClone removes the cloned directory.
+func (p *Provider) CompensateClone(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	return os.RemoveAll(path)
 }
 
 // Checkout checks out a ref in the given repository directory.
@@ -30,6 +48,16 @@ func (p *Provider) Checkout(repo, ref string, output io.Writer) error {
 // Pull pulls the latest changes in the given repository directory.
 func (p *Provider) Pull(repo string, output io.Writer) error {
 	cmd := exec.Command("git", "-C", repo, "pull")
+	cmd.Stdout = output
+	cmd.Stderr = output
+	return cmd.Run()
+}
+
+func (p *Provider) doClone(url, path string, output io.Writer) error {
+	if p.cloneFn != nil {
+		return p.cloneFn(url, path, output)
+	}
+	cmd := exec.Command("git", "clone", url, path)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	return cmd.Run()

--- a/internal/execution/provider/git/provider_test.go
+++ b/internal/execution/provider/git/provider_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package git
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloneAndCompensate(t *testing.T) {
+	dir := t.TempDir()
+	clonePath := filepath.Join(dir, "repo")
+
+	p := &Provider{
+		cloneFn: func(url, path string, output io.Writer) error {
+			return os.MkdirAll(path, 0755)
+		},
+	}
+
+	state, err := p.Clone("https://example.com/repo.git", clonePath, io.Discard)
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	path, _ := state["path"].(string)
+	if path != clonePath {
+		t.Errorf("expected path=%q, got %q", clonePath, path)
+	}
+
+	// Verify directory exists
+	if _, err := os.Stat(clonePath); err != nil {
+		t.Fatalf("cloned directory should exist: %v", err)
+	}
+
+	// Compensate: removes directory
+	if err := p.CompensateClone(state); err != nil {
+		t.Fatalf("CompensateClone: %v", err)
+	}
+
+	if _, err := os.Stat(clonePath); !os.IsNotExist(err) {
+		t.Error("cloned directory should have been removed")
+	}
+}
+
+func TestCompensateCloneEmptyPath(t *testing.T) {
+	p := &Provider{}
+	if err := p.CompensateClone(map[string]any{"path": ""}); err != nil {
+		t.Errorf("CompensateClone(empty path): %v", err)
+	}
+}
+
+func TestCompensateCloneNilState(t *testing.T) {
+	p := &Provider{}
+	if err := p.CompensateClone(nil); err != nil {
+		t.Errorf("CompensateClone(nil): %v", err)
+	}
+}

--- a/internal/execution/provider/net/actions_gen.go
+++ b/internal/execution/provider/net/actions_gen.go
@@ -46,13 +46,18 @@ func (o *Download) Do(ctx *execution.Context, slots map[string]any) (execution.R
 		if err := os.WriteFile(path, data, mode); err != nil {
 			return nil, nil, err
 		}
+		return data, map[string]any{"path": path}, nil
 	}
 
 	return data, nil, nil
 }
 
-func (o *Download) Undo(_ *execution.Context, _ map[string]any, _ execution.UndoState) error {
-	return nil
+func (o *Download) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
+	s, _ := state.(map[string]any)
+	if s == nil {
+		return nil
+	}
+	return o.Impl.CompensateDownload(s)
 }
 
 // Register registers all net actions with the given registry.

--- a/internal/execution/provider/net/provider.go
+++ b/internal/execution/provider/net/provider.go
@@ -7,9 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 )
 
 // Provider provides network operations.
+//
+// Compensable Backward methods accept the state map returned by the action's
+// Do method and undo the side effects.
 type Provider struct{}
 
 // Download fetches the content at the given URL and returns the response body.
@@ -29,4 +33,14 @@ func (p *Provider) Download(url string) ([]byte, error) {
 		return nil, fmt.Errorf("download %s: read body: %w", url, err)
 	}
 	return data, nil
+}
+
+// CompensateDownload removes the downloaded file at state["path"].
+// In-memory downloads (no path) produce nil state and are not compensated.
+func (p *Provider) CompensateDownload(state map[string]any) error {
+	path, _ := state["path"].(string)
+	if path == "" {
+		return nil
+	}
+	return os.Remove(path)
 }

--- a/internal/execution/provider/net/provider_test.go
+++ b/internal/execution/provider/net/provider_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package net
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompensateDownloadRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Provider{}
+	state := map[string]any{"path": path}
+	if err := p.CompensateDownload(state); err != nil {
+		t.Fatalf("CompensateDownload: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should have been removed")
+	}
+}
+
+func TestCompensateDownloadEmptyPath(t *testing.T) {
+	p := &Provider{}
+	if err := p.CompensateDownload(map[string]any{"path": ""}); err != nil {
+		t.Errorf("CompensateDownload(empty path): %v", err)
+	}
+}
+
+func TestCompensateDownloadNilState(t *testing.T) {
+	p := &Provider{}
+	if err := p.CompensateDownload(nil); err != nil {
+		t.Errorf("CompensateDownload(nil): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add compensation to 3 remaining providers (1 compensable action each)
- **net.Download**: captures file path in UndoState when writing to disk; CompensateDownload removes the file. In-memory downloads produce nil state (not compensable)
- **archive.Extract**: returns created file list in state; CompensateExtract removes created files in reverse order, then cleans empty directories
- **git.Clone**: returns cloned path in state; CompensateClone does `os.RemoveAll(path)`. Checkout/Pull unchanged (non-compensable)
- 9 round-trip tests across 3 providers

## Test plan

- [x] `go test ./internal/execution/provider/net/...` — 3/3 pass
- [x] `go test ./internal/execution/provider/archive/...` — 3/3 pass
- [x] `go test ./internal/execution/provider/git/...` — 3/3 pass
- [x] `go build ./...` — clean
- [ ] CI quality-gate passes