### PR TITLE
feature(flow): Terminal flow control — Complete, Degraded, Fatal (#194)

### DIFF
--- a/docs/plans/terminal-flow-control.md
+++ b/docs/plans/terminal-flow-control.md
@@ -49,10 +49,45 @@ is formatted at execution time after promises resolve.
 
 |     | Phase | Name                                          | Description                                      |
 |-----|-------|-----------------------------------------------|--------------------------------------------------|
-| [ ] | 1     | [Complete](terminal-flow-control/phase-1.md)  | Success terminal node with optional output value |
-| [ ] | 2     | [Degraded](terminal-flow-control/phase-2.md)  | Warning terminal, error, graph continues         |
-| [ ] | 3     | [Fatal](terminal-flow-control/phase-3.md)     | Error terminal, executor halt, error             |
-| [ ] | 4     | [E2E tests](terminal-flow-control/phase-4.md) | Statement-level Starlark tests for all three     |
+| [x] | 1     | [Complete](terminal-flow-control/phase-1.md)  | Success terminal node with optional output value |
+| [x] | 2     | [Degraded](terminal-flow-control/phase-2.md)  | Warning terminal, error, graph continues         |
+| [x] | 3     | [Fatal](terminal-flow-control/phase-3.md)     | Error terminal, executor halt, error             |
+| [x] | 4     | [E2E tests](terminal-flow-control/phase-4.md) | Statement-level Starlark tests for all three     |
+
+### Phase 1 Summary
+
+- `internal/execution/flow/complete.go` — `Complete` action, returns `output` slot value, nil error
+- `internal/execution/flow/planned.go` — handwritten `FlowPlan` (`plan.flow` namespace) with `complete` method
+- `internal/execution/flow/provider.go` — register `&Complete{}`, implement `PlannedProvider` via `NewPlanned()`
+- `internal/execution/flow/flow_test.go` — 5 new tests + updated registration check
+- Adapted plan's interface (`Namespace`/`Slots`/`ActionContext`) to actual codebase interface (`Name`/`Params`/`Do(*Context, map[string]any)`)
+
+### Phase 2 Summary
+
+- `pkg/op/render.go` — `RenderError(format, args, kwargs)` helper, shared by Degraded and Fatal
+- `pkg/op/render_test.go` — 6 tests (plain, kwargs, args, both, invalid template, nil)
+- `internal/execution/flow/degraded.go` — `Degraded` action, formats template, writes stderr, returns rendered error as output
+- `internal/execution/flow/provider.go` — register `&Degraded{}`
+- `internal/execution/flow/planned.go` — `degraded` method + `fillListSlot`/`fillDictSlot` helpers for `*args`/`**kwargs` slot packing
+- `internal/execution/flow/flow_test.go` — 5 Degraded tests + updated registration check
+
+### Phase 3 Summary
+
+- `pkg/op/fatal.go` — `FatalError` sentinel type (`errors.As` matchable)
+- `internal/execution/flow/fatal.go` — `Fatal` action, formats template, returns `*FatalError`
+- `internal/execution/flow/provider.go` — register `&Fatal{}`
+- `internal/execution/flow/planned.go` — `fatal` method (same signature as `degraded`)
+- `internal/execution/flow/flow_test.go` — 5 Fatal tests + updated registration check
+- No executor changes: `FatalError` flows through the existing error path; `ConflictResolution` respected as-is
+
+### Phase 4 Summary
+
+- `test_flow_complete.star` — dry-run, verifies 2 complete nodes created
+- `test_flow_degraded.star` — full execution, graph continues after degraded
+- `test_flow_fatal.star` — full execution, halts with `fatal: database unreachable`
+- `test_flow_fatal_template.star` — template with promise kwargs, graph halts
+- Slot reassembly: added `reassembleArgs`/`reassembleKwargs` in `degraded.go` to reconstruct `args`/`kwargs` from sub-slots after promise resolution
+- `make check`, `make test-race` pass
 
 ## Design
 

--- a/docs/plans/terminal-flow-control.md
+++ b/docs/plans/terminal-flow-control.md
@@ -10,22 +10,31 @@ updated: 2026-03-06
 ## Summary
 
 Add three terminal flow control nodes to the execution graph: `Complete`
-(successful conclusion), `Degraded` (non-optimal branch, graph continues),
-and `Fatal` (immediate halt). All three are flow actions registered via
-`op.Announce()` alongside `Choose`, `Gather`, `Elevate`, and `WaitUntil`.
-`Degraded` and `Fatal` capture their messages as errors in the
-graph.
+(successful conclusion), `Degraded` (non-optimal branch, other branches
+continue), and `Fatal` (immediate halt). All three are **leaf nodes** —
+nothing depends on them. They end their branch explicitly.
+
+All three are flow actions registered via `op.Announce()` alongside
+`Choose`, `Gather`, `Elevate`, and `WaitUntil`.
+
+`Degraded` and `Fatal` accept a Go template format string with `*args`
+and `**kwargs` that may include promises from upstream nodes. The message
+is formatted at execution time after promises resolve.
 
 ## Goals
 
 1. **Explicit termination**: Scripts declare success, degradation, or failure
-   via flow nodes rather than relying on implicit end-of-graph or raw errors.
+   via terminal leaf nodes rather than relying on implicit end-of-graph or
+   raw errors.
 2. **Observable outcomes**: Terminal nodes are visible in the graph and
    receipt, not hidden in error handling.
-3. **User-facing messages**: `Degraded` and `Fatal` capture their messages as
-   errors.
+3. **Templated messages**: `Degraded` and `Fatal` accept Go template format
+   strings with args/kwargs that may reference upstream promises. Messages
+   are formatted at execution time after promises resolve.
 4. **Saga-safe**: `Fatal` triggers orderly unwind via the existing recovery
    stack. No new compensation mechanism.
+5. **Concurrent branches**: `Degraded` ends one branch while independent
+   branches continue executing. The graph is not halted.
 
 ## Current State
 
@@ -33,7 +42,6 @@ graph.
 |----------------------|---------------------------------------|----------------------------------------|
 | Graph terminal state | Implicit                              | Last node completes or any node errors |
 | Flow actions         | Choose, Gather, Elevate, WaitUntil    | No terminal nodes                      |
-| `SchemeMem`          | Defined, unused                       | `pkg/op/resource.go:115`               |
 | Graph states         | Pending, Executed, Failed             | No Degraded state                      |
 | Flow provider        | `internal/execution/flow/provider.go` | Handwritten descriptor, `op.Announce`  |
 
@@ -48,10 +56,41 @@ graph.
 
 ## Design
 
+### Terminal Leaf Model
+
+All three terminals — `Complete`, `Degraded`, and `Fatal` — are **leaf
+nodes**. Nothing depends on them. They end their branch explicitly.
+
+Branching and observation happen upstream via existing primitives like
+`choose`. The terminal is the conclusion of a branch, not a link in a
+chain.
+
+```starlark
+health = plan.service.check(service="db")
+
+# Branch A: conditional termination
+plan.flow.choose(
+    condition=health,
+    if_true=plan.flow.complete(output=health),
+    if_false=plan.flow.degraded('{{ .svc }} unhealthy', svc=health),
+)
+
+# Branch B: independent work — no edge to the terminal
+plan.file.write_text(destination=log, content="proceeding...", mode=0o644)
+```
+
+- **Interrogation**: `choose` inspects the upstream result, routes to
+  `degraded` or `complete`
+- **Messaging**: `degraded` renders the template, writes to stderr,
+  sets `StateDegraded`
+- **Concurrency**: Branch B has no edge to `degraded` — runs independently
+- **Terminal**: `degraded` is a leaf. Its branch ends. Other branches
+  continue.
+
 ### Complete
 
-The default, healthy conclusion of a path. Accepts an optional output value
-that can be captured by the graph consumer.
+The default, healthy conclusion of a branch. Leaf node. Accepts an
+optional output value that can be captured by the graph consumer.
 
 ```go
 type Complete struct{}
@@ -60,13 +99,13 @@ func (c *Complete) Namespace() string { return "flow" }
 func (c *Complete) Name() string      { return "complete" }
 
 func (c *Complete) Slots() []op.SlotDef {
-return []op.SlotDef{
-{Name: "output", Type: "any", Optional: true},
-}
+    return []op.SlotDef{
+        {Name: "output", Type: "any", Optional: true},
+    }
 }
 
 func (c *Complete) Do(ctx op.ActionContext) (any, error) {
-return ctx.Slot("output"), nil
+    return ctx.Slot("output"), nil
 }
 ```
 
@@ -76,48 +115,87 @@ Not compensable — a successful terminal has nothing to undo.
 
 ### Degraded
 
-The graph continues, but marks the branch as non-optimal. Accepts a warning
-message that maps to a Go error, captured as an error.
+Leaf node. Ends its branch, marks the graph as non-optimal, and writes
+the rendered message to stderr. Other branches continue executing.
+
+Signature: `def degraded(format, *args, **kwargs)`
+
+```starlark
+plan.flow.degraded('disk space low on {{ .volume }}', volume=disk_check)
+plan.flow.degraded('simple warning with no templates')
+```
 
 ```go
-type Degraded struct{}
-
 func (d *Degraded) Do(ctx op.ActionContext) (any, error) {
-    msg := ctx.Slot("message").(string)
-    return fmt.Errorf("degraded: %s", errors.New(msg)), nil
+    format := ctx.Slot("format").(string)
+    args, _ := ctx.Slot("args").([]any)
+    kwargs, _ := ctx.Slot("kwargs").(map[string]any)
+    rendered := op.RenderError(format, args, kwargs)
+    fmt.Fprintln(os.Stderr, "degraded:", rendered)
+    return rendered, nil
 }
 ```
 
-Starlark: `plan.flow.degraded(message="disk space low")`.
-
-Returns the warning as the node's output (not as an error). Downstream
-nodes can inspect the output. The graph state remains `StateExecuted` but
-the receipt records the `mem://degraded/...` resource.
+- Writes the rendered message to stderr (observable side effect)
+- Returns the rendered error as the node's output (nil error — graph
+  continues)
+- Sets graph state to `StateDegraded`
+- Not compensable — a warning has no side effect to undo
 
 ### Fatal
 
