### PR TITLE
Resource Management Phase 1 | ResourceCatalog, NamespaceMap, and URI helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LDFLAGS := -ldflags "-X github.com/NobleFactor/devlore-cli/internal/cli.Version=
 PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
 
 # Code generator (star binary from sibling repo)
-STAR_REPO ?= ../noblefactor-ops.binding-unification
+STAR_REPO ?= ../noblefactor-ops
 STAR ?= $(STAR_REPO)/bin/star
 
 # Provider source root
@@ -157,6 +157,7 @@ generate: \
 build: generate
 	go build $(LDFLAGS) -o build/lore ./cmd/lore
 	go build $(LDFLAGS) -o build/writ ./cmd/writ
+	go build $(LDFLAGS) -o build/devlore-test ./cmd/devlore-test
 
 clean:
 	rm -rf build/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Monorepo for the **lore** and **writ** command-line tools.
 ## Building
 
 ```bash
-make build          # Build both binaries to bin/
-make lore           # Build lore only
-make writ           # Build writ only
+make build # Build both binaries to bin/
+make lore  # Build lore only
+make writ  # Build writ only
+
 ```
 
 ## Installing
@@ -39,22 +40,23 @@ writ man deploy                   # Display man page for subcommand
 
 ## XDG Compliance
 
-All paths follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
+All paths follow
+the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
 
-| Artifact | Default Path |
-|----------|--------------|
-| Shared config | `$XDG_CONFIG_HOME/devlore/config.yaml` |
-| Tool configs | `$XDG_CONFIG_HOME/devlore/config.d/{writ,lore}.yaml` |
-| Registry cache | `$XDG_CACHE_HOME/devlore/registry/` |
-| Downloads cache | `$XDG_CACHE_HOME/devlore/downloads/` |
-| Writ layers | `$XDG_DATA_HOME/devlore/writ/layers/` |
-| Writ receipts | `$XDG_STATE_HOME/devlore/writ/receipts/` |
-| Lore receipts | `$XDG_STATE_HOME/devlore/lore/receipts/` |
-| Man pages | `<prefix>/share/man/man1/` |
-| Bash completions | `<prefix>/share/bash-completion/completions/` |
-| Zsh completions | `<prefix>/share/zsh/site-functions/` |
-| Fish completions | `<prefix>/share/fish/vendor_completions.d/` |
-| PowerShell completions | `<prefix>/share/powershell/completions/` |
+| Artifact               | Default Path                                         |
+|------------------------|------------------------------------------------------|
+| Shared config          | `$XDG_CONFIG_HOME/devlore/config.yaml`               |
+| Tool configs           | `$XDG_CONFIG_HOME/devlore/config.d/{writ,lore}.yaml` |
+| Registry cache         | `$XDG_CACHE_HOME/devlore/registry/`                  |
+| Downloads cache        | `$XDG_CACHE_HOME/devlore/downloads/`                 |
+| Writ layers            | `$XDG_DATA_HOME/devlore/writ/layers/`                |
+| Writ receipts          | `$XDG_STATE_HOME/devlore/writ/receipts/`             |
+| Lore receipts          | `$XDG_STATE_HOME/devlore/lore/receipts/`             |
+| Man pages              | `<prefix>/share/man/man1/`                           |
+| Bash completions       | `<prefix>/share/bash-completion/completions/`        |
+| Zsh completions        | `<prefix>/share/zsh/site-functions/`                 |
+| Fish completions       | `<prefix>/share/fish/vendor_completions.d/`          |
+| PowerShell completions | `<prefix>/share/powershell/completions/`             |
 
 ## Project Structure
 

