### PR TITLE
feature(op): Variadic Starlark args — positional arg collection

### DIFF
--- a/internal/e2e/testrunner/data/test_imm_file.star
+++ b/internal/e2e/testrunner/data/test_imm_file.star
@@ -5,7 +5,10 @@
 #            file.move, file.remove, file.glob
 
 # Pure path functions — return strings
-t.expect_equal(file.join(parts=["a", "b", "c.txt"]), "a/b/c.txt")
+t.expect_equal(file.join(parts=["a", "b", "c.txt"]), "a/b/c.txt")  # keyword list
+t.expect_equal(file.join("a", "b", "c.txt"), "a/b/c.txt")          # positional args
+t.expect_equal(file.join("only"), "only")                           # single positional
+t.expect_equal(file.join(), "")                                     # empty
 t.expect_equal(file.name(path="/some/dir/file.txt"), "file.txt")
 t.expect_equal(file.parent(path="/some/dir/file.txt"), "/some/dir")
 

--- a/internal/e2e/testrunner/data/test_imm_file_join_variadic_error.star
+++ b/internal/e2e/testrunner/data/test_imm_file_join_variadic_error.star
@@ -1,0 +1,7 @@
+# test_imm_file_join_variadic_error.star — Reject ambiguous variadic call.
+#
+# Validates: file.join rejects both positional and keyword args for the
+# variadic param.
+
+t.expect_error("positional and keyword")
+file.join("a", "b", parts=["c", "d"])

--- a/internal/e2e/testrunner/runner_test.go
+++ b/internal/e2e/testrunner/runner_test.go
@@ -347,6 +347,10 @@ func TestImmFile(t *testing.T) {
 	runScriptImm(t, "test_imm_file.star", "file")
 }
 
+func TestImmFileJoinVariadicError(t *testing.T) {
+	runScriptImm(t, "test_imm_file_join_variadic_error.star", "file")
+}
+
 func TestImmJSON(t *testing.T) {
 	runScriptImm(t, "test_imm_json.star", "json")
 }