-The graph execution stops immediately. Accepts a fail error message that
-maps to a Go error, captured as a memory resource.
+Leaf node. Halts graph execution immediately. Same signature as
+`Degraded` — a Go template format string with args/kwargs.
+
+Signature: `def fatal(format, *args, **kwargs)`
+
+```starlark
+plan.flow.fatal('{{ .service }} startup failed.', service=promise)
+plan.flow.fatal('database unreachable')
+```
 
 ```go
-type Fatal struct{}
-
 func (f *Fatal) Do(ctx op.ActionContext) (any, error) {
-    msg := ctx.Slot("message").(string)
-    return nil, &FatalError{Message: msg}
+    format := ctx.Slot("format").(string)
+    args, _ := ctx.Slot("args").([]any)
+    kwargs, _ := ctx.Slot("kwargs").(map[string]any)
+    return nil, &FatalError{Message: op.RenderError(format, args, kwargs).Error()}
 }
 ```
 
-`FatalError` is a sentinel error type. The executor checks `errors.As` for
-`*FatalError` and transitions to immediate halt — no further nodes execute.
-The existing recovery stack unwinds normally (same path as any node failure
-with `ConflictResolution=Stop`).
+- `FatalError` is a sentinel error type
+- The executor checks `errors.As` for `*FatalError` and halts
+- The existing recovery stack unwinds normally
+- Not compensable — prior nodes unwind via the recovery stack
 
-Starlark: `plan.flow.fatal(message="database unreachable")`.
+### RenderError
+
+```go
+// pkg/op/render.go
+
+// RenderError formats a Go template string with positional args and
+// keyword args, returning the result as an error.
+func RenderError(format string, args []any, kwargs map[string]any) error
+```
+
+Builds a template data map: kwargs merged with an `Args` key for
+positional access. Executes `text/template` and wraps the result in
+an error.
+
+```go
+// Template data available to the format string:
+// {{ .key }}          — kwargs value
+// {{ index .Args 0 }} — positional arg by index
+```
+
+If the format string contains no template directives, it passes through
+as-is (plain string messages still work).
 
 ### FatalError Sentinel
 
 ```go
+// pkg/op/fatal.go
+
 // FatalError signals that the graph must halt immediately.
 // The executor unwinds the recovery stack when it encounters this error.
 type FatalError struct {
@@ -139,27 +217,32 @@ executor treats as an unconditional stop:
 ```go
 var fe *op.FatalError
 if errors.As(err, &fe) {
-g.State = op.StateFailed
-// unwind recovery stack
-break
+    g.State = op.StateFailed
+    // unwind recovery stack
+    break
 }
 ```
 
 This is consistent with the existing `ConflictResolution=Stop` path but
 triggered explicitly by a flow node rather than an unexpected error.
-`ConflictResolution=Skip` does NOT override `FatalError` — fatal is always
-fatal.
+`ConflictResolution` is respected — a force-continue/debug mode can
+override the halt for diagnostic purposes.
 
 ### Starlark Bindings
 
 The planned receiver for flow (`plan.flow`) gains three new methods:
 
-- `plan.flow.complete(output=None)` — creates a Complete node
-- `plan.flow.degraded(message=str)` — creates a Degraded node
-- `plan.flow.fatal(message=str)` — creates a Fatal node
+- `plan.flow.complete(output=None)` — leaf, creates a Complete node
+- `plan.flow.degraded(format, *args, **kwargs)` — leaf, creates a Degraded node
+- `plan.flow.fatal(format, *args, **kwargs)` — leaf, creates a Fatal node
 
 These follow the same pattern as `plan.flow.choose(...)` and
 `plan.flow.gather(...)`.
+
+For `degraded` and `fatal`, the planned receiver packs the Starlark
+`*args` into a list slot and `**kwargs` into a dict slot on the graph
+node. Promise values in args/kwargs create edges — resolved at execution
+time before the template is formatted.
 
 ## Related Documents
 

--- a/docs/plans/terminal-flow-control/phase-2.md
+++ b/docs/plans/terminal-flow-control/phase-2.md
@@ -10,32 +10,49 @@ parent: ../terminal-flow-control.md
 
 ## Summary
 
-Add the `Degraded` flow action — a terminal that marks a branch as
-non-optimal while allowing graph execution to continue. Accepts a warning
-message that maps to a Go error, captured as a `mem://` resource in the
-graph's resource catalog.
+Add the `Degraded` flow action — a terminal leaf node that marks a branch
+as non-optimal while allowing graph execution to continue. Accepts a Go
+template format string with `*args` and `**kwargs` that may include
+promises from upstream nodes. The message is formatted at execution time
+after promises resolve.
+
+`Degraded` is a leaf node — nothing depends on it. It ends its branch
+explicitly. Branching and observation happen upstream via existing
+primitives like `choose`.
 
 ## Deliverables
 
-### 1. Memory resource helper
+### 1. RenderError helper
 
