### PR TITLE
Resource Management Phase 5 | Executor catalog integration

### DIFF
--- a/docs/01-strategy.md
+++ b/docs/01-strategy.md
@@ -1,0 +1,1378 @@
+---
+notice: "© 2026 Noble Factor LLC. Confidential."
+type: Strategy
+title: DevLore Strategy
+audience: Business stakeholders
+purpose: Market analysis, go-to-market, revenue
+status: Draft
+version: "1.9"
+date: 2026-01-19
+---
+
+# DevLore Strategy
+
+**Version:** 1.9
+**Date:** 2026-01-19
+
+---
+
+## Section Status
+
+| Section | Status | Notes |
+|---------|--------|-------|
+| 1. Executive Summary | Approved | Vision and metrics defined |
+| 2. Market Analysis | Approved | TAM/SAM estimated |
+| 3. Competitive Landscape | Approved | Feature comparison complete |
+| 4. Product Thesis | Approved | Differentiation articulated |
+| 5. Primary Use Case | Approved | "Wiki to Working" scenario |
+| 6. Go-to-Market Strategy | Approved | Phases 0-3 overview; details in [02-roadmap.md](02-roadmap.md) |
+| 7. Revenue Model | Approved | Enterprise product definition, market sizing, pricing benchmarks |
+| 8. Business Model Alignment | Approved | Tribal knowledge positioning |
+| 9. Competitive Moat & IP | Approved | Protection strategy defined |
+| 10. Open Questions | Outstanding | Active research items |
+| Appendix A | Approved | Developer tools business model research |
+
+**Status key:** Outstanding (needs work) · Approved (reviewed, accepted) · Rejected (not proceeding) · Completed (implemented)
+
+---
+
+## 1. Executive Summary
+
+### 1.1. Vision
+
+New machine to productive developer in minutes, not days. Same environment everywhere—Mac, Linux, Windows. The tribal knowledge that lives in wikis and people's heads, encoded as executable manifests.
+
+**The progression:**
+
+```text
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Registry   │────▶│     Lore     │────▶│     Writ     │────▶│ Productivity │
+│              │     │              │     │              │     │              │
+│ Tribal       │     │ Installs     │     │ Deploys your │     │ New dev      │
+│ knowledge    │     │ packages     │     │ config       │     │ productive   │
+│ corpus       │     │ with wisdom  │     │ orchestrates │     │ in minutes   │
+└──────────────┘     └──────────────┘     └──────────────┘     └──────────────┘
+```
+
+The registry holds the collective wisdom—how to configure kubectl with cloud authentication, how to set up docker with registry credentials, the post-install steps that Homebrew's "caveats" never ran. Lore reads from the registry and installs packages with that knowledge. Writ orchestrates lore to set up your complete environment: tools, dotfiles, shell configuration. The result: a new developer goes from zero to productive in minutes, not days.
+
+### 1.2. Product Suite
+
+**Why "lore" and "writ"?**
+
+Every team has tribal knowledge—the unwritten wisdom about how to actually get things working. "Just run the script" doesn't help when you don't know which script, with what flags, after installing what prerequisites. That knowledge lives in people's heads, scattered across wikis, buried in Slack threads.
+
+DevLore makes that knowledge executable:
+
+- **Lore** — The wisdom. Tribal knowledge about installing software, encoded as manifests. What Homebrew's "caveats" should have been: not just text you ignore, but scripts that run.
+
+- **Writ** — The written form. Your configuration, inscribed. Dotfiles managed as deployable packages, with lore as the foundation.
+
+The metaphor is intentional: lore is passed down, writ is made permanent.
+
+| Product | Purpose | Status |
+|---------|---------|--------|
+| **Lore** | Package manager with tribal knowledge | Design complete |
+| **Writ** | Dotfiles and configuration manager | Design complete |
+| **devlore-registry** | Lore package repository | Design in progress |
+
+Together: _Your entire dev environment as a versioned, deployable artifact._
+
+**Which tool first?** Always lore.
+
+Lore is the entry point. It installs software and writes receipts. Writ is optional—add it when you want your dotfiles managed too.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  lore onboard ──▶ packages-manifest.yaml + config/                               │
+│  lore deploy   ──▶ receipt (what actually installed)                        │
+│  writ adopt --from-receipt ──▶ adopts packages-manifest.yaml and config          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Most users start with `lore onboard` on their team's wiki. It generates both packages and config. `lore deploy` installs the packages and writes a receipt. If you want your dotfiles version-controlled, `writ adopt --from-receipt` reads that receipt and adopts both the packages-manifest.yaml and config into your writ-managed repository. One direction, no confusion.
+
+> **Mitigation details:** See [Roadmap Section 8.2](02-roadmap.md#82-two-tool-complexity-mitigation) for the full lore-first design.
+
+### 1.3. Key Metrics
+
+| Metric | Target |
+|--------|--------|
+| Market | 36-47M developers who work cross-platform |
+| Differentiation | Cross-platform + post-install provisioning + tribal knowledge |
+| Timeline | 6 months to market validation, 18 months to sustainable business |
+| Investment | Self-funded through Phase 1; seek funding only if metrics prove market |
+
+---
+
+## 2. Market Analysis
+
+### 2.1. Target Audience
+
+Developers who:
+
+- Work across multiple platforms (macOS for dev, Linux for deploy, Windows for tooling)
+- Install tools beyond what's in their OS package manager
+- Suffer from "works on my machine" syndrome
+- Onboard to new teams/projects regularly
+- Manage developer workstations at scale
+- Maintain dotfiles across multiple machines
+
+### 2.2. Market Size Estimates
+
+| Segment | Size | Notes |
+|---------|------|-------|
+| **Global developers** | ~27M professional + ~20M hobbyist | Stack Overflow, GitHub, Evans Data |
+| **Cloud platform users** | ~47M | AWS, Azure, GCP combined |
+| **Cross-platform tooling need** | ~36M | Developers regularly using 2+ platforms |
+| **CLI-heavy workflows** | ~25M | Backend, DevOps, platform, data engineering |
+| **Developers with dotfiles repos** | ~10M | GitHub dotfiles repos |
+| **Using dotfile managers** | ~2M | chezmoi, yadm, stow users |
+
+### 2.3. Market Trajectory
+
+The target market is **expanding**, not shrinking:
+
+| Trend | Direction | Impact |
+|-------|-----------|--------|
+| Cloud adoption | ↑ | More developers need kubectl, terraform, cloud CLIs |
+| Remote/hybrid work | ↑ | More diverse machine setups, less IT standardization |
+| Platform engineering | ↑ | Teams building internal developer platforms need tooling |
+| DevOps democratization | ↑ | More developers touching infrastructure |
+| AI/ML tooling | ↑ | Python environments, GPU toolchains, complex setups |
+| Platform diversity | ↑ | Mac + Linux + Windows/WSL |
+| Cloud development | ↑ | Ephemeral environments need fast setup |
+
+### 2.4. Counter-Trends (Manageable)
+
+| Trend | Direction | Mitigation |
+|-------|-----------|------------|
+| Dev containers | ↑ | Lore works inside containers too |
+| Cloud IDEs | ↑ | Still need local setup for many workflows |
+| Managed services | ↑ | Reduces some tooling, but CLI access remains |
+
+---
+
+## 3. Competitive Landscape
+
+### 3.1. Feature Comparison
+
+| Tool | Packages | Dotfiles | Cross-Platform | Provisioning | Tribal Knowledge |
+|------|----------|----------|----------------|--------------|------------------|
+| Homebrew | ✓ | — | macOS + Linux | Caveats | — |
+| asdf/mise | Runtimes | — | ✓ | — | — |
+| Nix | ✓ | ✓ | ✓ | Flakes | Nixpkgs |
+| devbox | ✓ (Nix) | — | ✓ | devbox.json | — |
+| Ansible | ✓ | ✓ | ✓ | ✓ | Playbooks |
+| chezmoi | — | ✓ | ✓ | — | — |
+| GNU Stow | — | ✓ (symlinks) | Unix only | — | — |
+| yadm | — | ✓ | ✓ | — | — |
+| **Lore + Writ** | ✓ | ✓ | ✓ | ✓ | Registry |
+
+### 3.2. Lore Differentiation
+
+| Competitor | Invisible Dependencies? | Cross-Platform? | Post-Install Provisioning? |
+|------------|------------------------|-----------------|---------------------------|
+| **Homebrew** | No | macOS + Linux | Caveats only |
+| **asdf/mise** | No (runtimes only) | Yes | No |
+| **Nix** | Yes (hermetic) | Yes | Flake configs |
+| **devbox** | Yes (Nix under hood) | Yes | devbox.json |
+| **Ansible** | Yes | Yes | Full config mgmt |
+| **Lore** | **Yes** | **Yes** | **First-class** |
+
+### 3.3. Writ Differentiation (Dotfile Managers)
+
+The dotfile management space has three tiers: symlink farms (Stow, Tuckr), file transformers (chezmoi), and full declarative systems (Home Manager). Writ occupies a unique position: symlink-based simplicity with templating, encryption, and receipts.
+
+#### GNU Stow
+
+[GNU Stow](https://www.gnu.org/software/stow/manual/stow.html) is the venerable Perl-based symlink farm manager. Pure, simple, stateless.
+
+| Capability | GNU Stow | Writ |
+|------------|----------|------|
+| Symlink creation | ✓ | ✓ |
+| Package grouping | ✓ (directories) | ✓ (projects) |
+| Ignore patterns | ✓ (.stow-local-ignore) | ✓ |
+| Restow (prune stale) | ✓ | Planned |
+| Platform variants | ✗ | ✓ (`.Darwin`, `.Linux`, custom segments) |
+| Hooks | ✗ | ✗ (uses packages-manifest.yaml) |
+| Templating | ✗ | ✓ (Go text/template) |
+| Secrets/encryption | ✗ | ✓ (age) |
+| Conflict detection | Basic (stops) | Upfront (backup/overwrite/skip/stop) |
+| Receipts/state | ✗ (stateless) | ✓ (XDG-compliant YAML) |
+
+**Stow philosophy**: Pure symlink management. No opinions about what you're linking. You script everything else.
+
+**Writ advantage**: Cross-platform, templates, secrets, audit trail.
+
+#### Tuckr
+
+[Tuckr](https://github.com/RaphGL/Tuckr) is a Rust rewrite that extends the Stow model with hooks and platform detection.
+
+| Capability | Tuckr | Writ |
+|------------|-------|------|
+| Symlink creation | ✓ | ✓ |
+| Platform variants | ✓ (`_linux`, `_macos`, `_windows`, `_unix`) | ✓ (`.Darwin`, `.Linux`, `.Unix`, custom) |
+| Hooks | ✓ (pre/post scripts) | ✗ (uses packages-manifest.yaml) |
+| Templating | ✗ | ✓ |
+| Secrets/encryption | ⚠ WIP (not production-ready) | ✓ (age, mature) |
+| Env var expansion | ✓ (% prefix) | ✓ (in templates) |
+| Root file targeting | ✓ (^ prefix for /etc) | ✗ ($HOME only) |
+| Profiles | ✓ | Via segments |
+| Conflict detection | Basic | Upfront with strategies |
+| Receipts/state | ✗ | ✓ |
+
+**Tuckr philosophy**: Stow + hooks + platform awareness. Acknowledges you need setup scripts.
+
+**Writ advantage**: Mature encryption, templating, receipts. **Tuckr advantage**: Hooks, root file targeting.
+
+#### chezmoi (Writ Comparison)
+
+[chezmoi](https://www.chezmoi.io/) is feature-rich but complex—file transforms, scripts, encryption, hooks, and a templating language.
+
+| Capability | chezmoi | Writ |
+|------------|---------|------|
+| Approach | File transforms | Symlinks |
+| Templating | ✓ (powerful) | ✓ (Go text/template) |
+| Encryption | ✓ (age, gpg) | ✓ (age) |
+| Scripts/hooks | ✓ | ✗ |
+| Platform variants | ✓ (attributes) | ✓ (segments) |
+| Learning curve | Steep | Gentle |
+| Mental model | "Source of truth" | "Symlink farm" |
+
+**chezmoi philosophy**: Your dotfiles repo is the source of truth; chezmoi transforms it into your home directory.
+
+**Writ philosophy**: Your dotfiles are your dotfiles. Writ symlinks them. Changes in the repo are immediately live.
+
+**Writ advantage**: Simpler mental model—edit a file, it's changed. No `chezmoi apply` needed.
+
+#### Summary: Where Writ Excels
+
+1. **Templating** — Neither Stow nor Tuckr can interpolate variables into config files.
+2. **Secrets** — Tuckr's encryption is WIP. Writ uses mature age encryption with SSH key support.
+3. **Receipts** — Stow and Tuckr are stateless. Writ tracks what was deployed, when, with what segments.
+4. **Upfront conflict handling** — Detect all conflicts before touching anything; offer backup/overwrite/skip.
+5. **Composable segments** — Tuckr has fixed platform suffixes. Writ's segments are extensible (ROLE, DISTRO, etc.).
+
+#### Where Writ Currently Lacks
+
+1. **Hooks** — Tuckr has pre/post hooks. Writ uses packages-manifest.yaml for software but has no hook system.
+2. **Root file targeting** — Tuckr's `^` prefix targets `/etc`. Writ is `$HOME` only.
+3. **Restow/prune** — Stow can prune stale symlinks. Writ tracks via receipts but doesn't auto-prune yet.
+
+### 3.4. Our Gap
+
+**Simpler than Nix/Ansible, more complete than Homebrew/asdf, unified packages + dotfiles.**
+
+Differentiation:
+
+1. Cross-platform (Darwin + Linux + Windows) with single manifest
+2. Post-install provisioning as first-class concern
+3. Tribal knowledge capture (the kubectl → cloud auth problem)
+4. Simpler than Nix, lighter than Ansible, broader than asdf
+5. Symlink-based dotfiles (simpler than chezmoi transforms)
+
+### 3.5. Competitive Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Homebrew adds provisioning | Medium | High | Speed to market; differentiate on cross-platform |
+| Nix becomes easy | Low | High | Focus on simplicity; Nix culture unlikely to change |
+| Ansible targets developers | Low | Medium | Lighter weight, faster startup |
+| chezmoi adds simplicity mode | Low | Medium | Philosophy difference (symlinks vs transforms) |
+
+---
+
+## 4. Product Thesis
+
+### 4.1. The Problem is Real
+
+- Onboarding takes days, not hours
+- "Works on my machine" is still a punchline
+- Tribal knowledge walks out the door when people leave
+- Documentation is always stale
+- Dotfiles scattered across machines
+- Existing tools either too simple or too complex
+
+### 4.2. The Solution Exists in Pieces
+
+- Homebrew does packages (macOS + Linux only)
+- asdf/mise does runtimes (not full tools)
+- Nix does reproducibility (but is complex)
+- Ansible does configuration (but is enterprise-heavy)
+- Dotfiles repos exist (but are DIY)
+- chezmoi does dotfiles (but is complex)
+- GNU Stow does symlinks (but Unix only)
+
+### 4.3. What's Missing
+
+A unified, cross-platform, developer-friendly system that handles packages + configuration + tribal knowledge, simple enough that individuals use it but powerful enough that teams adopt it.
+
+---
+
+## 5. Primary Use Case: "Wiki to Working"
+
+### 5.1. Hero Story Selection
+
+| Candidate | Audience Reach | Emotional Resonance | Demo Complexity |
+|-----------|----------------|---------------------|-----------------|
+| kubectl cloud auth | DevOps/SRE | Medium ("I use EKS/GKE") | Medium |
+| Cloud stack | DevOps/SRE | Medium ("I use these tools") | Medium |
+| Day One (curated manifest) | Teams with manifests | Medium | Low |
+| **Wiki to Working (AI)** | **Everyone** | **High ("I'm stuck on step 12")** | Medium |
+| Emergency debug | On-call only | High but niche | High |
+
+**Decision:** "Wiki to Working" narrative wins because:
+
+- Universal resonance — everyone has been stuck on a messy wiki page
+- Realistic — doesn't assume someone already made a manifest
+- AI-powered — differentiates from every competitor
+- Honest — shows confidence levels, flags unknowns, expects iteration
+
+> **Demo script:** See [03-demo-script.md](03-demo-script.md) for the full scripted walkthrough.
+
+### 5.2. The Narrative
+
+**Before lore + writ:**
+> "I started Monday. It's Thursday. I still can't build the app. The wiki has 47 steps. I got stuck on step 12. I asked Sarah, she said 'just run the script' but it failed on line 47. The wiki was written by someone who left two years ago."
+
+**After lore + writ:**
+> "I started Monday. I was stuck on step 12 of the wiki. I pointed lore at the page. It generated a manifest AND config files. I deployed the packages, tweaked a few settings to get EKS working, then ran `writ adopt acme-backend` to capture everything. By lunch I was pushing my first PR. Now everyone on the team runs `writ add acme-backend` and skips the pain."
+
+### 5.3. The Combined Demo
+
+```bash
+# Onboard: parse wiki, extract deploy, upgrade, and decommission steps
+lore onboard --from https://wiki.acme.com/backend-setup
+
+# Deploy: prepare, install, provision, and verify
+lore deploy @packages-manifest.yaml
+# ✓ kubectl installed
+# ✓ aws-cli installed
+# ✓ kubectl get pods — cluster access works
+# ✗ aws sts get-caller-identity — credentials not configured
+
+# Troubleshoot: fix config or update pipeline, re-run deploy
+# Config fix: edit ~/.aws/config → re-run lore deploy
+# Pipeline fix: edit install.star → dev work (debug, test, commit)
+
+# Capture: receipt tracks all artifacts (Home + System)
+writ adopt acme-backend --from-receipt --layer=team
+
+# Next person: gets the verified config
+writ add acme-backend
+```
+
+**For users who want one command:** `lore deploy @packages-manifest.yaml --with-config` runs writ automatically.
+
+---
+
+## 6. Go-to-Market Strategy
+
+> **Detailed timelines, deliverables, and metrics:** See [02-roadmap.md](02-roadmap.md)
+
+### 6.1. Phase Overview
+
+| Phase | Objective | Key Gate |
+|-------|-----------|----------|
+| **Phase 0** (Weeks 1-4) | Validate market demand | 200+ waitlist, 5+ "I'd use this today" |
+| **Phase 1** (Weeks 5-12) | Working demo | Demo runs end-to-end, 100+ stars |
+| **Phase 2** (Months 4-12) | User growth, community | 1,000 WAU, 20+ contributors |
+| **Phase 3** (Months 12-18) | Sustainable revenue | $10K MRR, 5 enterprise pilots |
+
+Each phase has explicit fail-fast criteria. If we don't hit the gate, we stop or pivot.
+
+### 6.2. Distribution Strategy
+
+**Current state:** `self-install` via curl from GitHub releases.
+
+**Decision:** Defer native package manager distribution (apt, brew, dnf) until GitHub stars > 500. Exception: winget for Windows (native UX expectation).
+
+**Rationale:**
+
+- `self-install` is simpler than PPAs/taps (one curl command, no repo setup)
+- Homebrew tap still requires `brew tap` first
+- Maintenance burden not justified until adoption proves demand
+
+**Implementation:** Use [goreleaser](https://goreleaser.com/) when we proceed. See [02-devlore-rfc.md](../design/02-devlore-rfc.md#4-distribution) for details.
+
+---
+
+## 7. Revenue Model
+
+### 7.1. Where the Money Is
+
+**Enterprise is the revenue engine.** Individual developers adopt free tools; enterprises pay for the ROI.
+
+The value proposition is quantifiable:
+
+| Metric                             | Before DevLore   | After DevLore      | Enterprise Impact                |
+|------------------------------------|------------------|--------------------|----------------------------------|
+| New hire onboarding                | 1-3 days         | 15-30 minutes      | $500-2,000/hire saved            |
+| "Works on my machine" debugging    | Hours/week       | Near-zero          | Developer productivity reclaimed |
+| Senior engineer interruptions      | 10+ per new hire | ~1                 | Senior time protected            |
+| Environment drift incidents        | Weekly           | Tracked, auditable | Compliance + stability           |
+
+For a 100-person engineering org with 20 new hires/year, the savings are **$10K-40K annually** in onboarding time alone—before counting reduced debugging, fewer environment issues, and protected senior bandwidth.
+
+**Positioning:** DevLore sits between brew (individual, no provisioning) and Ansible (enterprise, complex). We target the gap: enterprise value with developer simplicity.
+
+### 7.2. SSPL as Commercial Moat
+
+The SSPL license is the business model enforcer:
+
+| What competitors can do | What they cannot do |
+|-------------------------|---------------------|
+| Fork the code | Host the service commercially |
+| Run internally | Offer "DevLore-as-a-Service" |
+| Contribute back | Compete without open-sourcing their stack |
+
+**This means:** An enterprise can fork DevLore and run it internally. They *cannot* build a commercial service on top without releasing their entire stack. AWS, GCP, Azure cannot offer "Managed DevLore" without SSPL compliance.
+
+**The forcing function:** Enterprises who want DevLore must either:
+1. Use the hosted service (future Phase 3 SaaS offering)
+2. Self-host internally (which is allowed, and is the Phase 2 model)
+3. Build from scratch (12-24 months, see Section 9)
+
+Self-hosting is the Phase 2 enterprise model. SaaS is Phase 3+.
+
+### 7.3. Enterprise Product Definition
+
+#### The Enterprise Product Story
+
+DevLore Enterprise is **operational intelligence for developer environments**.
+
+Individual developers use lore and writ to set up their machines. Enterprise customers get visibility into *all* machines:
+
+- **What's deployed?** — Every package, every version, every machine
+- **What's drifting?** — Alice's machine diverged from the team spec
+- **What's broken?** — Failed pipelines, automatically ticketed
+- **What's the ROI?** — Onboarding time reduced from 3 days to 30 minutes
+
+The receipts system (what actually deployed, not just what was requested) enables this visibility. Competitors can replicate the CLI; they can't replicate the operational intelligence without building the same telemetry infrastructure.
+
+#### Feature Categories
+
+**Table Stakes (Justify Procurement)**
+
+Every enterprise SaaS has these. They don't differentiate, but their absence blocks sales:
+
+| Feature | What It Is | Why Required |
+|---------|------------|--------------|
+| Private manifests | Org-specific packages not public | Intellectual property |
+| SSO/SAML | Login via existing IdP | IT compliance |
+| Audit logging | Who installed what when | SOC2, regulatory |
+| Air-gapped bundles | Works without internet | Defense, regulated industries |
+
+**Differentiated Value (Win Deals)**
+
+These justify the price premium over free tools:
+
+| Feature | What It Is | Business Value |
+|---------|------------|----------------|
+| **Environment drift detection** | "Alice's machine diverged from spec" | Reduced debugging, fewer "works on my machine" |
+| **Aggregated analytics** | Onboarding time, failure rates, adoption | ROI proof for procurement |
+| **Policy enforcement** | "Block packages not in approved list" | Security, compliance |
+| **Issue tracking integration** | Failed pipeline → Jira ticket | Faster resolution, less manual triage |
+| **Knowledge capture workflow** | "Sarah is leaving; capture her setup" | Tribal knowledge preservation |
+
+**AI Features (Tier Progression)**
+
+| Tier | AI Capability | Infrastructure |
+|------|---------------|----------------|
+| Individual | `lore onboard` with own API key | Claude API, OpenAI API |
+| Team | `lore onboard` with shared API key | Same as Individual |
+| Enterprise | `lore onboard` with org LLM | Azure OpenAI, Bedrock, Vertex AI in customer tenant |
+| Enterprise (Air-gapped) | `lore onboard` with self-hosted LLM | vLLM on customer infrastructure |
+
+See [ADR-049: Enterprise LLM Architecture](../design/adr/049-enterprise-llm-architecture.md) for details.
+
+#### Enterprise Feature Tiers
+
+| Feature | Individual (Free) | Team ($10/user/mo) | Enterprise ($20/user/mo) |
+|---------|-------------------|--------------------|-----------------------|
+| **Core** | | | |
+| Public registry | ✓ | ✓ | ✓ |
+| Private manifests | — | ✓ | ✓ |
+| AI parsing (`lore onboard`) | Own API key | Shared API key | Org LLM (Azure OpenAI, etc.) |
+| **Compliance** | | | |
+| SSO/SAML | — | — | ✓ |
+| Audit logging | — | — | ✓ |
+| Air-gapped bundles | — | ✓ | ✓ |
+| Compliance reporting | — | — | ✓ |
+| **Operational Intelligence** | | | |
+| Environment drift detection | — | — | ✓ |
+| Aggregated analytics dashboard | — | — | ✓ |
+| Policy enforcement | — | — | ✓ |
+| Issue tracking integration | — | — | ✓ |
+| Knowledge capture workflow | — | — | ✓ |
+| **Support** | | | |
+| Community support | ✓ | ✓ | ✓ |
+| Priority support | — | ✓ | ✓ |
+| Dedicated support + SLA | — | — | ✓ |
+
+#### Delivery Models
+
+| Model | Phase | Description | Customer Ops Burden |
+|-------|-------|-------------|---------------------|
+| **Self-hosted** | Phase 2 | Customer runs registry, receipts DB, analytics | High |
+| **Hosted** | Phase 3+ | Noble Factor runs everything | None |
+| **Hybrid** | Phase 3+ | Registry hosted, receipts on-prem | Medium |
+
+See [ADR-048: Enterprise Hosting Model](../design/adr/048-enterprise-hosting-model.md) for architecture details.
+
+#### Enterprise Sales Motion
+
+```text
+Individual Developer                Platform Engineering Team
+─────────────────────              ─────────────────────────
+        │                                     │
+        │ Uses lore/writ personally           │ Sees adoption spreading
+        ▼                                     ▼
+"This saved me a day"              "Can we get visibility into all machines?"
+        │                                     │
+        └─────────────────┬───────────────────┘
+                          │
+                          ▼
+                   Enterprise Sale
+                   • Aggregated analytics
+                   • Drift detection
+                   • Policy enforcement
+```
+
+The free tier creates adoption. Enterprise features capture the value at scale.
+
+### 7.4. Enterprise Market Sizing
+
+#### Adjacent Markets (2025)
+
+| Market Segment | 2025 Size | 2033 Projection | CAGR | Source |
+|----------------|-----------|-----------------|------|--------|
+| Platform Engineering | $5.76B | $47B (2035) | 23.4% | [Cervicorn Consulting](https://www.cervicornconsulting.com/platform-engineering-market) |
+| Internal Developer Platforms | $1.72B | $12.4B | 22.6% | [Data Insights Market](https://www.datainsightsmarket.com/reports/internal-developer-platforms-527289) |
+| Employee Onboarding Software | $3.9B | $10.1B | 12.5% | [Verified Market Reports](https://www.verifiedmarketreports.com/product/onboarding-software-market/) |
+| Configuration Management | $3.35B | $9.2B (2032) | 15.6% | [Fortune Business Insights](https://www.fortunebusinessinsights.com/configuration-management-market-109790) |
+| Software Development Tools | $6.4B | $13.7B (2030) | 16.4% | [Mordor Intelligence](https://www.mordorintelligence.com/industry-reports/software-development-tools-market) |
+
+#### Where DevLore Fits
+
+DevLore Enterprise is **not** a full platform engineering solution (like Backstage) or a CI/CD tool (like GitLab). It's narrower:
+
+```text
+Platform Engineering ($5.76B)
+├── Infrastructure provisioning (Terraform, Pulumi)
+├── CI/CD (GitHub Actions, GitLab CI)
+├── Internal Developer Portals (Backstage, Port)
+└── Developer Environment Management  ← DevLore is here
+    ├── Workstation setup
+    ├── Dotfiles/configuration
+    └── Onboarding automation
+```
+
+#### The Pain: Developer Productivity Loss
+
+**Industry research from highly-regarded sources quantifies the problem DevLore solves:**
+
+##### 1. Onboarding Costs & Time to Productivity
+
+| Metric | Finding | Source |
+|--------|---------|--------|
+| Onboarding cost | $4,100 per new hire | [SHRM](https://www.shrm.org/topics-tools/news/shrm-benchmarking-report-4129-average-cost-per-hire) |
+| Time to productivity | 8-12 months for full productivity; 25% productive in first 4 weeks | [SHRM Foundation](https://www.devlinpeck.com/content/employee-onboarding-statistics) |
+| Onboarding churn | $22B annual cost; 1/3 of engineers leave before onboarding completes | [Built In](https://builtin.com/software-engineering-perspectives/increase-new-developer-productivity) |
+| Environment setup | 6+ hours on first day; 25% of issues are environment inconsistencies | [DevZero](https://www.devzero.io/blog/developer-onboarding) |
+| Mentoring overhead | Senior engineers lose 30% productivity mentoring; sprint velocity drops 25-40% | [Full Scale](https://fullscale.io/blog/developer-onboarding-best-practices/) |
+| Structured onboarding | Companies with structured onboarding see 62% faster time-to-productivity | [Stack Overflow 2024](https://survey.stackoverflow.co/2024/) |
+| Spotify Backstage | Time to 10th commit dropped 55% after deploying internal developer portal | [Spotify Engineering](https://engineering.atspotify.com/2024/04/supercharged-developer-portals) |
+
+##### 2. Environment Setup & "Works on My Machine"
+
+| Metric | Finding | Source |
+|--------|---------|--------|
+| Environment troubleshooting | 10%+ of developer time on average; much higher for some | [Coder](https://coder.com/blog/it-works-on-my-machine-explained) |
+| Tools & environments | 14-16 hours/week on internal tools, environment setup, waiting for builds | [Garden.io](https://garden.io/blog/developer-productivity) |
+| Configuration drift | 40% of Kubernetes users report drift negatively impacts stability | [Release.com](https://release.com/blog/hidden-costs-of-staging) |
+| Environment costs untracked | 70% of CTOs don't track environment maintenance costs | [Release.com](https://release.com/blog/hidden-costs-of-staging) |
+
+##### 3. Context Switching & Support Burden
+
+| Metric | Finding | Source |
+|--------|---------|--------|
+| Recovery time | 23 minutes to regain focus after interruption | [UC Irvine](https://www.ics.uci.edu/~gmark/chi08-mark.pdf) |
+| App switching | Workers toggle 1,200 times/day; lose 4 hours/week reorienting | [Harvard Business Review](https://hbr.org/2022/08/how-much-time-and-energy-do-we-waste-toggling-between-applications) |
+| Productivity decrease | 40% productivity loss from context switching | [Atlassian](https://www.atlassian.com/blog/loom/cost-of-context-switching) |
+| Annual cost | $50,000 per developer per year from context switching | [TeamCamp](https://dev.to/teamcamp/the-hidden-cost-of-developer-context-switching-why-it-leaders-are-losing-50k-per-developer-1p2j) |
+| Deep work time | Only 2.3 hours of focused work per 8-hour day (47 interruptions average) | [Super Productivity](https://super-productivity.com/blog/context-switching-costs-for-developers/) |
+
+##### 4. Technical Debt & Maintenance
+
+| Metric | Finding | Source |
+|--------|---------|--------|
+| Maintenance time | 17.3 hours/week on debugging, refactoring, technical debt (42% of work week) | [Stripe Developer Coefficient](https://stripe.com/files/reports/the-developer-coefficient.pdf) |
+| Repetitive tasks | 30%+ of developer time on repetitive tasks | [McKinsey](https://www.mckinsey.com/industries/technology-media-and-telecommunications/our-insights/yes-you-can-measure-software-developer-productivity) |
+| Global opportunity cost | $85B annually from time on bad code; $300B GDP lost from developer inefficiency | [Stripe Developer Coefficient](https://stripe.com/files/reports/the-developer-coefficient.pdf) |
+| Knowledge silos | 45% of developers encounter knowledge silos frequently; 61% spend 30+ min/day searching | [Stack Overflow 2024](https://survey.stackoverflow.co/2024/) |
+
+##### 5. Platform Engineering ROI (Comparables)
+
+| Metric | Finding | Source |
+|--------|---------|--------|
+| Developer portal impact | Backstage users 2.3x more active in GitHub, deploy 2x as often | [Spotify Engineering](https://engineering.atspotify.com/2024/04/supercharged-developer-portals) |
+| Productivity boost | Internal developer portals boost productivity 20% | [Forrester TEI for Cortex](https://www.cortex.io/post/cortex-recognized-again-as-a-representative-vendor-in-the-2025-gartner-market-guide-for-internal-developer-portals) |
+| Deployment speed | 25% reduction in time to deploy new software | [Forrester TEI for Cortex](https://www.cortex.io/post/cortex-recognized-again-as-a-representative-vendor-in-the-2025-gartner-market-guide-for-internal-developer-portals) |
+| Documentation impact | Teams with high-quality docs 2x more likely to meet reliability targets | [DORA 2024](https://dora.dev/research/2024/dora-report/) |
+| Gartner prediction | By 2027, platform engineering will influence 50%+ of I&O decisions (up from 20%) | [Gartner Hype Cycle 2024](https://www.gartner.com/en/documents/5519995) |
+| C-suite priority | 58% of software engineering leaders say DevEx is "very/extremely critical" to C-suite | [Gartner Survey](https://www.gartner.com/en/newsroom/press-releases/2023-04-24-gartner-survey-finds-the-need-to-improve-developer-experience-is-driving-software-engineering-technology-adoption) |
+
+##### 6. Nearest Neighbors (No Direct Comparable)
+
+DevLore occupies a unique niche: **cross-platform developer environment management with tribal knowledge capture**. No existing product combines package installation, configuration management, post-install provisioning, and AI-assisted onboarding in a single tool. The nearest neighbors each solve a subset of the problem.
+
+###### Homebrew
+
+The dominant package manager for macOS, with Linux support added later. Developer-friendly, massive package catalog, strong community.
+
+| Factor | Homebrew | DevLore |
+|--------|----------|---------|
+| Platforms | macOS, Linux | macOS, Linux, Windows |
+| Scope | Package installation only | Packages + dotfiles + provisioning |
+| Post-install setup | Caveats (text instructions) | Executable provisioning scripts |
+| Enterprise features | None | SSO, audit logs, drift detection |
+| Tribal knowledge | None | Registry captures "kubectl needs cloud auth" wisdom |
+
+###### chezmoi
+
+The leading dotfile manager. Cross-platform, template-based, Git-backed. Sophisticated but complex.
+
+| Factor | chezmoi | DevLore (Writ) |
+|--------|---------|----------------|
+| Approach | File transforms + templates | Symlinks (simpler mental model) |
+| Package installation | None (separate concern) | Integrated via Lore |
+| Learning curve | Steep (templating language) | Shallow (declarative manifests) |
+| Enterprise features | None | SSO, audit logs, policy enforcement |
+| Status reporting | Manual | Unified receipts across packages + dotfiles |
+
+###### Ansible
+
+Enterprise configuration management. Powerful, declarative, agentless. Used for server fleets and infrastructure.
+
+| Factor | Ansible | DevLore |
+|--------|---------|---------|
+| Primary use case | Server/infrastructure provisioning | Developer workstation setup |
+| Complexity | High (playbooks, roles, inventory) | Low (single manifest file) |
+| Startup time | Slow (Python, SSH) | Fast (native binary) |
+| Developer adoption | Low (ops-focused) | High (developer-first UX) |
+| AI-assisted authoring | None | `lore onboard` parses wikis |
+
+###### Nix / Home Manager
+
+Purely functional package manager with reproducible builds. Hermetic, cross-platform, powerful. Notoriously steep learning curve.
+
+| Factor | Nix + Home Manager | DevLore |
+|--------|-------------------|---------|
+| Reproducibility | Hermetic (strongest guarantee) | Practical (works on real machines) |
+| Learning curve | Very steep (functional language) | Shallow (familiar syntax) |
+| Ecosystem integration | Isolated (Nix store) | Native (uses system package managers) |
+| Community culture | Purist, academic | Pragmatic, accessible |
+| Adoption barrier | High (requires mindset shift) | Low (drop-in replacement) |
+
+###### asdf / mise
+
+Runtime version managers. Install multiple versions of languages and tools. Cross-platform, plugin-based.
+
+| Factor | asdf / mise | DevLore |
+|--------|-------------|---------|
+| Scope | Runtime versions only | Full tool installation + configuration |
+| Package types | Languages, some CLIs | Any software with tribal knowledge |
+| Configuration management | None | Integrated (Writ) |
+| Post-install provisioning | None | First-class (shell_profile, etc.) |
+| Enterprise features | None | SSO, audit logs, drift detection |
+
+###### devbox
+
+Nix-powered development environments. Simpler than raw Nix, creates isolated project environments.
+
+| Factor | devbox | DevLore |
+|--------|--------|---------|
+| Underlying tech | Nix (abstracted) | Native package managers |
+| Scope | Project environments | Machine-wide setup + dotfiles |
+| Isolation | Full (Nix store) | None (uses system paths) |
+| Tribal knowledge | None | Registry captures post-install wisdom |
+| Onboarding | Project-specific | Machine-wide + AI-assisted |
+
+###### Product Links
+
+- [Homebrew](https://brew.sh/)
+- [chezmoi](https://www.chezmoi.io/)
+- [Ansible](https://www.ansible.com/)
+- [Nix](https://nixos.org/) / [Home Manager](https://nix-community.github.io/home-manager/)
+- [asdf](https://asdf-vm.com/) / [mise](https://mise.jdx.dev/)
+- [devbox](https://www.jetify.com/devbox)
+
+#### DevLore ROI Calculation
+
+**For a 300-developer organization:**
+
+| Cost Category | Annual Loss | DevLore Impact | Savings |
+|---------------|-------------|----------------|---------|
+| **Onboarding** (50 new hires/year × $75K lost productivity during ramp) | $3.75M | 30% faster ramp (structured setup) | $1.1M |
+| **Environment friction** (300 devs × 8 hrs/week × $75/hr × 50 weeks) | $9M | 10% time recovered | $900K |
+| **Context switching** (300 × $50K/year) | $15M | 5% reduction via unified tooling | $750K |
+| **Knowledge silos** (300 × 30 min/day × $75/hr × 250 days) | $2.8M | 20% faster answers via manifests | $560K |
+| **Total potential savings** | | | **$3.3M** |
+
+**DevLore Enterprise cost:** $90K/year (300 seats × $25/user/month)
+
+**ROI: 36x** ($3.3M savings ÷ $90K cost)
+
+Even at **10% of projected savings** ($330K), DevLore delivers **3.6x ROI**.
+
+#### TAM / SAM / SOM
+
+| Level | Scope | Estimate (2025) |
+|-------|-------|-----------------|
+| **TAM** | All companies that could use DevLore | $1.5-2.5B |
+| **SAM** | Companies with 50+ developers, cross-platform needs | $400-700M |
+| **SOM** | Realistic capture in 3-5 years | $10-40M |
+
+**TAM Calculation:**
+- IDP market ($1.72B) + developer portion of onboarding (~$400M) = ~$2.1B
+- DevLore targets a subset (environment setup, not full IDP)
+- Estimate: **$1.5-2.5B**
+
+**SAM Calculation:**
+- ~36M developers work cross-platform (per Section 2)
+- ~10% work at enterprises with 50+ developers and budget authority
+- 3.6M developers × $10-20/month potential = $432M-864M
+- Conservative: **$400-700M**
+
+**SOM Calculation:**
+- Year 3-5 target: 5,000-20,000 paid enterprise seats
+- At $25/user/month = $1.5M-6M ARR
+- With enterprise contracts (100+ seats): 50-200 customers at $30K-100K/year
+- Optimistic with strong product-market fit: **$10-40M**
+
+#### Pricing Benchmarks
+
+| Product | Model | Price | Notes |
+|---------|-------|-------|-------|
+| [GitLab Premium](https://about.gitlab.com/pricing/) | Per-seat | $29/user/month | Full DevOps platform |
+| [GitHub Enterprise](https://github.com/pricing) | Per-seat | $21/user/month | Repos + CI/CD |
+| [Terraform Enterprise](https://www.hashicorp.com/en/pricing) | Contract | $37K/year avg | Infrastructure provisioning |
+| [Backstage (self-hosted)](https://roadie.io/blog/backstage-how-much-does-it-really-cost/) | Internal | $1M+ first year | 7 FTEs for 300 devs |
+
+#### Recommended Pricing Structure
+
+Current plan: $20/user/month for Enterprise. This is **defensible but potentially underpriced**.
+
+**Recommended tiers:**
+
+| Tier | Price | Target | Minimum |
+|------|-------|--------|---------|
+| **Team** | $10/user/month | Startups, small teams | 5 seats |
+| **Enterprise** | $25/user/month | 50-500 devs | 25 seats ($7,500/year) |
+| **Enterprise Plus** | $35/user/month | 500+ devs, regulated | 100 seats ($42K/year) |
+
+**Rationale:** [Backstage costs $1M+/year](https://roadie.io/blog/backstage-how-much-does-it-really-cost/) for 300 developers. DevLore at $25/user × 300 = $90K/year is a 10x cost savings for operational intelligence.
+
+#### Concrete Target: $90K Enterprise Contracts
+
+A $90K/year contract = 300 developers at $25/user/month. This is our anchor enterprise deal size.
+
+**How many $90K contracts can we sell?**
+
+| Scenario | SOM | $90K Contracts | Notes |
+|----------|-----|----------------|-------|
+| Conservative | $10M | ~110 | Slow adoption, niche positioning |
+| Base case | $20M | ~220 | Solid product-market fit |
+| Optimistic | $40M | ~440 | Strong PMF, category leadership |
+
+**Reality check:** Not all contracts will be $90K. Expected distribution:
+
+| Contract Size | Seats | Annual Value | Expected Mix |
+|---------------|-------|--------------|--------------|
+| Small enterprise | 50 | $15K | 40% of customers |
+| Mid enterprise | 100 | $30K | 35% of customers |
+| Large enterprise | 300 | $90K | 20% of customers |
+| Very large | 500+ | $150K+ | 5% of customers |
+
+**Bottom line:** In a 3-5 year optimistic scenario, **50-200 enterprise customers** with an average contract of $50-90K. Roughly **30-100 of those** are $90K+ tier (300+ developers).
+
+#### Milestone: $500K ARR
+
+**Customer mix to reach $500K gross annual revenue:**
+
+| Segment | Customers | Avg Contract | Revenue |
+|---------|-----------|--------------|---------|
+| Team (small teams, startups) | 50 | $2,400 | $120K |
+| Mid Enterprise (100 seats) | 8 | $30K | $240K |
+| Large Enterprise (300 seats) | 2 | $70K | $140K |
+| **Total** | **60** | **$8,300 avg** | **$500K** |
+
+**Alternative paths to $500K:**
+
+| Strategy | Customers | Avg Contract | Trade-off |
+|----------|-----------|--------------|-----------|
+| Enterprise-heavy | 17 | $30K | Higher touch sales, slower close |
+| Team-heavy | 200+ | $2,500 | Self-serve scale, lower margin |
+| Whale hunting | 6 | $85K | High risk, relationship-dependent |
+| **Balanced (above)** | **60** | **$8,300** | **Diversified, scalable** |
+
+### 7.5. Revenue Projections
+
+| Phase | Model | Expected Revenue | Notes |
+|-------|-------|------------------|-------|
+| Phase 0-1 | Self-funded | $0 | Build credibility, gather testimonials |
+| Phase 2 | GitHub Sponsors + Team tier | $1-5K/month | Early adopters, small teams |
+| Phase 3 | Enterprise self-host licenses | $10K+/month | Platform engineering teams |
+| Phase 4+ | SaaS + Enterprise | TBD | Hosted registry, managed service |
+
+### 7.6. Community Sustainability
+
+**Risk:** AI-generated contributions can erode open source community culture.
+
+> "The OSS model requires engaged contributors who understand and maintain the code. AI-generated PRs that 'vibe-code' solutions without deep understanding create technical debt and devalue the community relationships that make OSS sustainable." — Craig McLuckie (paraphrased)
+
+**Our approach:**
+1. **Human curation required** — Registry contributions require human review, testing, and accountability
+2. **Trust levels earned** — MusicBrainz-style progression rewards sustained contribution, not volume
+3. **Receipts as truth** — What actually deployed (receipts) matters more than what was proposed (manifests)
+4. **Quality over quantity** — Lore packages with verified tribal knowledge are valuable; AI-generated stubs are not
+
+The registry's value comes from *proven working* knowledge, not autogenerated definitions. This protects against the "vibe-coded PRs" problem.
+
+### 7.7. Azure Marketplace Go-to-Market
+
+**Decision:** Ship DevLore Enterprise as an Azure Marketplace offering. Self-serve for Team tier; sales-assisted for Enterprise tier ($70K+ contracts).
+
+```text
+Customer flow:
+
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Find DevLore   │────▶│  Click Deploy   │────▶│  Running in     │
+│  in Marketplace │     │  (ARM/Bicep)    │     │  their tenant   │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                              │
+                              ▼
+                        Billing via Azure
+                        (no invoice from us)
+```
+
+#### Self-Serve vs. Sales-Assisted
+
+| Tier | ACV | Motion | Sales Touch |
+|------|-----|--------|-------------|
+| **Team** | <$25K | Self-serve | None—credit card signup |
+| **Enterprise** | $25K-$70K | Hybrid | Light touch—CS outreach at adoption threshold |
+| **Enterprise** | $70K+ | Sales-assisted | Full motion—PM/sales, security review, contract negotiation |
+
+**Why the split?** Data shows:
+
+- Enterprise SaaS sales cycles average **6-9 months** for deals >$100K ([Focus Digital](https://focus-digital.co/average-sales-cycle-length-by-industry/))
+- Median ACV hit **$62K** in 2024 ([KeyBanc via Rocking Web](https://www.rockingweb.com.au/saas-metrics-benchmark-report-2025/))
+- **61% of PLG companies** launch enterprise sales teams by $50M ARR ([Segment8](https://blog.segment8.com/posts/plg-sales-hybrid-model/))
+- Twilio triggers enterprise sales at **$100K ACV**; Dropbox at **3% employee adoption** ([McKinsey](https://www.mckinsey.com/industries/technology-media-and-telecommunications/our-insights/from-product-led-growth-to-product-led-sales-beyond-the-plg-hype))
+
+#### The Land-and-Expand Motion
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│  Individual/Team adopts DevLore (self-serve)                            │
+│                         │                                               │
+│                         ▼                                               │
+│  Usage threshold triggered (e.g., 10+ users, 3%+ org penetration)       │
+│                         │                                               │
+│                         ▼                                               │
+│  PM/CS outreach: "We noticed your team is using DevLore..."             │
+│                         │                                               │
+│                         ▼                                               │
+│  Discovery: pain points, expansion potential, security requirements     │
+│                         │                                               │
+│                         ▼                                               │
+│  Enterprise sale: SSO, audit logging, policy enforcement, SLA           │
+│                         │                                               │
+│                         ▼                                               │
+│  Larger contract ($70K-$150K+)                                          │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key triggers for outreach:**
+- Usage/licensing limits approached ([Dock](https://www.dock.us/library/land-and-expand-strategy))
+- Multiple teams/departments adopting
+- Champion requests enterprise features (SSO, audit)
+- 30-60 day adoption curve indicates long-term success ([Land and Expand Academy](https://www.landandexpand.academy/blog/land-and-expand-tactics))
+
+#### Wiki-Triggered Team Conversion
+
+The most natural conversion path: a new hire uses `lore onboard` on their team's wiki and discovers the gap between public packages (automated) and org-specific packages (manual).
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  NEW HIRE (Day 1)                                                           │
+│  ─────────────────                                                          │
+│  $ lore onboard --from https://wiki.acme.com/backend-setup                  │
+│                                                                             │
+│  Found 15 items:                                                            │
+│    HIGH confidence:  6 (docker, kubectl, go, node, helm, bazel)             │
+│    MEDIUM confidence: 2 (aws-cli, terraform)                                │
+│    LOW confidence:   5 (acme-cli, acme-secrets, internal-proxy...)          │
+│    UNPARSEABLE:      2                                                      │
+│                                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ 💡 We detected 5 org-specific packages not in the public registry. │    │
+│  │                                                                     │    │
+│  │ Want your whole team to get 95% automation instead of 40%?         │    │
+│  │                                                                     │    │
+│  │ → Start a free Team trial (14 days, up to 10 seats)                │    │
+│  │ → Learn more: devlore.noblefactor.com/teams                        │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Detection signals:**
+
+| Signal | What It Means |
+|--------|---------------|
+| Internal wiki URL (`wiki.*.com`, `*.internal`, `confluence.*`) | Org-specific content |
+| Multiple LOW confidence items | Org has custom tooling |
+| Same wiki URL from multiple IPs/users | Team adoption already happening |
+| `internal-*`, `acme-*`, company-named packages | Private tooling needs private registry |
+
+**The conversion hook:**
+
+| Individual Value (free, always) | Team Value (trial → paid) |
+|---------------------------------|---------------------------|
+| Public registry packages work perfectly | Private registry for org-specific lore packages |
+| 40-60% of any wiki gets automated | That 40% gap closes to 5% |
+| Receipts show what's installed | New hire onboarding becomes one command |
+| | Audit trail across the team |
+
+**Trial structure:**
+
+| Aspect | Value |
+|--------|-------|
+| Duration | 14 days |
+| Seats | Up to 10 |
+| Features | Full Team tier (private registry, shared manifests, basic audit) |
+| Conversion trigger | "Your trial ends in 3 days. Your team ran 47 deploys. Keep the private registry?" |
+
+**Why this works:**
+
+1. **Pain is personal** — New hire feels the wiki pain directly
+2. **Value is immediate** — 60% works on day one
+3. **Gap is visible** — "5 org-specific packages" quantifies what's missing
+4. **Champion is created** — New hire becomes internal advocate ("this tool saved me 2 days")
+5. **Team benefit is obvious** — "If I had this, everyone should have this"
+
+> **Demo this:** See [03-demo-script.md](03-demo-script.md) Act 2 for the scripted walkthrough of this conversion flow.
+
+#### What Enterprise Sales Requires
+
+| Requirement | Timeline | Notes |
+|-------------|----------|-------|
+| **Security review** | 2-8 weeks | SOC 2 Type II required; increases close rates 20-40% ([Warren Averett](https://warrenaverett.com/insights/soc-for-saas/)) |
+| **Contract negotiation** | 2-4 weeks | Legal review, custom terms, SLA |
+| **Technical validation** | 1-4 weeks | POC, integration testing |
+| **Budget approval** | Variable | Align outreach with budget cycles—120 days before renewal ([Nue.io](https://www.nue.io/resources/articles/tactical-strategies-cro-land-and-expands/)) |
+
+**Total enterprise sales cycle:** 3-6 months for $70K+ deals (vs. 6-18 months industry average for >$100K).
+
+#### What We Ship
+
+| Component | Description |
+|-----------|-------------|
+| **Marketplace listing** | Logo, description, screenshots, pricing tiers |
+| **ARM/Bicep template** | One-click deploy: ACR instance, Azure OpenAI connection, Entra app registration |
+| **Container images** | DevLore registry service artifacts in ACR |
+| **Usage metering** | Azure Marketplace metering API for per-seat or per-use billing |
+| **Documentation** | Quick start, admin guide, troubleshooting |
+
+#### Why Azure Marketplace
+
+| Benefit | Description |
+|---------|-------------|
+| **Self-serve Team tier** | Frictionless adoption for individuals and small teams |
+| **Simplified procurement** | Billing through Azure; taps pre-committed cloud budgets (MACC) |
+| **Reduced compliance friction** | "It's in Azure Marketplace" satisfies initial security screening |
+| **Try before buy** | Free tier or trial period built into listing |
+| **Co-sell potential** | Microsoft sales teams can recommend us |
+
+**What Marketplace does NOT do:**
+- Replace security reviews for $70K+ deals
+- Eliminate need for relationship building
+- Handle custom contract negotiation
+
+#### Pricing via Marketplace
+
+| Tier | Model | Price | Metering |
+|------|-------|-------|----------|
+| **Team** | Per-seat/month | $10/user | Azure AD user count |
+| **Enterprise** | Per-seat/month | $25/user | Azure AD user count |
+| **Enterprise Plus** | Per-seat/month | $35/user | Azure AD user count + API calls |
+
+#### What We Still Need
+
+| Function | Requirement | Notes |
+|----------|-------------|-------|
+| **Marketing** | Awareness, content, SEO, launch | Need to hire or contract |
+| **Developer Relations** | Docs, tutorials, community engagement | Can bootstrap with founder |
+| **Support** | GitHub Issues + email initially | Scale to Zendesk/Intercom later |
+| **Sales/PM (Phase 3)** | Enterprise outreach, security reviews, contract negotiation | 1-2 FTEs when pipeline justifies |
+
+#### Marketplace Timeline
+
+| Phase | Milestone | Dependency |
+|-------|-----------|------------|
+| Phase 2 | Private preview listing | Working self-hosted product |
+| Phase 2 | Public listing (Team tier) | 10+ beta customers |
+| Phase 3 | Enterprise tier | SSO/SAML, audit logging, SOC 2 Type II complete |
+| Phase 3 | Sales/PM hire | Pipeline of $70K+ opportunities |
+| Phase 3 | Co-sell ready | Microsoft partnership application |
+
+**Reference:** [Azure Marketplace Publisher Guide](https://learn.microsoft.com/en-us/partner-center/marketplace/overview)
+
+---
+
+## 8. Business Model Alignment: Tribal Knowledge as a Category
+
+### 9.1. Market Context (2026)
+
+Capturing tribal knowledge—the unwritten, informal expertise held by individuals—is a significant business challenge in 2026:
+
+- **Aging workforce retirement** — Decades of expertise walking out the door
+- **Remote work silos** — Knowledge fragmented across teams and time zones
+- **High turnover costs** — Replacement cost includes knowledge reconstruction
+- **Compliance pressure** — Industries require documented procedures
+
+### 9.2. Industry Models We Draw From
+
+| Model | Description | DevLore Alignment |
+|-------|-------------|-------------------|
+| **Knowledge Ops Platform** | Real-time "context infrastructure" that intercepts unstructured data (Slack, wikis) and documents best practices as they happen | `lore onboard` parses wikis; future: Slack integration for "how did you fix that?" moments |
+| **Connected Worker** | Mobile-friendly apps that turn implicit expertise into digital work instructions at the point of work (MaintainX, Parsable) | Lore packages are executable work instructions; lore bundles for air-gapped field deployment |
+| **Tribe Model** | Spotify-style organization where "Chapters" share knowledge across squads | Registry as the shared knowledge layer; community contribution model |
+| **Exit Management** | Standardized "Knowledge Transfer Checklists" as part of HR lifecycle | `lore manifest create` captures departing engineer's setup; receipts prove what was deployed |
+
+### 9.3. DevLore's Position in This Landscape
+
+DevLore is a **Knowledge Ops Platform for Developer Infrastructure**.
+
+Unlike generic knowledge management (Guru, ScreenSteps), we target a specific high-value domain: **developer environment setup**. This focus enables:
+
+1. **Executable knowledge** — Not just documentation, but runnable manifests
+2. **Verification** — "Did it work?" not "Did you read it?"
+3. **Cross-platform translation** — Knowledge captured on macOS works on Linux
+4. **Community leverage** — MusicBrainz model for crowdsourcing wisdom
+
+### 9.4. Revenue Implications
+
+| Model | Revenue Approach | DevLore Application |
+|-------|------------------|---------------------|
+| Knowledge Ops | Tiered SaaS (users, assets) | Team/Enterprise tiers (current plan) |
+| Connected Worker | Enterprise licensing (high-value sectors) | Air-gapped bundles for regulated industries |
+| Exit Management | HR tech module or "insurance" | Enterprise add-on: "Knowledge Continuity" |
+
+**Opportunity:** Position Enterprise tier as "Knowledge Continuity Insurance" for platform engineering teams.
+
+### 9.5. Feature Roadmap Implications
+
+| 2026 Trend | Feature Direction |
+|------------|-------------------|
+| **AI-Driven Discovery** | `lore onboard` already does this; expand to Slack/Teams integration |
+| **Gamification** | Registry contribution badges, "Knowledge Champion" status, leaderboards |
+| **Visual-First Documentation** | Lore packages could include video tutorials, diagram references |
+
+### 9.6. Messaging Evolution
+
+Current positioning focuses on the *solution* (cross-platform, provisioning). The tribal knowledge angle focuses on the *problem*—which resonates more broadly.
+
+**Proposed tagline:** "Tribal knowledge, automated."
+
+**Supporting messages:**
+- "The expertise that leaves when people leave. Captured."
+- "What took someone hours to figure out, you get in minutes."
+- "Developer wisdom, crowdsourced."
+
+### 8.7. Why "Tribal Knowledge" (Terminology Defense)
+
+**Alternative terms considered:**
+
+| Term                        | Origin                           | Strength                            | Weakness                    |
+| --------------------------- | -------------------------------- | ----------------------------------- | --------------------------- |
+| **Tribal Knowledge**        | Manufacturing/Ops (1980s+)       | Industry standard; precise          | Some find "tribal" dated    |
+| **Tacit Knowledge**         | Michael Polanyi (1966)           | Academically rigorous               | Abstract; not punchy        |
+| **Deep Smarts**             | Dorothy Leonard, Harvard (2005)  | Captures experience-based expertise | Book title; less recognized |
+| **Institutional Knowledge** | Business/HR                      | Neutral                             | Bureaucratic connotation    |
+
+**Why we use "Tribal Knowledge":**
+
+1. **Industry standard** — DevOps, SRE, and manufacturing communities use this term universally. Google's SRE handbook, AWS Well-Architected Framework, and countless engineering blog posts reference "tribal knowledge" as the undocumented expertise that lives in people's heads.
+
+2. **Precise meaning** — It names a specific problem: knowledge that isn't written down, is passed person-to-person, and walks out the door when someone leaves. "Tacit knowledge" is epistemologically accurate but fails to evoke the problem viscerally.
+
+3. **Searchable** — Engineers search for "tribal knowledge management" not "tacit knowledge automation." SEO matters for developer tools.
+
+4. **Universality of tribalism** — The term reflects a fundamental truth about human organization. Humans have organized in tribes for 200,000+ years. Every team, every company, every open source project forms tribal structures with in-group knowledge, rituals, and shared understanding. The word isn't pejorative—it describes how knowledge naturally forms and flows in groups.
+
+**Rude Q&A preparation:**
+
+> **Q: "Isn't 'tribal knowledge' an outdated or problematic term?"**
+>
+> **A:** The term describes a universal pattern of human organization, not any specific group. Humans form tribes—small groups with shared knowledge and practices—in every context: engineering teams, open source communities, companies. The knowledge that emerges is "tribal" because it's informal, passed person-to-person, and invisible to outsiders.
+>
+> We considered alternatives like "tacit knowledge" (academic) or "institutional knowledge" (bureaucratic), but "tribal knowledge" is what practitioners actually call it. Google's SRE handbook uses it. AWS documentation uses it. Every DevOps conference uses it. We value precision over euphemism, and clarity over compliance with linguistic trends.
+>
+> The pain point we solve is real: undocumented expertise that leaves when people leave. "Tribal knowledge" names that pain precisely.
+
+---
+
+## 9. Competitive Moat and IP Protection
+
+### 10.1. Cost to Reimplement
+
+A competitor attempting to replicate DevLore's registry and tooling would face significant investment:
+
+| Component | Effort | Notes |
+|-----------|--------|-------|
+| **Lore package corpus** | 6-12 months | 500+ packages with tribal knowledge, edge cases, multi-platform testing |
+| **CLI tooling** | 3-6 months | Cross-platform Starlark runtime, phase pipeline, host bindings |
+| **Registry infrastructure** | 2-3 months | Git-based registry, search, verification, trust chain |
+| **AI authoring prompts** | 2-4 months | Prompt engineering for parsing wikis, generating lore packages |
+| **Community + trust** | 12+ months | Cannot be bought; must be earned |
+
+**Total estimate:** 12-24 engineer-months to reach feature parity, plus ongoing maintenance burden.
+
+The registry is the hardest piece to replicate—it requires not just code, but curated knowledge accumulated over time. A fork starts at zero packages and zero community trust.
+
+### 10.2. What Creates the Moat
+
+| Asset | Defensibility | Notes |
+|-------|---------------|-------|
+| **Lore package corpus** | High | Crowdsourced knowledge; grows with community; hard to bootstrap |
+| **AI authoring prompts** | Medium | Trade secret; differentiates quality of generated lore packages |
+| **Community trust** | High | MusicBrainz-style reputation; takes years to build |
+| **Cross-platform coverage** | Medium | Tested lore packages for Darwin + Linux + Windows |
+| **Tribal knowledge capture** | High | The "kubectl needs cloud auth" insights competitors must rediscover |
+
+### 10.3. IP Protection Strategy
+
+> **Design decision:** [ADR-022: Licensing Strategy](../design/adr/022-licensing-strategy.md)
+
+| IP Type | Asset | Protection Mechanism |
+|---------|-------|----------------------|
+| **Trade Secret** | AI authoring prompts, AUTHORING.md | Keep closed; don't publish prompts |
+| **Trade Secret** | Verification heuristics | Internal quality scoring algorithms |
+| **Trademark** | "DevLore" (product name) | Register in US, EU, major markets |
+| **Copyright** | CLI source code | SSPL license (prevents cloud competitors) |
+| **Copyright** | Lore package corpus | SSPL license on registry |
+| **Community** | Contributor relationships | Recognition, badges, governance voice |
+
+### 10.4. Recommendations
+
+1. **Keep AI authoring closed** — The prompts that generate high-quality lore packages from wikis are a core differentiator. Ship the CLI, not the prompts.
+
+2. **SSPL on all infrastructure** — Prevents AWS/GCP/Azure from offering "DevLore-as-a-Service" without open-sourcing their stack.
+
+3. **Invest in lore package velocity** — Every new package in the registry increases switching cost for competitors. Aim for 1,000 lore packages by end of Phase 2.
+
+4. **Trademark "DevLore" only** — File in US, EU, and major markets. "lore" and "writ" are CLI command names (too generic to trademark, would invite challenges). Publish clear trademark policy (TRADEMARK.md) following Mozilla/Apache model: allow fair use, focus on preventing confusion.
+
+5. **Community-first governance** — The MusicBrainz model creates contributor loyalty that can't be forked.
+
+### 10.5. Competitive Response Scenarios
+
+| Scenario | Probability | Our Response |
+|----------|-------------|--------------|
+| Homebrew adds AI-powered provisioning | Medium | We have cross-platform + tribal knowledge corpus; they're macOS/Linux only |
+| AWS launches "Package Manager" service | Low | SSPL prevents them from using our code; they'd start from zero |
+| Competitor forks registry | Low | Fork starts with no community, no new contributions, stale lore packages |
+| Nix adds "easy mode" | Low | Cultural unlikely; we're simpler by design philosophy |
+
+---
+
+## 10. Open Questions
+
+1. **Tribal knowledge messaging** — Does "tribal knowledge" resonate with buyers, or is it too abstract?
+
+2. **Enterprise appetite** — Would companies pay? Need discovery calls with platform engineering teams.
+
+3. **Competitive response** — If Homebrew adds provisioning, what's our moat?
+
+4. **Community model details** — MusicBrainz-style voting vs. GitHub PR-based? Need to decide before Phase 2.
+
+5. **Why hasn't this been solved?** — Homebrew exists since 2009. Is the pain not big enough? Is cross-platform the actual gap?
+
+6. **Secrets scope** — In-scope (age/SOPS) for writ or out-of-scope (user handles)?
+
+---
+
+## 11. Contact
+
+- **Website:** <https://devlore.noblefactor.com>
+- **GitHub:** <https://github.com/NobleFactor/devlore-cli>
+- **Email:** <devlore@noblefactor.com>
+
+---
+
+## 12. Document History
+
+| Date | Version | Change |
+|------|---------|--------|
+| 2026-01-19 | 1.9 | Improved two-tool messaging: Section 1.2 now answers "Which tool first? Always lore" with lore-first workflow diagram; Section 5.3 updated to show `lore onboard` → `lore deploy` → `writ adopt --from-receipt` sequence |
+| 2026-01-19 | 1.8 | Added "Wiki-Triggered Team Conversion" to Section 7.7: new hire onboards from team wiki, detects org-specific packages, prompts for Team trial; includes detection signals, conversion hook, trial structure |
+| 2026-01-19 | 1.7 | Rewrote Section 7.7 Azure Marketplace: corrected "no sales team required" to realistic PLG-to-enterprise motion; added land-and-expand diagram, sales triggers, enterprise sales requirements with hard data (McKinsey, KeyBanc, Forrester) |
+| 2026-01-19 | 1.6 | Rewrote Section 1 (Executive Summary): added progression diagram (registry → lore → writ → productivity); led with brand rationale ("Why lore and writ?") |
+| 2026-01-18 | 1.5 | Replaced Backstage comparison with "Nearest Neighbors" analysis (Homebrew, chezmoi, Ansible, Nix, asdf/mise, devbox); DevLore occupies unique niche with no direct comparable |
+| 2026-01-18 | 1.4 | Added Section 7.7: Azure Marketplace Go-to-Market (self-serve deployment, no sales team, billing via Azure) |
+| 2026-01-18 | 1.3 | Expanded productivity research with 25+ sources (SHRM, Stripe, McKinsey, DORA, Gartner, Forrester, Stack Overflow, Spotify); added ROI calculation showing 36x return |
+| 2026-01-18 | 1.2 | Added concrete $90K contract targets and distribution expectations |
+| 2026-01-18 | 1.1 | Added Section 7.4: Enterprise Market Sizing (TAM/SAM/SOM, pricing benchmarks, recommended pricing structure) |
+| 2026-01-18 | 1.0 | Rewrote Section 7.3: Enterprise Product Definition (consolidated from ADR-048, added operational intelligence framing, feature categories, delivery models) |
+| 2026-01-16 | 0.9 | Added Appendix A: Developer Tools Business Model Research |
+| 2026-01-16 | 0.8 | Expanded Section 7 Revenue Model: enterprise ROI quantification, SSPL as moat, community sustainability |
+| 2026-01-15 | 0.7 | Moved to devlore/business/; deduplicated phases (details now in 02-roadmap.md); removed Risk Register (now in roadmap) |
+| 2026-01-14 | 0.6 | Added Section 6.5: Distribution Strategy (package managers go/no-go, goreleaser) |
+| 2026-01-14 | 0.5 | Added Section 10: Competitive Moat and IP Protection (cost to reimplement, IP strategy) |
+| 2026-01-13 | 0.4 | Added Section 9: Business Model Alignment (tribal knowledge as category); proposed tagline |
+| 2026-01-12 | 0.3 | Consolidated from lore + writ strategy docs into single strategy |
+| 2026-01-11 | 0.2 | Updated hero story to "Wiki to Working" |
+| 2026-01-11 | 0.1 | Initial strategy document |
+
+---
+
+## Appendix A: Developer Tools Business Model Research
+
+**Q: The pitch solves a real problem, but how do you monetize? Pitching to companies for their onboarding journey? Pay per LLM API usage? The creator of Homebrew never made anything from it. Ansible was acquired by Red Hat for $100 million. What's the business model?**
+
+**A:** You're asking exactly the right question. Your instincts are correct—the Homebrew story is cautionary, and the Ansible number is actually higher than you thought. Here's what I found.
+
+### A.1. The Cautionary Tale: Homebrew
+
+[Max Howell's own account](https://x.com/mxcl/status/1792673556465135937) is sobering: **15 years of unpaid work** on one of the most widely-used open source projects. His compensation? A blanket from Google and an iPad from Square.
+
+As he stated in a [Stack Overflow podcast](https://stackoverflow.blog/2022/11/18/the-creator-of-homebrew-has-a-plan-to-get-open-source-contributors-paid-ep-506/): "Open source was not paying the bills." To make a living from open source, "you have to be very lucky" and it's companies, not individuals, who should support it.
+
+This led Howell to create [tea protocol](https://medium.com/teaxyz/tea-brew-478a9e736638), attempting to solve the open source funding problem through decentralized technology.
+
+**Lesson:** Building a great tool isn't enough. Homebrew proves that even tens of millions of users don't translate to revenue without a monetization mechanism.
+
+### A.2. The $150M Success: Ansible
+
+The Ansible acquisition was **$150 million** (not $100M as sometimes reported). [TechCrunch reported](https://techcrunch.com/2015/10/16/red-hat-is-buying-it-automation-startup-ansible-reportedly-for-around-100m/) the initial rumor was $100M+, but [VentureBeat confirmed](https://venturebeat.com/2015/10/15/source-red-hat-is-buying-ansible-for-more-than-100m/) the final price was closer to $150M.
+
+**Key insight:** Ansible raised only **$6 million** before the acquisition—a 25x return. Their enterprise customers included Atlassian, Cisco, Evernote, Twitter, and Red Hat itself.
+
+**What worked:**
+
+- Enterprise traction before exit
+- Lean team (~50 employees)
+- Strategic buyer (Red Hat) who valued the technology for their portfolio
+
+### A.3. The Configuration Management Graveyard
+
+Per [Torsten Volk's analysis](https://torstenvolk.medium.com/the-end-of-an-era-puppet-calls-it-a-day-383837e36167), the configuration management tools had mixed outcomes:
+
+| Tool         | Outcome                                    | Funding | Notes                                      |
+|--------------|--------------------------------------------|---------|--------------------------------------------|
+| **Ansible**  | Acquired by Red Hat, $150M (2015)          | $6M     | Success—lean team, enterprise traction     |
+| **Chef**     | Acquired by Progress Software, $220M (2020)| $105M+  | Moderate return                            |
+| **Puppet**   | Acquired by Perforce (2022)                | $189M   | Poor return; included $40M debt financing  |
+| **SaltStack**| Acquired by VMware (2020)                  | —       | Bundled into larger platform               |
+
+**Warning:** Puppet and Chef raised nearly **$300M combined** and didn't IPO. They were disrupted by Kubernetes, GitOps, and immutable infrastructure.
+
+### A.4. The Big Winners: HashiCorp and GitLab
+
+These show what **works**:
+
+#### HashiCorp ([Wikipedia](https://en.wikipedia.org/wiki/HashiCorp))
+
+- IPO December 2021 at **$15B valuation**
+- Acquired by IBM for **$6.4 billion** (April 2024)
+- Revenue: ~$660M annually, 44% growth
+- Business model: **Open core** + enterprise tiers
+- 85% of revenue from just Terraform and Vault
+- 89% of revenue from customers paying **>$100K/year**
+- Bottom-up adoption: millions of downloads create enterprise sales pipeline
+
+#### GitLab ([FourWeekMBA analysis](https://fourweekmba.com/how-does-gitlab-make-money/))
+
+- IPO October 2021 at **$15B valuation**
+- Current: ~$906M revenue, $6B market cap
+- Business model: "Buyer-based open core" with 5x price escalation between tiers
+- Over 50% of Fortune 100 as customers
+- 30 million registered users → 1 million paid users
+
+### A.5. Business Model Comparison
+
+From [Blossom Capital's research](https://medium.com/blossom-capital/successful-open-source-business-models-2709e831e38a) and [Palark's analysis](https://blog.palark.com/open-source-business-models/):
+
+| Model                     | Example                   | Margin | Scalability |
+|---------------------------|---------------------------|--------|-------------|
+| **Open Core**             | HashiCorp, GitLab         | ~93%   | High        |
+| **SaaS/Hosted**           | WordPress.com, Databricks | High   | Very High   |
+| **Professional Services** | Early Red Hat             | ~31%   | Low         |
+| **Support-only**          | Pure open source          | Low    | Very Low    |
+
+**Red Hat's data is instructive:** Professional services margin is **31%** vs. **93%** for subscriptions. To hire one developer from consulting revenue requires **3x** the revenue of subscriptions.
+
+**Databricks** (raised at **$100B valuation**) proves hosted open source can scale massively.
+
+### A.6. The DevLore Monetization Path
+
+So to answer your question directly: the successful pattern is:
+
+1. **Open source core** → builds community, adoption, trust
+2. **Enterprise features** → RBAC, compliance, support
+3. **Hosted option** → convenience, no ops burden
+
+The formula: **Bottom-up adoption + enterprise upsell**.
+
+Millions of free users → thousands of paying enterprises.
+
+For DevLore specifically:
+
+| Tier            | Features                               | Target                | Model             |
+|-----------------|----------------------------------------|-----------------------|-------------------|
+| **Open Source** | CLI, public registry, local manifests  | Individual developers | Community building|
+| **Team**        | Private registry, shared manifests     | Startups, small teams | $10/user/mo       |
+| **Enterprise**  | RBAC, audit trails, SSO, SLA support   | Large organizations   | $20/user/mo       |
+
+### A.7. Market Context
+
+The [developer experience/platform engineering market](https://platformengineering.org/blog/platform-engineering-predictions-for-2025) is substantial:
+
+- Gartner predicts **80% of enterprises** will have platform engineering by 2026
+- Organizations with IDPs deliver updates **40% faster**
+- Global IT spending forecast: **$5.74 trillion** in 2025
+
+The **onboarding software market** specifically is valued at [$1.6-3.5 billion](https://www.verifiedmarketreports.com/product/employee-onboarding-software-market/) (2024), growing 10-14% annually.
+
+### A.8. Key Takeaways
+
+To summarize what this means for DevLore:
+
+1. **You're right to be skeptical of pure open source** — Homebrew is the cautionary tale
+2. **Enterprise features justify procurement** — SSO, RBAC, audit logs, compliance
+3. **Lean teams can exit well** — Ansible's $6M→$150M with ~50 people
+4. **Heavy funding doesn't guarantee success** — Puppet/Chef raised $300M combined, no IPO
+5. **Open core + bottom-up adoption** is the winning formula — HashiCorp, GitLab prove this at scale
+6. **The registry is the moat** — Tribal knowledge that must be rediscovered by competitors
+
+### A.9. Sources
+
+- [Max Howell on X (Twitter)](https://x.com/mxcl/status/1792673556465135937)
+- [Stack Overflow Podcast: Homebrew creator](https://stackoverflow.blog/2022/11/18/the-creator-of-homebrew-has-a-plan-to-get-open-source-contributors-paid-ep-506/)
+- [TechCrunch: Red Hat acquires Ansible](https://techcrunch.com/2015/10/16/red-hat-is-buying-it-automation-startup-ansible-reportedly-for-around-100m/)
+- [VentureBeat: Ansible acquisition details](https://venturebeat.com/2015/10/15/source-red-hat-is-buying-ansible-for-more-than-100m/)
+- [Medium: Puppet calls it a day](https://torstenvolk.medium.com/the-end-of-an-era-puppet-calls-it-a-day-383837e36167)
+- [HashiCorp Wikipedia](https://en.wikipedia.org/wiki/HashiCorp)
+- [HashiCorp IPO S-1 Breakdown](https://www.meritechcapital.com/blog/hashicorp-ipo-s-1-breakdown)
+- [How GitLab Makes Money](https://fourweekmba.com/how-does-gitlab-make-money/)
+- [Open Source Business Models - Blossom Capital](https://medium.com/blossom-capital/successful-open-source-business-models-2709e831e38a)
+- [Open Source Business Models - Palark](https://blog.palark.com/open-source-business-models/)
+- [Platform Engineering Predictions 2025](https://platformengineering.org/blog/platform-engineering-predictions-for-2025)
+- [Employee Onboarding Software Market](https://www.verifiedmarketreports.com/product/employee-onboarding-software-market/)

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -139,6 +139,7 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 
 	execCtx := &op.Context{
 		Context:  ctx,
+		Catalog:  g.Catalog,
 		DryRun:   e.options.DryRun,
 		Writer:   e.options.Writer,
 		Data:     e.options.Data,
@@ -185,6 +186,7 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) error { //nolint:gocognit,gocyclo // complexity is inherent to the algorithm
 	execCtx := &op.Context{
 		Context:  ctx,
+		Catalog:  g.Catalog,
 		DryRun:   e.options.DryRun,
 		Writer:   e.options.Writer,
 		Data:     e.options.Data,

--- a/internal/execution/preflight.go
+++ b/internal/execution/preflight.go
@@ -4,8 +4,12 @@
 package execution
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
@@ -142,4 +146,48 @@ func detectConflict(node *op.Node) Conflict {
 		Type:    ConflictRegularFile,
 		Message: fmt.Sprintf("file exists at %s (%d bytes)", path, info.Size()),
 	}
+}
+
+// ResolveResources verifies that all discovered resources in the catalog
+// exist on the target machine. Discovery entries are created by
+// catalog.Resolve during planning — they represent URIs referenced as
+// Resource-typed parameters.
+//
+// Only file:// scheme URIs are checked (os.Stat). Other schemes (git,
+// pkg, svc) are skipped — their resolution requires provider-specific
+// logic that runs during execution.
+//
+// Returns an error listing all missing sources. Callers should invoke
+// this explicitly when they know all discovery entries represent genuine
+// sources (inputs that must already exist). The executor does NOT call
+// this automatically because the planned bridge currently registers both
+// source and destination parameters via catalog.Resolve — destination
+// files may not exist yet (they will be created by the graph).
+func ResolveResources(catalog *op.ResourceCatalog) error {
+	if catalog == nil {
+		return nil
+	}
+
+	uris := catalog.DiscoveryURIs()
+	sort.Strings(uris) // deterministic error messages
+
+	var missing []string
+	for _, rawURI := range uris {
+		u, err := url.Parse(rawURI)
+		if err != nil {
+			continue
+		}
+		if u.Scheme != op.SchemeFile {
+			continue
+		}
+		if _, err := os.Stat(u.Path); errors.Is(err, os.ErrNotExist) {
+			missing = append(missing, u.Path)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("pre-flight: %d missing source(s): %s",
+			len(missing), strings.Join(missing, ", "))
+	}
+	return nil
 }

--- a/internal/execution/preflight_test.go
+++ b/internal/execution/preflight_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package execution
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+func TestResolveResources_NilCatalog(t *testing.T) {
+	err := ResolveResources(nil)
+	if err != nil {
+		t.Fatalf("ResolveResources(nil) = %v, want nil", err)
+	}
+}
+
+func TestResolveResources_AllExist(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "preflight-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	catalog := op.NewResourceCatalog()
+	catalog.Resolve("file://" + f.Name())
+
+	if err := ResolveResources(catalog); err != nil {
+		t.Fatalf("ResolveResources() = %v, want nil", err)
+	}
+}
+
+func TestResolveResources_MissingSource(t *testing.T) {
+	catalog := op.NewResourceCatalog()
+	catalog.Resolve("file:///nonexistent/path/to/missing")
+
+	err := ResolveResources(catalog)
+	if err == nil {
+		t.Fatal("ResolveResources() = nil, want error for missing source")
+	}
+	if !strings.Contains(err.Error(), "missing source") {
+		t.Errorf("error = %v, want to contain 'missing source'", err)
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/path/to/missing") {
+		t.Errorf("error = %v, want to contain the missing path", err)
+	}
+}
+
+func TestResolveResources_MultipleMissing(t *testing.T) {
+	catalog := op.NewResourceCatalog()
+	catalog.Resolve("file:///missing/alpha")
+	catalog.Resolve("file:///missing/beta")
+
+	err := ResolveResources(catalog)
+	if err == nil {
+		t.Fatal("ResolveResources() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "2 missing source") {
+		t.Errorf("error = %v, want to contain '2 missing source'", err)
+	}
+}
+
+func TestResolveResources_NonFileScheme_Skipped(t *testing.T) {
+	catalog := op.NewResourceCatalog()
+	catalog.Resolve("git://github.com/org/repo")
+	catalog.Resolve("pkg:///homebrew/nginx")
+	catalog.Resolve("svc:///nginx")
+
+	if err := ResolveResources(catalog); err != nil {
+		t.Fatalf("ResolveResources() = %v, want nil (non-file schemes skipped)", err)
+	}
+}
+
+func TestResolveResources_ShadowedEntry_Skipped(t *testing.T) {
+	catalog := op.NewResourceCatalog()
+	// Resolve then shadow — the shadow supersedes the discovery entry.
+	catalog.Resolve("file:///nonexistent/file")
+
+	base := op.NewResourceBase("file:///nonexistent/file")
+	catalog.Shadow(&base, "writer-node")
+
+	// The discovery entry is superseded; no file check needed.
+	if err := ResolveResources(catalog); err != nil {
+		t.Fatalf("ResolveResources() = %v, want nil (shadowed entry)", err)
+	}
+}
+
+func TestResolveResources_MixedSchemes(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "preflight-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	catalog := op.NewResourceCatalog()
+	catalog.Resolve("file://" + f.Name())        // exists
+	catalog.Resolve("git://github.com/org/repo") // non-file, skipped
+	catalog.Resolve("file:///nonexistent/path")  // missing
+
+	err = ResolveResources(catalog)
+	if err == nil {
+		t.Fatal("ResolveResources() = nil, want error for missing source")
+	}
+	if !strings.Contains(err.Error(), "1 missing source") {
+		t.Errorf("error = %v, want '1 missing source'", err)
+	}
+}

--- a/pkg/op/action_reflect.go
+++ b/pkg/op/action_reflect.go
@@ -46,7 +46,13 @@ func (a *reflectedAction) Do(ctx *Context, slots map[string]any) (Result, UndoSt
 	}
 
 	results := a.method.Func.Call(goArgs)
-	return classifyActionReturn(results)
+	result, undoState, err := classifyActionReturn(results)
+
+	if err == nil {
+		result = shadowResult(result, ctx.Catalog, ctx.NodeID)
+	}
+
+	return result, undoState, err
 }
 
 // reflectedCompensableAction extends reflectedAction with Undo.
@@ -137,11 +143,13 @@ func coerceMapToStruct(mapVal reflect.Value, targetType reflect.Type) (reflect.V
 // classifyActionReturn interprets Go method return values for the action layer.
 // Unlike classifyReturn (which marshals to Starlark), this keeps Go-native values.
 //
-// Patterns (error always consumed from last position):
+// Arity (after stripping trailing error):
 //
-//	(error)          → (nil, nil, error)
-//	(T, error)       → (T, nil, error)
-//	(T, U, error)    → (T, U, error)
+//	0 → (nil, nil, error)            — error-only method
+//	1 → (result, nil, error)         — Action
+//	2 → (result, undoState, error)   — CompensableAction
+//
+// NoResult at position 0 yields nil Result.
 func classifyActionReturn(results []reflect.Value) (Result, UndoState, error) {
 	n := len(results)
 	if n == 0 {
@@ -160,7 +168,10 @@ func classifyActionReturn(results []reflect.Value) (Result, UndoState, error) {
 	var undoState UndoState
 
 	if n > 0 {
-		result = results[0].Interface()
+		v := results[0].Interface()
+		if _, isNoResult := v.(NoResult); !isNoResult {
+			result = v
+		}
 	}
 	if n > 1 {
 		undoState = results[1].Interface()
@@ -169,11 +180,72 @@ func classifyActionReturn(results []reflect.Value) (Result, UndoState, error) {
 	return result, undoState, err
 }
 
+// resourceType is cached for result-type classification.
+var resourceType = reflect.TypeOf((*Resource)(nil)).Elem()
+
+// shadowResult shadows Resource results in the catalog without changing the
+// result type. Provider methods return resources by value (e.g., file.Resource).
+// The Resource interface requires pointer receivers (resourceBase), so a
+// temporary pointer is created for the Shadow call. The catalog stamps
+// id/originID on the underlying ResourceBase; the stamped value is returned.
+func shadowResult(result Result, catalog *ResourceCatalog, originID string) Result {
+	if result == nil || catalog == nil {
+		return result
+	}
+
+	rv := reflect.ValueOf(result)
+	t := rv.Type()
+
+	// Already satisfies Resource (pointer type or interface).
+	if t.Implements(resourceType) {
+		catalog.Shadow(result.(Resource), originID)
+		return result
+	}
+
+	// Struct whose pointer satisfies Resource (common case: file.Resource value).
+	// Create a temporary pointer for the Shadow call, then return the
+	// stamped value (same type as original).
+	if t.Kind() == reflect.Struct && reflect.PointerTo(t).Implements(resourceType) {
+		ptr := reflect.New(t)
+		ptr.Elem().Set(rv)
+		catalog.Shadow(ptr.Interface().(Resource), originID)
+		return ptr.Elem().Interface()
+	}
+
+	// Slice where elements satisfy Resource.
+	if t.Kind() == reflect.Slice {
+		et := t.Elem()
+		directImpl := et.Implements(resourceType)
+		ptrImpl := et.Kind() == reflect.Struct && reflect.PointerTo(et).Implements(resourceType)
+		if directImpl || ptrImpl {
+			for i := 0; i < rv.Len(); i++ {
+				if directImpl {
+					catalog.Shadow(rv.Index(i).Interface().(Resource), originID)
+				} else {
+					ptr := reflect.New(et)
+					ptr.Elem().Set(rv.Index(i))
+					catalog.Shadow(ptr.Interface().(Resource), originID)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
 // RegisterReflectedActions registers all action methods on a provider.
 // Methods must return error as their last value to qualify as actions.
 // Methods without error returns (e.g., Exists, IsDir) are skipped —
 // they are immediate-only, not graph actions.
-// A Compensate<GoName> companion method upgrades the action to CompensableAction.
+//
+// Arity determines action type:
+//
+//   - 1 return  (error)             → Action (error-only, no result)
+//   - 2 returns (result, error)     → Action
+//   - 3 returns (result, undo, error) → CompensableAction
+//
+// Every CompensableAction (3 returns) must have a Compensate<GoName>
+// companion method. Missing pairs panic at registration time.
 func RegisterReflectedActions(reg *ActionRegistry, name string, provider any, params MethodParams) {
 	pv := reflect.ValueOf(provider)
 	pt := pv.Type()
@@ -199,8 +271,24 @@ func RegisterReflectedActions(reg *ActionRegistry, name string, provider any, pa
 			paramNames: paramNames,
 		}
 
+		// 3 returns (result, undo, error) → CompensableAction.
+		// The companion Compensate<GoName> method is mandatory.
 		compensateName := "Compensate" + goName
-		if cm, ok := pt.MethodByName(compensateName); ok {
+		numNonError := mt.NumOut() - 1 // subtract trailing error
+		if numNonError >= 2 {
+			cm, ok := pt.MethodByName(compensateName)
+			if !ok {
+				panic(fmt.Sprintf(
+					"%s: method %s returns (result, undo, error) but %s.%s is missing",
+					actionName, goName, pt.Elem().Name(), compensateName,
+				))
+			}
+			reg.Register(&reflectedCompensableAction{
+				reflectedAction: base,
+				compensate:      cm,
+			})
+		} else if cm, ok := pt.MethodByName(compensateName); ok {
+			// 1-2 returns but has a Compensate companion — allow it.
 			reg.Register(&reflectedCompensableAction{
 				reflectedAction: base,
 				compensate:      cm,

--- a/pkg/op/action_reflect_test.go
+++ b/pkg/op/action_reflect_test.go
@@ -40,6 +40,18 @@ type actionConfig struct {
 	Label     string
 }
 
+// actionResource embeds ResourceBase and satisfies Resource via pointer receivers.
+// Used to test that promoteAndShadow correctly promotes value results to pointers.
+type actionResource struct {
+	ResourceBase
+	SourcePath string
+}
+
+func (r *actionResource) URI() string    { return r.NewURI(r) }
+func (r *actionResource) Scheme() string { return SchemeFile }
+func (r *actionResource) Host() string   { return "" }
+func (r *actionResource) Path() string   { return r.SourcePath }
+
 // actionProvider exercises all action patterns.
 type actionProvider struct{}
 
@@ -83,6 +95,29 @@ func (p *actionProvider) Configure(name string, cfg actionConfig) (string, error
 	return fmt.Sprintf("%s:enabled=%v,threshold=%d,label=%s", name, cfg.Enabled, cfg.Threshold, cfg.Label), nil
 }
 
+// Returns a Resource by value — tests shadowResult.
+func (p *actionProvider) Create(path string) (actionResource, string, error) {
+	return actionResource{SourcePath: path}, "undo:" + path, nil
+}
+
+func (p *actionProvider) CompensateCreate(state string) error {
+	return nil
+}
+
+// Takes a Resource parameter — tests plan-time catalog resolution.
+func (p *actionProvider) Touch(res actionResource) (actionResource, error) {
+	return res, nil
+}
+
+// Compensable with NoResult: (NoResult, map[string]any, error).
+func (p *actionProvider) Delete(path string) (NoResult, map[string]any, error) {
+	return NoResult{}, map[string]any{"path": path}, nil
+}
+
+func (p *actionProvider) CompensateDelete(state map[string]any) error {
+	return nil
+}
+
 // Immediate-only (no error return, should be skipped).
 func (p *actionProvider) Exists(path string) bool {
 	return path != ""
@@ -96,7 +131,10 @@ func (p *actionProvider) Noop() error {
 var actionParams = MethodParams{
 	"Configure": {"name", "cfg"},
 	"Copy":      {"source", "dest"},
+	"Create":    {"path"},
+	"Delete":    {"path"},
 	"Read":      {"path"},
+	"Touch":     {"res"},
 	"Validate":  {"path"},
 	"Mkdir":     {"path", "mode"},
 	"Deploy":    {"res"},
@@ -324,14 +362,17 @@ func TestRegisterReflectedActions_ActionNames(t *testing.T) {
 	names := reg.Names()
 	sort.Strings(names)
 
-	// Exists is skipped (no error return). Configure, Noop, Validate, Read, Copy, Mkdir, Deploy qualify.
+	// Exists is skipped (no error return). Configure, Copy, Create, Delete, Deploy, Mkdir, Noop, Read, Touch, Validate qualify.
 	expected := []string{
 		"test.configure",
 		"test.copy",
+		"test.create",
+		"test.delete",
 		"test.deploy",
 		"test.mkdir",
 		"test.noop",
 		"test.read",
+		"test.touch",
 		"test.validate",
 	}
 	if len(names) != len(expected) {
@@ -692,4 +733,230 @@ func TestReflectedCompensableAction_UndoError(t *testing.T) {
 	if err.Error() != "compensate failed" {
 		t.Errorf("err = %q, want 'compensate failed'", err)
 	}
+}
+
+// --- NoResult tests ---
+
+func TestClassifyActionReturn_NoResult(t *testing.T) {
+	results := []reflect.Value{
+		reflect.ValueOf(NoResult{}),
+		reflect.Zero(errorType),
+	}
+	result, undo, err := classifyActionReturn(results)
+	if result != nil {
+		t.Errorf("result = %v, want nil (NoResult sentinel)", result)
+	}
+	if undo != nil || err != nil {
+		t.Errorf("undo = %v, err = %v, want (nil, nil)", undo, err)
+	}
+}
+
+func TestClassifyActionReturn_NoResult_WithUndo(t *testing.T) {
+	state := map[string]any{"path": "/removed"}
+	results := []reflect.Value{
+		reflect.ValueOf(NoResult{}),
+		reflect.ValueOf(state),
+		reflect.Zero(errorType),
+	}
+	result, undo, err := classifyActionReturn(results)
+	if result != nil {
+		t.Errorf("result = %v, want nil (NoResult sentinel)", result)
+	}
+	undoMap, ok := undo.(map[string]any)
+	if !ok || undoMap["path"] != "/removed" {
+		t.Errorf("undo = %v, want map with path=/removed", undo)
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestReflectedAction_Do_NoResult(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	action := reg.MustGet("test.delete")
+	ctx := &Context{
+		Context: context.Background(),
+		Writer:  io.Discard,
+	}
+
+	result, undo, err := action.Do(ctx, map[string]any{"path": "/tmp/gone"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil (NoResult)", result)
+	}
+	undoMap, ok := undo.(map[string]any)
+	if !ok || undoMap["path"] != "/tmp/gone" {
+		t.Errorf("undo = %v, want map with path=/tmp/gone", undo)
+	}
+}
+
+func TestReflectedAction_Delete_IsCompensable(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	action, ok := reg.Get("test.delete")
+	if !ok {
+		t.Fatal("test.delete not registered")
+	}
+	if _, ok := action.(CompensableAction); !ok {
+		t.Error("test.delete should implement CompensableAction")
+	}
+}
+
+// --- Catalog shadow tests ---
+
+func TestReflectedAction_Do_ShadowsResource(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	catalog := NewResourceCatalog()
+	action := reg.MustGet("test.create")
+	ctx := &Context{
+		Context: context.Background(),
+		Catalog: catalog,
+		NodeID:  "node-1",
+		Writer:  io.Discard,
+	}
+
+	result, _, err := action.Do(ctx, map[string]any{"path": "/tmp/new"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Result should remain a value type (not promoted to pointer).
+	ar, ok := result.(actionResource)
+	if !ok {
+		t.Fatalf("result type = %T, want actionResource", result)
+	}
+	if ar.SourcePath != "/tmp/new" {
+		t.Errorf("SourcePath = %q, want %q", ar.SourcePath, "/tmp/new")
+	}
+
+	// Catalog should have the shadowed entry.
+	if catalog.Len() != 1 {
+		t.Fatalf("catalog.Len() = %d, want 1", catalog.Len())
+	}
+	id := catalog.Current("file:///tmp/new")
+	if id == "" {
+		t.Fatal("catalog has no entry for file:///tmp/new")
+	}
+	entry, ok := catalog.Lookup(id)
+	if !ok {
+		t.Fatalf("catalog.Lookup(%q) failed", id)
+	}
+	base := entry.resourceBase()
+	if base.originID != "node-1" {
+		t.Errorf("originID = %q, want %q", base.originID, "node-1")
+	}
+
+	// extractResource should find the stamped originID on the value result.
+	origin, found := extractResource(result)
+	if !found {
+		t.Fatal("extractResource did not find resource identity on value result")
+	}
+	if origin != "node-1" {
+		t.Errorf("extractResource originID = %q, want %q", origin, "node-1")
+	}
+}
+
+func TestReflectedAction_Do_NoCatalog_Unchanged(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	// No catalog — result should be returned unchanged.
+	action := reg.MustGet("test.create")
+	ctx := &Context{
+		Context: context.Background(),
+		Writer:  io.Discard,
+	}
+
+	result, _, err := action.Do(ctx, map[string]any{"path": "/tmp/file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result.(actionResource); !ok {
+		t.Errorf("result type = %T, want actionResource", result)
+	}
+}
+
+func TestReflectedAction_Do_NonResource_Unchanged(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	catalog := NewResourceCatalog()
+	action := reg.MustGet("test.read")
+	ctx := &Context{
+		Context: context.Background(),
+		Catalog: catalog,
+		NodeID:  "node-2",
+		Writer:  io.Discard,
+	}
+
+	result, _, err := action.Do(ctx, map[string]any{"path": "/tmp/f"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "content:/tmp/f" {
+		t.Errorf("result = %v, want 'content:/tmp/f'", result)
+	}
+	// Non-resource result should not shadow.
+	if catalog.Len() != 0 {
+		t.Errorf("catalog.Len() = %d, want 0 (non-resource)", catalog.Len())
+	}
+}
+
+func TestReflectedAction_Do_NoResult_NotShadowed(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	catalog := NewResourceCatalog()
+	action := reg.MustGet("test.delete")
+	ctx := &Context{
+		Context: context.Background(),
+		Catalog: catalog,
+		NodeID:  "node-3",
+		Writer:  io.Discard,
+	}
+
+	result, _, err := action.Do(ctx, map[string]any{"path": "/tmp/gone"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil (NoResult)", result)
+	}
+	if catalog.Len() != 0 {
+		t.Errorf("catalog.Len() = %d, want 0 (NoResult)", catalog.Len())
+	}
+}
+
+// --- Pairing validation tests ---
+
+// unpairedProvider has a method with 3 returns but no Compensate companion.
+type unpairedProvider struct{}
+
+func (p *unpairedProvider) Destroy(path string) (string, map[string]any, error) {
+	return "", nil, nil
+}
+
+func TestRegisterReflectedActions_MissingCompensate_Panics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for missing Compensate method")
+		}
+		msg := fmt.Sprint(r)
+		if !strings.Contains(msg, "CompensateDestroy") {
+			t.Errorf("panic message = %q, want mention of CompensateDestroy", msg)
+		}
+	}()
+
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &unpairedProvider{}, MethodParams{
+		"Destroy": {"path"},
+	})
 }

--- a/pkg/op/context.go
+++ b/pkg/op/context.go
@@ -9,6 +9,11 @@ import (
 type Context struct {
 	context.Context // https://pkg.go.dev/context
 
+	// Catalog is the resource catalog for the current execution session.
+	// The action layer uses it to shadow Resource results after dispatch.
+	// Nil when running without catalog integration (e.g., tests).
+	Catalog *ResourceCatalog
+
 	// Data holds tool-provided context: template variables, SOPS config,
 	// identities, segment maps, etc. Each tool populates this before
 	// calling GraphExecutor.Run().

--- a/pkg/op/output_test.go
+++ b/pkg/op/output_test.go
@@ -628,6 +628,11 @@ type testFileResource struct {
 	SourcePath string
 }
 
+func (r *testFileResource) URI() string    { return r.NewURI(r) }
+func (r *testFileResource) Scheme() string { return SchemeFile }
+func (r *testFileResource) Host() string   { return "" }
+func (r *testFileResource) Path() string   { return r.SourcePath }
+
 func TestFillSlotImplicitEdge_ResourceWithOrigin(t *testing.T) {
 	g := makeTestGraph()
 	consumer := makeTestNode("reader", "file.read")

--- a/pkg/op/planned_reflect.go
+++ b/pkg/op/planned_reflect.go
@@ -70,7 +70,7 @@ func WrapPlanned(
 			continue
 		}
 
-		bridge := buildPlannedBridge(name, snakeName, actionName, paramNames, graph, project, reg)
+		bridge := buildPlannedBridge(name, snakeName, actionName, paramNames, m, graph, project, reg)
 		p.methods[snakeName] = &plannedBridge{
 			name:   snakeName,
 			bridge: bridge,
@@ -113,9 +113,13 @@ func (p *ReflectedPlanned) AttrNames() []string {
 }
 
 // buildPlannedBridge creates a builtinFunc that creates a graph Node.
+// The reflect.Method is used to inspect parameter types for catalog
+// resolution: immediate values passed to Resource-typed parameters
+// are resolved in the graph's catalog at plan time.
 func buildPlannedBridge(
 	providerName, snakeName, actionName string,
 	paramNames []string,
+	method reflect.Method,
 	graph *Graph,
 	project string,
 	reg *ActionRegistry,
@@ -139,7 +143,8 @@ func buildPlannedBridge(
 			Project: project,
 		}
 
-		// 3. Fill slots from Starlark values.
+		// 3. Fill slots from Starlark values and resolve Resource params.
+		mt := method.Type
 		for i, name := range paramNames {
 			cleanName := strings.TrimSuffix(name, "?")
 			sv := vals[i]
@@ -149,10 +154,56 @@ func buildPlannedBridge(
 			if err := FillSlot(node, graph, cleanName, sv); err != nil {
 				return nil, fmt.Errorf("%s: %w", cleanName, err)
 			}
+
+			// Resolve immediate Resource parameters in the catalog.
+			// Skip promises — they're shadowed at execution time (step 5f).
+			if i+1 < mt.NumIn() {
+				resolveResourceParam(graph, sv, mt.In(i+1))
+			}
 		}
 
 		// 4. Append to graph and return promise.
 		graph.Nodes = append(graph.Nodes, node)
 		return NewOutput(node, graph, ""), nil
+	}
+}
+
+// resolveResourceParam checks if a Starlark slot value targets a Resource-typed
+// parameter. For immediate (non-promise) values, it constructs a plan-time
+// Resource and calls catalog.Resolve to register the URI.
+func resolveResourceParam(graph *Graph, sv starlark.Value, paramType reflect.Type) {
+	if graph.Catalog == nil {
+		return
+	}
+
+	// Skip promises and gathers — they'll be shadowed at execution time.
+	if _, ok := sv.(*Output); ok {
+		return
+	}
+	if _, ok := sv.(*Gather); ok {
+		return
+	}
+
+	// Check if the parameter type satisfies Resource.
+	if !paramType.Implements(resourceType) &&
+		!(paramType.Kind() == reflect.Struct && reflect.PointerTo(paramType).Implements(resourceType)) {
+		return
+	}
+
+	// Unmarshal the Starlark value to get the Go representation.
+	var goVal any
+	if err := unmarshal(sv, &goVal); err != nil {
+		return // best-effort; errors are caught later during execution
+	}
+
+	// Use the plan-time constructor to create a URI-only Resource.
+	r, ok := constructPlanTimeResource(paramType, goVal)
+	if !ok {
+		return
+	}
+
+	uri := r.URI()
+	if uri != "" {
+		graph.Catalog.Resolve(uri)
 	}
 }

--- a/pkg/op/planned_reflect_test.go
+++ b/pkg/op/planned_reflect_test.go
@@ -4,6 +4,7 @@
 package op
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -239,6 +240,86 @@ func TestWrapPlanned_Override(t *testing.T) {
 
 	if !called {
 		t.Error("override was not called")
+	}
+}
+
+func TestWrapPlanned_ResolvesResourceParams(t *testing.T) {
+	// Register plan-time constructor for actionResource.
+	RegisterPlanTimeConstructor(func(v any) (actionResource, error) {
+		s, ok := v.(string)
+		if !ok {
+			return actionResource{}, fmt.Errorf("expected string, got %T", v)
+		}
+		return actionResource{SourcePath: s}, nil
+	})
+	defer planTimeConstructorRegistry.Delete(reflect.TypeOf(actionResource{}))
+
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	graph := NewGraph("test")
+	providerType := reflect.TypeOf(&actionProvider{})
+
+	// Touch takes an actionResource parameter — should trigger catalog resolution.
+	p := WrapPlanned("test", providerType, graph, "proj", reg, MethodParams{
+		"Touch": {"res"},
+	})
+
+	attr, _ := p.Attr("touch")
+	builtin := attr.(*starlark.Builtin)
+	_, err := builtin.CallInternal(nil, nil, []starlark.Tuple{
+		{starlark.String("res"), starlark.String("/tmp/new-file")},
+	})
+	if err != nil {
+		t.Fatalf("touch() error: %v", err)
+	}
+
+	// The res parameter is actionResource-typed. The plan-time constructor
+	// should have created a URI-only Resource and resolved it in the catalog.
+	uri := "file:///tmp/new-file"
+	id := graph.Catalog.Current(uri)
+	if id == "" {
+		t.Errorf("catalog has no entry for %q — resolveResourceParam did not fire", uri)
+	}
+}
+
+func TestWrapPlanned_SkipsPromiseResolution(t *testing.T) {
+	reg := NewActionRegistry()
+	RegisterReflectedActions(reg, "test", &actionProvider{}, actionParams)
+
+	graph := NewGraph("test")
+	providerType := reflect.TypeOf(&actionProvider{})
+
+	p := WrapPlanned("test", providerType, graph, "proj", reg, MethodParams{
+		"Create": {"path"},
+		"Delete": {"path"},
+	})
+
+	// First call: create returns a promise.
+	createAttr, _ := p.Attr("create")
+	createBuiltin := createAttr.(*starlark.Builtin)
+	promise, err := createBuiltin.CallInternal(nil, nil, []starlark.Tuple{
+		{starlark.String("path"), starlark.String("/tmp/x")},
+	})
+	if err != nil {
+		t.Fatalf("create() error: %v", err)
+	}
+
+	// Second call: pass promise to delete — should NOT resolve.
+	catalogBefore := graph.Catalog.Len()
+	deleteAttr, _ := p.Attr("delete")
+	deleteBuiltin := deleteAttr.(*starlark.Builtin)
+	_, err = deleteBuiltin.CallInternal(nil, nil, []starlark.Tuple{
+		{starlark.String("path"), promise},
+	})
+	if err != nil {
+		t.Fatalf("delete() error: %v", err)
+	}
+
+	// Catalog should not have grown (promise is deferred, not resolved).
+	if graph.Catalog.Len() != catalogBefore {
+		t.Errorf("catalog grew from %d to %d — promise should not be resolved at plan time",
+			catalogBefore, graph.Catalog.Len())
 	}
 }
 

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -74,18 +74,23 @@ func (p *Provider) Backup(path Resource, backupSuffix string) (result Resource, 
 	}
 
 	timestamp := time.Now().Format("20060102-150405")
-	backupPath := path.SourcePath + backupSuffix + "." + timestamp
+	originalPath := path.SourcePath
+	backupPath := originalPath + backupSuffix + "." + timestamp
 
-	if err := os.Rename(path.SourcePath, backupPath); err != nil {
+	if err := os.Rename(originalPath, backupPath); err != nil {
 		return Resource{}, Tombstone{}, err
 	}
 
 	result = path
 	result.SourcePath = backupPath
 
+	// Undo resource reflects where the data IS (backup path).
+	// OriginalPath records where it WAS (restoration target).
+	undoResource := path
+	undoResource.SourcePath = backupPath
 	undo = Tombstone{
-		TombstoneBase: op.NewTombstoneBase(&path),
-		RecoveryPath:  backupPath,
+		TombstoneBase: op.NewTombstoneBase(&undoResource),
+		OriginalPath:  originalPath,
 	}
 
 	return result, undo, nil
@@ -100,13 +105,14 @@ func (p *Provider) CompensateBackup(undo Tombstone) error {
 	}
 
 	resource := undo.Resource().(*Resource)
+	recoveryPath := resource.SourcePath
 	if resource.Checksum != "" {
-		actual := checksumFile(undo.RecoveryPath)
+		actual := checksumFile(recoveryPath)
 		if actual == "" {
-			return fmt.Errorf("cannot read %s for verification", undo.RecoveryPath)
+			return fmt.Errorf("cannot read %s for verification", recoveryPath)
 		}
 		if actual != resource.Checksum {
-			return fmt.Errorf("%s has been modified (checksum mismatch)", undo.RecoveryPath)
+			return fmt.Errorf("%s has been modified (checksum mismatch)", recoveryPath)
 		}
 	}
 
@@ -238,9 +244,13 @@ func (p *Provider) Move(source, destination Resource) (result Resource, undo Tom
 	result = source
 	result.SourcePath = destination.SourcePath
 
+	// Undo resource reflects where the data IS (destination).
+	// OriginalPath records where it WAS (source).
+	undoResource := source
+	undoResource.SourcePath = destination.SourcePath
 	undo = Tombstone{
-		TombstoneBase: op.NewTombstoneBase(&source),
-		RecoveryPath:  destination.SourcePath,
+		TombstoneBase: op.NewTombstoneBase(&undoResource),
+		OriginalPath:  source.SourcePath,
 	}
 
 	return result, undo, nil
@@ -255,13 +265,14 @@ func (p *Provider) CompensateMove(undo Tombstone) error {
 	}
 
 	resource := undo.Resource().(*Resource)
+	recoveryPath := resource.SourcePath
 	if resource.Checksum != "" {
-		actual := checksumFile(undo.RecoveryPath)
+		actual := checksumFile(recoveryPath)
 		if actual == "" {
-			return fmt.Errorf("cannot read %s for verification", undo.RecoveryPath)
+			return fmt.Errorf("cannot read %s for verification", recoveryPath)
 		}
 		if actual != resource.Checksum {
-			return fmt.Errorf("%s has been modified (checksum mismatch)", undo.RecoveryPath)
+			return fmt.Errorf("%s has been modified (checksum mismatch)", recoveryPath)
 		}
 	}
 
@@ -649,30 +660,36 @@ func (p *Provider) Read(path Resource) (result Resource, err error) {
 // region Internal
 
 // compensateWrite reverts a write or link operation by removing the new file and restoring the original from recovery.
+//
+// When OriginalPath is empty, no file existed before — the new file at
+// Resource.SourcePath is simply removed. When OriginalPath is set, the
+// new file at OriginalPath is removed and the old file is restored from
+// Resource.SourcePath (recovery) back to OriginalPath.
 func (p *Provider) compensateWrite(undo Tombstone) error {
 	if undo.Resource() == nil {
 		return nil
 	}
 
-	originalPath := undo.Resource().(*Resource).SourcePath
-
-	if err := os.Remove(originalPath); err != nil {
-		if !os.IsNotExist(err) {
+	if undo.OriginalPath == "" {
+		// Nothing existed before — just remove the new file.
+		recoveryPath := undo.Resource().(*Resource).SourcePath
+		if err := os.Remove(recoveryPath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+		return nil
 	}
 
-	if undo.RecoveryPath != "" {
-		return p.restoreFromRecovery(undo)
+	// Something existed before — remove the new file, restore the old.
+	if err := os.Remove(undo.OriginalPath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
-
-	return nil
+	return p.restoreFromRecovery(undo)
 }
 
 // prepareWrite handles pre-write backup for destructive operations.
 // If the destination exists, it is moved to a recovery site before the
 // write proceeds. If the destination does not exist, the parent directory
-// is created and a tombstone with no recovery path is returned (compensation
+// is created and a tombstone with no OriginalPath is returned (compensation
 // will simply remove the newly created file).
 func (p *Provider) prepareWrite(resource Resource) (result Resource, undo Tombstone, err error) {
 
@@ -687,6 +704,9 @@ func (p *Provider) prepareWrite(resource Resource) (result Resource, undo Tombst
 			return Resource{}, Tombstone{}, errors.Join(os.ErrNotExist, err)
 		}
 
+		// Nothing existed before. Resource.SourcePath = the destination
+		// (where the new file will be). OriginalPath is empty — compensation
+		// will just remove the new file.
 		undo = Tombstone{
 			TombstoneBase: op.NewTombstoneBase(&result),
 		}

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -48,8 +48,8 @@ func TestLink_CreatesNewSymlink(t *testing.T) {
 	if state.Resource() == nil {
 		t.Fatal("state.Resource() is nil, want non-nil")
 	}
-	if state.RecoveryPath != "" {
-		t.Errorf("state.RecoveryPath = %q, want empty (nothing to recover)", state.RecoveryPath)
+	if state.OriginalPath != "" {
+		t.Errorf("state.OriginalPath = %q, want empty (nothing to recover)", state.OriginalPath)
 	}
 
 	got, err := os.Readlink(linkPath)
@@ -86,8 +86,8 @@ func TestLink_OverwritesExistingSymlink(t *testing.T) {
 	}
 
 	// Old symlink was moved to recovery.
-	if state.RecoveryPath == "" {
-		t.Error("state.RecoveryPath is empty, want non-empty (old symlink moved to recovery)")
+	if state.OriginalPath == "" {
+		t.Error("state.OriginalPath is empty, want non-empty (old symlink moved to recovery)")
 	}
 
 	got, err := os.Readlink(linkPath)
@@ -191,10 +191,11 @@ func TestCompensateLink_ExistedBefore_RestoresFromRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource := Resource{SourcePath: linkPath}
+	// Resource.SourcePath = where data IS (recovery). OriginalPath = where it WAS.
+	resource := Resource{SourcePath: recoveryPath}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  recoveryPath,
+		OriginalPath:  linkPath,
 	}
 
 	p := Provider{}
@@ -336,10 +337,10 @@ func TestCompensateCopy_Overwrite_RestoresOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource := Resource{SourcePath: path}
+	resource := Resource{SourcePath: recoveryPath}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  recoveryPath,
+		OriginalPath:  path,
 	}
 
 	p := Provider{}
@@ -398,13 +399,14 @@ func TestBackup_MovesFileToTimestampedBackup(t *testing.T) {
 		t.Errorf("backup content = %q, want %q", got, "backup me")
 	}
 
-	// Tombstone should carry the original resource.
-	originalPath := state.Resource().(*Resource).SourcePath
-	if originalPath != path {
-		t.Errorf("tombstone resource path = %q, want %q", originalPath, path)
+	// Tombstone resource reflects where data IS (backup path).
+	// OriginalPath records where data WAS (original location).
+	resourcePath := state.Resource().(*Resource).SourcePath
+	if resourcePath != result.SourcePath {
+		t.Errorf("tombstone resource path = %q, want %q", resourcePath, result.SourcePath)
 	}
-	if state.RecoveryPath != result.SourcePath {
-		t.Errorf("tombstone recovery path = %q, want %q", state.RecoveryPath, result.SourcePath)
+	if state.OriginalPath != path {
+		t.Errorf("tombstone original path = %q, want %q", state.OriginalPath, path)
 	}
 
 	// Checksum should match the original file content.
@@ -444,10 +446,10 @@ func TestCompensateBackup_RestoresOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource := Resource{SourcePath: originalPath}
+	resource := Resource{SourcePath: backupPath}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  backupPath,
+		OriginalPath:  originalPath,
 	}
 
 	p := Provider{}
@@ -480,10 +482,10 @@ func TestCompensateBackup_ChecksumMismatch_ReturnsError(t *testing.T) {
 	h := sha256.Sum256([]byte("original content"))
 	wrongChecksum := "sha256:" + hex.EncodeToString(h[:])
 
-	resource := Resource{SourcePath: originalPath, Checksum: wrongChecksum}
+	resource := Resource{SourcePath: backupPath, Checksum: wrongChecksum}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  backupPath,
+		OriginalPath:  originalPath,
 	}
 
 	p := Provider{}
@@ -581,8 +583,8 @@ func TestRemove_RemovesFile(t *testing.T) {
 	if result.Resource() == nil {
 		t.Fatal("result.Resource() is nil, want non-nil")
 	}
-	if result.RecoveryPath == "" {
-		t.Error("result.RecoveryPath should not be empty")
+	if result.OriginalPath == "" {
+		t.Error("result.OriginalPath should not be empty")
 	}
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -693,13 +695,14 @@ func TestMove(t *testing.T) {
 		t.Errorf("result = %q, want %q", result.SourcePath, dst)
 	}
 
-	// Tombstone carries the source resource and destination as recovery path.
-	source := state.Resource().(*Resource).SourcePath
-	if source != src {
-		t.Errorf("tombstone resource path = %q, want %q", source, src)
+	// Tombstone resource reflects where data IS (destination).
+	// OriginalPath records where data WAS (source).
+	resourcePath := state.Resource().(*Resource).SourcePath
+	if resourcePath != dst {
+		t.Errorf("tombstone resource path = %q, want %q", resourcePath, dst)
 	}
-	if state.RecoveryPath != dst {
-		t.Errorf("tombstone recovery path = %q, want %q", state.RecoveryPath, dst)
+	if state.OriginalPath != src {
+		t.Errorf("tombstone original path = %q, want %q", state.OriginalPath, src)
 	}
 
 	// Checksum should match the original file content.
@@ -742,10 +745,10 @@ func TestCompensateMove_ChecksumMismatch_ReturnsError(t *testing.T) {
 	h := sha256.Sum256([]byte("original"))
 	wrongChecksum := "sha256:" + hex.EncodeToString(h[:])
 
-	resource := Resource{SourcePath: src, Checksum: wrongChecksum}
+	resource := Resource{SourcePath: dst, Checksum: wrongChecksum}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  dst,
+		OriginalPath:  src,
 	}
 
 	p := Provider{}

--- a/pkg/op/provider/file/recovery.go
+++ b/pkg/op/provider/file/recovery.go
@@ -15,14 +15,12 @@ func (p *Provider) moveToRecovery(resource Resource, prune bool, pruneBoundary s
 
 	// Normalize to absolute path for reliable recovery regardless of working directory at restore time.
 
-	absolutePath, err := filepath.Abs(resource.SourcePath)
+	originalPath, err := filepath.Abs(resource.SourcePath)
 	if err != nil {
 		return Tombstone{}, err
 	}
 
-	resource.SourcePath = absolutePath
-
-	recoveryBase, err := p.getRecoveryBase(absolutePath)
+	recoveryBase, err := p.getRecoveryBase(originalPath)
 	if err != nil {
 		return Tombstone{}, err
 	}
@@ -40,35 +38,42 @@ func (p *Provider) moveToRecovery(resource Resource, prune bool, pruneBoundary s
 
 	// Perform the removal in O(1) time with no data movement because it's on the same partition
 
-	if err := os.Rename(absolutePath, recoveryPath); err != nil {
+	if err := os.Rename(originalPath, recoveryPath); err != nil {
 		return Tombstone{}, err
 	}
 
-	pruneEmptyParents(resource.SourcePath, prune, pruneBoundary)
+	pruneEmptyParents(originalPath, prune, pruneBoundary)
+
+	// Resource reflects where the data IS now (recovery path).
+	// OriginalPath records where it WAS (restoration target).
+	resource.SourcePath = recoveryPath
 
 	return Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		RecoveryPath:  recoveryPath,
+		OriginalPath:  originalPath,
 	}, nil
 }
 
 // restoreFromRecovery is the compensating action (undo) for any removal operation.
 //
 // It moves the entity back to its original location from the recovery site.
+// The recovery path is Resource.SourcePath (where the data IS); the
+// restoration target is tombstone.OriginalPath (where it WAS).
 func (p *Provider) restoreFromRecovery(tombstone Tombstone) error {
 
-	originalPath := tombstone.Resource().(*Resource).SourcePath
+	recoveryPath := tombstone.Resource().(*Resource).SourcePath
+	originalPath := tombstone.OriginalPath
 
 	// Validate the tombstone
 
-	if tombstone.RecoveryPath == "" || originalPath == "" {
+	if recoveryPath == "" || originalPath == "" {
 		return fmt.Errorf("invalid tombstone: missing path metadata")
 	}
 
 	// Verify the recovery site still exists
 
-	if _, err := os.Lstat(tombstone.RecoveryPath); errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("recovery source not found: %s. Was it purged?", tombstone.RecoveryPath)
+	if _, err := os.Lstat(recoveryPath); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("recovery source not found: %s. Was it purged?", recoveryPath)
 	}
 
 	// Ensure the original destination's parent exists
@@ -81,7 +86,7 @@ func (p *Provider) restoreFromRecovery(tombstone Tombstone) error {
 
 	// Relocate with no data movement since we guaranteed we are on the same partition as the original file
 
-	if err := os.Rename(tombstone.RecoveryPath, originalPath); err != nil {
+	if err := os.Rename(recoveryPath, originalPath); err != nil {
 		return fmt.Errorf("failed to restore from tombstone: %w", err)
 	}
 

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -12,12 +13,23 @@ import (
 )
 
 func init() {
+	// Execution-time constructor: creates a Resource with full metadata (os.Stat).
 	op.RegisterConstructor(func(v any) (Resource, error) {
 		s, ok := v.(string)
 		if !ok {
 			return Resource{}, fmt.Errorf("file.Resource: expected string path, got %T", v)
 		}
 		return NewResource(s)
+	})
+
+	// Plan-time constructor: creates a URI-only Resource with no I/O.
+	// Used by the planned bridge for catalog resolution.
+	op.RegisterPlanTimeConstructor(func(v any) (Resource, error) {
+		s, ok := v.(string)
+		if !ok {
+			return Resource{}, fmt.Errorf("file.Resource: expected string path, got %T", v)
+		}
+		return Resource{SourcePath: s}, nil
 	})
 }
 
@@ -33,11 +45,33 @@ type Resource struct {
 	Checksum   string
 }
 
-// Tombstone holds file-specific compensation state. The embedded [op.TombstoneBase] carries the affected [Resource]
-// (whose SourcePath is the original location). RecoveryPath is where the file was stashed for safe keeping.
+// URI returns the canonical file:// URI for this resource.
+func (r *Resource) URI() string { return r.NewURI(r) }
+
+// Scheme returns "file".
+func (r *Resource) Scheme() string { return op.SchemeFile }
+
+// Host returns empty string — file URIs have no authority.
+func (r *Resource) Host() string { return "" }
+
+// Path returns the canonicalized absolute path.
+func (r *Resource) Path() string {
+	abs, err := filepath.Abs(r.SourcePath)
+	if err != nil {
+		return filepath.Clean(r.SourcePath)
+	}
+	return filepath.Clean(abs)
+}
+
+// Tombstone holds file-specific compensation state.
+//
+// The embedded [op.TombstoneBase] carries the affected [Resource] whose
+// SourcePath reflects where the data physically IS after the operation
+// (e.g., the recovery path after moveToRecovery). OriginalPath records
+// where the data WAS before the operation — the restoration target.
 type Tombstone struct {
 	op.TombstoneBase
-	RecoveryPath string
+	OriginalPath string
 }
 
 // NewResource initializes a new [Resource] by checking the existence and size of the file at the provided sourcePath.
@@ -47,40 +81,30 @@ type Tombstone struct {
 //
 // Returns: an error if the path does not exist or is a directory
 func NewResource(path string) (Resource, error) {
-
-	// Generate a URI for the resource
-	uri := fmt.Sprintf("file://%s", path)
+	r := Resource{SourcePath: path}
 
 	info, err := os.Stat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// This is a "Known Path but No Data" state.
-			// The Executor will need to fulfill this via a Node later.
-			return Resource{
-				ResourceBase: op.NewResourceBase(uri),
-				SourcePath:   path,
-			}, nil
+			// Known path but no data — the executor will resolve this later.
+			return r, nil
 		}
 		return Resource{}, fmt.Errorf("failed to stat blob source: %w", err)
 	}
 
-	// Extract syscall.Stat_t to get the Inode and Device
 	var inode, device uint64
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		inode = stat.Ino
 		device = uint64(stat.Dev)
 	}
 
-	return Resource{
-		ResourceBase: op.NewResourceBase(uri),
-		Inode:        inode,
-		Device:       device,
-		SourcePath:   path,
-		Size:         info.Size(),
-		Mode:         info.Mode(),
-		ModTime:      info.ModTime(),
-		Checksum:     checksumFile(path),
-	}, nil
+	r.Inode = inode
+	r.Device = device
+	r.Size = info.Size()
+	r.Mode = info.Mode()
+	r.ModTime = info.ModTime()
+	r.Checksum = checksumFile(path)
+	return r, nil
 }
 
 // Exists returns true if the Resource references a file that existed when the Resource was created.
@@ -211,8 +235,7 @@ func (r *Resource) refreshMetadataWith(info os.FileInfo, checksum string, size i
 	r.Mode = info.Mode()
 	r.ModTime = info.ModTime()
 
-	// We re-calculate the checksum because the content has changed
-	r.Checksum = checksumFile(r.SourcePath)
+	r.Checksum = checksum
 
 	return nil
 }

--- a/pkg/op/receiver_reflect.go
+++ b/pkg/op/receiver_reflect.go
@@ -20,20 +20,37 @@ type MethodParams map[string][]string
 // ReflectedReceiver wraps a Go struct for immediate-mode Starlark use.
 // Exported methods become Starlark builtins; method dispatch, argument
 // unpacking, and return value marshaling are handled by reflection.
+//
+// Optional catalog and stack fields enable resource management
+// integration. When set, Resource results are shadowed in the catalog
+// after successful dispatch.
 type ReflectedReceiver struct {
 	Receiver
 	providerValue reflect.Value
 	methods       map[string]*methodBridge
 	attrList      []string
+	catalog       *ResourceCatalog // optional; set via SetCatalog
+	stack         *RecoveryStack   // optional; set via SetStack
 }
+
+// SetCatalog sets the resource catalog for immediate-mode dispatch.
+// When set, Resource results are shadowed in the catalog after each
+// successful method call.
+func (r *ReflectedReceiver) SetCatalog(c *ResourceCatalog) { r.catalog = c }
+
+// SetStack sets the recovery stack for immediate-mode dispatch.
+func (r *ReflectedReceiver) SetStack(s *RecoveryStack) { r.stack = s }
 
 type methodBridge struct {
 	name   string
 	bridge builtinFunc
 }
 
-// errorType is cached for return-type classification.
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
+// errorType and noResultType are cached for return-type classification.
+var (
+	errorType    = reflect.TypeOf((*error)(nil)).Elem()
+	noResultType = reflect.TypeOf(NoResult{})
+)
 
 // WrapReceiver wraps a Go struct for immediate-mode Starlark use.
 // Only methods listed in params are exposed. Compensate* methods are
@@ -59,7 +76,7 @@ func WrapReceiver(name string, provider any, params MethodParams) *ReflectedRece
 		}
 
 		snakeName := camelToSnake(m.Name)
-		bridge := buildMethodBridge(name, rv, m, snakeName, paramNames)
+		bridge := buildMethodBridge(name, rv, m, snakeName, paramNames, r)
 		r.methods[snakeName] = &methodBridge{
 			name:   snakeName,
 			bridge: bridge,
@@ -104,12 +121,15 @@ func (r *ReflectedReceiver) AttrNames() []string {
 }
 
 // buildMethodBridge creates a builtinFunc that bridges a Go method to Starlark.
+// The receiver parameter provides optional catalog/stack integration —
+// Resource results are shadowed in the catalog after successful dispatch.
 func buildMethodBridge(
 	receiverName string,
 	providerVal reflect.Value,
 	method reflect.Method,
 	snakeName string,
 	paramNames []string,
+	receiver *ReflectedReceiver,
 ) builtinFunc {
 	methodType := method.Type
 	numParams := len(paramNames)
@@ -153,7 +173,16 @@ func buildMethodBridge(
 			results = method.Func.Call(goArgs)
 		}
 
-		// 4. Classify and marshal return values.
+		// 4. Shadow Resource results in catalog (success path only).
+		if receiver.catalog != nil && len(results) > 0 {
+			lastIdx := len(results) - 1
+			isErr := results[lastIdx].Type().Implements(errorType) && !results[lastIdx].IsNil()
+			if !isErr && results[0].Type() != noResultType {
+				shadowResult(results[0].Interface(), receiver.catalog, "")
+			}
+		}
+
+		// 5. Classify and marshal return values.
 		return classifyReturn(results)
 	}
 }
@@ -168,6 +197,7 @@ func buildMethodBridge(
 //	(T, error)                 → marshal(T) or error
 //	(T, map[string]any, error) → marshal(T), discard undo state, or error
 //	(T, *RecoveryStack, error) → marshal(T), discard stack, or error
+//	(NoResult, ...)            → None (sentinel for no-output methods)
 func classifyReturn(results []reflect.Value) (starlark.Value, error) {
 	n := len(results)
 	if n == 0 {
@@ -183,6 +213,11 @@ func classifyReturn(results []reflect.Value) (starlark.Value, error) {
 	}
 
 	if n == 0 {
+		return starlark.None, nil
+	}
+
+	// NoResult sentinel → starlark.None.
+	if results[0].Type() == noResultType {
 		return starlark.None, nil
 	}
 

--- a/pkg/op/receiver_reflect_test.go
+++ b/pkg/op/receiver_reflect_test.go
@@ -51,6 +51,14 @@ func (p *testProvider) Write(path, content string) (string, map[string]any, erro
 // Compensate method — should be excluded.
 func (p *testProvider) CompensateWrite(_ map[string]any) error { return nil }
 
+// NoResult pattern: (NoResult, map[string]any, error).
+func (p *testProvider) Remove(path string) (NoResult, map[string]any, error) {
+	return NoResult{}, map[string]any{"path": path}, nil
+}
+
+// Compensate method for Remove.
+func (p *testProvider) CompensateRemove(_ map[string]any) error { return nil }
+
 // Struct return.
 func (p *testProvider) GetPoint() testPoint { return testPoint{X: 10, Y: 20} }
 
@@ -83,6 +91,7 @@ var testParams = MethodParams{
 	"Noop":      {},
 	"Validate":  {"s"},
 	"Write":     {"path", "content"},
+	"Remove":    {"path"},
 	"GetPoint":  {},
 	"Search":    {"query", "limit?"},
 	"TryParse":  {"s"},
@@ -98,7 +107,7 @@ func TestWrapReceiver_MethodDiscovery(t *testing.T) {
 	// Verify expected methods are present.
 	expected := []string{
 		"count", "divide", "exists", "get_point", "greet",
-		"list_files", "noop", "search", "try_parse", "validate", "write",
+		"list_files", "noop", "remove", "search", "try_parse", "validate", "write",
 	}
 	if len(names) != len(expected) {
 		t.Fatalf("AttrNames() = %v (len %d), want %v (len %d)", names, len(names), expected, len(expected))
@@ -444,5 +453,81 @@ func TestReflectedReceiver_StarlarkValue(t *testing.T) {
 	}
 	if r.Truth() != starlark.True {
 		t.Error("Truth() should be True")
+	}
+}
+
+// --- NoResult tests ---
+
+func TestCall_NoResultReturn(t *testing.T) {
+	r := WrapReceiver("test", &testProvider{}, testParams)
+	result := callMethod(t, r, "remove", starlark.String("/tmp/file"))
+
+	if result != starlark.None {
+		t.Errorf("remove() = %v, want None", result)
+	}
+}
+
+// --- Catalog integration tests ---
+
+func TestWrapReceiver_CatalogShadow(t *testing.T) {
+	catalog := NewResourceCatalog()
+	r := WrapReceiver("test", &actionProvider{}, MethodParams{
+		"Create": {"path"},
+	})
+	r.SetCatalog(catalog)
+
+	callMethod(t, r, "create", starlark.String("/tmp/new"))
+
+	if catalog.Len() != 1 {
+		t.Errorf("catalog len = %d, want 1 (Resource result should be shadowed)", catalog.Len())
+	}
+}
+
+func TestWrapReceiver_NoCatalog_NoShadow(t *testing.T) {
+	r := WrapReceiver("test", &actionProvider{}, MethodParams{
+		"Create": {"path"},
+	})
+	// No catalog set — should not panic.
+	callMethod(t, r, "create", starlark.String("/tmp/new"))
+}
+
+func TestWrapReceiver_CatalogError_NoShadow(t *testing.T) {
+	catalog := NewResourceCatalog()
+	r := WrapReceiver("test", &testProvider{}, testParams)
+	r.SetCatalog(catalog)
+
+	// Validate("") returns error — should not shadow.
+	err := callMethodErr(t, r, "validate", starlark.String(""))
+	if err == nil {
+		t.Fatal("validate('') should return error")
+	}
+	if catalog.Len() != 0 {
+		t.Errorf("catalog len = %d, want 0 (error result should not be shadowed)", catalog.Len())
+	}
+}
+
+func TestWrapReceiver_CatalogNonResource_NoShadow(t *testing.T) {
+	catalog := NewResourceCatalog()
+	r := WrapReceiver("test", &testProvider{}, testParams)
+	r.SetCatalog(catalog)
+
+	// Greet returns string — not a Resource, should not be shadowed.
+	callMethod(t, r, "greet", starlark.String("world"))
+
+	if catalog.Len() != 0 {
+		t.Errorf("catalog len = %d, want 0 (non-Resource result should not be shadowed)", catalog.Len())
+	}
+}
+
+func TestWrapReceiver_CatalogNoResult_NoShadow(t *testing.T) {
+	catalog := NewResourceCatalog()
+	r := WrapReceiver("test", &testProvider{}, testParams)
+	r.SetCatalog(catalog)
+
+	// Remove returns NoResult — nothing to shadow.
+	callMethod(t, r, "remove", starlark.String("/tmp/file"))
+
+	if catalog.Len() != 0 {
+		t.Errorf("catalog len = %d, want 0 (NoResult should not be shadowed)", catalog.Len())
 	}
 }

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -5,7 +5,6 @@ package op
 
 import (
 	"net/url"
-	"path/filepath"
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -15,8 +14,19 @@ import (
 //
 // Every provider-specific resource (e.g., file.Resource) must embed [ResourceBase] to satisfy it. The unexported
 // resourceBase method seals the interface to package op. Only types embedding [ResourceBase] can implement [Resource].
+//
+// Concrete types must implement [Scheme], [Host], and [Path] to provide URI components. [URI] should be implemented
+// as a one-liner delegating to [ResourceBase.NewURI]:
+//
+//	func (r *Resource) URI() string { return r.NewURI(r) }
+//
+// [ResourceBase] provides default implementations of all four methods by parsing the stored uri field. Concrete types
+// shadow these with efficient, component-based implementations.
 type Resource interface {
 	URI() string
+	Scheme() string
+	Host() string
+	Path() string
 	resourceBase() *ResourceBase
 }
 
@@ -37,9 +47,48 @@ func NewResourceBase(uri string) ResourceBase {
 	return ResourceBase{uri: uri}
 }
 
-// URI returns the canonical URI of this resource.
+// URI returns the canonical URI of this resource. Concrete types should
+// shadow this with: func (r *Resource) URI() string { return r.NewURI(r) }
 func (b ResourceBase) URI() string {
 	return b.uri
+}
+
+// Scheme returns the URI scheme by parsing the stored uri. Concrete types
+// should shadow this with a constant (e.g., "file").
+func (b ResourceBase) Scheme() string {
+	u, err := url.Parse(b.uri)
+	if err != nil {
+		return ""
+	}
+	return u.Scheme
+}
+
+// Host returns the URI host by parsing the stored uri. Concrete types
+// should shadow this with their authority component (often empty).
+func (b ResourceBase) Host() string {
+	u, err := url.Parse(b.uri)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// Path returns the URI path by parsing the stored uri. Concrete types
+// should shadow this with their provider-specific identifier.
+func (b ResourceBase) Path() string {
+	u, err := url.Parse(b.uri)
+	if err != nil {
+		return ""
+	}
+	return u.Path
+}
+
+// NewURI builds a canonical URI from a concrete Resource's component methods.
+// Concrete types call this to implement URI():
+//
+//	func (r *Resource) URI() string { return r.NewURI(r) }
+func (b *ResourceBase) NewURI(r Resource) string {
+	return (&url.URL{Scheme: r.Scheme(), Host: r.Host(), Path: r.Path()}).String()
 }
 
 // resourceBase returns a pointer to the embedded ResourceBase, allowing the
@@ -77,8 +126,14 @@ type Tombstone interface {
 	tombstoneBase()
 }
 
-// TombstoneBase holds the resource that was affected by a compensable action. Provider-specific tombstone types must
-// embed it by value.
+// TombstoneBase holds the resource that was affected by a compensable action.
+// Provider-specific tombstone types must embed it by value.
+//
+// The embedded Resource reflects post-operation state: its identity fields
+// (e.g., SourcePath for file resources) point to where the data physically
+// IS after the operation, not where it was before. Provider-specific fields
+// on the tombstone (e.g., file.Tombstone.OriginalPath) record where the
+// data came from — the restoration target.
 type TombstoneBase struct {
 	resource Resource
 }
@@ -95,19 +150,8 @@ func (b TombstoneBase) Resource() Resource {
 
 func (b TombstoneBase) tombstoneBase() {}
 
-// ResourceURI builds a canonicalized URI from a scheme and an identifier.
-// For file:// URIs, id is resolved via filepath.Abs + filepath.Clean.
-// All URIs use the authority form with an empty host: scheme:///id.
-func ResourceURI(scheme, id string) string {
-	if scheme == SchemeFile {
-		abs, err := filepath.Abs(id)
-		if err == nil {
-			id = abs
-		}
-		id = filepath.Clean(id)
-	}
-	if len(id) == 0 || id[0] != '/' {
-		id = "/" + id
-	}
-	return (&url.URL{Scheme: scheme, Path: id}).String()
-}
+// NoResult signals that a provider method produces no output. Used by
+// CompensableAction methods like Remove and RemoveAll that can be undone
+// but produce no result for downstream nodes. classifyActionReturn maps
+// NoResult to nil Result; classifyReturn maps it to starlark.None.
+type NoResult struct{}

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -5,6 +5,7 @@ package op
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 )
 
@@ -79,6 +80,28 @@ func (c *ResourceCatalog) Current(uri string) string {
 	return c.ns[uri]
 }
 
+// DiscoveryURIs returns the URIs of catalog entries that were discovered
+// (created by Resolve) but not yet shadowed. These are inputs that should
+// exist on the target machine before execution begins. URIs whose current
+// entry has been superseded by Shadow are excluded.
+func (c *ResourceCatalog) DiscoveryURIs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var uris []string
+	for uri, id := range c.ns {
+		idx, ok := c.byID[id]
+		if !ok {
+			continue
+		}
+		base := c.entries[idx].resourceBase()
+		if base.originID == "" {
+			uris = append(uris, uri)
+		}
+	}
+	return uris
+}
+
 // catalogLocked adds a resource to the ledger, stamps its id and originID,
 // updates the namespace, and returns the assigned ID. Caller must hold c.mu.
 func (c *ResourceCatalog) catalogLocked(r Resource, originID string) string {
@@ -99,8 +122,10 @@ func (c *ResourceCatalog) catalogLocked(r Resource, originID string) string {
 // the originID if found. It is used by [FillSlot] to create implicit edges
 // when a resource produced by one node flows to another.
 //
-// It handles two forms:
-//   - Values implementing the [Resource] interface
+// It handles three forms:
+//   - Values implementing the [Resource] interface (pointer types)
+//   - Struct values whose pointer type implements [Resource] (value types
+//     returned by provider methods, stamped by [shadowResult])
 //   - map[string]any with "uri"/"id"/"origin_id" keys (produced by
 //     unmarshal when a starlarkstruct.Struct is decoded to *any)
 func extractResource(v any) (originID string, ok bool) {
@@ -108,8 +133,20 @@ func extractResource(v any) (originID string, ok bool) {
 		return "", false
 	}
 
-	// Interface match — the normal path.
+	// Interface match — pointer types.
 	if r, ok := v.(Resource); ok {
+		base := r.resourceBase()
+		return base.originID, base.originID != ""
+	}
+
+	// Struct value whose pointer satisfies Resource. Provider methods
+	// return resources by value; shadowResult stamps id/originID on the
+	// embedded ResourceBase. Create a temporary pointer to access it.
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Struct && reflect.PointerTo(rv.Type()).Implements(resourceType) {
+		ptr := reflect.New(rv.Type())
+		ptr.Elem().Set(rv)
+		r := ptr.Interface().(Resource)
 		base := r.resourceBase()
 		return base.originID, base.originID != ""
 	}

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -45,10 +45,7 @@ func TestCatalog_Shadow(t *testing.T) {
 	cat := NewResourceCatalog()
 
 	origID := cat.Resolve("file:///target")
-	res := &testEmbeddingResource{
-		ResourceBase: NewResourceBase("file:///target"),
-		Extra:        "shadowed",
-	}
+	res := &testEmbeddingResource{SourcePath: "/target"}
 	shadowID := cat.Shadow(res, "writer-node")
 
 	if origID == shadowID {
@@ -72,9 +69,7 @@ func TestCatalog_Shadow_OverwritesResolve(t *testing.T) {
 	cat := NewResourceCatalog()
 
 	cat.Resolve("file:///overwrite")
-	res := &testEmbeddingResource{
-		ResourceBase: NewResourceBase("file:///overwrite"),
-	}
+	res := &testEmbeddingResource{SourcePath: "/overwrite"}
 	cat.Shadow(res, "nodeA")
 	resolvedID := cat.Resolve("file:///overwrite")
 
@@ -90,9 +85,7 @@ func TestCatalog_ImplicitDependency(t *testing.T) {
 	cat := NewResourceCatalog()
 
 	// Shadow by nodeA creates a resource version owned by nodeA
-	res := &testEmbeddingResource{
-		ResourceBase: NewResourceBase("file:///dep"),
-	}
+	res := &testEmbeddingResource{SourcePath: "/dep"}
 	cat.Shadow(res, "nodeA")
 
 	// Resolve (as if nodeB is reading) returns nodeA's version
@@ -126,9 +119,7 @@ func TestCatalog_Current_AfterShadow(t *testing.T) {
 	cat := NewResourceCatalog()
 
 	cat.Resolve("file:///shadowed")
-	res := &testEmbeddingResource{
-		ResourceBase: NewResourceBase("file:///shadowed"),
-	}
+	res := &testEmbeddingResource{SourcePath: "/shadowed"}
 	shadowID := cat.Shadow(res, "node-1")
 
 	if got := cat.Current("file:///shadowed"); got != shadowID {
@@ -209,6 +200,43 @@ func TestCatalog_ConcurrentAccess(t *testing.T) {
 
 	if len(seen) != goroutines {
 		t.Errorf("expected %d unique IDs, got %d", goroutines, len(seen))
+	}
+}
+
+func TestCatalog_DiscoveryURIs_ReturnsUnshadowed(t *testing.T) {
+	cat := NewResourceCatalog()
+
+	cat.Resolve("file:///source1")
+	cat.Resolve("file:///source2")
+	// Shadow a different URI — not a supersede.
+	res := &testEmbeddingResource{SourcePath: "/target"}
+	cat.Shadow(res, "node-1")
+
+	uris := cat.DiscoveryURIs()
+	if len(uris) != 2 {
+		t.Fatalf("DiscoveryURIs() returned %d, want 2", len(uris))
+	}
+}
+
+func TestCatalog_DiscoveryURIs_ShadowSupersedes(t *testing.T) {
+	cat := NewResourceCatalog()
+
+	cat.Resolve("file:///source")
+	res := &testEmbeddingResource{SourcePath: "/source"}
+	cat.Shadow(res, "node-1")
+
+	uris := cat.DiscoveryURIs()
+	if len(uris) != 0 {
+		t.Fatalf("DiscoveryURIs() returned %d, want 0 (shadow superseded)", len(uris))
+	}
+}
+
+func TestCatalog_DiscoveryURIs_Empty(t *testing.T) {
+	cat := NewResourceCatalog()
+
+	uris := cat.DiscoveryURIs()
+	if len(uris) != 0 {
+		t.Fatalf("DiscoveryURIs() returned %d, want 0", len(uris))
 	}
 }
 

--- a/pkg/op/resource_test.go
+++ b/pkg/op/resource_test.go
@@ -9,55 +9,74 @@ import (
 	"testing"
 )
 
-func TestResourceURI_File(t *testing.T) {
-	// Relative path should become absolute
-	uri := ResourceURI(SchemeFile, "relative/path")
-	if !strings.HasPrefix(uri, "file://") {
-		t.Errorf("ResourceURI(file, relative/path) = %q, want file:// prefix", uri)
-	}
-	path := strings.TrimPrefix(uri, "file://")
-	if !filepath.IsAbs(path) {
-		t.Errorf("ResourceURI(file, relative/path) produced non-absolute path: %q", path)
-	}
-
-	// Clean resolves ../
-	uri2 := ResourceURI(SchemeFile, "/etc/../etc/foo")
-	if uri2 != "file:///etc/foo" {
-		t.Errorf("ResourceURI(file, /etc/../etc/foo) = %q, want file:///etc/foo", uri2)
-	}
-
-	// Absolute path stays absolute
-	uri3 := ResourceURI(SchemeFile, "/usr/local/bin")
-	if uri3 != "file:///usr/local/bin" {
-		t.Errorf("ResourceURI(file, /usr/local/bin) = %q, want file:///usr/local/bin", uri3)
-	}
-}
-
-func TestResourceURI_OtherSchemes(t *testing.T) {
-	tests := []struct {
-		scheme string
-		id     string
-		want   string
-	}{
-		{SchemeGit, "github.com/org/repo", "git:///github.com/org/repo"},
-		{SchemePackage, "brew/vim", "pkg:///brew/vim"},
-		{SchemeService, "nginx", "svc:///nginx"},
-		{SchemeMem, "buffer-1", "mem:///buffer-1"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.scheme, func(t *testing.T) {
-			got := ResourceURI(tt.scheme, tt.id)
-			if got != tt.want {
-				t.Errorf("ResourceURI(%s, %s) = %q, want %q", tt.scheme, tt.id, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestResourceBase_URI(t *testing.T) {
 	base := NewResourceBase("file:///foo")
 	if base.URI() != "file:///foo" {
 		t.Errorf("URI() = %q, want file:///foo", base.URI())
+	}
+}
+
+func TestResourceBase_ComponentsParsedFromURI(t *testing.T) {
+	base := NewResourceBase("file:///usr/local/bin")
+	if base.Scheme() != "file" {
+		t.Errorf("Scheme() = %q, want file", base.Scheme())
+	}
+	if base.Host() != "" {
+		t.Errorf("Host() = %q, want empty", base.Host())
+	}
+	if base.Path() != "/usr/local/bin" {
+		t.Errorf("Path() = %q, want /usr/local/bin", base.Path())
+	}
+}
+
+func TestResourceBase_ComponentsWithHost(t *testing.T) {
+	base := NewResourceBase("git://github.com/org/repo")
+	if base.Scheme() != "git" {
+		t.Errorf("Scheme() = %q, want git", base.Scheme())
+	}
+	if base.Host() != "github.com" {
+		t.Errorf("Host() = %q, want github.com", base.Host())
+	}
+	if base.Path() != "/org/repo" {
+		t.Errorf("Path() = %q, want /org/repo", base.Path())
+	}
+}
+
+func TestResourceBase_NewURI(t *testing.T) {
+	base := NewResourceBase("")
+	r := &testResource{scheme: "svc", host: "", path: "/nginx"}
+	uri := base.NewURI(r)
+	if uri != "svc:///nginx" {
+		t.Errorf("NewURI() = %q, want svc:///nginx", uri)
+	}
+}
+
+func TestResourceBase_NewURI_WithHost(t *testing.T) {
+	base := NewResourceBase("")
+	r := &testResource{scheme: "git", host: "github.com", path: "/org/repo"}
+	uri := base.NewURI(r)
+	if uri != "git://github.com/org/repo" {
+		t.Errorf("NewURI() = %q, want git://github.com/org/repo", uri)
+	}
+}
+
+func TestResourceBase_NewURI_File(t *testing.T) {
+	base := NewResourceBase("")
+	r := &testResource{scheme: "file", host: "", path: "/usr/local/bin"}
+	uri := base.NewURI(r)
+	if uri != "file:///usr/local/bin" {
+		t.Errorf("NewURI() = %q, want file:///usr/local/bin", uri)
+	}
+}
+
+func TestResourceBase_NewURI_RelativeFilePath(t *testing.T) {
+	// A testResource that returns a relative path gets a relative URI.
+	// Real file.Resource.Path() always canonicalizes via filepath.Abs.
+	base := NewResourceBase("")
+	r := &testResource{scheme: "file", host: "", path: "/etc/foo"}
+	uri := base.NewURI(r)
+	if !strings.HasPrefix(uri, "file:///") {
+		t.Errorf("NewURI() = %q, want file:/// prefix", uri)
 	}
 }
 
@@ -69,19 +88,60 @@ func TestResourceBase_SatisfiesInterface(t *testing.T) {
 	}
 }
 
+// testResource is a concrete Resource implementation for testing NewURI.
+type testResource struct {
+	ResourceBase
+	scheme string
+	host   string
+	path   string
+}
+
+func (r *testResource) URI() string    { return r.NewURI(r) }
+func (r *testResource) Scheme() string { return r.scheme }
+func (r *testResource) Host() string   { return r.host }
+func (r *testResource) Path() string   { return r.path }
+
+func TestConcreteResource_URI(t *testing.T) {
+	r := &testResource{scheme: "file", host: "", path: "/usr/local/bin"}
+	if r.URI() != "file:///usr/local/bin" {
+		t.Errorf("URI() = %q, want file:///usr/local/bin", r.URI())
+	}
+
+	// Verify it satisfies the Resource interface
+	var iface Resource = r
+	if iface.URI() != "file:///usr/local/bin" {
+		t.Errorf("Resource.URI() = %q, want file:///usr/local/bin", iface.URI())
+	}
+}
+
 // testEmbeddingResource embeds ResourceBase, like file.Resource does.
 type testEmbeddingResource struct {
 	ResourceBase
-	Extra string
+	SourcePath string
 }
 
-func TestResourceBase_EmbeddingSatisfiesInterface(t *testing.T) {
-	r := &testEmbeddingResource{
-		ResourceBase: NewResourceBase("file:///embedded"),
-		Extra:        "metadata",
+func (r *testEmbeddingResource) URI() string    { return r.NewURI(r) }
+func (r *testEmbeddingResource) Scheme() string { return SchemeFile }
+func (r *testEmbeddingResource) Host() string   { return "" }
+func (r *testEmbeddingResource) Path() string {
+	abs, err := filepath.Abs(r.SourcePath)
+	if err != nil {
+		return r.SourcePath
 	}
+	return abs
+}
+
+func TestEmbeddingResource_URIComputedFromComponents(t *testing.T) {
+	r := &testEmbeddingResource{SourcePath: "/etc/foo"}
+	if r.URI() != "file:///etc/foo" {
+		t.Errorf("URI() = %q, want file:///etc/foo", r.URI())
+	}
+	if r.Scheme() != "file" {
+		t.Errorf("Scheme() = %q, want file", r.Scheme())
+	}
+
 	var iface Resource = r
-	if iface.URI() != "file:///embedded" {
-		t.Errorf("Resource.URI() = %q, want file:///embedded", iface.URI())
+	if iface.URI() != "file:///etc/foo" {
+		t.Errorf("Resource.URI() = %q, want file:///etc/foo", iface.URI())
 	}
 }

--- a/pkg/op/starvalue_marshal.go
+++ b/pkg/op/starvalue_marshal.go
@@ -33,6 +33,48 @@ func RegisterConstructor[T any](fn func(any) (T, error)) {
 	})
 }
 
+// planTimeConstructorRegistry maps reflect.Type → func(any) (any, error).
+// Plan-time constructors create URI-only resources with no I/O.
+// Used by buildPlannedBridge for catalog resolution at plan time.
+var planTimeConstructorRegistry sync.Map
+
+// RegisterPlanTimeConstructor registers a function that constructs a
+// URI-only resource from a simpler representation (e.g., string → Resource).
+// Unlike RegisterConstructor, the plan-time constructor must not perform I/O.
+func RegisterPlanTimeConstructor[T any](fn func(any) (T, error)) {
+	t := reflect.TypeOf((*T)(nil)).Elem()
+	planTimeConstructorRegistry.Store(t, func(v any) (any, error) {
+		return fn(v)
+	})
+}
+
+// constructPlanTimeResource creates a Resource for plan-time catalog
+// resolution using the plan-time constructor registry. Returns nil, false
+// if no plan-time constructor exists for the given type.
+func constructPlanTimeResource(targetType reflect.Type, value any) (Resource, bool) {
+	ctor, ok := planTimeConstructorRegistry.Load(targetType)
+	if !ok {
+		return nil, false
+	}
+	result, err := ctor.(func(any) (any, error))(value)
+	if err != nil {
+		return nil, false
+	}
+
+	// The result is typically a value type. Create a temporary pointer
+	// to satisfy the Resource interface (pointer receivers).
+	rv := reflect.ValueOf(result)
+	if rv.Kind() == reflect.Struct && reflect.PointerTo(rv.Type()).Implements(resourceType) {
+		ptr := reflect.New(rv.Type())
+		ptr.Elem().Set(rv)
+		return ptr.Interface().(Resource), true
+	}
+	if r, ok := result.(Resource); ok {
+		return r, true
+	}
+	return nil, false
+}
+
 // --- Receiver params registry ---
 
 // receiverParamsRegistry maps reflect.Type (struct, not pointer) to


### PR DESCRIPTION
## Summary

- Wires `ResourceCatalog` into the executor and action layers
- Action layer shadows Resource results after dispatch (`shadowResult`)
- Planned bridge resolves Resource-typed params in catalog at plan time
- `NoResult` sentinel for destruction-only methods (Remove, Unlink)
- `classifyActionReturn` / `classifyReturn` detect NoResult → nil / None
- CompensableAction pairing validation (panics on missing Compensate)
- Tombstone polarity corrected: Resource reflects where data IS
- Pre-flight resolution pass (`ResolveResources`) for source verification
- Immediate mode gains `SetCatalog` / `SetStack` for catalog integration
- Plan-time constructor registry (no I/O) separate from execution-time

## Test plan

- [x] `make vet` passes
- [x] `make test` passes — zero failures
- [x] `make test-race` passes — zero failures
- [x] `make build` passes (after gen file fix)
- [x] No standalone `ResourceURI(` calls in code (only plan docs)
- [x] No `fmt.Sprintf("file://` in code (only plan docs)
- [x] e2e testrunner passes (WriteText, Copy, Compensation, Trace, DryRun)