--- a/pkg/op/receiver_reflect.go
+++ b/pkg/op/receiver_reflect.go
@@ -123,6 +123,11 @@ func (r *ReflectedReceiver) AttrNames() []string {
 // buildMethodBridge creates a builtinFunc that bridges a Go method to Starlark.
 // The receiver parameter provides optional catalog/stack integration —
 // Resource results are shadowed in the catalog after successful dispatch.
+//
+// Variadic parameters are marked with a "*" prefix in paramNames (e.g. "*parts").
+// Remaining positional Starlark args are collected into the variadic slot.
+// The keyword form (parts=["a","b"]) is also accepted as a fallback.
+// Supplying both positional and keyword args for a variadic param is an error.
 func buildMethodBridge(
 	receiverName string,
 	providerVal reflect.Value,
@@ -132,50 +137,116 @@ func buildMethodBridge(
 	receiver *ReflectedReceiver,
 ) builtinFunc {
 	methodType := method.Type
+
+	// Separate named params from the variadic param (at most one, always last).
+	var variadicName string // snake_case name without "*"
+	var variadicIdx int     // index in paramNames
+	namedParams := make([]string, 0, len(paramNames))
+	for i, p := range paramNames {
+		if strings.HasPrefix(p, "*") {
+			variadicName = strings.TrimPrefix(p, "*")
+			variadicIdx = i
+		} else {
+			namedParams = append(namedParams, p)
+		}
+	}
+	numNamed := len(namedParams)
 	numParams := len(paramNames)
 
 	return func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		// 1. Unpack Starlark args into starlark.Value slots.
-		vals := make([]starlark.Value, numParams)
-		pairs := make([]any, 0, numParams*2)
-		for i, name := range paramNames {
-			pairs = append(pairs, name, &vals[i])
+		if variadicName == "" {
+			// ── Non-variadic path (unchanged) ──────────────────────
+			return callNonVariadic(receiverName, providerVal, method, methodType, snakeName, paramNames, numParams, receiver, args, kwargs)
 		}
-		if err := starlark.UnpackArgs(snakeName, args, kwargs, pairs...); err != nil {
+
+		// ── Variadic path ──────────────────────────────────────────
+		// 1. Unpack named (non-variadic) params.
+		namedVals := make([]starlark.Value, numNamed)
+		pairs := make([]any, 0, numNamed*2)
+		for i, name := range namedParams {
+			pairs = append(pairs, name, &namedVals[i])
+		}
+
+		// Extract the variadic keyword if present, so UnpackArgs doesn't
+		// reject it as unexpected.
+		var kwVariadic starlark.Value
+		var filteredKwargs []starlark.Tuple
+		for _, kv := range kwargs {
+			key, _ := starlark.AsString(kv[0])
+			if key == variadicName {
+				kwVariadic = kv[1]
+			} else {
+				filteredKwargs = append(filteredKwargs, kv)
+			}
+		}
+
+		// Positional args beyond the named params are variadic candidates.
+		namedArgs := args
+		var positionalVariadic starlark.Tuple
+		if len(args) > numNamed {
+			namedArgs = args[:numNamed]
+			positionalVariadic = args[numNamed:]
+		}
+
+		if err := starlark.UnpackArgs(snakeName, namedArgs, filteredKwargs, pairs...); err != nil {
 			return nil, err
 		}
 
-		// 2. Convert Starlark values to Go values via reflection.
-		// methodType.In(0) is the receiver; params start at index 1.
+		// 2. Resolve the variadic value.
+		if len(positionalVariadic) > 0 && kwVariadic != nil {
+			return nil, fmt.Errorf("%s: %s() got both positional and keyword args for variadic param %q",
+				receiverName, snakeName, variadicName)
+		}
+
+		var variadicList *starlark.List
+		if len(positionalVariadic) > 0 {
+			elems := make([]starlark.Value, len(positionalVariadic))
+			copy(elems, positionalVariadic)
+			variadicList = starlark.NewList(elems)
+		} else if kwVariadic != nil {
+			list, ok := kwVariadic.(*starlark.List)
+			if !ok {
+				return nil, fmt.Errorf("%s.%s: keyword %s must be a list, got %s",
+					receiverName, snakeName, variadicName, kwVariadic.Type())
+			}
+			variadicList = list
+		}
+
+		// 3. Build Go args: named params + variadic slice.
 		goArgs := make([]reflect.Value, numParams+1)
 		goArgs[0] = providerVal
 
-		for i, sv := range vals {
-			paramType := methodType.In(i + 1) // skip receiver
+		for i, sv := range namedVals {
+			paramType := methodType.In(i + 1)
 			if sv == nil {
-				// Optional param not provided; use Go zero value.
 				goArgs[i+1] = reflect.Zero(paramType)
 				continue
 			}
 			goVal := reflect.New(paramType).Elem()
 			if err := unmarshalValue(sv, goVal); err != nil {
-				name := strings.TrimSuffix(paramNames[i], "?")
+				name := strings.TrimSuffix(namedParams[i], "?")
 				return nil, fmt.Errorf("%s.%s: param %s: %w", receiverName, snakeName, name, err)
 			}
 			goArgs[i+1] = goVal
 		}
 
-		// 3. Call the Go method.
-		var results []reflect.Value
-		if methodType.IsVariadic() {
-			results = method.Func.CallSlice(goArgs)
+		// Variadic param: unmarshal list → Go slice type.
+		// For CallSlice, the variadic arg must be the slice itself.
+		variadicGoType := methodType.In(variadicIdx + 1) // e.g. []string
+		if variadicList == nil || variadicList.Len() == 0 {
+			goArgs[variadicIdx+1] = reflect.Zero(variadicGoType)
 		} else {
-			results = method.Func.Call(goArgs)
+			goVal := reflect.New(variadicGoType).Elem()
+			if err := unmarshalValue(variadicList, goVal); err != nil {
+				return nil, fmt.Errorf("%s.%s: param %s: %w", receiverName, snakeName, variadicName, err)
+			}
+			goArgs[variadicIdx+1] = goVal
 		}
 
-		// 4. Shadow Resource results in catalog (success path only).
-		// The originID is the qualified method name (e.g., "file.copy")
-		// since immediate mode has no graph nodes.
+		// 4. Call via CallSlice (variadic methods).
+		results := method.Func.CallSlice(goArgs)
+
+		// 5. Shadow Resource results in catalog.
 		if receiver.catalog != nil && len(results) > 0 {
 			lastIdx := len(results) - 1
 			isErr := results[lastIdx].Type().Implements(errorType) && !results[lastIdx].IsNil()
@@ -185,9 +256,73 @@ func buildMethodBridge(
 			}
 		}
 
-		// 5. Classify and marshal return values.
 		return classifyReturn(results)
 	}
+}
+
+// callNonVariadic handles the common case: no variadic params.
+func callNonVariadic(
+	receiverName string,
+	providerVal reflect.Value,
+	method reflect.Method,
+	methodType reflect.Type,
+	snakeName string,
+	paramNames []string,
+	numParams int,
+	receiver *ReflectedReceiver,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	// 1. Unpack Starlark args into starlark.Value slots.
+	vals := make([]starlark.Value, numParams)
+	pairs := make([]any, 0, numParams*2)
+	for i, name := range paramNames {
+		pairs = append(pairs, name, &vals[i])
+	}
+	if err := starlark.UnpackArgs(snakeName, args, kwargs, pairs...); err != nil {
+		return nil, err
+	}
+
+	// 2. Convert Starlark values to Go values via reflection.
+	// methodType.In(0) is the receiver; params start at index 1.
+	goArgs := make([]reflect.Value, numParams+1)
+	goArgs[0] = providerVal
+
+	for i, sv := range vals {
+		paramType := methodType.In(i + 1) // skip receiver
+		if sv == nil {
+			// Optional param not provided; use Go zero value.
+			goArgs[i+1] = reflect.Zero(paramType)
+			continue
+		}
+		goVal := reflect.New(paramType).Elem()
+		if err := unmarshalValue(sv, goVal); err != nil {
+			name := strings.TrimSuffix(paramNames[i], "?")
+			return nil, fmt.Errorf("%s.%s: param %s: %w", receiverName, snakeName, name, err)
+		}
+		goArgs[i+1] = goVal
+	}
+
+	// 3. Call the Go method.
+	var results []reflect.Value
+	if methodType.IsVariadic() {
+		results = method.Func.CallSlice(goArgs)
+	} else {
+		results = method.Func.Call(goArgs)
+	}
+
+	// 4. Shadow Resource results in catalog (success path only).
+	if receiver.catalog != nil && len(results) > 0 {
+		lastIdx := len(results) - 1
+		isErr := results[lastIdx].Type().Implements(errorType) && !results[lastIdx].IsNil()
+		if !isErr && results[0].Type() != noResultType {
+			originID := receiverName + "." + snakeName
+			shadowResult(results[0].Interface(), receiver.catalog, originID)
+		}
+	}
+
+	// 5. Classify and marshal return values.
+	return classifyReturn(results)
 }
 
 // classifyReturn interprets Go method return values for Starlark.

--- a/pkg/op/receiver_reflect_test.go
+++ b/pkg/op/receiver_reflect_test.go
@@ -82,6 +82,27 @@ func (p *testProvider) TryParse(s string) (int, bool) {
 	return 0, false
 }
 
+// Variadic method.
+func (p *testProvider) Join(parts ...string) string {
+	result := ""
+	for i, part := range parts {
+		if i > 0 {
+			result += "/"
+		}
+		result += part
+	}
+	return result
+}
+
+// Variadic with a named param before the variadic.
+func (p *testProvider) Prefix(pfx string, parts ...string) string {
+	result := pfx
+	for _, part := range parts {
+		result += "/" + part
+	}
+	return result
+}
+
 var testParams = MethodParams{
 	"Greet":     {"name"},
 	"Exists":    {"path"},
@@ -95,6 +116,8 @@ var testParams = MethodParams{
 	"GetPoint":  {},
 	"Search":    {"query", "limit?"},
 	"TryParse":  {"s"},
+	"Join":      {"*parts"},
+	"Prefix":    {"pfx", "*parts"},
 }
 
 // wrapTestReceiver registers params and wraps a provider in one step.
@@ -114,7 +137,7 @@ func TestWrapReceiver_MethodDiscovery(t *testing.T) {
 	// Verify expected methods are present.
 	expected := []string{
 		"count", "divide", "exists", "get_point", "greet",
-		"list_files", "noop", "remove", "search", "try_parse", "validate", "write",
+		"join", "list_files", "noop", "prefix", "remove", "search", "try_parse", "validate", "write",
 	}
 	if len(names) != len(expected) {
 		t.Fatalf("AttrNames() = %v (len %d), want %v (len %d)", names, len(names), expected, len(expected))
@@ -190,6 +213,16 @@ func callMethodKw(t *testing.T, r *ReflectedReceiver, name string, kwargs []star
 		t.Fatalf("%s() error: %v", name, err)
 	}
 	return result
+}
+
+func callMethodArgsKw(t *testing.T, r *ReflectedReceiver, name string, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	t.Helper()
+	attr, err := r.Attr(name)
+	if err != nil {
+		t.Fatalf("Attr(%s) error: %v", name, err)
+	}
+	builtin := attr.(*starlark.Builtin)
+	return builtin.CallInternal(nil, args, kwargs)
 }
 
 func callMethodErr(t *testing.T, r *ReflectedReceiver, name string, args ...starlark.Value) error {
@@ -550,5 +583,115 @@ func TestWrapReceiver_CatalogNoResult_NoShadow(t *testing.T) {
 
 	if catalog.Len() != 0 {
 		t.Errorf("catalog len = %d, want 0 (NoResult should not be shadowed)", catalog.Len())
+	}
+}
+
+// --- Variadic tests ---
+
+func TestCall_Variadic_Positional(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	result := callMethod(t, r, "join", starlark.String("a"), starlark.String("b"), starlark.String("c"))
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "a/b/c" {
+		t.Errorf("join('a','b','c') = %v, want 'a/b/c'", result)
+	}
+}
+
+func TestCall_Variadic_Keyword(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	result := callMethodKw(t, r, "join", []starlark.Tuple{
+		{starlark.String("parts"), starlark.NewList([]starlark.Value{
+			starlark.String("x"), starlark.String("y"),
+		})},
+	})
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "x/y" {
+		t.Errorf("join(parts=['x','y']) = %v, want 'x/y'", result)
+	}
+}
+
+func TestCall_Variadic_Empty(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	result := callMethod(t, r, "join")
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "" {
+		t.Errorf("join() = %v, want ''", result)
+	}
+}
+
+func TestCall_Variadic_Single(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	result := callMethod(t, r, "join", starlark.String("only"))
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "only" {
+		t.Errorf("join('only') = %v, want 'only'", result)
+	}
+}
+
+func TestCall_Variadic_BothPositionalAndKeyword_Error(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	_, err := callMethodArgsKw(t, r, "join",
+		starlark.Tuple{starlark.String("a")},
+		[]starlark.Tuple{
+			{starlark.String("parts"), starlark.NewList([]starlark.Value{starlark.String("b")})},
+		},
+	)
+	if err == nil {
+		t.Fatal("join with both positional and keyword variadic should fail")
+	}
+}
+
+func TestCall_Variadic_WithNamedParam_Positional(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	// prefix("root", "a", "b") → pfx="root", parts=["a", "b"]
+	result := callMethod(t, r, "prefix",
+		starlark.String("root"), starlark.String("a"), starlark.String("b"))
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "root/a/b" {
+		t.Errorf("prefix('root','a','b') = %v, want 'root/a/b'", result)
+	}
+}
+
+func TestCall_Variadic_WithNamedParam_Keyword(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	result := callMethodKw(t, r, "prefix", []starlark.Tuple{
+		{starlark.String("pfx"), starlark.String("root")},
+		{starlark.String("parts"), starlark.NewList([]starlark.Value{
+			starlark.String("c"), starlark.String("d"),
+		})},
+	})
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "root/c/d" {
+		t.Errorf("prefix(pfx='root', parts=['c','d']) = %v, want 'root/c/d'", result)
+	}
+}
+
+func TestCall_Variadic_WithNamedParam_NoVariadicArgs(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	// prefix("root") → pfx="root", parts=[]
+	result := callMethod(t, r, "prefix", starlark.String("root"))
+
+	s, ok := starlark.AsString(result)
+	if !ok || s != "root" {
+		t.Errorf("prefix('root') = %v, want 'root'", result)
+	}
+}
+
+func TestCall_Variadic_KeywordNotList_Error(t *testing.T) {
+	r := wrapTestReceiver("test", &testProvider{}, testParams)
+	_, err := callMethodArgsKw(t, r, "join",
+		nil,
+		[]starlark.Tuple{
+			{starlark.String("parts"), starlark.String("not-a-list")},
+		},
+	)
+	if err == nil {
+		t.Fatal("join(parts='not-a-list') should fail — keyword variadic must be a list")
 	}
 }

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -1117,13 +1117,16 @@ def compute_param_names_list(method):
 
     Replicates templateFuncParamNamesList from codegen.go.
     Callable params are excluded. Optional params get '?' suffix.
+    Variadic params get '*' prefix.
     """
     parts = []
     for p in method.get("params", []):
         if p.get("callable"):
             continue
         name = to_snake(p["name"])
-        if p.get("optional") or p.get("default", ""):
+        if p.get("variadic"):
+            name = "*" + name
+        elif p.get("optional") or p.get("default", ""):
             name += "?"
         parts.append('"' + name + '"')
     return ", ".join(parts)


### PR DESCRIPTION
## Summary

- Variadic Go parameters now accept positional args in Starlark: `file.join("a", "b")` works alongside `file.join(parts=["a", "b"])`
- `buildMethodBridge` detects `*` prefix in `MethodParams` and collects remaining positional args into the variadic slot
- Keyword list fallback preserved; supplying both positional and keyword for the same variadic param is rejected
- `compute_param_names_list` in `generate.star` emits `*name` for variadic Go params — only `file.Join` affected today

## Test plan

- [x] `make clean && make build` succeeds
- [x] `make test` — all tests pass
- [x] `make test-race` — no data races
- [x] 10 unit tests: positional, keyword, empty, single, mixed named+variadic, ambiguity error, type error
- [x] e2e: `file.join("a", "b", "c.txt")` positional + `file.join(parts=[...])` keyword
- [x] e2e: `file.join("a", parts=["b"])` rejected with error
- [x] Planned mode `plan.file.join(parts=[...])` unchanged
- [x] Only `file/gen/params.gen.go` has `*` prefix — no other providers affected