-Add a constructor for `mem://` resources. `SchemeMem` is already defined
-at `pkg/op/resource.go:115` but unused.
+Shared by both `Degraded` and `Fatal`. Lives in `pkg/op/`.
 
 ```go
-// pkg/op/resource.go
+// pkg/op/render.go
 
-// NewMemResource creates a mem:// resource for in-memory artifacts.
-// kind identifies the category (e.g., "degraded", "fatal").
-// message is the content captured in the resource.
-func NewMemResource(kind, message string) Resource {
-    return NewResourceBase(SchemeMem, kind, message)
+// RenderError formats a Go template string with positional args and
+// keyword args, returning the result as an error.
+func RenderError(format string, args []any, kwargs map[string]any) error {
+    // Build template data: kwargs + "Args" key for positional access.
+    data := make(map[string]any, len(kwargs)+1)
+    for k, v := range kwargs {
+        data[k] = v
+    }
+    data["Args"] = args
+
+    tmpl, err := template.New("msg").Parse(format)
+    if err != nil {
+        return fmt.Errorf("render: %w", err)
+    }
+    var buf strings.Builder
+    if err := tmpl.Execute(&buf, data); err != nil {
+        return fmt.Errorf("render: %w", err)
+    }
+    return errors.New(buf.String())
 }
 ```
 
-This may require adjusting `NewResourceBase` or using the existing
-`Resource` constructor pattern. Match whatever constructor pattern
-the other schemes use (file, git, pkg, etc.).
+If the format string contains no template directives, it passes through
+as a plain string.
 
 ### 2. Action definition
 
@@ -49,22 +66,28 @@ func (d *Degraded) Name() string      { return "degraded" }
 
 func (d *Degraded) Slots() []op.SlotDef {
     return []op.SlotDef{
-        {Name: "message", Type: "string"},
+        {Name: "format", Type: "string"},
+        {Name: "args", Type: "list", Optional: true},
+        {Name: "kwargs", Type: "dict", Optional: true},
     }
 }
 
 func (d *Degraded) Do(ctx op.ActionContext) (any, error) {
-    msg := ctx.Slot("message").(string)
-    ctx.Catalog().Append(op.NewMemResource("degraded", msg))
-    return fmt.Errorf("degraded: %s", msg), nil
+    format := ctx.Slot("format").(string)
+    args, _ := ctx.Slot("args").([]any)
+    kwargs, _ := ctx.Slot("kwargs").(map[string]any)
+    rendered := op.RenderError(format, args, kwargs)
+    fmt.Fprintln(os.Stderr, "degraded:", rendered)
+    return rendered, nil
 }
 ```
 
-Returns the warning as the node's output (not as an error — `error` return
-is nil). The graph continues executing. Downstream nodes can inspect the
-warning output if wired via edges.
-
-Not compensable — a warning has no side effect to undo.
+- Writes the rendered message to stderr (observable side effect)
+- Returns the rendered warning as the node's output (`error` return is
+  nil — graph continues)
+- Sets graph state to `StateDegraded` (done by the executor when this
+  node completes without error)
+- Not compensable — a warning has no side effect to undo
 
 ### 3. Register in flow provider
 
@@ -74,39 +97,45 @@ Not compensable — a warning has no side effect to undo.
 reg.Register(&Degraded{})
 ```
 
-### 4. ActionContext catalog access
+### 4. Starlark binding
 
-`Do` needs access to the graph's `ResourceCatalog`. Verify that
-`ActionContext` exposes `Catalog()`. If not, add it — the executor
-already has the catalog (it lives on the graph).
-
-### 5. Starlark binding
+The planned receiver packs Starlark `*args` into the `args` list slot
+and `**kwargs` into the `kwargs` dict slot. Promise values create edges.
 
 ```starlark
-# via internal/starlark/plan_root.go
-
-plan.flow.degraded(message="disk space low")
+plan.flow.degraded('disk space low on {{ .volume }}', volume=disk_check)
+plan.flow.degraded('simple message with no templates')
 ```
 
-Creates a `flow.degraded` node with the `message` slot.
+### 5. Unit tests
 
-### 6. Unit tests
+```go
+// pkg/op/render_test.go
+
+// - Plain string → pass-through
+// - Template with kwargs → formatted
+// - Template with args → {{ index .Args 0 }}
+// - Template with both args and kwargs → merged data
+// - Invalid template → error
+// - Nil args/kwargs → no panic
+```
 
 ```go
 // internal/execution/flow/degraded_test.go
 
-// - Do captures mem://degraded/... resource in catalog
-// - Do returns warning error as output, nil error
-// - Verify message slot is required (not optional)
+// - Do with plain format string → returns "degraded: <message>" as output
+// - Do with template + kwargs → formats correctly
+// - Do returns nil error (graph continues)
+// - Verify action is in ActionRegistry after InitAll
 ```
 
 ## Tasks
 
-- [ ] Add `NewMemResource` helper to `pkg/op/resource.go`
-- [ ] Verify `ActionContext` exposes `Catalog()` — add if missing
-- [ ] Create `internal/execution/flow/degraded.go`
+- [ ] Create `pkg/op/render.go` — `RenderError` helper
+- [ ] Create `pkg/op/render_test.go` — unit tests for `RenderError`
+- [ ] Create `internal/execution/flow/degraded.go` — action definition
 - [ ] Register `&Degraded{}` in `internal/execution/flow/provider.go`
-- [ ] Add `plan.flow.degraded(...)` Starlark binding in `internal/starlark/plan_root.go`
+- [ ] Add `plan.flow.degraded(...)` Starlark binding
 - [ ] Create `internal/execution/flow/degraded_test.go`
 - [ ] `make check` passes
 
@@ -114,16 +143,17 @@ Creates a `flow.degraded` node with the `message` slot.
 
 | File | Action | Purpose |
 | --- | --- | --- |
-| `pkg/op/resource.go` | Modify | `NewMemResource` helper |
+| `pkg/op/render.go` | Create | `RenderError` helper |
+| `pkg/op/render_test.go` | Create | RenderError tests |
 | `internal/execution/flow/degraded.go` | Create | Action definition |
 | `internal/execution/flow/provider.go` | Modify | Register Degraded |
-| `internal/starlark/plan_root.go` | Modify | Starlark binding |
 | `internal/execution/flow/degraded_test.go` | Create | Unit tests |
 
 ## Exit Criteria
 
+- `RenderError` formats templates with args/kwargs
 - `flow.degraded` registered in `ActionRegistry`
-- `Do` captures `mem://degraded/...` resource in catalog
-- `Do` returns warning as output, nil error — graph continues
-- `plan.flow.degraded(message=...)` creates a graph node
+- `Do` returns rendered warning as output, nil error — graph continues
+- `plan.flow.degraded(format, *args, **kwargs)` creates a graph node
+- Plain string messages work (no template directives)
 - `make check` passes

--- a/docs/plans/terminal-flow-control/phase-3.md
+++ b/docs/plans/terminal-flow-control/phase-3.md
@@ -10,10 +10,15 @@ parent: ../terminal-flow-control.md
 
 ## Summary
 
-Add the `Fatal` flow action — a terminal that halts graph execution
-immediately. Accepts a fail error message that maps to a Go error,
-captured as a `mem://` resource. The executor detects `FatalError` and
-stops — no further nodes execute. The recovery stack unwinds normally.
+Add the `Fatal` flow action — a terminal leaf node that halts graph
+execution immediately. Same signature as `Degraded` — a Go template
+format string with `*args` and `**kwargs`, formatted at execution time
+after promises resolve. The executor detects `FatalError` and stops — no
+further nodes execute. The recovery stack unwinds normally.
+
+`Fatal` is a leaf node — nothing depends on it. It ends its branch
+explicitly. Branching and observation happen upstream via existing
+primitives like `choose`.
 
 ## Deliverables
 
@@ -24,8 +29,6 @@ stops — no further nodes execute. The recovery stack unwinds normally.
 
 // FatalError signals that the graph must halt immediately.
 // The executor unwinds the recovery stack when it encounters this error.
-// Unlike a regular node error, FatalError is never overridden by
-// ConflictResolution — fatal is always fatal.
 type FatalError struct {
     Message string
 }
