### PR TITLE
feat(gen): compensation pair detection and service signature standardization

### DIFF
--- a/docs/plans/compensation/phase-5.md
+++ b/docs/plans/compensation/phase-5.md
@@ -1,0 +1,85 @@
+---
+title: "Compensation Phase 5: Generator Template Update"
+parent: compensation.md
+status: in-progress
+created: 2026-02-17
+updated: 2026-02-17
+---
+
+# Phase 5: Generator Template Update
+
+## Summary
+
+Update the `graph_actions` code generator to detect `Compensate<Method>` pairs
+and emit correct Do/Undo wiring automatically. After this phase, providers that
+follow the standard pattern produce correct actions_gen.go via the generator.
+
+## Prerequisites
+
+Service provider Compensate methods must be standardized to
+`func(state map[string]any) error` (drop `io.Writer` param) so the generator
+can emit uniform Undo delegation. Compensation runs silently via `io.Discard`.
+
+## Changes
+
+### noblefactor-ops: `receiver_go_gen.go`
+
+| Change | Detail |
+|---|---|
+| `methodInfo.Compensable` | New `bool` field — has a Compensate pair |
+| `methodInfoFromValue` | Read `compensable` from descriptor dict |
+| `validateCompensableReturn` | New function: accepts `(map[string]any, error)` or `(T, map[string]any, error)` |
+| Gate 2 update | Use compensable-aware validation for compensable methods |
+| `tplGraphReturn` | Capture state from Forward's state return when compensable |
+| `tplGraphUndo` | Emit delegation to `Impl.Compensate<GoName>(state)` when compensable; nil stub otherwise |
+| Slot reader safety | Use `_, _ :=` form for safe type assertions in graphReaders |
+
+### devlore-cli: `generate.star`
+
+| Change | Detail |
+|---|---|
+| Filter Compensate* | Skip methods starting with "Compensate" from action list |
+| Detect pairs | Check if `Compensate<Name>` exists for each Forward method |
+| Set compensable | Add `compensable: True/False` to method descriptors |
+| Gate 3 | Validate Compensate method returns `error` and takes single `map[string]any` param |
+
+### devlore-cli: Service Provider Signature Standardization
+
+| File | Change |
+|---|---|
+| `provider/service/provider.go` | Compensate methods: `(map[string]any, io.Writer) error` → `(map[string]any) error` |
+| `provider/service/actions_gen.go` | Undo: `o.Impl.CompensateX(s, ctx.Logger)` → `o.Impl.CompensateX(s)` |
+| `provider/service/provider_test.go` | Update mock calls to match new signatures |
+
+### devlore-cli: `graph_actions.go.template`
+
+No changes needed — template already uses `{{graphReturn .}}` and `{{graphUndo .}}`.
+
+## Compensable Return Signatures
+
+The generator handles two compensable return patterns:
+
+| Return Signature | ValueType | State | Example |
+|---|---|---|---|
+| `(map[string]any, error)` | none | captured | `Install`, `Start`, `Clone` |
+| `(T, map[string]any, error)` | T | captured | `Copy` (returns checksum) |
+
+Non-compensable methods keep current validation: `error` or `(T, error)`.
+
+## Files
+
+### noblefactor-ops
+
+| File | Action |
+|---|---|
+| `internal/starlark/receiver_go_gen.go` | Modify |
+| `internal/starlark/receiver_go_gen_test.go` | Create |
+
+### devlore-cli
+
+| File | Action |
+|---|---|
+| `star/extensions/.../commands/generate.star` | Modify |
+| `internal/execution/provider/service/provider.go` | Modify |
+| `internal/execution/provider/service/actions_gen.go` | Modify |
+| `internal/execution/provider/service/provider_test.go` | Modify |

--- a/internal/execution/provider/service/actions_gen.go
+++ b/internal/execution/provider/service/actions_gen.go
@@ -28,12 +28,12 @@ func (o *Start) Do(ctx *execution.Context, slots map[string]any) (execution.Resu
 	return nil, state, err
 }
 
-func (o *Start) Undo(ctx *execution.Context, _ map[string]any, state execution.UndoState) error {
+func (o *Start) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
 	s, _ := state.(map[string]any)
 	if s == nil {
 		return nil
 	}
-	return o.Impl.CompensateStart(s, ctx.Logger)
+	return o.Impl.CompensateStart(s)
 }
 
 // Stop stops a service.