--- a/cmd/devlore-test/main.go
+++ b/cmd/devlore-test/main.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+// Command devlore-test is the graph test harness for Starlark plan + execute + verify.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/NobleFactor/devlore-cli/internal/e2e/testrunner"
+)
+
+func main() {
+	script := flag.String("script", "", "path to test .star script (required)")
+	dryRun := flag.Bool("dry-run", false, "plan only, no side effects")
+	trace := flag.Bool("trace", false, "enable Starlark step trace")
+	provider := flag.String("provider", "", "restrict to a specific provider")
+	flag.Parse()
+
+	if *script == "" {
+		fmt.Fprintln(os.Stderr, "error: --script is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	var opts []testrunner.Option
+	if *dryRun {
+		opts = append(opts, testrunner.WithDryRun())
+	}
+	if *trace {
+		opts = append(opts, testrunner.WithTrace())
+	}
+	if *provider != "" {
+		opts = append(opts, testrunner.WithProvider(*provider))
+	}
+
+	runner := testrunner.New(*script, opts...)
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		errResult := map[string]any{
+			"passed":  false,
+			"error":   err.Error(),
+			"node_count": 0,
+			"expectation_count": 0,
+			"failures": []any{},
+		}
+		data, _ := json.Marshal(errResult)
+		fmt.Println(string(data))
+		os.Exit(2)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshaling result: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Println(string(data))
+
+	if !result.Passed {
+		os.Exit(1)
+	}
+}

--- a/docs/architecture/devlore-resource-management.md
+++ b/docs/architecture/devlore-resource-management.md
@@ -45,7 +45,16 @@ path was modified by node A, so node B must wait."
 ## 2. Architectural Summary
 
 The resource management architecture separates **intent** (planning) from
-**reality** (execution) using three core components and a shadowing mechanism.
+**reality** (execution). A graph is planned once and can be executed on
+many machines — local or remote. This forces a clean separation:
+
+- **Coercion** (plan time): Type-tagging raw values to typed Resources.
+  Pure — no I/O, no `os.Stat`. The planner knows *what type* a slot
+  should hold.
+- **Resolution** (execution time): Metadata population against a target
+  machine. The executor knows *what exists* on each target.
+
+Three core components and a shadowing mechanism:
 
 ```
                          ┌──────────────────────────────┐
@@ -79,11 +88,12 @@ type Resource struct {
 }
 ```
 
-**Ledger** — An append-only list of every `Resource` created during planning.
-Each entry records its producer (`OriginNodeID`) or marks itself as
-pre-existing (discovered). The ledger is the audit trail for the entire plan.
-It stores `any` because Go generics do not allow `[]Resource[T]` for mixed `T`
-in a single slice.
+**Ledger** — An append-only collection of every `Resource` created during
+planning, keyed by resource ID. Each entry records its producer
+(`OriginNodeID`) or marks itself as pre-existing (discovered). The ledger
+is the plan-time skeleton — URIs and relationships, no metadata. It is
+portable across machines. Metadata is populated per-execution by the
+executor's pre-flight resolution pass against the target machine.
 
 **NamespaceMap** — A mutable URI-to-ResourceID lookup used during planning.
 When a provider method reads a path, it calls `Resolve` to get the current
@@ -134,10 +144,21 @@ Each field serves a specific purpose:
 | `ModTime` | `os.FileInfo.ModTime()` | Last modification time |
 | `Checksum` | `checksumFile()` (SHA-256) | Content integrity |
 
+**Three resource states:**
+
+- **Unresolved** — Source input. URI and type set, metadata empty. Created
+  at plan time by `namespace.Resolve()`. Resolved by the executor's
+  pre-flight pass (os.Stat against target machine).
+- **Pending** — Output. URI and type set, metadata empty. Created at plan
+  time by `namespace.Shadow()`. Resolved by node execution results — the
+  provider populates metadata after creating the entity.
+- **Resolved** — Metadata populated (inode, device, size, mode, modtime,
+  checksum). Either resolved by pre-flight or by node execution.
+
 **Discovery**: `NewResource` (`resource.go:47`) performs `os.Stat` and
-populates all metadata fields. If the file does not exist, it returns a
-partial resource with only `URI` and `SourcePath` set — a "known path but no
-data" state that the executor must fulfill via a node later.
+populates all metadata fields. In the target architecture, `NewResource` is
+called only during execution (on the target machine), never during planning.
+At plan time, `ResourceFromPath` creates a typed but metadata-empty Resource.
 
 **Post-write refresh**: After a successful mutation, `RefreshMetadataWith`
 (`resource.go:146`) re-stats the file to capture kernel-assigned identity
@@ -321,11 +342,31 @@ it walks through five coercion steps:
  6. Error         → "cannot coerce %T to %s"
 ```
 
-Step 5 is where string-to-Resource conversion happens. The coercion is
+Step 5 is where string-to-Resource conversion happens today. The coercion is
 transparent to Starlark scripts and provider code — Starlark passes a string
-path, the constructor calls `NewResource`, and the provider method receives a
-fully populated `file.Resource` with Inode, Size, Mode, and Checksum already
-filled in.
+path, the constructor calls `NewResource` (which does `os.Stat`), and the
+provider method receives a fully populated `file.Resource`.
+
+**Target architecture — planner coerces, executor resolves:**
+
+The constructor registry evolves into a coercion table with two kinds of
+entries:
+
+- **Plan-time coercions** (pure, no I/O): `string → file.Resource{URI
+  only}`. Called by `buildPlannedBridge` when a Starlark string is passed
+  to a slot expecting `file.Resource`. Creates a typed but unresolved
+  Resource — URI and type set, metadata empty. The planner is pure because
+  a graph is planned once and executed on many machines; `os.Stat` at plan
+  time gives the wrong machine's metadata.
+- **Execution-time resolvers**: `file.Resource{unresolved} →
+  file.Resource{resolved}`. Called by the executor's pre-flight pass
+  against the target machine. These do I/O (os.Stat, service status
+  check, package version query).
+
+The coercion table also supports cross-provider conversions:
+`(mem.Resource, file.Resource) → converter`. The provider never sees a
+foreign resource type — coercion is the only place where cross-provider
+type bridging happens.
 
 ## 5. The Recovery Model Today
 
@@ -461,26 +502,35 @@ management plan is fully implemented.
 ### 6.1 ResourceManager
 
 The `ResourceManager` is a graph-level object that owns the ledger. One
-`ResourceManager` per plan session. The ledger stores `any` because Go
-generics do not allow mixed type parameters in a single slice.
+`ResourceManager` per plan session. The ledger is the plan-time skeleton —
+URIs, relationships, and resource states, but no target-machine-specific
+metadata. Metadata is populated per-execution by the executor's pre-flight
+resolution pass.
 
 ```
 ResourceManager
-├── ledger: []any             ← append-only, mixed Resource types
-├── metadata: map[ID]Metadata ← physical state (hash, inode, size)
+├── ledger: map[ID]Resource   ← append-only, keyed by resource ID
 └── methods:
     ├── EnsureCataloged(uri, producerID) → Resource
-    └── LookupResource[T](id) → T, bool
+    ├── Lookup(id) → Resource, bool
+    ├── Unresolved() → []Resource   ← entries needing pre-flight resolution
+    └── Resolve(id, metadata)       ← called by executor after stat
 ```
 
-Type-safe access is via `LookupResource[T]`:
+The ledger stores `Resource` values (with `op.Resource` embedded). The
+`NamespaceMap` deduplicates by URI — if 5 nodes reference the same source
+path, `namespace.Resolve()` returns the same resource ID. Pre-flight
+resolution stat's each unique URI once.
 
-```go
-// Target API — type-safe access to the any-typed ledger
-func LookupResource[T any](mgr *ResourceManager, id string) (T, bool) {
-    // Iterate ledger, type-assert to Resource wrapper containing T metadata
-}
-```
+**Plan-time vs execution-time ownership:**
+
+| Concern | Owner | When |
+| --- | --- | --- |
+| URIs and relationships | Planner (ResourceManager + NamespaceMap) | Plan time |
+| Implicit edges via shadowing | Planner | Plan time |
+| Resource state (unresolved/pending/resolved) | ResourceManager | Both |
+| Metadata (inode, size, checksum) | Executor pre-flight | Execution time, per target |
+| Pending → resolved transitions | Node execution results | Execution time |
 
 ### 6.2 NamespaceMap
 
@@ -524,24 +574,50 @@ Step 2: plan.file.read(path="/etc/foo")
 Result: write happens before read. No explicit Output passing needed.
 ```
 
-### 6.4 Planning Data Flow
+### 6.4 Planning Data Flow (Pure — No I/O)
+
+The planner is pure. It coerces strings to typed Resources (URI only, no
+metadata) and builds the ledger skeleton. No `os.Stat`, no filesystem
+access. This is required because a graph is planned once and executed on
+many machines.
 
 ```
 Starlark call: plan.file.write_text(destination="/etc/foo", content="v2", mode=0o644)
     │
     ▼
-PlannedReceiver.write_text()
-    ├─ uri = "file://" + destination
-    ├─ namespace.Shadow(uri, node.ID)    ← new Resource in ledger
-    ├─ createNode("file.write_text")     ← graph node with slots
-    ├─ fillSlots(node, {destination, content, mode})
-    └─ return Resource (carries Output promise internally)
+buildPlannedBridge.write_text()
+    ├─ coerce "/etc/foo" → file.Resource{URI: "file:///etc/foo", state: pending}
+    ├─ namespace.Shadow("file:///etc/foo", node.ID)  ← new entry in ledger
+    ├─ createNode("file.write_text")                 ← graph node
+    ├─ fillSlots(node, {destination: file.Resource{pending}, content, mode})
+    └─ return Output (promise)
+
+Starlark call: plan.file.read(path="/etc/foo")
+    │
+    ▼
+buildPlannedBridge.read()
+    ├─ coerce "/etc/foo" → file.Resource (type-tag only)
+    ├─ namespace.Resolve("file:///etc/foo")
+    │   └─ returns resource from Shadow above → OriginNodeID = write node
+    ├─ createNode("file.read") with implicit edge from write node
+    └─ return Output (promise)
 ```
 
-### 6.5 Execution Data Flow
+### 6.5 Execution Data Flow (Per Target Machine)
+
+The executor resolves the plan-time skeleton against a specific target
+machine. Pre-flight resolution populates metadata for unresolved entries.
+Node execution populates metadata for pending entries.
 
 ```
-Executor.executeNode(node)
+Executor.Run(ctx, graph)  — on target machine
+    │
+    ├─ Pre-flight: resolution pass (flat iteration over ledger)
+    │   ├─ For each entry with state=unresolved:
+    │   │   ├─ os.Stat on target machine → populate metadata
+    │   │   ├─ Mark entry as resolved
+    │   │   └─ Fail-fast if source does not exist
+    │   └─ Pending entries skipped (don't exist yet)
     │
     ├─ Pre-flight: tombstone scan
     │   ├─ For each resource slot with OriginNodeID:
@@ -549,15 +625,93 @@ Executor.executeNode(node)
     │   │   └─ URI unoccupied? → no action
     │   └─ Inject physical state into slots
     │
-    ├─ action.Do(ctx, resolvedSlots) → result, undoState, error
+    ├─ For each node (topological order):
+    │   ├─ action.Do(ctx, resolvedSlots) → result, undoState, error
+    │   ├─ Post-flight: metadata update
+    │   │   ├─ Re-stat file for kernel-assigned identity
+    │   │   ├─ Record actual hash, inode, size in ledger
+    │   │   ├─ Mark pending resource as resolved
+    │   │   └─ Fulfill resource slot for downstream nodes
+    │   └─ Push recovery entry onto stack
     │
-    ├─ Post-flight: metadata update
-    │   ├─ Re-stat file for kernel-assigned identity
-    │   ├─ Record actual hash, inode, size in ledger
-    │   └─ Fulfill resource slot for downstream nodes
-    │
-    └─ Push recovery entry onto stack
+    └─ Same graph can be executed again on a different target
 ```
+
+### 6.6 Platform Provider — Data Provider
+
+The platform provider (`pkg/op/provider/platform/`) is a data provider, not
+an action provider. It is the Starlark surface for `op.Context.Platform` —
+no independent state, no side effects, no compensation pairs.
+
+Access type is `both`:
+
+- **Immediate** — `platform.distro` returns a string from the local
+  machine's Platform. Useful for single-machine local plans.
+- **Planned** — `plan.platform.distro` returns a promise (`Output`) that
+  the executor resolves against the target machine's Platform at execution
+  time. This is the mechanism by which a single graph targets many machines.
+
+```python
+# Immediate: branch on local machine's distro (single-target plans)
+if platform.distro == "Debian":
+    plan.pkg.install(packages=["nginx"])
+
+# Planned: branch at execution time (multi-target graphs)
+distro = plan.platform.distro
+plan.choose(distro, {
+    "Debian": lambda: plan.pkg.install(packages=["nginx"]),
+    "Fedora": lambda: plan.pkg.install(packages=["nginx"]),
+})
+```
+
+The executor populates `op.Context.Platform` before running any node. For
+remote targets, a different `*op.Platform` is constructed with the remote
+machine's OS, Arch, Distro, and its package/service manager implementations.
+The planned projection's promises resolve against whichever Platform the
+executor provides — the graph itself is target-agnostic.
+
+Because the provider is read-only, it requires no codegen (no actions, no
+params, no compensation). It will evolve as the Starlark receiver surface
+takes shape.
+
+### 6.7 Provider Lifecycle and Context Injection
+
+Providers are singletons. In a graph, a provider follows the lifetime of
+the graph. In a Starlark script, a provider follows the lifetime of the
+script. Every provider needs context — and context is provided at
+construction time. Every provider needs a constructor that accepts a
+context object by reference.
+
+**Current state** — Providers are zero-value structs with no constructor:
+
+```go
+// Generated code — no context, no lifecycle
+op.RegisterReflectedActions(reg, "pkg", &provider.Provider{}, Params)
+NewPkgReceiver(&provider.Provider{})
+```
+
+Context arrives per-call via `op.Context` in `action.Do(ctx, slots)`, but
+providers have no access to it at construction time. This forces providers
+that need platform info (pkg, service) to take manager arguments on every
+method call or to call `host.NewHost()` on every invocation.
+
+**Target state** — Every provider has a constructor that accepts context:
+
+```go
+// Target — context-injected singleton
+p := provider.New(ctx)
+op.RegisterReflectedActions(reg, "pkg", p, Params)
+NewPkgReceiver(p)
+```
+
+The provider holds a reference to the context and reads from it for the
+duration of the graph or script. For the platform provider, this means
+reading `ctx.Platform` directly. For file, pkg, and service providers,
+this means accessing Platform's managers without method-level arguments.
+
+This is a codegen change: the generated binding registrars and receiver
+factories must call a provider constructor with context instead of
+creating zero-value structs.
 
 ## 7. Integration with Current Architecture
 
@@ -594,16 +748,31 @@ create tombstones: the executor's pre-flight pass instead of each provider's
 ### 7.3 Relationship to Constructor Registry
 
 The existing `RegisterConstructor`/`Construct`/`coerceSlotValue` chain
-(`marshal.go:27-48`, `action_reflect.go:82-112`) already handles
-string-to-Resource coercion. When a Starlark script passes `"/etc/foo"` to a
-provider method expecting `file.Resource`, the constructor calls `NewResource`
-and returns a fully populated resource.
+(`marshal.go:27-48`, `action_reflect.go:82-112`) handles string-to-Resource
+coercion at execution time. When a Starlark script passes `"/etc/foo"` to a
+method expecting `file.Resource`, the constructor calls `NewResource` (which
+does `os.Stat`) and returns a fully populated resource.
 
-Resources formalize what the constructor registry does informally. Today, the
-constructor converts a path string to a `file.Resource` with discovery
-metadata. With the full resource architecture, the constructor becomes the
-entry point for namespace resolution — converting a string path into a
-namespace-tracked resource handle with lineage.
+**Target architecture**: The constructor registry evolves into a coercion
+table with two concerns:
+
+1. **Plan-time coercion** (pure, no I/O) — `string → file.Resource{URI
+   only}`. Called by `buildPlannedBridge` during planning. Creates typed
+   but metadata-empty Resources. This is the entry point for namespace
+   resolution — the coerced Resource is tracked in the ledger via
+   `namespace.Resolve()` or `namespace.Shadow()`.
+
+2. **Execution-time resolution** — `file.Resource{unresolved} →
+   file.Resource{resolved}`. Called by the executor's pre-flight pass on
+   the target machine. Populates metadata via `os.Stat`. This cannot
+   happen at plan time because a graph is planned once and executed on
+   many machines with different filesystem state.
+
+The coercion table also supports cross-provider conversions:
+`(mem.Resource, file.Resource) → converter`. Provider methods are
+monomorphic in their resource types — they never see a foreign resource
+type. The coercion table is the only place where cross-provider type
+bridging happens.
 
 ## 8. Provider Signature Migration
 
@@ -700,38 +869,50 @@ ResourceTombstone
    that shadows a `svc://nginx` resource causes the executor to capture the
    current service state before the node executes.
 
-## 10. Open Questions
+## 10. Open Questions and Resolved Decisions
 
-1. **Go generics constraint** — `Resource[T]` with mixed `T` in a single
-   ledger requires `any`-typed storage. Current code leans toward non-generic
-   `Resource` with embedding (as `file.Resource` already does).
+### Resolved
 
-2. **URI canonicalization** — Should `file:///etc/foo` and
-   `file:///etc/../etc/foo` resolve to the same resource? Current leaning:
-   yes — `filepath.Clean` before URI creation (already effectively done by
-   `os.Stat` in `NewResource`).
+1. **Go generics constraint** — Non-generic `Resource` with embedding.
+   `file.Resource` embeds `op.Resource`. The ledger stores `Resource` values
+   keyed by ID.
 
-3. **Immediate mode** — Immediate receivers (non-plan) have no graph and
-   nothing to shadow. Resources may be unnecessary for
-   `file.exists(path="/tmp/foo")`. Current leaning: immediate mode passes
-   through raw values; resources are planning-only.
+2. **URI canonicalization** — Yes. `filepath.Abs` + `filepath.Clean` before
+   URI creation. Applied at plan time (no `os.Stat` needed for
+   canonicalization).
 
-4. **Namespace scope** — One namespace per graph or one per phase? Per-graph
-   means phase boundaries don't reset visibility. Per-phase means phase A's
-   writes aren't visible to phase B unless explicitly passed. Current leaning:
-   per-graph, since phases are saga boundaries (compensation), not isolation
-   boundaries (visibility).
+3. **Immediate mode** — Immediate receivers pass through raw values;
+   resources are planning-only.
 
-5. **Tombstone ownership** — Should the executor own ALL tombstone logic, or
-   should providers retain the option for domain-specific compensation?
-   `service.Stop` → `service.Start` has no filesystem tombstone. Current
-   leaning: executor owns the *decision* of when to tombstone; providers own
-   the *mechanism* for their resource type.
+4. **Namespace scope** — Per-graph. Phases are saga boundaries
+   (compensation), not visibility boundaries.
 
-6. **Gather + resources** — When a gather produces N outputs at the same URI
+5. **Tombstone ownership** — Executor owns the *decision*; providers own
+   the *mechanism*.
+
+6. **Coercion vs resolution** — Planner coerces (pure type-tagging, no
+   I/O). Executor resolves (metadata population per target machine).
+   Required because a graph is planned once and executed on many machines.
+
+7. **Resolution timing** — Executor pre-flight pass resolves all unresolved
+   entries as a flat iteration over the ledger before any node executes.
+   Fail-fast: missing source files detected before partial execution.
+   Pending entries are resolved by node execution results.
+
+### Open
+
+1. **Gather + resources** — When a gather produces N outputs at the same URI
    scheme, how does the namespace handle uniqueness? Current leaning: each
    iteration gets a unique URI suffix (e.g., `file:///etc/foo.0`,
    `file:///etc/foo.1`).
+
+2. **Remote execution transport** — The graph is portable (planned once,
+   executed on many machines). The platform provider (section 6.6) resolves
+   target-machine identity via `op.Context.Platform`, but the execution
+   transport itself — how the executor runs nodes and stats files on a
+   remote machine — is not yet defined. The pre-flight resolution pass
+   needs a filesystem abstraction for remote targets (Platform carries
+   package/service managers but not filesystem operations).
 
 ## 11. Implementation Phases
 
@@ -749,7 +930,8 @@ details, requirements, and file listings.
 
 Phases 1-2 are pure additions (no existing code changes). Phase 3 is the
 pilot migration using the file provider as reference implementation. Phase 4
-extracts tombstone logic from the file provider to the executor. Phases 5-6
-propagate the pattern to all providers and generated code. During migration,
-the system runs in mixed mode: resource-aware providers coexist with raw-type
-providers.
+extracts tombstone logic from the file provider to the executor. Phase 5
+propagates the pattern to all providers. Phase 6 updates the codegen pipeline
+(`MethodParams` → `ParamSpec`, `generate.star` resource detection,
+`params.go.template`). During migration, the system runs in mixed mode:
+resource-aware providers coexist with raw-type providers.

--- a/docs/plans/resource-management.md
+++ b/docs/plans/resource-management.md
@@ -2,7 +2,7 @@
 title: "Resource Management: URI-Based Resource Tracking for Providers"
 status: draft
 created: 2026-02-27
-updated: 2026-03-01
+updated: 2026-03-02
 ---
 
 # Plan: Resource Management
@@ -13,9 +13,11 @@ Add a `ResourceManager` (append-only ledger) and `NamespaceMap`
 (URI-to-resource-ID lookup with Resolve/Shadow) to the execution graph so that
 providers track external state through typed resource handles instead of raw
 strings. The file provider already implements the resource pattern — `op.Resource`
-with URI/ID/OriginNodeID, `file.Resource` with filesystem metadata, constructor
-registry coercion from string to Resource. This plan extends that foundation to
-the graph, the executor, and all providers.
+with URI/ID/OriginNodeID, `file.Resource` with filesystem metadata. This plan
+extends that foundation to the graph, the executor, and all providers. Resource
+coercion (e.g., `string → file.Resource`) moves from provider init-time
+registration to the executor's planner boundary — providers always receive their
+own typed Resource, possibly in an unresolved state.
 
 ## Goals
 
@@ -96,8 +98,8 @@ What exists today, grounded in code:
 | `op.Resource` | Implemented | `pkg/op/resource.go:6` — `{URI, ID, OriginNodeID}` |
 | `file.Resource` | Implemented | `pkg/op/provider/file/resource.go:25` — embeds `op.Resource` + Inode, Device, Size, Mode, ModTime, Checksum |
 | `file.Tombstone` | Implemented | `pkg/op/provider/file/resource.go:36` — `{RecoveryPath, OriginalPath}` |
-| Constructor registry | Implemented | `pkg/op/marshal.go:23` — `RegisterConstructor`, `Construct`, `constructorRegistry` sync.Map |
-| String→Resource coercion | Implemented | `pkg/op/provider/file/resource.go:14` — `init()` registers `string → file.Resource` via `NewResource` |
+| Constructor registry | Implemented (moving) | `pkg/op/marshal.go:23` — `RegisterConstructor`, `Construct`, `constructorRegistry` sync.Map. Per Decision #7, ownership moves from provider init() to the executor's coercion layer. |
+| String→Resource coercion | Implemented (moving) | `pkg/op/provider/file/resource.go:14` — `init()` registers `string → file.Resource` via `NewResource`. Will move to executor boundary. |
 | Coercion chain | Implemented | `pkg/op/action_reflect.go:82` — nil → assignable → convertible → map→struct → constructor → error |
 | `NewResource` (discovery) | Implemented | `pkg/op/provider/file/resource.go:47` — `os.Stat` + `checksumFile` + `syscall.Stat_t` |
 | `RefreshMetadataWith` | Implemented | `pkg/op/provider/file/resource.go:146` — post-write metadata update |
@@ -113,6 +115,7 @@ What exists today, grounded in code:
 | Conflict detection | **Missing** | Two nodes targeting same path = silent race |
 | Executor tombstone layer | **Missing** | Only file provider has recovery; others have none |
 | Other provider resources | **Missing** | Only file provider has a Resource type |
+| Provider lifecycle | **Gap** | Providers are zero-value structs (`&Provider{}`). No constructor, no context injection. Context arrives per-call via `op.Context` in `Do()`. See Decision #8. |
 
 ## Design Decisions (Resolved)
 
@@ -175,6 +178,377 @@ gather body derive from per-iteration data and are naturally unique. If
 collisions arise in practice, the namespace will report the conflict. No
 special handling needed until a concrete case demands it.
 
+### 7. Resource Coercion at the Planner/Executor Boundary
+
+**Decision**: Coercion from raw values (strings) to typed Resources is an
+executor concern, not a provider concern. Providers always receive their own
+typed `Resource` — possibly unresolved (path exists but not yet stat'd) or
+pending (destination that doesn't exist yet), but always typed.
+
+#### What Is: Current Coercion Chain
+
+The coercion chain spans three time boundaries, with type knowledge locked
+in Go reflection:
+
+**Registration time** — Provider `init()` registers constructors:
+
+```
+file/resource.go:init()
+    → op.RegisterConstructor(func(v any) (file.Resource, error) { ... })
+    → constructorRegistry sync.Map: reflect.Type(file.Resource) → func
+```
+
+**Plan time** — `buildPlannedBridge` stores raw Starlark values in slots:
+
+```
+plan.file.copy(source_file="src.txt", destination_filename="dst.txt")
+    → starlark.UnpackArgs → vals[0] = starlark.String("src.txt")
+    → FillSlot(node, graph, "source_file", starlark.String("src.txt"))
+    → Unmarshal → node.SetSlotImmediate("source_file", "src.txt")  // string
+```
+
+No type checking. No Resource creation. Strings stay as strings.
+
+**Execution time** — `reflectedAction.Do()` coerces slots to method types:
+
+```
+reflectedAction.Do(ctx, slots{"source_file": "src.txt", ...})
+    → paramType := method.Type.In(1)  // file.Resource (via reflection)
+    → coerceSlotValue("src.txt", file.Resource)
+        Level 1: nil?                No
+        Level 2: assignable?         No (string ≠ file.Resource)
+        Level 3: convertible?        No
+        Level 4: map → struct?       No
+        Level 5: constructor?        YES → NewResource("src.txt")
+            → os.Stat("src.txt") → inode, size, checksum, mode, modtime
+            → file.Resource{SourcePath: "src.txt", Inode: ..., ...}
+    → Provider.Copy receives file.Resource
+```
+
+**Generated code carries NO type metadata.** `MethodParams` is
+`map[string][]string` — just param names. The 4-file codegen pattern:
+
+| File | Type info | What it does |
+| --- | --- | --- |
+| `params.gen.go` | None — names only | `MethodParams{"Copy": {"source_file", "destination_filename", ...}}` |
+| `actions.gen.go` | Implicit — Go reflection | `RegisterReflectedActions` reflects on `Provider` struct at runtime |
+| `planned.gen.go` | None | `WrapPlanned` → `buildPlannedBridge` → `FillSlot` stores raw values |
+| `immediate.gen.go` | Implicit — Go reflection | `WrapReceiver` → `buildMethodBridge` → `unmarshalValue` at call time |
+
+**Problems with current design:**
+
+1. **Late coercion** — `os.Stat` discovery happens inside `coerceSlotValue`
+   during execution. Errors surface at execution time, not planning time.
+2. **No cross-provider coercion** — the constructor registry maps
+   `target_type → func(any)`. There's no path from `mem.Resource` →
+   `file.Resource` — only `string → file.Resource`.
+3. **Scattered registration** — each provider's `resource.go:init()`
+   registers its constructor independently. The executor has no visibility
+   into what coercions are available.
+4. **No type validation at plan time** — passing an `int` to a Resource
+   slot silently stores it. The error surfaces in `coerceSlotValue` during
+   execution.
+
+#### What Will Be: Planner Coerces, Executor Resolves
+
+Two distinct operations, cleanly separated:
+
+- **Coercion** (plan time): Type-tagging. `string → file.Resource{URI,
+  state=unresolved}`. Pure — no I/O, no `os.Stat`. The planner knows
+  *what type* a slot value should be.
+- **Resolution** (execution time): Metadata population. `file.Resource
+  {unresolved} → file.Resource{resolved, inode, size, checksum}`. I/O
+  against the *target machine*. The executor knows *what exists*.
+
+This separation is forced by a hard constraint: **a graph can be planned
+once and executed on many machines**. A graph can target the local host or
+any number of remote machines. `os.Stat` at plan time gives the planning
+machine's metadata, not the target's. `/etc/nginx/nginx.conf` has different
+inode, size, and checksum on every machine. The planner must be pure.
+
+**Registration time** — the registry evolves from a constructor registry
+to a **coercion table** that maps `(source_type, target_type)` pairs:
+
+```
+// Current: target_type → constructor (does I/O via NewResource → os.Stat)
+constructorRegistry: reflect.Type(file.Resource) → func(any) (any, error)
+
+// Target: (source_type, target_type) → coercion_func (pure, no I/O)
+coercionTable:
+    (string, file.Resource)        → file.ResourceFromPath(s)  // URI only, no stat
+    (string, service.Resource)     → service.ResourceFromName(s)
+    (string, pkg.Resource)         → pkg.ResourceFromName(s)
+    (mem.Resource, file.Resource)  → file.ResourceFromMem(m)
+```
+
+**Plan time** — `buildPlannedBridge` coerces slot values to typed
+Resources using the coercion table. This requires `buildPlannedBridge` to
+know param types — either via `reflect.Method` (passed from `WrapPlanned`)
+or via enriched `MethodParams`. The result is typed but metadata-empty:
+
+```
+plan.file.copy(source_file="src.txt", destination_filename="dst.txt")
+    → buildPlannedBridge knows: param 0 expects file.Resource
+    → coercionTable.Coerce("src.txt", file.Resource)
+        → file.Resource{URI: "file:///src.txt", state: unresolved}  // no os.Stat
+    → namespace.Resolve("file:///src.txt") → resource-1 (cataloged, unresolved)
+    → node.SetSlotImmediate("source_file", file.Resource{...})
+```
+
+The graph now contains typed Resources in its slots. The ledger contains
+URIs and relationships. No metadata. Portable across machines.
+
+**Executor pre-flight** (NEW, per execution target) — resolves all
+unresolved resources against the target machine before any node runs:
+
+```
+for each entry in resourceManager.Ledger():
+    if entry.State == unresolved:
+        metadata := resolve(entry)  // os.Stat on target machine
+        if err:
+            fail-fast: "source file not found: /etc/foo"
+        entry.State = resolved
+        entry.Metadata = metadata
+    // pending entries (outputs) skip — they don't exist yet
+```
+
+This is a flat iteration over the ledger — O(unique source URIs), not a
+graph traversal. The namespace deduplicates by URI: if 5 nodes reference
+the same source path, `namespace.Resolve()` returns the same resource ID,
+and pre-flight stat's it once.
+
+**Execution time** — `reflectedAction.Do()` receives typed, resolved
+Resources. `coerceSlotValue` Level 2 (assignable) matches immediately.
+Level 5 (constructor) never fires. Pending Resources (outputs) are
+populated by node results and flow downstream via promise resolution.
+
+**Example flow:**
+
+```
+PLAN (pure, no I/O):
+    plan.file.copy("source.txt", "dest.txt")
+        → slot: source_file = file.Resource{URI: "file:///src.txt", state: unresolved}
+        → slot: destination_filename = "dst.txt"  (string, not a Resource)
+        → ledger: [resource-1: file:///src.txt, unresolved]
+
+EXECUTE on machine A:
+    pre-flight:
+        → resolve resource-1 against machine A
+        → os.Stat("/src.txt") → inode=42, size=1024, checksum=abc...
+        → resource-1.State = resolved, resource-1.Metadata = {...}
+
+    reflectedAction.Do():
+        → slot source_file: file.Resource{resolved} → Level 2: assignable ✓
+        → Provider.Copy receives (file.Resource, string, os.FileMode)
+
+EXECUTE on machine B (same graph, different target):
+    pre-flight:
+        → resolve resource-1 against machine B
+        → os.Stat("/src.txt") → inode=99, size=1024, checksum=def...
+        → resource-1.State = resolved, resource-1.Metadata = {...}  // different inode, checksum
+```
+
+#### Ledger Structure
+
+The ledger is an append-only collection keyed by resource ID. The
+`NamespaceMap` deduplicates by URI — multiple nodes referencing the same
+path share a single ledger entry. Multiple entries per URI exist only from
+shadowing (a write creates a new version).
+
+**Three resource states:**
+- **Unresolved**: Source input — the external entity should exist but
+  hasn't been stat'd. URI and type are set, metadata is empty. Created by
+  `namespace.Resolve()` when the planner encounters a source path.
+  Resolved by the executor's pre-flight pass against the target machine.
+- **Pending**: Output — the external entity does not yet exist. URI and
+  type are set, metadata is empty. Created by `namespace.Shadow()` when
+  the planner encounters a destination. Resolved by the node's execution
+  result — the provider populates metadata after creating the entity.
+- **Resolved**: Metadata populated. For files: inode, device, size, mode,
+  modtime, checksum. For services: status. For packages: version.
+
+```
+Ledger (plan-time skeleton — portable):
+  resource-1: URI=file:///src.txt,  state=unresolved, origin=""
+  resource-2: URI=file:///dst.txt,  state=pending,    origin=copy-node
+
+Namespace:
+  file:///src.txt → resource-1
+  file:///dst.txt → resource-2
+
+After pre-flight on target machine (execution-scoped):
+  resource-1: URI=file:///src.txt,  state=resolved, metadata={inode:42, ...}
+  resource-2: URI=file:///dst.txt,  state=pending   (still pending — not yet created)
+
+After copy-node executes:
+  resource-2: URI=file:///dst.txt,  state=resolved, metadata={inode:87, ...}
+```
+
+#### Codegen Tool Changes
+
+Three layers of change, in dependency order:
+
+**Layer 1: Action interface — `SlotTypes()` (devlore-cli, no codegen)**
+
+Add `SlotTypes() map[string]reflect.Type` to the `Action` interface.
+`reflectedAction` implements it by reflecting on `method.Type.In(i+1)` for
+each param name. `WrapPlanned` passes the `reflect.Method` to
+`buildPlannedBridge` so it can coerce at plan time.
+
+```go
+func (a *reflectedAction) SlotTypes() map[string]reflect.Type {
+    types := make(map[string]reflect.Type, len(a.paramNames))
+    for i, name := range a.paramNames {
+        types[name] = a.method.Type.In(i + 1) // skip receiver
+    }
+    return types
+}
+```
+
+**Layer 2: Coercion table (devlore-cli, replaces constructor registry)**
+
+Evolve `constructorRegistry` in `marshal.go` to a coercion table. Two
+kinds of entries:
+
+- **Plan-time coercions** (pure, no I/O): `string → file.Resource{URI
+  only}`, `mem.Resource → file.Resource`. Called by `buildPlannedBridge`.
+- **Execution-time resolvers**: `file.Resource{unresolved} → file.Resource
+  {resolved}`. Called by the executor's pre-flight pass. These do I/O
+  (os.Stat, service status check, package version query).
+
+**Layer 3: `MethodParams` type evolution (devlore-cli + noblefactor-ops)**
+
+Extend `MethodParams` to carry type metadata:
+
+```go
+// Current:
+type MethodParams map[string][]string
+
+// Target:
+type ParamSpec struct {
+    Name       string
+    TypeName   string // Go type as string: "string", "file.Resource", "os.FileMode"
+    IsResource bool   // true if type embeds op.Resource
+}
+type MethodParams map[string][]ParamSpec
+```
+
+This requires changes to:
+
+| Component | Repo | Change |
+| --- | --- | --- |
+| `MethodParams` type | devlore-cli `pkg/op/receiver_reflect.go` | `[]string` → `[]ParamSpec` |
+| `params.go.template` | devlore-cli `star/extensions/.../templates/` | Emit `ParamSpec` structs |
+| `generate.star` | devlore-cli `star/extensions/.../commands/` | Detect Resource types, set `IsResource` |
+| `go.type_embeds()` | noblefactor-ops GoReceiver | New introspection: does type T embed type U? |
+| `WrapPlanned` | devlore-cli `pkg/op/planned_reflect.go` | Pass `reflect.Method` to `buildPlannedBridge` for plan-time coercion |
+| `WrapReceiver` | devlore-cli `pkg/op/receiver_reflect.go` | Extract param names from `ParamSpec` |
+| `RegisterReflectedActions` | devlore-cli `pkg/op/action_reflect.go` | Extract param names from `ParamSpec` |
+
+**Layer 4: Provider constructors (devlore-cli + codegen)**
+
+Per Decision #8, every provider needs a constructor that accepts context.
+The generated binding code must change from zero-value struct creation to
+constructor calls:
+
+| Component | Repo | Change |
+| --- | --- | --- |
+| `actions.gen.go` | devlore-cli (generated) | `&provider.Provider{}` → `provider.New(ctx)` |
+| `immediate.gen.go` | devlore-cli (generated) | `&provider.Provider{}` → `provider.New(ctx)` |
+| `graph_actions.go.template` | devlore-cli templates | Emit constructor call with context |
+| `immediate_receiver.go.template` | devlore-cli templates | Emit constructor call with context |
+| `ProviderBinding` | devlore-cli `pkg/op/binding.go` | `ActionRegistrar` and `ImmediateFactory` closures receive context |
+| Each `provider.go` | devlore-cli `pkg/op/provider/*/` | Add `func New(ctx) *Provider` constructor |
+
+#### `generate.star` Changes
+
+`build_method_descriptors()` already receives param type strings from
+`go.methods()` AST introspection. It currently stores `p.type` but only
+uses it for struct_param and callable detection. Changes:
+
+1. **Resource detection** — for each param, check if its Go type embeds
+   `op.Resource`. This requires a new `go.type_embeds(path, type_name,
+   target_type)` introspection method on the GoReceiver (noblefactor-ops).
+   Alternatively, maintain a known-Resource-types list in the generator,
+   since all Resource types are defined in devlore-cli and their names are
+   predictable (`file.Resource`, `git.Resource`, `service.Resource`,
+   `pkg.Resource`).
+
+2. **Param descriptor annotation** — add `is_resource: true` to param
+   descriptors for Resource-typed params. The `params.go.template` uses
+   this to emit `IsResource: true` in the generated `ParamSpec`.
+
+3. **Plan-time type name** — include the Go type name in the param
+   descriptor so `params.go.template` can emit `TypeName: "file.Resource"`.
+
+#### Implementation Order
+
+| Step | What | Where | Depends on |
+| --- | --- | --- | --- |
+| 1 | `Action.SlotTypes()` + pass `reflect.Method` to planned bridge | devlore-cli `pkg/op/` | Nothing |
+| 2 | Coercion table (plan-time coercions + execution-time resolvers) | devlore-cli `pkg/op/marshal.go` | Step 1 |
+| 3 | Plan-time coercion in `buildPlannedBridge` | devlore-cli `pkg/op/planned_reflect.go` | Steps 1-2 |
+| 4 | Executor pre-flight resolution pass | devlore-cli `internal/execution/` | Step 2 |
+| 5 | `go.type_embeds()` | noblefactor-ops GoReceiver | Nothing |
+| 6 | `ParamSpec` type + template | devlore-cli + templates | Step 5 |
+| 7 | `generate.star` annotations | devlore-cli extension | Steps 5-6 |
+| 8 | Provider constructors + context injection | devlore-cli providers + templates | Steps 6-7 |
+
+Steps 1-4 can ship independently (reflection-only, no codegen changes).
+Steps 5-7 ship together (codegen pipeline update).
+Step 8 ships after codegen — it changes every provider and every generated
+binding.
+
+### 8. Provider Lifecycle: Singletons with Context Injection
+
+**Decision**: Providers are singletons. In a graph, a provider follows the
+lifetime of the graph. In a Starlark script, a provider follows the lifetime
+of the script. Every provider needs context, and context is provided at
+construction time — every provider needs a constructor that accepts a
+context object by reference.
+
+**Current state** — Providers are zero-value structs with no constructor:
+
+```go
+// Generated actions.gen.go — zero-value, no context
+op.RegisterReflectedActions(reg, "pkg", &provider.Provider{}, Params)
+
+// Generated immediate.gen.go — zero-value, no context
+NewPkgReceiver(&provider.Provider{})
+```
+
+Context arrives per-call via `op.Context` in `action.Do(ctx, slots)`. The
+provider cannot access Platform, Writer, or Data at construction time.
+Providers that need platform info (pkg, service) take manager arguments on
+every method call or call `host.NewHost()` on every invocation.
+
+**Target state** — Every provider has a constructor that accepts context:
+
+```go
+// Target — context-injected singleton
+p := provider.New(ctx)
+op.RegisterReflectedActions(reg, "pkg", p, Params)
+NewPkgReceiver(p)
+```
+
+The provider holds a reference to the context and reads from it for its
+entire lifetime. For the platform provider, this means reading
+`ctx.Platform` directly — the provider is just a Starlark surface for
+Platform data. For file, pkg, and service providers, this means accessing
+Platform's managers without method-level arguments.
+
+**Codegen impact**: The generated `actions.gen.go` and `immediate.gen.go`
+files currently create `&provider.Provider{}`. These must change to call a
+provider constructor with context. The `ProviderBinding` struct's
+`ActionRegistrar` and `ImmediateFactory` closures both need access to a
+context parameter. This affects every generated binding for every provider.
+
+**Relationship to Design Decision #7**: Context injection and resource
+coercion are complementary. The provider receives context at construction
+(Decision #8) and receives typed Resources in its method params (Decision
+#7). Together, they eliminate both the "providers can't access platform"
+problem and the "providers receive raw strings" problem.
+
 ## Implementation Phases
 
 ### Phase 0: `star devlore test` Extension
@@ -204,10 +578,37 @@ Today's test infrastructure has a gap between planning and execution:
 No test currently does the full loop: **Starlark plan → graph → execute →
 verify results → verify compensation**.
 
-#### Extension Structure
+#### Architecture
 
-The extension follows the same pattern as the existing four extensions in
-`star/extensions/`:
+`devlore-test` is a **separate binary** (`cmd/devlore-test/`) with
+process-level isolation, not an embedded receiver. It runs under `star`
+command control via an extension that shells out to the binary (CLI args +
+stdout + exit code). No noblefactor-ops spec changes — the `.star` command
+resolves the binary path by convention.
+
+```
+star devlore test run --script path.star
+        |
+        v
+   run.star (extension command)
+        |  shells out to devlore-test binary
+        v
+   devlore-test --script path.star [--dry-run] [--trace]
+        |
+        |  1. Creates temp dir
+        |  2. Sets up BindingSet -> plan namespace
+        |  3. Injects `t` namespace (expectations)
+        |  4. Executes .star script (plan.* builds graph)
+        |  5. Wraps nodes in a Phase for RunPhased compensation
+        |  6. Executes graph via GraphExecutor
+        |  7. Checks queued expectations
+        |  8. Writes structured results to stdout
+        |  9. Exit code: 0 = pass, 1 = fail, 2 = error
+        v
+   run.star reads stdout, reports via ui.*
+```
+
+#### Extension Structure
 
 ```
 star/extensions/com.noblefactor.devlore.Test/
@@ -216,68 +617,48 @@ star/extensions/com.noblefactor.devlore.Test/
     └── run.star
 ```
 
-**extension.yaml**:
+**extension.yaml** declares the command with flags for `--script`,
+`--dry-run`, `--trace`, and `--tool-path` (path to the `devlore-test`
+binary, resolved via flag → env var → config default `build/devlore-test`).
 
-```yaml
-extension: com.noblefactor.devlore.Test
-description: Test harness for Starlark graph planning and execution
+#### Runner Package (`internal/e2e/testrunner/`)
 
-receivers:
-  - name: test
-    builtin: true
-    type: TestReceiver
-    description: Graph planning, execution, and expectation verification
-  - name: ui
-    builtin: true
-    type: UiReceiver
-    description: Status output (note, warn, success, fail)
-
-commands:
-  - name: devlore.test.run
-    help: Run a Starlark test script that plans and executes a graph
-    implementation: commands/run.star
-    flags:
-      - name: script
-        type: string
-        required: true
-        help: Path to the test script (.star)
-      - name: provider
-        type: string
-        default: ""
-        help: "Restrict to a specific provider (default: all)"
-      - name: dry-run
-        type: bool
-        default: "false"
-        help: Execute in dry-run mode (plan only, no side effects)
-```
-
-#### TestReceiver
-
-A builtin Go receiver that wraps `BindingSet` (planned receivers) +
-`GraphExecutor`. It implements the full plan→execute→verify pipeline as
-a single `test.run()` call.
+Core orchestration lives in `internal/e2e/testrunner/`, sibling to the
+existing LLM accuracy harness in `internal/e2e/`. The LLM harness tests
+migrate/onboard via provider configs and F1 metrics. This package tests
+the graph pipeline: Starlark plan → graph → execute → verify.
 
 ```go
-// TestReceiver implements the star devlore test harness.
-// It loads a test script, sets up the plan namespace via BindingSet,
-// executes the script to build a graph, runs the graph through
-// GraphExecutor, and checks expectations registered during script
-// execution.
-type TestReceiver struct {
-    // ...
+type Runner struct {
+    script   string
+    dryRun   bool
+    trace    bool
+    provider string
+    writer   io.Writer
 }
+
+func New(script string, opts ...Option) *Runner
+func (r *Runner) Start(ctx context.Context) (*Result, error)
 ```
 
-`test.run(script, opts)` does the following:
+`Runner.Start()` does the following:
 
 1. Creates a temp directory for filesystem operations
-2. Sets up `BindingSet` with all planned receivers → `plan` namespace
-3. Injects a `t` namespace into the script environment (see below)
-4. Executes the test script — `plan.*` calls build graph nodes,
+2. Creates `BindingSet` with `op.BindingConfig{}` + `.With("plan", "file")`
+3. Creates `ActionRegistry` via `bs.NewPopulatedRegistry()`
+4. Creates `Platform` via `platform.New()`
+5. Creates `op.Graph("devlore-test")`
+6. Builds Starlark globals from `bs.BuildGlobals(graph, project, reg)`
+7. Injects a `t` namespace into the script environment (see below)
+8. Configures Starlark `Thread` with trace handler
+9. Executes the test script — `plan.*` calls build graph nodes,
    `t.expect_*` calls register post-execution expectations
-5. Executes the graph through `GraphExecutor`
-6. Checks all queued expectations against actual results
-7. Returns a result struct with pass/fail, assertion details, node count
+10. Wraps all nodes in a single `phase.test` Phase for RunPhased
+    compensation semantics (without phases, `runFlat` executes but does
+    not unwind the recovery stack on failure)
+11. Executes the graph through `GraphExecutor`
+12. Checks all queued expectations against actual results
+13. Returns a `Result` struct with pass/fail, assertion details, node count
 
 #### The `t` Namespace
 
@@ -302,30 +683,35 @@ separated by the `plan.*` vs `t.expect_*` convention.
 
 #### The Star Command
 
-The command (`commands/run.star`) is a thin wrapper:
+The command (`commands/run.star`) resolves the `devlore-test` binary via a
+3-tier lookup: `--tool-path` flag → `DEVLORE_TEST_TOOL_PATH` env var →
+extension config `test.tool_path` (default: `build/devlore-test` relative
+to the git worktree root). It shells out with flags, parses JSON stdout,
+and reports via `ui.*`.
 
-```starlark
-def run(ctx):
-    result = test.run(
-        script = ctx.args["script"],
-        provider = ctx.args.get("provider", ""),
-        dry_run = ctx.args.get("dry-run", False),
-    )
-    if result.passed:
-        success(
-            "All expectations met ("
-            + str(result.expectation_count) + " expectations, "
-            + str(result.node_count) + " nodes)"
-        )
-    else:
-        for f in result.failures:
-            error(f.expectation + ": " + f.message)
-        fail(str(len(result.failures)) + " expectation(s) failed")
+Note: Direct exec from Starlark requires a future `host.exec()` receiver
+in noblefactor-ops. Until then, the `run.star` command documents the
+intended flow but cannot shell out natively.
+
+#### Stdout Protocol
+
+JSON object on stdout:
+
+```json
+{
+  "passed": true,
+  "node_count": 3,
+  "expectation_count": 2,
+  "failures": [],
+  "trace": ["script: test.star", "tmpdir: /tmp/...", "..."]
+}
 ```
+
+Exit codes: `0` = all pass, `1` = expectation failure, `2` = harness error.
 
 #### Test Script Convention
 
-Test scripts live in `testdata/` directories. They follow a naming
+Test scripts live in `internal/e2e/testrunner/data/`. They follow a naming
 convention: `test_<scenario>.star`.
 
 ```starlark
@@ -387,14 +773,18 @@ its new functionality.
 
 | File | Action | Purpose |
 | --- | --- | --- |
-| `star/extensions/com.noblefactor.devlore.Test/extension.yaml` | Create | Extension spec with TestReceiver and run command |
-| `star/extensions/com.noblefactor.devlore.Test/commands/run.star` | Create | Thin wrapper calling `test.run()` |
-| `internal/starlark/test_receiver.go` | Create | `TestReceiver` — BindingSet + GraphExecutor + expectation checking |
-| `internal/starlark/test_receiver_test.go` | Create | Unit tests for TestReceiver |
-| `internal/starlark/testdata/test_write_text.star` | Create | Baseline: write text |
-| `internal/starlark/testdata/test_copy.star` | Create | Baseline: copy file |
-| `internal/starlark/testdata/test_write_and_read.star` | Create | Baseline: write then read |
-| `internal/starlark/testdata/test_compensation.star` | Create | Baseline: write + fail → compensate |
+| `cmd/devlore-test/main.go` | Create | Binary entry point (flags, JSON output, exit codes) |
+| `internal/e2e/testrunner/runner.go` | Create | Runner orchestration (BindingSet + GraphExecutor + phase wrapping) |
+| `internal/e2e/testrunner/runner_test.go` | Create | Go-level test entry points (GoLand-debuggable) |
+| `internal/e2e/testrunner/test_context.go` | Create | `t` namespace (Starlark receiver for expectations) |
+| `internal/e2e/testrunner/trace.go` | Create | Starlark trace mode (step callback + variable inspection) |
+| `internal/e2e/testrunner/data/test_write_text.star` | Create | Baseline: write text |
+| `internal/e2e/testrunner/data/test_copy.star` | Create | Baseline: copy file |
+| `internal/e2e/testrunner/data/test_write_and_read.star` | Create | Baseline: write then read |
+| `internal/e2e/testrunner/data/test_compensation.star` | Create | Baseline: write + fail → compensate |
+| `star/extensions/com.noblefactor.devlore.Test/extension.yaml` | Create | Extension spec with run command |
+| `star/extensions/com.noblefactor.devlore.Test/commands/run.star` | Create | Star command (shells out to devlore-test binary) |
+| `Makefile` | Modify | Add devlore-test build target |
 | `pkg/op/provider/file/gen/integration_test.go` | Modify | Un-skip #170, #171 |
 
 ### Phase 1: ResourceManager and NamespaceMap
@@ -593,10 +983,11 @@ which resources.
 
 Finish migrating all file provider method inputs to `Resource`. The outputs
 are already `Resource` for Copy, WriteText, WriteBytes, and Read. This phase
-converts the remaining string inputs. The constructor registry ensures
-backward compatibility — Starlark scripts passing string paths still work
-because `coerceSlotValue` calls the registered `string → file.Resource`
-constructor.
+converts the remaining string inputs. Per Design Decision #7, the executor's
+coercion layer converts strings to typed `file.Resource` values at the
+planner/executor boundary — provider methods always receive `file.Resource`,
+either resolved (existing file with metadata) or pending (destination path
+with empty metadata).
 
 **Repo**: devlore-cli
 
@@ -793,7 +1184,8 @@ type Resource struct {
 }
 ```
 
-Each registers a constructor in `init()` following the file provider pattern:
+Each registers a resource constructor in `init()` following the file
+provider pattern:
 
 ```go
 func init() {
@@ -804,6 +1196,16 @@ func init() {
         }
         return NewResource(s)
     })
+}
+```
+
+Each provider also gains a provider constructor per Decision #8:
+
+```go
+// New creates a Provider with context injected at construction time.
+// The provider is a singleton — one per graph or script lifetime.
+func New(ctx *op.Context) *Provider {
+    return &Provider{ctx: ctx}
 }
 ```
 
@@ -896,10 +1298,11 @@ after provider signatures change. That is the only interaction with codegen.
 2. **Phase 2**: Graph gains Resources/Namespace fields. `FillSlot` gains
    resource-aware edge creation. Legacy graphs (nil Resources) work unchanged.
    Test scripts verify implicit edge creation via shadowing.
-3. **Phase 3**: File provider completes its input migration. Constructor
-   registry ensures Starlark scripts passing strings still work. Generated
-   code regenerated. Harness tests verify every file provider method with
-   Resource inputs, including compensation round-trips.
+3. **Phase 3**: File provider completes its input migration. The executor's
+   coercion layer converts strings to `file.Resource` at the planner boundary
+   (Design Decision #7). Generated code regenerated. Harness tests verify
+   every file provider method with Resource inputs, including compensation
+   round-trips.
 4. **Phase 4**: Executor gains pre-flight tombstone pass. File provider's
    internal `prepareWrite` calls migrate to the executor. Legacy graphs
    without resources skip the pre-flight pass. Test scripts verify tombstone
@@ -913,10 +1316,14 @@ after provider signatures change. That is the only interaction with codegen.
 
 | File | Phase | Action | Purpose |
 | --- | --- | --- | --- |
+| `cmd/devlore-test/main.go` | 0 | Create | Binary entry point |
+| `internal/e2e/testrunner/runner.go` | 0 | Create | Runner orchestration (plan + execute + verify) |
+| `internal/e2e/testrunner/runner_test.go` | 0 | Create | Go-level test entry points |
+| `internal/e2e/testrunner/test_context.go` | 0 | Create | `t` namespace |
+| `internal/e2e/testrunner/trace.go` | 0 | Create | Starlark trace mode |
+| `internal/e2e/testrunner/data/test_*.star` | 0 | Create | Baseline test scripts |
 | `star/extensions/com.noblefactor.devlore.Test/` | 0 | Create | Extension spec + star command |
-| `internal/starlark/test_receiver.go` | 0 | Create | TestReceiver (plan + execute + verify) |
-| `internal/starlark/test_receiver_test.go` | 0 | Create | TestReceiver unit tests |
-| `internal/starlark/testdata/test_*.star` | 0 | Create | Baseline test scripts |
+| `Makefile` | 0 | Modify | Add devlore-test build target |
 | `pkg/op/provider/file/gen/integration_test.go` | 0 | Modify | Un-skip #170, #171 |
 | `pkg/op/resource.go` | 1 | Modify | ResourceManager, URI helpers |
 | `pkg/op/resource_test.go` | 1 | Create | Manager and URI tests |
@@ -950,7 +1357,7 @@ conflicts in `action.go`, every `provider.go`, and `executor.go`.
 
 ## Debugging Strategy: JetBrains + Starlark
 
-The `star devlore test` extension must be debuggable in GoLand (or IntelliJ
+The `devlore-test` harness must be debuggable in GoLand (or IntelliJ
 with the Go plugin). The goal: set a breakpoint in a `.star` test script and
 step through into the graph builder and executor Go code.
 
@@ -963,13 +1370,13 @@ us the building blocks.
 
 ### Layer 1: Go Test Entry Point (Day 1)
 
-The `TestReceiver` has a Go test file (`test_receiver_test.go`) with tests
-that call `TestReceiver.Run()` directly. Run these in GoLand's debugger:
+The runner package has a Go test file (`runner_test.go`) with tests
+that call `Runner.Start()` directly. Run these in GoLand's debugger:
 
 ```go
 func TestWriteAndRead(t *testing.T) {
-    r := NewTestReceiver(/* ... */)
-    result := r.Run("testdata/test_write_and_read.star", TestOptions{})
+    runner := testrunner.New(filepath.Join(testdataDir, "test_write_and_read.star"))
+    result, err := runner.Start(context.Background())
     // ...
 }
 ```
@@ -990,9 +1397,9 @@ This gives full visibility into the graph builder and executor from day 1.
 
 ### Layer 2: Starlark Trace Mode (Phase 0)
 
-Add a `--trace` flag to `star devlore test run`. When enabled, the
-`TestReceiver` installs a step callback on the Starlark `Thread` that logs
-each statement with file, line, and local variables:
+The `--trace` flag on `devlore-test` enables the `Tracer` which records
+each Starlark statement with file, line, and local variables via the
+thread's print handler:
 
 ```
 [trace] test_write_and_read.star:4  dest = t.tmp("foo.txt")
@@ -1010,12 +1417,12 @@ each statement with file, line, and local variables:
 [verify] file_content("hello") → PASS
 ```
 
-The step callback uses `thread.CallStack()` for position and
+The trace uses `thread.CallStack()` for position and
 `thread.DebugFrame(0)` for local variable inspection. The trace output
-goes to `ui.note()` so it appears in the star command's output.
+appears in the JSON result's `trace` array.
 
-In GoLand, combine trace mode with a conditional breakpoint on the step
-callback — break when `pos.Filename` and `pos.Line` match a specific
+In GoLand, combine trace mode with a conditional breakpoint on the
+`Tracer.RecordThread` method — break when position matches a specific
 `.star` location. This gives you "breakpoints in Starlark" via Go.
 
 ### Layer 3: Bazel Plugin Starlark Support
@@ -1026,12 +1433,12 @@ navigation, and structure view for `.star` / `.bzl` files. Install it for
 `.star` editing comfort.
 
 The plugin also includes a Starlark debug adapter, but it speaks Bazel's
-debug protocol (not go.starlark.net). To bridge this gap, the `TestReceiver`
+debug protocol (not go.starlark.net). To bridge this gap, the `Runner`
 can optionally expose a **DAP (Debug Adapter Protocol)** server using
 `DebugFrame`:
 
-- `--debug-port <port>` flag on `star devlore test run`
-- The receiver starts a DAP server before executing the script
+- `--debug-port <port>` flag on `devlore-test`
+- The runner starts a DAP server before executing the script
 - GoLand connects to the DAP server as a "Remote Debug" run configuration
 - Breakpoints set in `.star` files are honored via the step callback
 - Variable inspection uses `DebugFrame.Local(i)` to report Starlark locals

--- a/docs/plans/resource-management.md
+++ b/docs/plans/resource-management.md
@@ -982,7 +982,7 @@ func FillSlot(node *Node, graph *Graph, slotName string, value starlark.Value) e
 
 | File | Action | Purpose |
 | --- | --- | --- |
-| `pkg/op/graph.go` | Modify | Add Resources/Namespace fields, init in NewGraph |
+| `pkg/op/graph.go` | Modify | Add Resources/Namespace fields, init in NewGraph; remove dead `backup` annotation check and `BackedUp` summary field |
 | `pkg/op/output.go` | Modify | Resource-aware FillSlot with implicit edges |
 | `pkg/op/resource.go` | Modify | Add `extractResource` reflection helper |
 | `pkg/op/graph_test.go` | Modify | Tests for resource fields on Graph |

--- a/docs/plans/resource-management.md
+++ b/docs/plans/resource-management.md
@@ -2,7 +2,7 @@
 title: "Resource Management: URI-Based Resource Tracking for Providers"
 status: draft
 created: 2026-02-27
-updated: 2026-03-02
+updated: 2026-03-03
 ---
 
 # Plan: Resource Management
@@ -109,8 +109,9 @@ What exists today, grounded in code:
 | Node slots | Working | `map[string]SlotValue` — immediate values or promises |
 | Output/FillSlot | Working | `pkg/op/output.go:121` — routes Output/Gather/immediate/None into slots |
 | Graph edges | Working | Created by FillSlot when it sees an Output |
-| ResourceManager | **Missing** | No ledger, no ID generation, no EnsureCataloged |
-| NamespaceMap | **Missing** | No Resolve/Shadow, no URI-to-ID tracking |
+| ResourceManager | Implemented | `pkg/op/resource.go` — append-only ledger, `EnsureCataloged`/`Lookup`/`LedgerLen`, mutex-guarded monotonic `res-<N>` IDs |
+| NamespaceMap | Implemented | `pkg/op/namespace.go` — `Resolve`/`Shadow`/`Current`, URI→ResourceID mapping |
+| URI helpers | Implemented | `pkg/op/resource.go` — `SchemeFile`/`SchemeGit`/`SchemePackage`/`SchemeService`/`SchemeMem`, `ResourceURI()` with file path canonicalization |
 | Implicit edges | **Missing** | Only explicit Output passing creates edges |
 | Conflict detection | **Missing** | Two nodes targeting same path = silent race |
 | Executor tombstone layer | **Missing** | Only file provider has recovery; others have none |
@@ -498,6 +499,27 @@ Steps 1-4 can ship independently (reflection-only, no codegen changes).
 Steps 5-7 ship together (codegen pipeline update).
 Step 8 ships after codegen — it changes every provider and every generated
 binding.
+
+### 9. Ledger Is the Sole Source of Truth — No Node Annotations
+
+**Decision**: The `ResourceManager` ledger is the single source of truth
+for resource identity and lineage. Node annotations (`resource.input`,
+`resource.output`) are eliminated.
+
+The ledger already records URI, origin node ID, and version lineage through
+`EnsureCataloged` (called by `NamespaceMap.Resolve` and `Shadow`).
+Annotations would duplicate information the ledger already holds and cannot
+represent resources produced at runtime — globs returning N files, dynamic
+template expansions, gather iterations producing unknown resource sets.
+
+The executor's pre-flight pass (Phase 4) queries the ledger directly:
+resources with non-empty `OriginNodeID` whose URI matches a previously
+discovered resource need tombstones. No annotation scanning required.
+
+**Impact**: Phase 2c (Resource Annotations on Nodes) is removed from the
+plan. Phase 2 consists of 2a (Graph owns Manager and Namespace) and 2b
+(FillSlot detects resource identity). The `extractResource` reflection
+helper moves to `resource.go` without annotation constants.
 
 ### 8. Provider Lifecycle: Singletons with Context Injection
 
@@ -922,9 +944,11 @@ func NewGraph(tool string) *Graph {
 #### 2b. FillSlot Detects Resource Identity
 
 Extend `FillSlot` (`output.go:121`) to handle the case where a slot value
-carries resource identity. When an `Output`'s producer node has a resource
-annotation (`resource.output`), the consumer node gets an implicit edge
-even without explicit Output passing.
+carries resource identity. When a slot value embeds `op.Resource` with a
+non-empty `OriginNodeID` (set by `NamespaceMap.Shadow`), the consumer node
+gets an implicit edge from the origin node — even without explicit Output
+passing. The ledger is the sole source of truth (Decision #9); no node
+annotations are needed.
 
 The current flow is unchanged — `Output` still creates edges via
 `output.FillSlot`. The new behavior adds a check: if a Starlark value
@@ -954,28 +978,13 @@ func FillSlot(node *Node, graph *Graph, slotName string, value starlark.Value) e
 
 `extractResource` uses reflection to check if the value embeds `op.Resource`.
 
-#### 2c. Resource Annotations on Nodes
-
-Add annotation helpers so planned receivers can tag nodes with resource IDs:
-
-```go
-const (
-    AnnotationResourceInput  = "resource.input"   // Comma-separated input resource IDs
-    AnnotationResourceOutput = "resource.output"   // Output resource ID
-)
-```
-
-These annotations are metadata — they don't affect execution, but they enable
-the executor's pre-flight binding pass (Phase 4) to know which nodes produce
-which resources.
-
 #### Files
 
 | File | Action | Purpose |
 | --- | --- | --- |
 | `pkg/op/graph.go` | Modify | Add Resources/Namespace fields, init in NewGraph |
 | `pkg/op/output.go` | Modify | Resource-aware FillSlot with implicit edges |
-| `pkg/op/resource.go` | Modify | Add `extractResource` reflection helper, annotation constants |
+| `pkg/op/resource.go` | Modify | Add `extractResource` reflection helper |
 | `pkg/op/graph_test.go` | Modify | Tests for resource fields on Graph |
 | `pkg/op/output_test.go` | Modify | Tests for implicit edge creation in FillSlot |
 

--- a/docs/plans/resource-management/phase-1.md
+++ b/docs/plans/resource-management/phase-1.md
@@ -100,6 +100,14 @@ The executor's pre-flight pass (Phase 4) queries the ledger directly via
 `OriginNodeID` to determine which resources were shadowed and by which
 node.
 
+### Remove Legacy `backup` Annotation (Phase 2)
+
+The `Annotations["backup"]` check in `graph.go:613` and the
+`Summary.BackedUp` counter predate the resource model. No production code
+ever sets this annotation — it only appears in test fixtures. Phase 2
+already modifies `graph.go` to add `Resources`/`Namespace` fields, so the
+removal belongs there.
+
 ## What This Does NOT Touch
 
 - `graph.go` — Graph gets Resources/Namespace fields in Phase 2

--- a/docs/plans/resource-management/phase-1.md
+++ b/docs/plans/resource-management/phase-1.md
@@ -80,6 +80,26 @@ URI→ResourceID mapping with version tracking:
 | `pkg/op/namespace.go` | Create | NamespaceMap with Resolve/Shadow/Current |
 | `pkg/op/namespace_test.go` | Create | Tests for namespace operations |
 
+## Design Decisions
+
+### Ledger Is the Sole Source of Truth (Decision #9)
+
+Node annotations (`resource.input`, `resource.output`) were originally
+planned for Phase 2c to tag nodes with resource IDs so the executor's
+pre-flight pass could identify which nodes produce which resources.
+
+**Decision**: Drop annotations entirely. The `ResourceManager` ledger
+already records URI, origin node ID, and version lineage through
+`Resolve`/`Shadow`. Annotations would duplicate what the ledger already
+knows and cannot represent resources produced at runtime (globs, dynamic
+template expansions, gather iterations). There should always be one source
+of truth — the ledger is it.
+
+**Impact on Phase 2**: Phase 2c (Resource Annotations on Nodes) is removed.
+The executor's pre-flight pass (Phase 4) queries the ledger directly via
+`OriginNodeID` to determine which resources were shadowed and by which
+node.
+
 ## What This Does NOT Touch
 
 - `graph.go` — Graph gets Resources/Namespace fields in Phase 2

--- a/docs/plans/resource-management/phase-1.md
+++ b/docs/plans/resource-management/phase-1.md
@@ -1,0 +1,89 @@
+# Phase 1: ResourceManager, NamespaceMap, and URI Helpers
+
+## Context
+
+Phase 1 adds the core resource-tracking types that all subsequent phases
+depend on: the `ResourceManager` (append-only ledger), `NamespaceMap`
+(URI→ResourceID with Resolve/Shadow), and URI helpers with scheme constants.
+
+These are **pure additions** — no existing code changes, no existing tests
+break. The existing `op.Resource` struct (`pkg/op/resource.go`) has three
+fields (`URI`, `ID`, `OriginNodeID`) but no manager to assign IDs and no
+namespace to track versions. `file.Resource` already embeds `op.Resource`
+and sets `URI` as `file://<path>` — the pattern is established but not yet
+connected to a ledger.
+
+Phase 0 (`devlore-test` harness) shipped in commit `b2c7834`.
+
+**Repo**: devlore-cli
+**Branch**: `feature/resource-management`
+
+## Changes
+
+### URI Helpers (`pkg/op/resource.go`)
+
+Scheme constants and a URI builder:
+
+- `SchemeFile`, `SchemeGit`, `SchemePackage`, `SchemeService`, `SchemeMem`
+- `ResourceURI(scheme, path) string` — for `file://`, canonicalizes via
+  `filepath.Abs` + `filepath.Clean`; other schemes pass through as-is
+
+### ResourceManager (`pkg/op/resource.go`)
+
+Append-only ledger with mutex-guarded monotonic counter:
+
+- `NewResourceManager() *ResourceManager`
+- `EnsureCataloged(uri, originNodeID) string` — creates new entry, returns
+  `res-<N>` ID. Does NOT deduplicate by URI (that's the NamespaceMap's job).
+- `Lookup(id) (Resource, bool)` — retrieve by ID
+- `LedgerLen() int` — entry count
+
+### NamespaceMap (`pkg/op/namespace.go`)
+
+URI→ResourceID mapping with version tracking:
+
+- `NewNamespaceMap() *NamespaceMap`
+- `Resolve(mgr, uri) string` — returns current ID for URI; catalogs
+  discovery (OriginNodeID="") on first access
+- `Shadow(mgr, uri, producerNodeID) string` — creates new version,
+  updates namespace to point to it
+- `Current(uri) string` — returns current ID or ""
+
+### Tests
+
+**`pkg/op/resource_test.go`**:
+- `TestResourceURI_File` — canonicalization via Abs+Clean
+- `TestResourceURI_OtherSchemes` — git, pkg, svc, mem pass through
+- `TestResourceManager_EnsureCataloged` — monotonic IDs (res-1, res-2, ...)
+- `TestResourceManager_Lookup` — correct Resource by ID; false for unknown
+- `TestResourceManager_LedgerLen` — starts at 0, increments
+- `TestResourceManager_ConcurrentAccess` — 50 goroutines, all unique IDs
+
+**`pkg/op/namespace_test.go`**:
+- `TestNamespace_Resolve_FirstAccess` — catalogs discovery, empty OriginNodeID
+- `TestNamespace_Resolve_Idempotent` — same URI twice → same ID, 1 entry
+- `TestNamespace_Shadow` — new version, 2 entries, correct OriginNodeID
+- `TestNamespace_Shadow_OverwritesResolve` — Resolve after Shadow returns shadow's ID
+- `TestNamespace_ImplicitDependency` — Shadow by nodeA → Resolve returns nodeA's resource
+- `TestNamespace_Current_Empty` — unknown URI → ""
+- `TestNamespace_Current_AfterResolve` — returns ID
+- `TestNamespace_Current_AfterShadow` — returns new ID
+- `TestNamespace_MultipleURIs` — independent URIs
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `docs/plans/resource-management/phase-1.md` | Create | This document |
+| `pkg/op/resource.go` | Modify | Add ResourceManager, URI scheme constants, ResourceURI |
+| `pkg/op/resource_test.go` | Create | Tests for ResourceManager and URI helpers |
+| `pkg/op/namespace.go` | Create | NamespaceMap with Resolve/Shadow/Current |
+| `pkg/op/namespace_test.go` | Create | Tests for namespace operations |
+
+## What This Does NOT Touch
+
+- `graph.go` — Graph gets Resources/Namespace fields in Phase 2
+- `output.go` — FillSlot gets resource-aware edges in Phase 2
+- `provider/file/resource.go` — continues using `fmt.Sprintf` for now; updated in Phase 3
+- No generated code changes
+- No existing tests modified

--- a/internal/cli/xdg.go
+++ b/internal/cli/xdg.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 )
 
-// XDG Base Directory Specification paths.
+// XDG ProviderBase Directory Specification paths.
 // See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 
 // ConfigHome returns XDG_CONFIG_HOME or ~/.config

--- a/internal/e2e/testrunner/data/test_compensation.star
+++ b/internal/e2e/testrunner/data/test_compensation.star
@@ -1,0 +1,13 @@
+# test_compensation.star — Write a file, then trigger a failing copy.
+# RunPhased compensation should undo the write, removing the file.
+
+dest = t.tmp("compensated.txt")
+written = plan.file.write_text(destination=dest, content="should be undone", mode=0o644)
+
+# Copy using the write output as source (creates an edge for ordering),
+# but target a read-only path that will fail.
+plan.file.copy(source_file=written, destination_filename="/dev/null/impossible/path.txt", destination_file_mode=0o644)
+
+# After compensation, the written file should be removed.
+t.expect_no_file(dest)
+t.expect_error("file.copy")

--- a/internal/e2e/testrunner/data/test_copy.star
+++ b/internal/e2e/testrunner/data/test_copy.star
@@ -1,0 +1,13 @@
+# test_copy.star — Verify plan.file.copy duplicates a file to a new path.
+
+# Write a source file first. The Output is passed to copy's source_file
+# parameter, creating an edge that guarantees execution order.
+src = t.tmp("source.txt")
+written = plan.file.write_text(destination=src, content="copy me", mode=0o644)
+
+# Copy source to destination — pass the Output as source_file for ordering.
+dst = t.tmp("destination.txt")
+plan.file.copy(source_file=written, destination_filename=dst, destination_file_mode=0o644)
+
+t.expect_file(dst, content="copy me")
+t.expect_node_count(2)

--- a/internal/e2e/testrunner/data/test_write_and_read.star
+++ b/internal/e2e/testrunner/data/test_write_and_read.star
@@ -1,0 +1,8 @@
+# test_write_and_read.star — Write then read the same path.
+# Both nodes target the same path. Nodes without edges are sorted by
+# insertion order within the same path depth, so write runs first.
+dest = t.tmp("readback.txt")
+plan.file.write_text(destination=dest, content="read me back", mode=0o644)
+plan.file.read(path=dest)
+t.expect_file(dest, content="read me back")
+t.expect_node_count(2)

--- a/internal/e2e/testrunner/data/test_write_text.star
+++ b/internal/e2e/testrunner/data/test_write_text.star
@@ -1,0 +1,5 @@
+# test_write_text.star — Verify plan.file.write_text creates a file with correct content.
+dest = t.tmp("hello.txt")
+plan.file.write_text(destination=dest, content="hello world", mode=0o644)
+t.expect_file(dest, content="hello world")
+t.expect_node_count(1)

--- a/internal/e2e/testrunner/runner.go
+++ b/internal/e2e/testrunner/runner.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package testrunner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/internal/execution"
+	loreStar "github.com/NobleFactor/devlore-cli/internal/starlark"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/platform"
+
+	// Blank import registers all provider actions via init().
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider"
+)
+
+// Result is the structured output of a test run.
+type Result struct {
+	Passed           bool      `json:"passed"`
+	NodeCount        int       `json:"node_count"`
+	ExpectationCount int       `json:"expectation_count"`
+	Failures         []Failure `json:"failures"`
+	Trace            []string  `json:"trace,omitempty"`
+}
+
+// Option configures a Runner.
+type Option func(*Runner)
+
+// WithDryRun enables dry-run mode (plan only, no side effects).
+func WithDryRun() Option {
+	return func(r *Runner) { r.dryRun = true }
+}
+
+// WithTrace enables Starlark step-by-step trace logging.
+func WithTrace() Option {
+	return func(r *Runner) { r.trace = true }
+}
+
+// WithProvider restricts execution to a specific provider.
+func WithProvider(name string) Option {
+	return func(r *Runner) { r.provider = name }
+}
+
+// WithWriter sets the output writer for executor messages.
+func WithWriter(w io.Writer) Option {
+	return func(r *Runner) { r.writer = w }
+}
+
+// Runner orchestrates a single test script execution.
+type Runner struct {
+	script   string
+	dryRun   bool
+	trace    bool
+	provider string
+	writer   io.Writer
+}
+
+// New creates a Runner for the given script path.
+func New(script string, opts ...Option) *Runner {
+	r := &Runner{
+		script: script,
+		writer: io.Discard,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Start executes the test script and returns structured results.
+func (r *Runner) Start(ctx context.Context) (*Result, error) {
+	// 1. Create temp directory
+	tmpDir, err := os.MkdirTemp("", "devlore-test-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// 2. Create BindingSet with plan namespace
+	bs := loreStar.NewBindingSet(op.BindingConfig{
+		Writer:      r.writer,
+		ProgramName: "devlore-test",
+		WorkDir:     tmpDir,
+	}).With("plan", "file")
+
+	// 3. Create ActionRegistry with all provider actions
+	reg := bs.NewPopulatedRegistry()
+
+	// 4. Create Platform
+	plat := platform.New()
+
+	// 5. Create Graph
+	graph := op.NewGraph("devlore-test")
+
+	// 6. Build Starlark globals
+	globals := bs.BuildGlobals(graph, "devlore-test", reg)
+
+	// 7. Create TestContext and add to globals
+	tc := NewTestContext(tmpDir)
+	globals["t"] = tc.StarlarkValue()
+
+	// 8. Set up tracer
+	tracer := NewTracer(r.trace)
+
+	// 9. Configure thread
+	thread := &starlark.Thread{
+		Name:  "devlore-test",
+		Print: tracer.PrintHandler(),
+	}
+	bs.ConfigureThread(thread, graph, "devlore-test", reg)
+
+	// 10. Read and execute .star script
+	scriptData, err := os.ReadFile(r.script)
+	if err != nil {
+		return nil, fmt.Errorf("reading script %s: %w", r.script, err)
+	}
+
+	opts := &syntax.FileOptions{
+		Set:             true,
+		GlobalReassign:  true,
+		TopLevelControl: true,
+	}
+
+	if tracer.Enabled() {
+		tracer.Record("script: %s", r.script)
+		tracer.Record("tmpdir: %s", tmpDir)
+	}
+
+	_, err = starlark.ExecFileOptions(opts, thread, r.script, scriptData, globals)
+	if err != nil {
+		// Check if we expected an error
+		if hasErrorExpectation(tc) {
+			return r.buildResult(graph, tc, tracer, err), nil
+		}
+		return nil, fmt.Errorf("executing script: %w", err)
+	}
+
+	// 11. Hydrate graph (actions are already set by planned bindings, but
+	//     this ensures any deserialized stubs are resolved)
+	if err := op.HydrateGraph(graph, reg); err != nil {
+		return nil, fmt.Errorf("hydrating graph: %w", err)
+	}
+
+	// 12. Wrap nodes in a single phase for saga-pattern compensation.
+	//     Without phases, runFlat executes but does not unwind the recovery
+	//     stack on failure. Wrapping gives us RunPhased semantics.
+	if len(graph.Phases) == 0 && len(graph.Nodes) > 0 {
+		phase := &op.Phase{
+			ID:     "phase.test",
+			Name:   "test",
+			Status: op.PhasePending,
+		}
+		for _, n := range graph.Nodes {
+			phase.NodeIDs = append(phase.NodeIDs, n.ID)
+		}
+		graph.Phases = []*op.Phase{phase}
+	}
+
+	// 13. Execute graph
+	executor := execution.NewGraphExecutor(execution.ExecutorOptions{
+		DryRun:   r.dryRun,
+		Writer:   r.writer,
+		Platform: plat,
+	})
+
+	if tracer.Enabled() {
+		tracer.Record("executing graph: %d nodes", len(graph.Nodes))
+	}
+
+	execErr := executor.Run(ctx, graph)
+
+	if tracer.Enabled() {
+		if execErr != nil {
+			tracer.Record("execution error: %v", execErr)
+		} else {
+			tracer.Record("execution completed: state=%s", graph.State)
+		}
+	}
+
+	// 14. Check expectations
+	return r.buildResult(graph, tc, tracer, execErr), nil
+}
+
+// buildResult evaluates expectations and constructs the Result.
+func (r *Runner) buildResult(graph *op.Graph, tc *TestContext, tracer *Tracer, execErr error) *Result {
+	failures := tc.Check(graph, execErr)
+	if failures == nil {
+		failures = []Failure{}
+	}
+
+	result := &Result{
+		Passed:           len(failures) == 0,
+		NodeCount:        len(graph.Nodes),
+		ExpectationCount: len(tc.Expectations()),
+		Failures:         failures,
+	}
+
+	// If there were no error expectations but execution failed, report it
+	if execErr != nil && !hasErrorExpectation(tc) {
+		result.Passed = false
+		result.Failures = append(result.Failures, Failure{
+			Expectation: "execution",
+			Message:     execErr.Error(),
+		})
+	}
+
+	if tracer.Enabled() {
+		result.Trace = tracer.Entries()
+	}
+
+	return result
+}
+
+// hasErrorExpectation returns true if any expectation is of kind "error".
+func hasErrorExpectation(tc *TestContext) bool {
+	for _, exp := range tc.Expectations() {
+		if exp.Kind == "error" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/e2e/testrunner/runner_test.go
+++ b/internal/e2e/testrunner/runner_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package testrunner_test
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/internal/e2e/testrunner"
+)
+
+// testdataDir returns the absolute path to the data/ directory.
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	return filepath.Join(filepath.Dir(file), "data")
+}
+
+func TestWriteText(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_write_text.star")
+	runner := testrunner.New(script)
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if !result.Passed {
+		for _, f := range result.Failures {
+			t.Errorf("FAIL: %s — %s", f.Expectation, f.Message)
+		}
+	}
+	if result.NodeCount != 1 {
+		t.Errorf("node_count = %d, want 1", result.NodeCount)
+	}
+	if result.ExpectationCount != 2 {
+		t.Errorf("expectation_count = %d, want 2", result.ExpectationCount)
+	}
+}
+
+func TestCopy(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_copy.star")
+	runner := testrunner.New(script)
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if !result.Passed {
+		for _, f := range result.Failures {
+			t.Errorf("FAIL: %s — %s", f.Expectation, f.Message)
+		}
+	}
+	if result.NodeCount != 2 {
+		t.Errorf("node_count = %d, want 2", result.NodeCount)
+	}
+}
+
+func TestWriteAndRead(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_write_and_read.star")
+	runner := testrunner.New(script)
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if !result.Passed {
+		for _, f := range result.Failures {
+			t.Errorf("FAIL: %s — %s", f.Expectation, f.Message)
+		}
+	}
+}
+
+func TestCompensation(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_compensation.star")
+	runner := testrunner.New(script)
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if !result.Passed {
+		for _, f := range result.Failures {
+			t.Errorf("FAIL: %s — %s", f.Expectation, f.Message)
+		}
+	}
+}
+
+func TestTrace(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_write_text.star")
+	runner := testrunner.New(script, testrunner.WithTrace())
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if !result.Passed {
+		for _, f := range result.Failures {
+			t.Errorf("FAIL: %s — %s", f.Expectation, f.Message)
+		}
+	}
+	if len(result.Trace) == 0 {
+		t.Error("trace enabled but no trace entries recorded")
+	}
+}
+
+func TestDryRun(t *testing.T) {
+	script := filepath.Join(testdataDir(t), "test_write_text.star")
+	runner := testrunner.New(script, testrunner.WithDryRun())
+	result, err := runner.Start(context.Background())
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	// In dry-run mode, the file should NOT exist (no side effects).
+	// The expect_file expectation should fail because the file wasn't written.
+	if result.Passed {
+		t.Error("dry-run should cause file expectation to fail")
+	}
+}

--- a/internal/e2e/testrunner/test_context.go
+++ b/internal/e2e/testrunner/test_context.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package testrunner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// Expectation represents a single test assertion queued during script execution.
+type Expectation struct {
+	Kind    string // "file_exists", "no_file", "node_count", "error"
+	Path    string // for file expectations
+	Content string // optional expected content
+	Count   int    // for node_count
+	Pattern string // for error expectations
+}
+
+// Failure records a failed expectation.
+type Failure struct {
+	Expectation string `json:"expectation"`
+	Message     string `json:"message"`
+}
+
+// TestContext is the `t` namespace injected into Starlark test scripts.
+// It provides a temp directory and queues expectations that are checked
+// after graph execution completes.
+type TestContext struct {
+	tmpDir       string
+	expectations []Expectation
+}
+
+// NewTestContext creates a TestContext rooted at the given temp directory.
+func NewTestContext(tmpDir string) *TestContext {
+	return &TestContext{tmpDir: tmpDir}
+}
+
+// Expectations returns the queued expectations.
+func (tc *TestContext) Expectations() []Expectation {
+	return tc.expectations
+}
+
+// TmpDir returns the temp directory path.
+func (tc *TestContext) TmpDir() string {
+	return tc.tmpDir
+}
+
+// Check evaluates all queued expectations against the executed graph and filesystem.
+// Returns failures for any expectations that did not hold.
+func (tc *TestContext) Check(graph *op.Graph, execErr error) []Failure {
+	var failures []Failure
+
+	for _, exp := range tc.expectations {
+		switch exp.Kind {
+		case "file_exists":
+			f := tc.checkFileExists(exp)
+			if f != nil {
+				failures = append(failures, *f)
+			}
+
+		case "no_file":
+			f := tc.checkNoFile(exp)
+			if f != nil {
+				failures = append(failures, *f)
+			}
+
+		case "node_count":
+			if len(graph.Nodes) != exp.Count {
+				failures = append(failures, Failure{
+					Expectation: fmt.Sprintf("node_count(%d)", exp.Count),
+					Message:     fmt.Sprintf("got %d nodes", len(graph.Nodes)),
+				})
+			}
+
+		case "error":
+			f := tc.checkError(exp, execErr)
+			if f != nil {
+				failures = append(failures, *f)
+			}
+		}
+	}
+
+	return failures
+}
+
+func (tc *TestContext) checkFileExists(exp Expectation) *Failure {
+	info, err := os.Stat(exp.Path)
+	if err != nil {
+		return &Failure{
+			Expectation: fmt.Sprintf("file_exists(%s)", exp.Path),
+			Message:     "file not found",
+		}
+	}
+	if info.IsDir() {
+		return &Failure{
+			Expectation: fmt.Sprintf("file_exists(%s)", exp.Path),
+			Message:     "path is a directory, not a file",
+		}
+	}
+
+	if exp.Content != "" {
+		data, err := os.ReadFile(exp.Path)
+		if err != nil {
+			return &Failure{
+				Expectation: fmt.Sprintf("file_exists(%s, content=...)", exp.Path),
+				Message:     fmt.Sprintf("cannot read file: %v", err),
+			}
+		}
+		if string(data) != exp.Content {
+			return &Failure{
+				Expectation: fmt.Sprintf("file_exists(%s, content=%q)", exp.Path, exp.Content),
+				Message:     fmt.Sprintf("content mismatch: got %q", string(data)),
+			}
+		}
+	}
+
+	return nil
+}
+
+func (tc *TestContext) checkNoFile(exp Expectation) *Failure {
+	_, err := os.Stat(exp.Path)
+	if err == nil {
+		return &Failure{
+			Expectation: fmt.Sprintf("no_file(%s)", exp.Path),
+			Message:     "file exists but should not",
+		}
+	}
+	if !os.IsNotExist(err) {
+		return &Failure{
+			Expectation: fmt.Sprintf("no_file(%s)", exp.Path),
+			Message:     fmt.Sprintf("unexpected error: %v", err),
+		}
+	}
+	return nil
+}
+
+func (tc *TestContext) checkError(exp Expectation, execErr error) *Failure {
+	if execErr == nil {
+		return &Failure{
+			Expectation: fmt.Sprintf("error(%q)", exp.Pattern),
+			Message:     "execution succeeded, expected error",
+		}
+	}
+	matched, err := regexp.MatchString(exp.Pattern, execErr.Error())
+	if err != nil {
+		return &Failure{
+			Expectation: fmt.Sprintf("error(%q)", exp.Pattern),
+			Message:     fmt.Sprintf("invalid pattern: %v", err),
+		}
+	}
+	if !matched {
+		return &Failure{
+			Expectation: fmt.Sprintf("error(%q)", exp.Pattern),
+			Message:     fmt.Sprintf("error %q did not match pattern", execErr.Error()),
+		}
+	}
+	return nil
+}
+
+// StarlarkValue returns the `t` namespace as a Starlark struct.
+func (tc *TestContext) StarlarkValue() starlark.Value {
+	return starlarkstruct.FromStringDict(starlark.String("t"), starlark.StringDict{
+		"tmp":               starlark.NewBuiltin("t.tmp", tc.starTmp),
+		"expect_file":       starlark.NewBuiltin("t.expect_file", tc.starExpectFile),
+		"expect_no_file":    starlark.NewBuiltin("t.expect_no_file", tc.starExpectNoFile),
+		"expect_node_count": starlark.NewBuiltin("t.expect_node_count", tc.starExpectNodeCount),
+		"expect_error":      starlark.NewBuiltin("t.expect_error", tc.starExpectError),
+	})
+}
+
+// starTmp implements t.tmp(relative) -> absolute path under temp dir.
+func (tc *TestContext) starTmp(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var relative string
+	if err := starlark.UnpackPositionalArgs("t.tmp", args, kwargs, 1, &relative); err != nil {
+		return nil, err
+	}
+
+	// Prevent path traversal
+	if strings.Contains(relative, "..") {
+		return nil, fmt.Errorf("t.tmp: path traversal not allowed: %s", relative)
+	}
+
+	return starlark.String(filepath.Join(tc.tmpDir, relative)), nil
+}
+
+// starExpectFile implements t.expect_file(path, content=None).
+func (tc *TestContext) starExpectFile(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	var content starlark.Value
+
+	if err := starlark.UnpackArgs("t.expect_file", args, kwargs,
+		"path", &path,
+		"content?", &content,
+	); err != nil {
+		return nil, err
+	}
+
+	exp := Expectation{
+		Kind: "file_exists",
+		Path: path,
+	}
+
+	if content != nil && content != starlark.None {
+		s, ok := content.(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("t.expect_file: content must be a string, got %s", content.Type())
+		}
+		exp.Content = string(s)
+	}
+
+	tc.expectations = append(tc.expectations, exp)
+	return starlark.None, nil
+}
+
+// starExpectNoFile implements t.expect_no_file(path).
+func (tc *TestContext) starExpectNoFile(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackPositionalArgs("t.expect_no_file", args, kwargs, 1, &path); err != nil {
+		return nil, err
+	}
+
+	tc.expectations = append(tc.expectations, Expectation{
+		Kind: "no_file",
+		Path: path,
+	})
+	return starlark.None, nil
+}
+
+// starExpectNodeCount implements t.expect_node_count(n).
+func (tc *TestContext) starExpectNodeCount(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var count int
+	if err := starlark.UnpackPositionalArgs("t.expect_node_count", args, kwargs, 1, &count); err != nil {
+		return nil, err
+	}
+
+	tc.expectations = append(tc.expectations, Expectation{
+		Kind:  "node_count",
+		Count: count,
+	})
+	return starlark.None, nil
+}
+
+// starExpectError implements t.expect_error(pattern).
+func (tc *TestContext) starExpectError(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern string
+	if err := starlark.UnpackPositionalArgs("t.expect_error", args, kwargs, 1, &pattern); err != nil {
+		return nil, err
+	}
+
+	// Validate the pattern compiles
+	if _, err := regexp.Compile(pattern); err != nil {
+		return nil, fmt.Errorf("t.expect_error: invalid regex: %v", err)
+	}
+
+	tc.expectations = append(tc.expectations, Expectation{
+		Kind:    "error",
+		Pattern: pattern,
+	})
+	return starlark.None, nil
+}

--- a/internal/e2e/testrunner/trace.go
+++ b/internal/e2e/testrunner/trace.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package testrunner
+
+import (
+	"fmt"
+	"sync"
+
+	"go.starlark.net/starlark"
+)
+
+// Tracer collects trace entries during Starlark script execution.
+// When enabled, it records position and expression info via the
+// thread's Print handler and captures plan.* invocations.
+type Tracer struct {
+	mu      sync.Mutex
+	entries []string
+	enabled bool
+}
+
+// NewTracer creates a Tracer. If enabled is false, all operations are no-ops.
+func NewTracer(enabled bool) *Tracer {
+	return &Tracer{enabled: enabled}
+}
+
+// Enabled returns whether tracing is active.
+func (tr *Tracer) Enabled() bool {
+	return tr.enabled
+}
+
+// Record adds a trace entry.
+func (tr *Tracer) Record(format string, args ...any) {
+	if !tr.enabled {
+		return
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.entries = append(tr.entries, fmt.Sprintf(format, args...))
+}
+
+// RecordThread logs the current thread position.
+func (tr *Tracer) RecordThread(thread *starlark.Thread, msg string) {
+	if !tr.enabled {
+		return
+	}
+	pos := ""
+	if stack := thread.CallStack(); len(stack) > 0 {
+		frame := stack[len(stack)-1]
+		pos = frame.Pos.String()
+	}
+	tr.Record("%s: %s", pos, msg)
+}
+
+// Entries returns a copy of all recorded trace entries.
+func (tr *Tracer) Entries() []string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	out := make([]string, len(tr.entries))
+	copy(out, tr.entries)
+	return out
+}
+
+// PrintHandler returns a starlark.Thread.Print function that captures
+// print() output as trace entries and logs them.
+func (tr *Tracer) PrintHandler() func(*starlark.Thread, string) {
+	return func(thread *starlark.Thread, msg string) {
+		if tr.enabled {
+			tr.RecordThread(thread, msg)
+		}
+	}
+}

--- a/internal/execution/flow/elevate.go
+++ b/internal/execution/flow/elevate.go
@@ -3,7 +3,9 @@
 
 package flow
 
-import "github.com/NobleFactor/devlore-cli/pkg/op"
+import (
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
 
 // Elevate is a privilege transition flow action. It marks the boundary between
 // unprivileged and privileged execution as an explicit graph node. In dry-run

--- a/internal/execution/hooks.go
+++ b/internal/execution/hooks.go
@@ -3,7 +3,9 @@
 
 package execution
 
-import "github.com/NobleFactor/devlore-cli/pkg/op"
+import (
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
 
 // LifecycleHook receives events at phase and node boundaries during execution.
 // Hooks are fire-and-forget — a hook panic is recovered and logged but does not

--- a/internal/execution/lifecycle_test.go
+++ b/internal/execution/lifecycle_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	filegen "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/template"
-
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/lorepackage/synthetic.go
+++ b/internal/lorepackage/synthetic.go
@@ -15,7 +15,7 @@ import (
 // Synthetic packages are created for native PM packages that aren't in the lore registry.
 // The cache reduces repeated package manager queries and provides persistence.
 type SyntheticCache struct {
-	cacheDir string // Base cache directory (e.g., ~/.cache/devlore/registry)
+	cacheDir string // ProviderBase cache directory (e.g., ~/.cache/devlore/registry)
 }
 
 // SyntheticPackageInfo is the cached metadata for a synthetic package.

--- a/internal/writ/segment/segment_test.go
+++ b/internal/writ/segment/segment_test.go
@@ -303,7 +303,7 @@ func TestUnassignedSegmentMatching(t *testing.T) {
 		t.Error("noblefactor.desktop should not match when ROLE is empty")
 	}
 
-	// Base directory should match
+	// ProviderBase directory should match
 	if !segs.Match("noblefactor") {
 		t.Error("noblefactor should match")
 	}

--- a/internal/writ/tree/tree_test.go
+++ b/internal/writ/tree/tree_test.go
@@ -525,7 +525,7 @@ func TestBuildMultiSourceLayerBeatsSpecificity(t *testing.T) {
 	personalDir := t.TempDir()
 	targetDir := t.TempDir()
 
-	// Base layer with high specificity (all.Darwin)
+	// ProviderBase layer with high specificity (all.Darwin)
 	if err := os.MkdirAll(filepath.Join(baseDir, "all.Darwin"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestBuildMultiSourceLayerBeatsSpecificity(t *testing.T) {
 		if c.WinnerSpecificity != 0 {
 			t.Errorf("winner specificity = %d, want 0 (personal/all)", c.WinnerSpecificity)
 		}
-		// Base loses with specificity 1
+		// ProviderBase loses with specificity 1
 		if c.LoserSpecificity != 1 {
 			t.Errorf("loser specificity = %d, want 1 (base/all.Darwin)", c.LoserSpecificity)
 		}

--- a/pkg/op/action.go
+++ b/pkg/op/action.go
@@ -4,9 +4,7 @@
 package op
 
 import (
-	"context"
 	"errors"
-	"io"
 )
 
 // ErrNotCompensable signals that an action acknowledges rollback but cannot
@@ -59,33 +57,4 @@ type CompensableAction interface {
 	// Returns:
 	//   - err: any error encountered during compensation
 	Undo(ctx *Context, undo UndoState) error
-}
-
-// Context provides execution context to actions.
-type Context struct {
-	context.Context // https://pkg.go.dev/context
-
-	// Data holds tool-provided context: template variables, SOPS config,
-	// identities, segment maps, etc. Each tool populates this before
-	// calling GraphExecutor.Run().
-	Data map[string]any
-
-	// DryRun prevents filesystem modifications when true.
-	DryRun bool
-
-	// Graph is the graph being executed. Flow actions use this to look up
-	// phases referenced by their slots (e.g., gather body, choose branch).
-	Graph *Graph
-
-	// NodeID is the ID of the currently executing node. Flow actions use
-	// this to identify themselves (e.g., gather uses it for proxy context).
-	NodeID string
-
-	// Platform provides platform abstractions (package manager, service
-	// manager) to action providers. Nil when running in environments
-	// where host access is not needed (e.g., pure data transforms).
-	Platform *Platform
-
-	// Writer receives user-facing output messages.
-	Writer io.Writer
 }

--- a/pkg/op/context.go
+++ b/pkg/op/context.go
@@ -1,0 +1,35 @@
+package op
+
+import (
+	"context"
+	"io"
+)
+
+// Context provides execution context to actions.
+type Context struct {
+	context.Context // https://pkg.go.dev/context
+
+	// Data holds tool-provided context: template variables, SOPS config,
+	// identities, segment maps, etc. Each tool populates this before
+	// calling GraphExecutor.Run().
+	Data map[string]any
+
+	// DryRun prevents filesystem modifications when true.
+	DryRun bool
+
+	// Graph is the graph being executed. Flow actions use this to look up
+	// phases referenced by their slots (e.g., gather body, choose branch).
+	Graph *Graph
+
+	// NodeID is the ID of the currently executing node. Flow actions use
+	// this to identify themselves (e.g., gather uses it for proxy context).
+	NodeID string
+
+	// Platform provides platform abstractions (package manager, service
+	// manager) to action providers. Nil when running in environments
+	// where host access is not needed (e.g., pure data transforms).
+	Platform *Platform
+
+	// Writer receives user-facing output messages.
+	Writer io.Writer
+}

--- a/pkg/op/namespace.go
+++ b/pkg/op/namespace.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+// NamespaceMap maps URIs to the most recent resource ID during planning.
+// One per Graph, used only during planning (not serialized).
+type NamespaceMap struct {
+	current map[string]string // URI → resource ID
+}
+
+// NewNamespaceMap creates an empty namespace.
+func NewNamespaceMap() *NamespaceMap {
+	return &NamespaceMap{
+		current: make(map[string]string),
+	}
+}
+
+// Resolve returns the current resource ID for a URI. If the URI has
+// never been seen, catalogs a discovery in the manager (originNodeID = "")
+// and returns the new ID.
+func (ns *NamespaceMap) Resolve(mgr *ResourceManager, uri string) string {
+	if id, ok := ns.current[uri]; ok {
+		return id
+	}
+	id := mgr.EnsureCataloged(uri, "")
+	ns.current[uri] = id
+	return id
+}
+
+// Shadow creates a new resource version in the manager, updates the
+// namespace to point to it, and returns the new resource ID.
+func (ns *NamespaceMap) Shadow(mgr *ResourceManager, uri string, producerNodeID string) string {
+	id := mgr.EnsureCataloged(uri, producerNodeID)
+	ns.current[uri] = id
+	return id
+}
+
+// Current returns the resource ID currently mapped to a URI, or "".
+func (ns *NamespaceMap) Current(uri string) string {
+	return ns.current[uri]
+}

--- a/pkg/op/namespace_test.go
+++ b/pkg/op/namespace_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import "testing"
+
+func TestNamespace_Resolve_FirstAccess(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	id := ns.Resolve(mgr, "file:///first")
+
+	r, ok := mgr.Lookup(id)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned false", id)
+	}
+	if r.OriginNodeID != "" {
+		t.Errorf("discovery resource should have empty OriginNodeID, got %q", r.OriginNodeID)
+	}
+	if r.URI != "file:///first" {
+		t.Errorf("r.URI = %q, want file:///first", r.URI)
+	}
+}
+
+func TestNamespace_Resolve_Idempotent(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	id1 := ns.Resolve(mgr, "file:///same")
+	id2 := ns.Resolve(mgr, "file:///same")
+
+	if id1 != id2 {
+		t.Errorf("Resolve same URI twice: %q != %q", id1, id2)
+	}
+	if mgr.LedgerLen() != 1 {
+		t.Errorf("expected 1 ledger entry after 2 resolves of same URI, got %d", mgr.LedgerLen())
+	}
+}
+
+func TestNamespace_Shadow(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	origID := ns.Resolve(mgr, "file:///target")
+	shadowID := ns.Shadow(mgr, "file:///target", "writer-node")
+
+	if origID == shadowID {
+		t.Error("Shadow should create a new resource ID, got same as original")
+	}
+	if mgr.LedgerLen() != 2 {
+		t.Errorf("expected 2 ledger entries, got %d", mgr.LedgerLen())
+	}
+
+	r, ok := mgr.Lookup(shadowID)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned false", shadowID)
+	}
+	if r.OriginNodeID != "writer-node" {
+		t.Errorf("shadow OriginNodeID = %q, want writer-node", r.OriginNodeID)
+	}
+}
+
+func TestNamespace_Shadow_OverwritesResolve(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	ns.Resolve(mgr, "file:///overwrite")
+	ns.Shadow(mgr, "file:///overwrite", "nodeA")
+	resolvedID := ns.Resolve(mgr, "file:///overwrite")
+
+	// Resolve after Shadow should return the shadow's ID
+	r, _ := mgr.Lookup(resolvedID)
+	if r.OriginNodeID != "nodeA" {
+		t.Errorf("resolve after shadow: OriginNodeID = %q, want nodeA", r.OriginNodeID)
+	}
+}
+
+func TestNamespace_ImplicitDependency(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	// Shadow by nodeA creates a resource version owned by nodeA
+	ns.Shadow(mgr, "file:///dep", "nodeA")
+
+	// Resolve (as if nodeB is reading) returns nodeA's version
+	id := ns.Resolve(mgr, "file:///dep")
+
+	r, _ := mgr.Lookup(id)
+	if r.OriginNodeID != "nodeA" {
+		t.Errorf("implicit dependency: OriginNodeID = %q, want nodeA", r.OriginNodeID)
+	}
+}
+
+func TestNamespace_Current_Empty(t *testing.T) {
+	ns := NewNamespaceMap()
+
+	if got := ns.Current("file:///unknown"); got != "" {
+		t.Errorf("Current for unknown URI = %q, want empty", got)
+	}
+}
+
+func TestNamespace_Current_AfterResolve(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	id := ns.Resolve(mgr, "file:///resolved")
+	if got := ns.Current("file:///resolved"); got != id {
+		t.Errorf("Current after Resolve = %q, want %q", got, id)
+	}
+}
+
+func TestNamespace_Current_AfterShadow(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	ns.Resolve(mgr, "file:///shadowed")
+	shadowID := ns.Shadow(mgr, "file:///shadowed", "node-1")
+
+	if got := ns.Current("file:///shadowed"); got != shadowID {
+		t.Errorf("Current after Shadow = %q, want %q", got, shadowID)
+	}
+}
+
+func TestNamespace_MultipleURIs(t *testing.T) {
+	mgr := NewResourceManager()
+	ns := NewNamespaceMap()
+
+	id1 := ns.Resolve(mgr, "file:///alpha")
+	id2 := ns.Resolve(mgr, "file:///beta")
+
+	if id1 == id2 {
+		t.Error("different URIs should have different IDs")
+	}
+	if ns.Current("file:///alpha") != id1 {
+		t.Error("alpha should still map to its original ID")
+	}
+	if ns.Current("file:///beta") != id2 {
+		t.Error("beta should still map to its original ID")
+	}
+}

--- a/pkg/op/provider.go
+++ b/pkg/op/provider.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+// Provider is an interface for objects that can supply an execution [Context].
+//
+// Actions that need access to the execution environment implement this interface to receive the [Context] during graph
+// execution. The [Context] includes execution parameters, platform abstractions, and runtime state.
+//
+// Types should satisfy this interface by embedding [ProviderBase].
+type Provider interface {
+	Context() Context
+}
+
+// ProviderBase provides a standardized implementation of the [Provider] interface.
+//
+// It must be embedded in all domain-specific providers to ensure they adhere to the execution graph's strictly enforced
+// lifetime.
+//
+// ProviderBase should only be instantiated by authorized builders using [New].
+type ProviderBase struct {
+	ctx Context
+}
+
+// NewProviderBase returns a new ProviderBase provider instance with the given [Context].
+func NewProviderBase(ctx Context) ProviderBase {
+	return ProviderBase{ctx: ctx}
+}
+
+// Context returns the context associated with this provider's lifetime.
+func (b ProviderBase) Context() Context {
+	return b.ctx
+}

--- a/pkg/op/provider/file/gen/params.gen.go
+++ b/pkg/op/provider/file/gen/params.gen.go
@@ -15,7 +15,7 @@ var Params = op.MethodParams{
 	"Unlink":     {"path", "prune", "prune_boundary"},
 	"WriteBytes": {"destination", "content", "mode"},
 	"WriteText":  {"destination", "content", "mode"},
-	"Exists":     {"blob"},
+	"Exists":     {"file_resource"},
 	"Glob":       {"pattern", "honor_gitignore"},
 	"IsDir":      {"path"},
 	"IsFile":     {"path"},

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -18,6 +18,8 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gitignore"
 )
 
+var _ op.Provider = (*Provider)(nil) // Interface Guard: ensures *Provider implements op.Provider.
+
 // Provider provides file system actions.
 //
 // Compensable forward methods return (string, map[string]any, error): the resource path, the compensation receipt, and
@@ -26,7 +28,8 @@ import (
 // +devlore:access=both
 // +devlore:bind Root=WorkDir
 type Provider struct {
-	Root string // Working directory for Glob and WalkTree
+	op.ProviderBase
+	Root string
 }
 
 // Actor returns a Reducer that calls the given function for each file or directory in a WalkTree operation.
@@ -643,8 +646,8 @@ func (p *Provider) CompensateWriteText(undo map[string]any) error {
 //
 // Returns:
 //   - bool: true if the file at "path" exists, false otherwise
-func (p *Provider) Exists(blob Resource) bool {
-	_, err := os.Lstat(blob.SourcePath)
+func (p *Provider) Exists(fileResource Resource) bool {
+	_, err := os.Lstat(fileResource.SourcePath)
 	return err == nil
 }
 

--- a/pkg/op/provider/platform/provider.go
+++ b/pkg/op/provider/platform/provider.go
@@ -1,9 +1,29 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
-// Package platform provides platform-specific package and service managers.
-// Concrete manager types are private; consumers see only op.PackageManager
-// and op.ServiceManager.
+// Package platform is a data provider — the Starlark surface for
+// op.Context.Platform. It holds no independent state; it wraps the Platform
+// struct that the executor places on the execution context.
+//
+// Like all providers, platform is a singleton that follows the lifetime of
+// its graph (execution) or script (planning). It receives context at
+// construction time via a constructor that accepts a context object by
+// reference. The provider reads Platform data from that context — it never
+// creates or owns a Platform.
+//
+// Access type is "both":
+//
+//   - Immediate: platform.distro returns a string from the local machine's
+//     Platform. Useful for single-machine local plans.
+//   - Planned: plan.platform.distro returns a promise (Output) that the
+//     executor resolves against the target machine's Platform at execution
+//     time. This is critical for graphs targeting remote machines — the
+//     graph is planned once and can be executed on many targets, each with
+//     a different Platform.
+//
+// Because the provider is read-only (no side effects), it has no action
+// methods, no compensation pairs, and no codegen. Concrete manager types
+// are private; consumers see only op.PackageManager and op.ServiceManager.
 package platform
 
 import (

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -1,5 +1,11 @@
 package op
 
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+)
+
 // Resource represents a logical data item identified by a URI and tracked across distributed nodes.
 //
 // It serves as a reference entry in the ResourceLedger with origin tracking information.
@@ -7,4 +13,80 @@ type Resource struct {
 	URI          string // logical address of the resource (e.g., a file URL)
 	ID           string // unique identifier in the flat ResourceLedger
 	OriginNodeID string // ID of the node that created this resource
+}
+
+// URI scheme constants.
+const (
+	SchemeFile    = "file"
+	SchemeGit     = "git"
+	SchemePackage = "pkg"
+	SchemeService = "svc"
+	SchemeMem     = "mem"
+)
+
+// ResourceURI builds a canonicalized URI from a scheme and path.
+// For file:// URIs, path is resolved via filepath.Abs + filepath.Clean.
+// Other schemes use the path as-is.
+func ResourceURI(scheme, path string) string {
+	if scheme == SchemeFile {
+		abs, err := filepath.Abs(path)
+		if err == nil {
+			path = abs
+		}
+		path = filepath.Clean(path)
+	}
+	return fmt.Sprintf("%s://%s", scheme, path)
+}
+
+// ResourceManager owns the append-only ledger of all resources created
+// during a single planning session. One per Graph.
+type ResourceManager struct {
+	mu      sync.Mutex
+	entries []Resource     // append-only ledger; index = sequence number
+	byID    map[string]int // resource ID → index in entries
+	nextID  int            // monotonic counter
+}
+
+// NewResourceManager creates an empty resource manager.
+func NewResourceManager() *ResourceManager {
+	return &ResourceManager{
+		byID: make(map[string]int),
+	}
+}
+
+// EnsureCataloged creates a new Resource in the ledger with a unique ID.
+// Returns the new resource's ID.
+func (m *ResourceManager) EnsureCataloged(uri string, originNodeID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nextID++
+	id := fmt.Sprintf("res-%d", m.nextID)
+	r := Resource{
+		URI:          uri,
+		ID:           id,
+		OriginNodeID: originNodeID,
+	}
+	m.byID[id] = len(m.entries)
+	m.entries = append(m.entries, r)
+	return id
+}
+
+// Lookup returns the Resource with the given ID, or false.
+func (m *ResourceManager) Lookup(id string) (Resource, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	idx, ok := m.byID[id]
+	if !ok {
+		return Resource{}, false
+	}
+	return m.entries[idx], true
+}
+
+// LedgerLen returns the count of resources in the ledger.
+func (m *ResourceManager) LedgerLen() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.entries)
 }

--- a/pkg/op/resource_test.go
+++ b/pkg/op/resource_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestResourceURI_File(t *testing.T) {
+	// Relative path should become absolute
+	uri := ResourceURI(SchemeFile, "relative/path")
+	if !strings.HasPrefix(uri, "file://") {
+		t.Errorf("ResourceURI(file, relative/path) = %q, want file:// prefix", uri)
+	}
+	path := strings.TrimPrefix(uri, "file://")
+	if !filepath.IsAbs(path) {
+		t.Errorf("ResourceURI(file, relative/path) produced non-absolute path: %q", path)
+	}
+
+	// Clean resolves ../
+	uri2 := ResourceURI(SchemeFile, "/etc/../etc/foo")
+	if uri2 != "file:///etc/foo" {
+		t.Errorf("ResourceURI(file, /etc/../etc/foo) = %q, want file:///etc/foo", uri2)
+	}
+
+	// Absolute path stays absolute
+	uri3 := ResourceURI(SchemeFile, "/usr/local/bin")
+	if uri3 != "file:///usr/local/bin" {
+		t.Errorf("ResourceURI(file, /usr/local/bin) = %q, want file:///usr/local/bin", uri3)
+	}
+}
+
+func TestResourceURI_OtherSchemes(t *testing.T) {
+	tests := []struct {
+		scheme string
+		path   string
+		want   string
+	}{
+		{SchemeGit, "github.com/org/repo", "git://github.com/org/repo"},
+		{SchemePackage, "brew/vim", "pkg://brew/vim"},
+		{SchemeService, "nginx", "svc://nginx"},
+		{SchemeMem, "buffer-1", "mem://buffer-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scheme, func(t *testing.T) {
+			got := ResourceURI(tt.scheme, tt.path)
+			if got != tt.want {
+				t.Errorf("ResourceURI(%s, %s) = %q, want %q", tt.scheme, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceManager_EnsureCataloged(t *testing.T) {
+	mgr := NewResourceManager()
+
+	id1 := mgr.EnsureCataloged("file:///a", "")
+	id2 := mgr.EnsureCataloged("file:///b", "node-1")
+	id3 := mgr.EnsureCataloged("file:///c", "")
+
+	if id1 != "res-1" {
+		t.Errorf("first ID = %q, want res-1", id1)
+	}
+	if id2 != "res-2" {
+		t.Errorf("second ID = %q, want res-2", id2)
+	}
+	if id3 != "res-3" {
+		t.Errorf("third ID = %q, want res-3", id3)
+	}
+}
+
+func TestResourceManager_Lookup(t *testing.T) {
+	mgr := NewResourceManager()
+
+	id := mgr.EnsureCataloged("file:///foo", "node-1")
+
+	r, ok := mgr.Lookup(id)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned false", id)
+	}
+	if r.URI != "file:///foo" {
+		t.Errorf("r.URI = %q, want file:///foo", r.URI)
+	}
+	if r.ID != id {
+		t.Errorf("r.ID = %q, want %q", r.ID, id)
+	}
+	if r.OriginNodeID != "node-1" {
+		t.Errorf("r.OriginNodeID = %q, want node-1", r.OriginNodeID)
+	}
+
+	// Unknown ID returns false
+	_, ok = mgr.Lookup("res-999")
+	if ok {
+		t.Error("Lookup(res-999) should return false")
+	}
+}
+
+func TestResourceManager_LedgerLen(t *testing.T) {
+	mgr := NewResourceManager()
+
+	if mgr.LedgerLen() != 0 {
+		t.Errorf("empty ledger len = %d, want 0", mgr.LedgerLen())
+	}
+
+	mgr.EnsureCataloged("file:///a", "")
+	if mgr.LedgerLen() != 1 {
+		t.Errorf("after 1 catalog, len = %d, want 1", mgr.LedgerLen())
+	}
+
+	mgr.EnsureCataloged("file:///b", "")
+	mgr.EnsureCataloged("file:///c", "")
+	if mgr.LedgerLen() != 3 {
+		t.Errorf("after 3 catalogs, len = %d, want 3", mgr.LedgerLen())
+	}
+}
+
+func TestResourceManager_ConcurrentAccess(t *testing.T) {
+	mgr := NewResourceManager()
+	const goroutines = 50
+	var wg sync.WaitGroup
+	ids := make(chan string, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := mgr.EnsureCataloged("file:///concurrent", "")
+			ids <- id
+		}()
+	}
+
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[string]bool)
+	for id := range ids {
+		if seen[id] {
+			t.Fatalf("duplicate ID from concurrent access: %q", id)
+		}
+		seen[id] = true
+	}
+
+	if len(seen) != goroutines {
+		t.Errorf("expected %d unique IDs, got %d", goroutines, len(seen))
+	}
+}

--- a/star/extensions/com.noblefactor.devlore.Test/commands/run.star
+++ b/star/extensions/com.noblefactor.devlore.Test/commands/run.star
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: SSPL-1.0
+# Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+# run.star — Run a Starlark test script via the devlore-test binary.
+#
+# Resolves the devlore-test binary via a 3-tier lookup:
+#   1. --tool-path flag (explicit override)
+#   2. DEVLORE_TEST_TOOL_PATH environment variable
+#   3. Extension config test.tool_path (default: build/devlore-test)
+#
+# The resolved path is relative to the git worktree root (the same root
+# that star uses for extension discovery).
+
+def resolve_tool_path(ctx):
+    """Resolve the devlore-test binary path via 3-tier lookup."""
+
+    # Tier 1: explicit --tool-path flag
+    tool_path = ctx.args.get("tool-path", "")
+    if tool_path:
+        return tool_path
+
+    # Tier 2: environment variable
+    env_path = ctx.env.get("DEVLORE_TEST_TOOL_PATH", "")
+    if env_path:
+        return env_path
+
+    # Tier 3: extension config (default: build/devlore-test relative to worktree root)
+    config_path = ctx.config.get("test.tool_path", "build/devlore-test")
+    workspace = ctx.env.get("GIT_WORKSPACE_ROOT", "")
+    if workspace:
+        return file.join(parts=[workspace, config_path])
+
+    return config_path
+
+def build_args(ctx, tool_path):
+    """Build the devlore-test command arguments."""
+    args = [tool_path, "--script", ctx.args["script"]]
+
+    if ctx.args.get("dry-run", "false") == "true":
+        args.append("--dry-run")
+    if ctx.args.get("trace", "false") == "true":
+        args.append("--trace")
+
+    return args
+
+def run(ctx):
+    """Run a Starlark test script that plans and executes a graph."""
+    tool_path = resolve_tool_path(ctx)
+
+    if not file.exists(blob=tool_path):
+        ui.fail("devlore-test binary not found: " + tool_path)
+        ui.note("Run 'make build' to compile the binary")
+        return
+
+    args = build_args(ctx, tool_path)
+    ui.note("Running: " + " ".join(args))
+
+    # Execute the binary and parse JSON output.
+    # Requires host.exec() receiver — planned for noblefactor-ops.
+    # For now, run devlore-test directly from the command line:
+    #   build/devlore-test --script <path>
+    ui.warn("Direct execution from star not yet wired — run the binary manually:")
+    ui.note("  " + " ".join(args))

--- a/star/extensions/com.noblefactor.devlore.Test/extension.yaml
+++ b/star/extensions/com.noblefactor.devlore.Test/extension.yaml
@@ -1,0 +1,37 @@
+extension: com.noblefactor.devlore.Test
+description: Test harness for Starlark graph planning and execution
+
+receivers:
+  - name: ui
+    builtin: true
+    type: UiReceiver
+    description: Status output (note, warn, success, fail)
+
+commands:
+  - name: devlore.test.run
+    help: Run a Starlark test script that plans and executes a graph
+    implementation: commands/run.star
+    flags:
+      - name: script
+        type: string
+        required: true
+        help: Path to the test script (.star)
+      - name: dry-run
+        type: bool
+        default: "false"
+        help: "Plan only, no side effects"
+      - name: trace
+        type: bool
+        default: "false"
+        help: "Enable Starlark step trace"
+      - name: tool-path
+        type: string
+        default: ""
+        help: "Path to devlore-test binary (overrides config and env)"
+
+config:
+  path: "test"
+  fields:
+    tool_path: string
+  defaults:
+    tool_path: "build/devlore-test"


### PR DESCRIPTION
## Summary

- Append-only `ResourceManager` ledger with monotonic `res-<N>` ID assignment, mutex-guarded for concurrent access
- `NamespaceMap` with `Resolve`/`Shadow`/`Current` for URI→ResourceID tracking with version lineage
- `ResourceURI()` helper with `file://` path canonicalization (`filepath.Abs` + `filepath.Clean`) and scheme constants (`file`, `git`, `pkg`, `svc`, `mem`)
- 15 new tests (6 resource, 9 namespace) including concurrent access verification

**Design Decision #9**: The ledger is the sole source of truth for resource identity and lineage. Node annotations (`resource.input`/`resource.output`) eliminated from Phase 2 — they would duplicate ledger data and cannot represent resources produced at runtime. Legacy `backup` annotation flagged for removal in Phase 2.

Pure additions — no existing code changed, no existing tests modified.

## Test plan

- [x] `make test` — all tests pass
- [x] `make vet` — clean
- [x] No `legacy|backward|compat|deprecated` in new code
- [x] No stub functions — all methods fully implemented