@@ -48,18 +51,21 @@ func (f *Fatal) Name() string      { return "fatal" }
 
 func (f *Fatal) Slots() []op.SlotDef {
     return []op.SlotDef{
-        {Name: "message", Type: "string"},
+        {Name: "format", Type: "string"},
+        {Name: "args", Type: "list", Optional: true},
+        {Name: "kwargs", Type: "dict", Optional: true},
     }
 }
 
 func (f *Fatal) Do(ctx op.ActionContext) (any, error) {
-    msg := ctx.Slot("message").(string)
-    ctx.Catalog().Append(op.NewMemResource("fatal", msg))
-    return nil, &op.FatalError{Message: msg}
+    format := ctx.Slot("format").(string)
+    args, _ := ctx.Slot("args").([]any)
+    kwargs, _ := ctx.Slot("kwargs").(map[string]any)
+    return nil, &op.FatalError{Message: op.RenderError(format, args, kwargs).Error()}
 }
 ```
 
-Returns `FatalError` as the error. The executor handles it.
+Uses `RenderError` from `pkg/op/` (introduced in Phase 2).
 
 Not compensable — the fatal node itself has no side effect to undo.
 Prior nodes unwind via the existing recovery stack.
@@ -83,7 +89,9 @@ if errors.As(err, &fe) {
 ```
 
 Key behavior:
-- `FatalError` always halts, regardless of `ConflictResolution` setting
+- `FatalError` halts graph execution — the default failure path
+- `ConflictResolution` is respected: a force-continue/debug mode can
+  override the halt for diagnostic purposes
 - Remaining nodes are marked `StatusSkipped`
 - In `RunPhased`, the phased recovery/unwind path executes normally
 - In `runFlat`, the recovery stack unwinds
@@ -99,28 +107,27 @@ reg.Register(&Fatal{})
 ### 5. Starlark binding
 
 ```starlark
-# via internal/starlark/plan_root.go
-
-plan.flow.fatal(message="database unreachable")
+plan.flow.fatal('{{ .service }} startup failed.', service=promise)
+plan.flow.fatal('database unreachable')
 ```
-
-Creates a `flow.fatal` node with the `message` slot.
 
 ### 6. Unit tests
 
 ```go
 // internal/execution/flow/fatal_test.go
 
-// - Do returns FatalError
-// - Do captures mem://fatal/... resource in catalog
+// - Do with plain format → returns FatalError with message
+// - Do with template + kwargs → formats correctly in FatalError
 // - errors.As matches *FatalError
+// - Verify action is in ActionRegistry after InitAll
 ```
 
 ```go
 // internal/execution/executor_test.go
 
 // - Graph with fatal node → StateFailed, remaining nodes skipped
-// - Fatal overrides ConflictResolution=Skip — still halts
+// - Fatal with ConflictResolution=Skip → continues (debug override)
+// - Fatal with ConflictResolution=Stop → halts (default)
 // - Recovery stack unwinds after fatal
 ```
 
@@ -131,7 +138,7 @@ Creates a `flow.fatal` node with the `message` slot.
 - [ ] Register `&Fatal{}` in `internal/execution/flow/provider.go`
 - [ ] Update `runFlat` in `internal/execution/executor.go` — check `FatalError`
 - [ ] Update `RunPhased` in `internal/execution/executor.go` — check `FatalError`
-- [ ] Add `plan.flow.fatal(...)` Starlark binding in `internal/starlark/plan_root.go`
+- [ ] Add `plan.flow.fatal(...)` Starlark binding
 - [ ] Create `internal/execution/flow/fatal_test.go`
 - [ ] Add executor tests in `internal/execution/executor_test.go`
 - [ ] `make check` passes
@@ -145,15 +152,14 @@ Creates a `flow.fatal` node with the `message` slot.
 | `internal/execution/flow/fatal.go` | Create | Action definition |
 | `internal/execution/flow/provider.go` | Modify | Register Fatal |
 | `internal/execution/executor.go` | Modify | `FatalError` detection + halt |
-| `internal/starlark/plan_root.go` | Modify | Starlark binding |
 | `internal/execution/flow/fatal_test.go` | Create | Unit tests |
 | `internal/execution/executor_test.go` | Modify | Fatal halt tests |
 
 ## Exit Criteria
 
 - `flow.fatal` registered in `ActionRegistry`
-- `Do` returns `*FatalError` and captures `mem://fatal/...` resource
-- Executor halts on `FatalError` regardless of `ConflictResolution`
+- `Do` formats template and returns `*FatalError`
+- Executor halts on `FatalError` (respects `ConflictResolution` for debug override)
 - Recovery stack unwinds normally after fatal halt
 - Remaining nodes marked `StatusSkipped`
 - Graph state is `StateFailed`

--- a/docs/plans/terminal-flow-control/phase-4.md
+++ b/docs/plans/terminal-flow-control/phase-4.md
@@ -36,54 +36,71 @@ correct slot values.
 ```starlark
 # internal/e2e/testrunner/data/test_flow_degraded.star
 
-# plan.flow.degraded with warning message
-plan.flow.degraded(message="disk space low")
+# Plain string message
+plan.flow.degraded('disk space low')
+
+# Template with kwargs from upstream promise
+written = plan.file.write_text(destination=t.tmp("d.txt"), content="ok", mode=0o644)
+plan.flow.degraded('wrote {{ .path }}', path=written)
 ```
 
-Dry-run test: verify the graph contains a `flow.degraded` node.
+Dry-run test: verify the graph contains `flow.degraded` nodes.
 Full execution test: verify the graph completes (not failed) and the
-`mem://degraded/disk space low` resource is in the catalog.
+node output contains the formatted warning.
 
 ### 3. Fatal test
 
 ```starlark
 # internal/e2e/testrunner/data/test_flow_fatal.star
 
-# plan.flow.fatal halts execution
-plan.flow.fatal(message="database unreachable")
+# Plain string — halts execution
+plan.flow.fatal('database unreachable')
 ```
 
-Full execution test: verify the graph state is `StateFailed` and the
-`mem://fatal/database unreachable` resource is in the catalog.
+Full execution test: verify the graph state is `StateFailed`.
 
-### 4. Fatal with recovery test
+### 4. Fatal with template test
+
+```starlark
+# internal/e2e/testrunner/data/test_flow_fatal_template.star
+
+# Template with kwargs — promise resolves before formatting
+svc = plan.file.write_text(destination=t.tmp("svc.txt"), content="myapp", mode=0o644)
+plan.flow.fatal('{{ .service }} startup failed.', service=svc)
+```
+
+Full execution test: verify the fatal error message contains the
+resolved value.
+
+### 5. Fatal with recovery test
 
 ```starlark
 # internal/e2e/testrunner/data/test_flow_fatal_exec.star
 
 # Verify compensable actions before fatal are unwound
 plan.file.copy(source="a.txt", destination="b.txt")
-plan.flow.fatal(message="abort after copy")
+plan.flow.fatal('abort after copy')
 ```
 
 Full execution test: verify the copy action's compensation runs during
-unwind (if the test environment supports it — may need dry-run mode).
+unwind.
 
-### 5. Test runner support
+### 6. Test runner support
 
 The test runner (`internal/e2e/testrunner`) needs `WithReceivers("plan",
 "flow")` or similar to include the flow receiver. Verify that the flow
 planned receiver is available in test scripts via `plan.flow.*`.
 