@@ -55,12 +55,12 @@ func (o *Stop) Do(ctx *execution.Context, slots map[string]any) (execution.Resul
 	return nil, state, err
 }
 
-func (o *Stop) Undo(ctx *execution.Context, _ map[string]any, state execution.UndoState) error {
+func (o *Stop) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
 	s, _ := state.(map[string]any)
 	if s == nil {
 		return nil
 	}
-	return o.Impl.CompensateStop(s, ctx.Logger)
+	return o.Impl.CompensateStop(s)
 }
 
 // Restart restarts a service.
@@ -82,12 +82,12 @@ func (o *Restart) Do(ctx *execution.Context, slots map[string]any) (execution.Re
 	return nil, state, err
 }
 
-func (o *Restart) Undo(ctx *execution.Context, _ map[string]any, state execution.UndoState) error {
+func (o *Restart) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
 	s, _ := state.(map[string]any)
 	if s == nil {
 		return nil
 	}
-	return o.Impl.CompensateRestart(s, ctx.Logger)
+	return o.Impl.CompensateRestart(s)
 }
 
 // Enable enables a service to start at boot.
@@ -109,12 +109,12 @@ func (o *Enable) Do(ctx *execution.Context, slots map[string]any) (execution.Res
 	return nil, state, err
 }
 
-func (o *Enable) Undo(ctx *execution.Context, _ map[string]any, state execution.UndoState) error {
+func (o *Enable) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
 	s, _ := state.(map[string]any)
 	if s == nil {
 		return nil
 	}
-	return o.Impl.CompensateEnable(s, ctx.Logger)
+	return o.Impl.CompensateEnable(s)
 }
 
 // Disable disables a service from starting at boot.
@@ -136,12 +136,12 @@ func (o *Disable) Do(ctx *execution.Context, slots map[string]any) (execution.Re
 	return nil, state, err
 }
 