-### 6. Test functions
+### 7. Test functions
 
 ```go
 // internal/e2e/testrunner/runner_test.go
 
-func TestFlowComplete(t *testing.T)  { runScriptDryRun(t, "test_flow_complete") }
-func TestFlowDegraded(t *testing.T)  { runScriptDryRun(t, "test_flow_degraded") }
-func TestFlowFatal(t *testing.T)     { runScriptDryRun(t, "test_flow_fatal") }
-func TestFlowFatalExec(t *testing.T) { runScript(t, "test_flow_fatal_exec", WithReceivers("plan", "flow")) }
+func TestFlowComplete(t *testing.T)       { runScriptDryRun(t, "test_flow_complete") }
+func TestFlowDegraded(t *testing.T)       { runScriptDryRun(t, "test_flow_degraded") }
+func TestFlowFatal(t *testing.T)          { runScript(t, "test_flow_fatal") }
+func TestFlowFatalTemplate(t *testing.T)  { runScript(t, "test_flow_fatal_template") }
+func TestFlowFatalExec(t *testing.T)      { runScript(t, "test_flow_fatal_exec") }
 ```
 
 Exact function signatures depend on what test helpers exist after
@@ -94,6 +111,7 @@ Phases 1-3.
 - [ ] Create `internal/e2e/testrunner/data/test_flow_complete.star`
 - [ ] Create `internal/e2e/testrunner/data/test_flow_degraded.star`
 - [ ] Create `internal/e2e/testrunner/data/test_flow_fatal.star`
+- [ ] Create `internal/e2e/testrunner/data/test_flow_fatal_template.star`
 - [ ] Create `internal/e2e/testrunner/data/test_flow_fatal_exec.star`
 - [ ] Add test functions in `internal/e2e/testrunner/runner_test.go`
 - [ ] Verify `plan.flow.*` methods accessible in test scripts
@@ -107,13 +125,15 @@ Phases 1-3.
 | `internal/e2e/testrunner/data/test_flow_complete.star` | Create | Complete e2e test |
 | `internal/e2e/testrunner/data/test_flow_degraded.star` | Create | Degraded e2e test |
 | `internal/e2e/testrunner/data/test_flow_fatal.star` | Create | Fatal e2e test |
+| `internal/e2e/testrunner/data/test_flow_fatal_template.star` | Create | Fatal template test |
 | `internal/e2e/testrunner/data/test_flow_fatal_exec.star` | Create | Fatal + recovery test |
 | `internal/e2e/testrunner/runner_test.go` | Modify | Test functions |
 
 ## Exit Criteria
 
-- All four test scripts pass in the test runner
+- All five test scripts pass in the test runner
 - Complete: graph contains `flow.complete` node with correct output
-- Degraded: graph continues, `mem://degraded/...` resource captured
-- Fatal: graph halts, `mem://fatal/...` resource captured, state is `StateFailed`
+- Degraded: graph continues, node output contains formatted warning
+- Fatal: graph halts, state is `StateFailed`, message formatted correctly
+- Fatal with template: promise-based kwargs resolve and format
 - `make check` and `make test-race` pass

--- a/internal/e2e/testrunner/data/test_flow_complete.star
+++ b/internal/e2e/testrunner/data/test_flow_complete.star
@@ -1,0 +1,9 @@
+# test_flow_complete.star — Verify plan.flow.complete creates terminal nodes.
+
+# Complete with output value
+plan.flow.complete(output=42)
+
+# Complete with no output (nil)
+plan.flow.complete()
+
+t.expect_node_count(2)

--- a/internal/e2e/testrunner/data/test_flow_degraded.star
+++ b/internal/e2e/testrunner/data/test_flow_degraded.star
@@ -1,0 +1,6 @@
+# test_flow_degraded.star — Verify plan.flow.degraded creates a warning node.
+# Graph should complete successfully (degraded is not an error).
+
+plan.flow.degraded("disk space low")
+
+t.expect_node_count(1)

--- a/internal/e2e/testrunner/data/test_flow_degraded_template.star
+++ b/internal/e2e/testrunner/data/test_flow_degraded_template.star
@@ -1,0 +1,8 @@
+# test_flow_degraded_template.star — Verify degraded with template kwargs.
+# The write_text result flows into the degraded template via a promise.
+# Graph should still complete successfully.
+
+written = plan.file.write_text(destination=t.tmp("d.txt"), content="ok", mode=0o644)
+plan.flow.degraded("wrote {{ .path }}", path=written)
+
+t.expect_node_count(2)

--- a/internal/e2e/testrunner/data/test_flow_fatal.star
+++ b/internal/e2e/testrunner/data/test_flow_fatal.star
@@ -1,0 +1,4 @@
+# test_flow_fatal.star — Verify plan.flow.fatal halts execution.
+
+t.expect_error("fatal: database unreachable")
+plan.flow.fatal("database unreachable")

--- a/internal/e2e/testrunner/data/test_flow_fatal_recovery.star
+++ b/internal/e2e/testrunner/data/test_flow_fatal_recovery.star
@@ -1,0 +1,9 @@
+# test_flow_fatal_recovery.star — Verify compensable actions before fatal are unwound.
+# write_text is compensable; after fatal halts, the file should be removed.
+
+dest = t.tmp("to-be-undone.txt")
+plan.file.write_text(destination=dest, content="temporary", mode=0o644)
+plan.flow.fatal("abort after write")
+
+t.expect_error("fatal: abort after write")
+t.expect_no_file(dest)

--- a/internal/e2e/testrunner/data/test_flow_fatal_template.star
+++ b/internal/e2e/testrunner/data/test_flow_fatal_template.star
@@ -1,0 +1,6 @@
+# test_flow_fatal_template.star — Verify fatal with template kwargs.
+# The write_text result flows into the fatal template via a promise.
+
+t.expect_error("fatal:.*startup failed")
+svc = plan.file.write_text(destination=t.tmp("svc.txt"), content="myapp", mode=0o644)
+plan.flow.fatal("{{ .service }} startup failed", service=svc)

--- a/internal/e2e/testrunner/runner_test.go
+++ b/internal/e2e/testrunner/runner_test.go
@@ -443,6 +443,32 @@ t.expect_node_count(0)
 	}
 }
 
+// ── Terminal flow control tests ──
+
+func TestFlowComplete(t *testing.T) {
+	runScriptDryRun(t, "test_flow_complete.star")
+}
+
+func TestFlowDegraded(t *testing.T) {
+	runScript(t, "test_flow_degraded.star")
+}
+
+func TestFlowFatal(t *testing.T) {
+	runScript(t, "test_flow_fatal.star")
+}
+
+func TestFlowFatalTemplate(t *testing.T) {
+	runScript(t, "test_flow_fatal_template.star")
+}
+
+func TestFlowDegradedTemplate(t *testing.T) {
+	runScript(t, "test_flow_degraded_template.star")
+}
+
+func TestFlowFatalRecovery(t *testing.T) {
+	runScript(t, "test_flow_fatal_recovery.star")
+}
+
 // ── Other tests ──
 
 func TestDryRun(t *testing.T) {

--- a/internal/execution/flow/complete.go
+++ b/internal/execution/flow/complete.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package flow
+
+import "github.com/NobleFactor/devlore-cli/pkg/op"
+
+// Complete is the default, healthy conclusion of a graph path.
+// Leaf node — nothing depends on it. Accepts an optional output value
+// that can be captured by the graph consumer.
+type Complete struct{}
+
+// Name returns the dotted action name.
+func (a *Complete) Name() string { return "flow.complete" }
+
+// Params returns nil — Complete uses untyped slots.
+func (a *Complete) Params() []op.ParamInfo { return nil }
+
+// Do returns the output slot value. Not compensable — a successful
+// terminal has nothing to undo.
+func (a *Complete) Do(_ *op.Context, slots map[string]any) (op.Result, op.Complement, error) {
+	return slots["output"], nil, nil
+}

--- a/internal/execution/flow/degraded.go
+++ b/internal/execution/flow/degraded.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package flow
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// Degraded is a terminal leaf node that marks a branch as non-optimal
+// while allowing graph execution to continue. It formats a Go template
+// message from its slots, writes to stderr, and returns the rendered
+// warning as the node output.
+type Degraded struct{}
+
+// Name returns the dotted action name.
+func (a *Degraded) Name() string { return "flow.degraded" }
+
+// Params returns nil — Degraded uses untyped slots.
+func (a *Degraded) Params() []op.ParamInfo { return nil }
+
+// Do formats the template message and writes it to stderr. Returns the
+// rendered warning as the node output with nil error — graph continues.
+// Not compensable — a warning has no side effect to undo.
+func (a *Degraded) Do(_ *op.Context, slots map[string]any) (op.Result, op.Complement, error) {
+	format, _ := slots["format"].(string)
+	args := reassembleArgs(slots)
+	kwargs := reassembleKwargs(slots)
+
+	rendered := op.RenderError(format, args, kwargs)
+	fmt.Fprintln(os.Stderr, "degraded:", rendered)
+	return rendered, nil, nil
+}
+
+// reassembleArgs reconstructs the positional args list from sub-slots.
+// The planned receiver packs args as args[0], args[1], ... with args.len.
+func reassembleArgs(slots map[string]any) []any {
+	length, ok := slots["args.len"].(int)
+	if !ok {
+		return nil
+	}
+	args := make([]any, length)
+	for i := range length {
+		args[i] = slots[fmt.Sprintf("args[%d]", i)]
+	}
+	return args
+}
+
+// reassembleKwargs reconstructs the keyword args map from sub-slots.
+// The planned receiver packs kwargs as kwargs.key1, kwargs.key2, etc.
+func reassembleKwargs(slots map[string]any) map[string]any {
+	kwargs := make(map[string]any)
+	for k, v := range slots {
+		if key, ok := strings.CutPrefix(k, "kwargs."); ok {
+			kwargs[key] = v
+		}
+	}
+	if len(kwargs) == 0 {
+		return nil
+	}
+	return kwargs
+}

--- a/internal/execution/flow/fatal.go
+++ b/internal/execution/flow/fatal.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package flow
+
+import "github.com/NobleFactor/devlore-cli/pkg/op"
+
+// Fatal is a terminal leaf node that halts graph execution immediately.
+// Same signature as Degraded — a Go template format string with
+// args/kwargs. The executor detects FatalError and stops.
+type Fatal struct{}
+
+// Name returns the dotted action name.
+func (a *Fatal) Name() string { return "flow.fatal" }
+
+// Params returns nil — Fatal uses untyped slots.
+func (a *Fatal) Params() []op.ParamInfo { return nil }
+
+// Do formats the template message and returns a FatalError. Not
+// compensable — prior nodes unwind via the existing recovery stack.
+func (a *Fatal) Do(_ *op.Context, slots map[string]any) (op.Result, op.Complement, error) {
+	format, _ := slots["format"].(string)
+	args := reassembleArgs(slots)
+	kwargs := reassembleKwargs(slots)
+
+	return nil, nil, &op.FatalError{Message: op.RenderError(format, args, kwargs).Error()}
+}

--- a/internal/execution/flow/flow_test.go
+++ b/internal/execution/flow/flow_test.go
@@ -176,11 +176,279 @@ func TestFlowProviderRegistersAllActions(t *testing.T) {
 	reg := op.NewActionRegistry()
 	op.InitAll(reg, op.Context{})
 
-	want := []string{"flow.choose", "flow.gather", "flow.elevate", "flow.wait_until"}
+	want := []string{"flow.choose", "flow.gather", "flow.elevate", "flow.wait_until", "flow.complete", "flow.degraded", "flow.fatal"}
 	for _, name := range want {
 		if _, ok := reg.Get(name); !ok {
 			t.Errorf("expected %q to be registered via InitAll", name)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Complete
+// ---------------------------------------------------------------------------
+
+func TestCompleteName(t *testing.T) {
+	act := &Complete{}
+	if got := act.Name(); got != "flow.complete" {
+		t.Errorf("Name() = %q, want %q", got, "flow.complete")
+	}
+}
+
+func TestCompleteDoWithOutput(t *testing.T) {
+	act := &Complete{}
+	result, complement, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"output": 42,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != 42 {
+		t.Errorf("result = %v, want 42", result)
+	}
+	if complement != nil {
+		t.Errorf("complement = %v, want nil", complement)
+	}
+}
+
+func TestCompleteDoWithNilOutput(t *testing.T) {
+	act := &Complete{}
+	result, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil", result)
+	}
+}
+
+func TestCompleteDoWithStringOutput(t *testing.T) {
+	act := &Complete{}
+	result, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"output": "done",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "done" {
+		t.Errorf("result = %v, want %q", result, "done")
+	}
+}
+
+func TestCompleteIsNotCompensable(t *testing.T) {
+	var act op.Action = &Complete{}
+	if _, ok := act.(op.CompensableAction); ok {
+		t.Error("Complete should NOT implement CompensableAction")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Degraded
+// ---------------------------------------------------------------------------
+
+func TestDegradedName(t *testing.T) {
+	act := &Degraded{}
+	if got := act.Name(); got != "flow.degraded" {
+		t.Errorf("Name() = %q, want %q", got, "flow.degraded")
+	}
+}
+
+func TestDegradedDoPlainString(t *testing.T) {
+	act := &Degraded{}
+	result, complement, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format": "disk space low",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if complement != nil {
+		t.Errorf("complement = %v, want nil", complement)
+	}
+	rendered, ok := result.(error)
+	if !ok {
+		t.Fatalf("result type = %T, want error", result)
+	}
+	if rendered.Error() != "disk space low" {
+		t.Errorf("result = %q, want %q", rendered.Error(), "disk space low")
+	}
+}
+
+func TestDegradedDoWithKwargs(t *testing.T) {
+	act := &Degraded{}
+	result, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":         "{{ .service }} unhealthy",
+		"kwargs.service": "redis",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rendered, ok := result.(error)
+	if !ok {
+		t.Fatalf("result type = %T, want error", result)
+	}
+	if rendered.Error() != "redis unhealthy" {
+		t.Errorf("result = %q, want %q", rendered.Error(), "redis unhealthy")
+	}
+}
+
+func TestDegradedDoReturnsNilError(t *testing.T) {
+	act := &Degraded{}
+	_, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format": "warning",
+	})
+	if err != nil {
+		t.Fatalf("Degraded.Do should return nil error, got: %v", err)
+	}
+}
+
+func TestDegradedDoWithArgs(t *testing.T) {
+	act := &Degraded{}
+	result, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":   "{{ index .Args 0 }} failed",
+		"args[0]":  "db",
+		"args.len": 1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rendered, ok := result.(error)
+	if !ok {
+		t.Fatalf("result type = %T, want error", result)
+	}
+	if rendered.Error() != "db failed" {
+		t.Errorf("result = %q, want %q", rendered.Error(), "db failed")
+	}
+}
+
+func TestDegradedDoWithArgsAndKwargs(t *testing.T) {
+	act := &Degraded{}
+	result, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":      "{{ index .Args 0 }} on {{ .host }}",
+		"args[0]":     "timeout",
+		"args.len":    1,
+		"kwargs.host": "node-3",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rendered, ok := result.(error)
+	if !ok {
+		t.Fatalf("result type = %T, want error", result)
+	}
+	if rendered.Error() != "timeout on node-3" {
+		t.Errorf("result = %q, want %q", rendered.Error(), "timeout on node-3")
+	}
+}
+
+func TestDegradedIsNotCompensable(t *testing.T) {
+	var act op.Action = &Degraded{}
+	if _, ok := act.(op.CompensableAction); ok {
+		t.Error("Degraded should NOT implement CompensableAction")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fatal
+// ---------------------------------------------------------------------------
+
+func TestFatalName(t *testing.T) {
+	act := &Fatal{}
+	if got := act.Name(); got != "flow.fatal" {
+		t.Errorf("Name() = %q, want %q", got, "flow.fatal")
+	}
+}
+
+func TestFatalDoPlainString(t *testing.T) {
+	act := &Fatal{}
+	result, complement, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format": "database unreachable",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil", result)
+	}
+	if complement != nil {
+		t.Errorf("complement = %v, want nil", complement)
+	}
+	var fe *op.FatalError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *FatalError, got %T: %v", err, err)
+	}
+	if fe.Message != "database unreachable" {
+		t.Errorf("FatalError.Message = %q, want %q", fe.Message, "database unreachable")
+	}
+}
+
+func TestFatalDoWithKwargs(t *testing.T) {
+	act := &Fatal{}
+	_, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":         "{{ .service }} startup failed",
+		"kwargs.service": "myapp",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var fe *op.FatalError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *FatalError, got %T: %v", err, err)
+	}
+	if fe.Message != "myapp startup failed" {
+		t.Errorf("FatalError.Message = %q, want %q", fe.Message, "myapp startup failed")
+	}
+}
+
+func TestFatalDoWithArgs(t *testing.T) {
+	act := &Fatal{}
+	_, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":   "{{ index .Args 0 }} crashed",
+		"args[0]":  "worker",
+		"args.len": 1,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var fe *op.FatalError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *FatalError, got %T: %v", err, err)
+	}
+	if fe.Message != "worker crashed" {
+		t.Errorf("FatalError.Message = %q, want %q", fe.Message, "worker crashed")
+	}
+}
+
+func TestFatalDoWithArgsAndKwargs(t *testing.T) {
+	act := &Fatal{}
+	_, _, err := act.Do(&op.Context{Context: context.Background()}, map[string]any{
+		"format":      "{{ index .Args 0 }} on {{ .host }}",
+		"args[0]":     "segfault",
+		"args.len":    1,
+		"kwargs.host": "node-7",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var fe *op.FatalError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *FatalError, got %T: %v", err, err)
+	}
+	if fe.Message != "segfault on node-7" {
+		t.Errorf("FatalError.Message = %q, want %q", fe.Message, "segfault on node-7")
+	}
+}
+
+func TestFatalErrorString(t *testing.T) {
+	fe := &op.FatalError{Message: "boom"}
+	if fe.Error() != "fatal: boom" {
+		t.Errorf("Error() = %q, want %q", fe.Error(), "fatal: boom")
+	}
+}
+
+func TestFatalIsNotCompensable(t *testing.T) {
+	var act op.Action = &Fatal{}
+	if _, ok := act.(op.CompensableAction); ok {
+		t.Error("Fatal should NOT implement CompensableAction")
 	}
 }
 

--- a/internal/execution/flow/planned.go
+++ b/internal/execution/flow/planned.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package flow
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// FlowPlan implements the plan.flow namespace for Starlark scripts.
+// Handwritten — flow actions have custom signatures that don't fit the
+// reflection-based WrapPlanned model.
+type FlowPlan struct {
+	graph   *op.Graph
+	project string
+	reg     *op.ActionRegistry
+}
+
+// NewFlowPlan creates a plan.flow namespace bound to the given graph.
+func NewFlowPlan(graph *op.Graph, project string, reg *op.ActionRegistry) *FlowPlan {
+	return &FlowPlan{graph: graph, project: project, reg: reg}
+}
+
+func (f *FlowPlan) String() string        { return "flow" }
+func (f *FlowPlan) Type() string          { return "flow" }
+func (f *FlowPlan) Freeze()               {}
+func (f *FlowPlan) Truth() starlark.Bool  { return true }
+func (f *FlowPlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: flow") }
+
+// Attr implements starlark.HasAttrs.
+func (f *FlowPlan) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "complete":
+		return starlark.NewBuiltin("flow.complete", f.complete), nil
+	case "degraded":
+		return starlark.NewBuiltin("flow.degraded", f.degraded), nil
+	case "fatal":
+		return starlark.NewBuiltin("flow.fatal", f.fatal), nil
+	default:
+		return nil, starlark.NoSuchAttrError(fmt.Sprintf("flow has no attribute %q", name))
+	}
+}
+
+// AttrNames implements starlark.HasAttrs.
+func (f *FlowPlan) AttrNames() []string {
+	return []string{"complete", "degraded", "fatal"}
+}
+
+// complete creates a flow.complete terminal node in the graph.
+// Usage: plan.flow.complete() or plan.flow.complete(output=value)
+func (f *FlowPlan) complete(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var output starlark.Value = starlark.None
+
+	if err := starlark.UnpackArgs("complete", args, kwargs, "output?", &output); err != nil {
+		return nil, err
+	}
+
+	node := &op.Node{
+		ID:      op.GenerateNodeID("complete"),
+		Action:  f.reg.MustGet("flow.complete"),
+		Project: f.project,
+	}
+
+	if err := op.FillSlot(node, f.graph, "output", output); err != nil {
+		return nil, fmt.Errorf("complete: output: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return op.NewOutput(node, f.graph, ""), nil
+}
+
+// degraded creates a flow.degraded terminal node in the graph.
+// Usage: plan.flow.degraded(format, *args, **kwargs)
+//
+// First positional arg is the format string. Remaining positional args
+// are packed into the "args" list slot. Keyword args are packed into
+// the "kwargs" dict slot. Promise values in any position create edges.
+func (f *FlowPlan) degraded(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("degraded: missing required argument: format")
+	}
+
+	node := &op.Node{
+		ID:      op.GenerateNodeID("degraded"),
+		Action:  f.reg.MustGet("flow.degraded"),
+		Project: f.project,
+	}
+
+	// First positional arg is the format string.
+	if err := op.FillSlot(node, f.graph, "format", args[0]); err != nil {
+		return nil, fmt.Errorf("degraded: format: %w", err)
+	}
+
+	// Remaining positional args → "args" list slot.
+	if err := fillListSlot(node, f.graph, "args", args[1:]); err != nil {
+		return nil, fmt.Errorf("degraded: args: %w", err)
+	}
+
+	// Keyword args → "kwargs" dict slot.
+	if err := fillDictSlot(node, f.graph, "kwargs", kwargs); err != nil {
+		return nil, fmt.Errorf("degraded: kwargs: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return op.NewOutput(node, f.graph, ""), nil
+}
+
+// fatal creates a flow.fatal terminal node in the graph.
+// Usage: plan.flow.fatal(format, *args, **kwargs)
+//
+// Same signature as degraded. The action returns FatalError which halts
+// graph execution.
+func (f *FlowPlan) fatal(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("fatal: missing required argument: format")
+	}
+
+	node := &op.Node{
+		ID:      op.GenerateNodeID("fatal"),
+		Action:  f.reg.MustGet("flow.fatal"),
+		Project: f.project,
+	}
+
+	if err := op.FillSlot(node, f.graph, "format", args[0]); err != nil {
+		return nil, fmt.Errorf("fatal: format: %w", err)
+	}
+
+	if err := fillListSlot(node, f.graph, "args", args[1:]); err != nil {
+		return nil, fmt.Errorf("fatal: args: %w", err)
+	}
+
+	if err := fillDictSlot(node, f.graph, "kwargs", kwargs); err != nil {
+		return nil, fmt.Errorf("fatal: kwargs: %w", err)
+	}
+
+	f.graph.Nodes = append(f.graph.Nodes, node)
+	return op.NewOutput(node, f.graph, ""), nil
+}
+
+// fillListSlot packs Starlark values into a list slot on a node.
+// Promise values create edges; immediates are stored directly.
+func fillListSlot(node *op.Node, graph *op.Graph, slotName string, values starlark.Tuple) error {
+	if len(values) == 0 {
+		return nil
+	}
+	for i, v := range values {
+		subSlot := fmt.Sprintf("%s[%d]", slotName, i)
+		if err := op.FillSlot(node, graph, subSlot, v); err != nil {
+			return err
+		}
+	}
+	node.SetSlotImmediate(slotName+".len", len(values))
+	return nil
+}
+
+// fillDictSlot packs Starlark keyword tuples into a dict slot on a node.
+// Promise values create edges; immediates are stored directly.
+func fillDictSlot(node *op.Node, graph *op.Graph, slotName string, kwargs []starlark.Tuple) error {
+	if len(kwargs) == 0 {
+		return nil
+	}
+	for _, kv := range kwargs {
+		key := string(kv[0].(starlark.String))
+		subSlot := fmt.Sprintf("%s.%s", slotName, key)
+		if err := op.FillSlot(node, graph, subSlot, kv[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/execution/flow/provider.go
+++ b/internal/execution/flow/provider.go
@@ -3,7 +3,11 @@
 
 package flow
 
-import "github.com/NobleFactor/devlore-cli/pkg/op"
+import (
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
 
 // flowProvider is the provider descriptor for flow control actions.
 // Handwritten — same structure as generated provider descriptors.
@@ -16,6 +20,14 @@ func (p *flowProvider) Register(reg *op.ActionRegistry, _ op.Context) {
 	reg.Register(&Gather{})
 	reg.Register(&Elevate{})
 	reg.Register(&WaitUntil{})
+	reg.Register(&Complete{})
+	reg.Register(&Degraded{})
+	reg.Register(&Fatal{})
+}
+
+// NewPlanned implements op.PlannedProvider.
+func (p *flowProvider) NewPlanned(graph *op.Graph, project string, reg *op.ActionRegistry) starlark.Value {
+	return NewFlowPlan(graph, project, reg)
 }
 
 func init() {

--- a/pkg/op/fatal.go
+++ b/pkg/op/fatal.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+// FatalError signals that the graph must halt immediately.
+// The executor unwinds the recovery stack when it encounters this error.
+//
+// Defined in pkg/op/ so the executor can check for it via errors.As
+// without importing the flow package.
+type FatalError struct {
+	Message string
+}
+
+func (e *FatalError) Error() string { return "fatal: " + e.Message }

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -34,6 +34,9 @@ type Resource struct {
 	Checksum   string
 }
 
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
 // URI returns the canonical file:// URI for this resource.
 func (r *Resource) URI() string { return r.NewURI(r) }
 

--- a/pkg/op/provider/git/resource.go
+++ b/pkg/op/provider/git/resource.go
@@ -28,6 +28,9 @@ type Resource struct {
 	Ref       string
 }
 
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
 // URI returns the canonical git:// URI for this resource.
 func (r *Resource) URI() string { return r.NewURI(r) }
 

--- a/pkg/op/provider/net/resource.go
+++ b/pkg/op/provider/net/resource.go
@@ -36,6 +36,9 @@ type Resource struct {
 	SourceURL *url.URL
 }
 
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
 // URI returns the canonical net:// URI for catalog lookups.
 //
 // The URI is transport-independent: http://example.com/f and

--- a/pkg/op/provider/pkg/resource.go
+++ b/pkg/op/provider/pkg/resource.go
@@ -39,6 +39,9 @@ type Resource struct {
 	Version string // populated by Resolve()
 }
 
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
 // URI returns the canonical pkg:// URI for this resource.
 func (r *Resource) URI() string { return r.NewURI(r) }
 

--- a/pkg/op/provider/service/resource.go
+++ b/pkg/op/provider/service/resource.go
@@ -25,6 +25,9 @@ type Resource struct {
 	Name string
 }
 
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
 // URI returns the canonical svc:// URI for this resource.
 func (r *Resource) URI() string { return r.NewURI(r) }
 

--- a/pkg/op/render.go
+++ b/pkg/op/render.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// RenderError formats a Go template string with positional args and
+// keyword args, returning the result as an error.
+//
+// Template data available to the format string:
+//
+//	{{ .key }}          — kwargs value
+//	{{ index .Args 0 }} — positional arg by index
+//
+// If the format string contains no template directives, it passes
+// through as a plain string.
+func RenderError(format string, args []any, kwargs map[string]any) error {
+	data := make(map[string]any, len(kwargs)+1)
+	for k, v := range kwargs {
+		data[k] = v
+	}
+	data["Args"] = args
+
+	tmpl, err := template.New("msg").Parse(format)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	return errors.New(buf.String())
+}

--- a/pkg/op/render_test.go
+++ b/pkg/op/render_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderErrorPlainString(t *testing.T) {
+	err := RenderError("disk space low", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "disk space low" {
+		t.Errorf("got %q, want %q", err.Error(), "disk space low")
+	}
+}
+
+func TestRenderErrorWithKwargs(t *testing.T) {
+	err := RenderError("{{ .service }} is down", nil, map[string]any{"service": "redis"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "redis is down" {
+		t.Errorf("got %q, want %q", err.Error(), "redis is down")
+	}
+}
+
+func TestRenderErrorWithArgs(t *testing.T) {
+	err := RenderError("{{ index .Args 0 }} failed", []any{"db"}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "db failed" {
+		t.Errorf("got %q, want %q", err.Error(), "db failed")
+	}
+}
+
+func TestRenderErrorWithArgsAndKwargs(t *testing.T) {
+	err := RenderError(
+		"{{ index .Args 0 }} on {{ .host }}",
+		[]any{"timeout"},
+		map[string]any{"host": "node-3"},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "timeout on node-3" {
+		t.Errorf("got %q, want %q", err.Error(), "timeout on node-3")
+	}
+}
+
+func TestRenderErrorInvalidTemplate(t *testing.T) {
+	err := RenderError("{{ .unclosed", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.HasPrefix(err.Error(), "render: ") {
+		t.Errorf("expected render prefix, got %q", err.Error())
+	}
+}
+
+func TestRenderErrorNilArgsKwargs(t *testing.T) {
+	err := RenderError("all clear", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "all clear" {
+		t.Errorf("got %q, want %q", err.Error(), "all clear")
+	}
+}

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -4,6 +4,8 @@
 package op
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/url"
 
 	"go.starlark.net/starlark"
@@ -98,6 +100,16 @@ func (b *ResourceBase) NewURI(r Resource) string {
 // Resolve() then check the result. An unresolved resource reports
 // Exists() == false.
 func (b *ResourceBase) Resolve() error { return nil }
+
+// Format marshals v as compact JSON. Concrete resource types call this from
+// their String() method: func (r Resource) String() string { return r.Format(r) }
+func (b ResourceBase) Format(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(data)
+}
 
 // resourceBase returns a pointer to the embedded ResourceBase, allowing the
 // catalog to stamp id and originID. This method seals the Resource interface.


### PR DESCRIPTION
## Summary

- **Complete** — leaf terminal node, returns optional output value
- **Degraded** — leaf terminal, renders Go template with `*args`/`**kwargs`, writes stderr, graph continues
- **Fatal** — leaf terminal, renders Go template, returns `FatalError` sentinel, executor halts (ConflictResolution respected)
- **RenderError** — shared `text/template` formatter in `pkg/op/render.go`
- **FatalError** — sentinel error type in `pkg/op/fatal.go`, `errors.As` matchable
- **FlowPlan** — handwritten `plan.flow` Starlark namespace with `complete`, `degraded`, `fatal` methods
- **Sub-slot packing** — `fillListSlot`/`fillDictSlot` for variadic args, `reassembleArgs`/`reassembleKwargs` at execution time
- **Resource Stringer** — `ResourceBase.Format(any)` produces compact JSON; one-liner `String()` on all 5 provider resource types
- **E2E tests** — 6 Starlark scripts: complete, degraded, degraded-template, fatal, fatal-template, fatal-recovery
- **Unit tests** — 19 new tests for Complete (5), Degraded (7), Fatal (7), plus 6 RenderError tests

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all 70 packages)
- [x] `make check` (vet + lint + test)
- [x] `make test-race`