-func (o *Disable) Undo(ctx *execution.Context, _ map[string]any, state execution.UndoState) error {
+func (o *Disable) Undo(_ *execution.Context, _ map[string]any, state execution.UndoState) error {
 	s, _ := state.(map[string]any)
 	if s == nil {
 		return nil
 	}
-	return o.Impl.CompensateDisable(s, ctx.Logger)
+	return o.Impl.CompensateDisable(s)
 }
 
 // Register registers all service actions with the given registry.

--- a/internal/execution/provider/service/provider.go
+++ b/internal/execution/provider/service/provider.go
@@ -41,7 +41,7 @@ func (p *Provider) Start(name string, output io.Writer) (map[string]any, error) 
 
 // CompensateStart undoes a Start by stopping the service if it wasn't
 // running before.
-func (p *Provider) CompensateStart(state map[string]any, output io.Writer) error {
+func (p *Provider) CompensateStart(state map[string]any) error {
 	name, _ := state["name"].(string)
 	if name == "" {
 		return nil
@@ -50,7 +50,7 @@ func (p *Provider) CompensateStart(state map[string]any, output io.Writer) error
 	if wasRunning {
 		return nil // Was already running — no-op
 	}
-	return p.run(output, stopArgs(name)...)
+	return p.run(io.Discard, stopArgs(name)...)
 }
 
 // Stop stops a service. Returns compensation state with pre-action
@@ -69,7 +69,7 @@ func (p *Provider) Stop(name string, output io.Writer) (map[string]any, error) {
 
 // CompensateStop undoes a Stop by starting the service if it was
 // running before.
-func (p *Provider) CompensateStop(state map[string]any, output io.Writer) error {
+func (p *Provider) CompensateStop(state map[string]any) error {
 	name, _ := state["name"].(string)
 	if name == "" {
 		return nil
@@ -78,7 +78,7 @@ func (p *Provider) CompensateStop(state map[string]any, output io.Writer) error 
 	if !wasRunning {
 		return nil // Wasn't running — no-op
 	}
-	return p.run(output, startArgs(name)...)
+	return p.run(io.Discard, startArgs(name)...)
 }
 
 // Restart restarts a service. Returns compensation state. Compensation
@@ -94,7 +94,7 @@ func (p *Provider) Restart(name string, output io.Writer) (map[string]any, error
 
 // CompensateRestart is a no-op. A restarted service was already running;
 // the service is still running after restart — nothing to undo.
-func (p *Provider) CompensateRestart(_ map[string]any, _ io.Writer) error {
+func (p *Provider) CompensateRestart(_ map[string]any) error {
 	return nil
 }
 
@@ -114,7 +114,7 @@ func (p *Provider) Enable(name string, output io.Writer) (map[string]any, error)
 
 // CompensateEnable undoes an Enable by disabling the service if it
 // wasn't enabled before.
-func (p *Provider) CompensateEnable(state map[string]any, output io.Writer) error {
+func (p *Provider) CompensateEnable(state map[string]any) error {
 	name, _ := state["name"].(string)
 	if name == "" {
 		return nil
@@ -123,7 +123,7 @@ func (p *Provider) CompensateEnable(state map[string]any, output io.Writer) erro
 	if wasEnabled {
 		return nil // Was already enabled — no-op
 	}
-	return p.run(output, disableArgs(name)...)
+	return p.run(io.Discard, disableArgs(name)...)
 }
 
 // Disable disables a service from starting at boot. Returns
@@ -142,7 +142,7 @@ func (p *Provider) Disable(name string, output io.Writer) (map[string]any, error
 
 // CompensateDisable undoes a Disable by enabling the service if it was
 // enabled before.
-func (p *Provider) CompensateDisable(state map[string]any, output io.Writer) error {
+func (p *Provider) CompensateDisable(state map[string]any) error {
 	name, _ := state["name"].(string)
 	if name == "" {
 		return nil
@@ -151,7 +151,7 @@ func (p *Provider) CompensateDisable(state map[string]any, output io.Writer) err
 	if !wasEnabled {
 		return nil // Wasn't enabled — no-op
 	}
-	return p.run(output, enableArgs(name)...)
+	return p.run(io.Discard, enableArgs(name)...)
 }
 
 // --- Platform-specific command builders ---

--- a/internal/execution/provider/service/provider_test.go
+++ b/internal/execution/provider/service/provider_test.go
@@ -38,7 +38,7 @@ func TestStartNotRunning(t *testing.T) {
 	}
 
 	// Compensate: should stop (wasn't running before)
-	if err := p.CompensateStart(state, io.Discard); err != nil {
+	if err := p.CompensateStart(state); err != nil {
 		t.Fatalf("CompensateStart: %v", err)
 	}
 	if len(*log) != 2 {
@@ -62,7 +62,7 @@ func TestStartAlreadyRunning(t *testing.T) {
 	}
 
 	// Compensate: should be no-op (was already running)
-	if err := p.CompensateStart(state, io.Discard); err != nil {
+	if err := p.CompensateStart(state); err != nil {
 		t.Fatalf("CompensateStart: %v", err)
 	}
 	if len(*log) != 1 {
@@ -85,7 +85,7 @@ func TestStopWasRunning(t *testing.T) {
 	}
 
 	// Compensate: should start (was running before)
-	if err := p.CompensateStop(state, io.Discard); err != nil {
+	if err := p.CompensateStop(state); err != nil {
 		t.Fatalf("CompensateStop: %v", err)
 	}
 	if len(*log) != 2 {
@@ -104,7 +104,7 @@ func TestStopNotRunning(t *testing.T) {
 	}
 
 	// Compensate: should be no-op (wasn't running)
-	if err := p.CompensateStop(state, io.Discard); err != nil {
+	if err := p.CompensateStop(state); err != nil {
 		t.Fatalf("CompensateStop: %v", err)
 	}
 	if len(*log) != 1 {
@@ -122,7 +122,7 @@ func TestRestartCompensateNoOp(t *testing.T) {
 	}
 
 	// Compensate: always no-op
-	if err := p.CompensateRestart(state, io.Discard); err != nil {
+	if err := p.CompensateRestart(state); err != nil {
 		t.Fatalf("CompensateRestart: %v", err)
 	}
 	if len(*log) != 1 {
@@ -145,7 +145,7 @@ func TestEnableNotEnabled(t *testing.T) {
 	}
 
 	// Compensate: should disable (wasn't enabled before)
-	if err := p.CompensateEnable(state, io.Discard); err != nil {
+	if err := p.CompensateEnable(state); err != nil {
 		t.Fatalf("CompensateEnable: %v", err)
 	}
 	if len(*log) != 2 {
@@ -164,7 +164,7 @@ func TestEnableAlreadyEnabled(t *testing.T) {
 	}
 
 	// Compensate: should be no-op (was already enabled)
-	if err := p.CompensateEnable(state, io.Discard); err != nil {
+	if err := p.CompensateEnable(state); err != nil {
 		t.Fatalf("CompensateEnable: %v", err)
 	}
 	if len(*log) != 1 {
@@ -187,7 +187,7 @@ func TestDisableWasEnabled(t *testing.T) {
 	}
 
 	// Compensate: should enable (was enabled before)
-	if err := p.CompensateDisable(state, io.Discard); err != nil {
+	if err := p.CompensateDisable(state); err != nil {
 		t.Fatalf("CompensateDisable: %v", err)
 	}
 	if len(*log) != 2 {
@@ -206,7 +206,7 @@ func TestDisableNotEnabled(t *testing.T) {
 	}
 
 	// Compensate: should be no-op (wasn't enabled)
-	if err := p.CompensateDisable(state, io.Discard); err != nil {
+	if err := p.CompensateDisable(state); err != nil {
 		t.Fatalf("CompensateDisable: %v", err)
 	}
 	if len(*log) != 1 {
@@ -219,19 +219,19 @@ func TestDisableNotEnabled(t *testing.T) {
 func TestCompensateNilState(t *testing.T) {
 	p, _ := mockProvider(false, false)
 
-	if err := p.CompensateStart(nil, io.Discard); err != nil {
+	if err := p.CompensateStart(nil); err != nil {
 		t.Errorf("CompensateStart(nil): %v", err)
 	}
-	if err := p.CompensateStop(nil, io.Discard); err != nil {
+	if err := p.CompensateStop(nil); err != nil {
 		t.Errorf("CompensateStop(nil): %v", err)
 	}
-	if err := p.CompensateRestart(nil, io.Discard); err != nil {
+	if err := p.CompensateRestart(nil); err != nil {
 		t.Errorf("CompensateRestart(nil): %v", err)
 	}
-	if err := p.CompensateEnable(nil, io.Discard); err != nil {
+	if err := p.CompensateEnable(nil); err != nil {
 		t.Errorf("CompensateEnable(nil): %v", err)
 	}
-	if err := p.CompensateDisable(nil, io.Discard); err != nil {
+	if err := p.CompensateDisable(nil); err != nil {
 		t.Errorf("CompensateDisable(nil): %v", err)
 	}
 }

--- a/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Ops/commands/generate.star
@@ -88,11 +88,16 @@ def run(ctx):
     if len(methods) == 0:
         fail("no methods found for " + struct_name + " in " + path)
 
-    # Filter to public methods, excluding skip list
+    # Filter to public methods, excluding skip list and Compensate* methods
     methods_filter = ctx.args.get("methods", "")
     include_list = []
     if methods_filter:
         include_list = methods_filter.split(",")
+
+    # First pass: collect all method names for compensation pair detection
+    all_method_names = {}
+    for m in methods:
+        all_method_names[m.name] = True
 
     filtered = []
     for m in methods:
@@ -101,6 +106,9 @@ def run(ctx):
             continue
         # Skip starlark.Value / HasAttrs interface methods
         if m.name in SKIP_METHODS:
+            continue
+        # Skip Compensate* backward methods (handled via compensable flag)
+        if m.name.startswith("Compensate"):
             continue
         # Apply inclusion filter if specified
         if include_list and m.name not in include_list:
@@ -130,7 +138,7 @@ def run(ctx):
 
     pkg_override = ctx.args.get("package", "")
 
-    # Build method descriptors
+    # Build method descriptors with compensation pair detection
     method_descriptors = []
     for m in filtered:
         params = []
@@ -140,11 +148,13 @@ def run(ctx):
                 "type": p.type,
                 "variadic": p.variadic,
             })
+        compensable = ("Compensate" + m.name) in all_method_names
         method_descriptors.append({
             "name": m.name,
             "returns": m.returns,
             "doc": m.doc,
             "params": params,
+            "compensable": compensable,
         })
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `generate.star` filters Compensate* methods and sets `compensable` flag on forward method descriptors
- Service provider Compensate methods standardized from `(map[string]any, io.Writer) error` to `(map[string]any) error`
- Service `actions_gen.go` Undo methods updated to match new signatures

## Test plan
- [x] All 10 service provider tests pass
- [x] All 48 provider tests pass across all packages
- [x] Full build clean