### PR TITLE
docs(arch): Resource identity, mem: scheme, and callables plan

### DIFF
--- a/docs/architecture/devlore-mem-resource.md
+++ b/docs/architecture/devlore-mem-resource.md
@@ -1,0 +1,406 @@
+# Memory Resources
+
+This document describes the `mem:` resource scheme — in-memory data
+with a serialization lifecycle. Memory resources exist in the process
+heap during execution, serialize to portable formats for transfer and
+checkpointing, and compile on demand at the execution site.
+
+See also: [mem-resource plan](../plans/mem-resource.md) — implementation
+plan with phases, files, and tests.
+
+## 1. The Portability Problem
+
+A graph planned on machine A should execute on machine B. For external
+resources this works: `file://` paths, `git://` URLs, `pkg://` names,
+and `svc://` service identifiers are portable strings that resolve
+against the target machine's state.
+
+But some graph inputs are not external — they're computed at plan time
+and exist only in the process heap. A Starlark lambda passed to
+`file.walk_tree` is a live function object. A rendered template payload
+is a byte buffer. A JSON document assembled from config fragments is a
+`map[string]any`. These values have no URI, no on-disk representation,
+and no way to cross a process boundary.
+
+| Resource Type | Identity | Portable? | Problem |
+|---|---|---|---|
+| `file://` | Filesystem path | Yes | Resolves via `os.Stat` |
+| `git://` | Clone path + ref | Yes | Resolves via `git` |
+| `pkg://` | Package name + type | Yes | Resolves via package manager |
+| `svc://` | Service name | Yes | Resolves via service manager |
+| In-memory data | None | No | Dies with the process |
+
+The `mem:` scheme gives in-memory data a URI, a serialization format,
+and a resolution lifecycle — making it portable.
+
+## 2. Design
+
+### 2.1 mem.Resource
+
+A `mem.Resource` is a typed byte buffer with an opaque URI.
+
+```go
+type Resource struct {
+    op.ResourceBase
+    ContentType string // "callable", "json", "template", etc.
+    Data        []byte // raw content
+    Hash        string // SHA-256 of Data — change detection, not identity
+}
+```
+
+- **Scheme**: `mem`
+- **Opaque**: `ContentType` + type-specific segments (no `//`, no Host/Path)
+- **URI**: `mem:callable/file.Reducer/myfn`, `mem:json/config`
+- **Hash**: metadata field for change detection and integrity — NOT in URI
+
+The URI is stable across content changes. When a resource with the same
+URI appears with a different hash, the catalog creates a shadow. Two
+nodes referencing the same callable by name share one catalog entry.
+See [devlore-resource-identity.md](devlore-resource-identity.md) for
+the full URI design.
+
+### 2.2 Lifecycle
+
+```
+                    ┌──────────────┐
+                    │  Plan Time   │
+                    │              │
+                    │  Starlark VM │
+                    │  produces    │
+                    │  in-memory   │
+                    │  value       │
+                    └──────┬───────┘
+                           │
+                    ┌──────▼───────┐
+                    │   Extract    │
+                    │              │
+                    │  Capture     │
+                    │  metadata,   │
+                    │  serialize   │
+                    │  to bytes    │
+                    └──────┬───────┘
+                           │
+                    ┌──────▼───────┐
+                    │ mem.Resource │
+                    │              │
+                    │  Data []byte │
+                    │  URI  string │
+                    └──────┬───────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+       ┌──────▼──────┐ ┌──▼──────┐ ┌───▼─────────┐
+       │  Slot       │ │ Persist │ │  Transfer   │
+       │  (graph     │ │ (disk   │ │  (network   │
+       │  node)      │ │ chkpt)  │ │  to remote) │
+       └──────┬──────┘ └──┬──────┘ └───┬─────────┘
+              │            │            │
+              └────────────┼────────────┘
+                           │
+                    ┌──────▼───────┐
+                    │  Exec Time   │
+                    │              │
+                    │  Resolve /   │
+                    │  compile     │
+                    │  on demand   │
+                    └──────────────┘
+```
+
+Unlike `file://` or `git://` resources that reference external state,
+`mem:` resources carry their content inline. The resource IS the data,
+not a handle to data stored elsewhere. This means:
+
+- **Serialization is lossless** — the full content travels with the graph.
+- **No external dependencies** — no filesystem path, no URL, no package
+  name to look up on the target machine.
+- **Resolution is local** — `Resolve()` operates on the embedded `Data`,
+  not on external I/O.
+
+### 2.3 Persistence
+
+A `mem.Resource` can be persisted to disk through any mechanism:
+
+- **Graph serialization**: When a graph is written to YAML/JSON, the
+  `Data` field is included (base64-encoded for binary content).
+- **Recovery checkpoint**: The recovery stack can write `mem.Resource`
+  data to disk as part of a saga checkpoint.
+- **Receipt**: A completed execution receipt includes `mem.Resource`
+  data for audit and replay.
+
+Persistence is a property of the byte buffer, not of the resource type.
+Any `[]byte` can be written to disk. The `mem.Resource` adds identity
+(URI), typing (ContentType), and catalog integration.
+
+### 2.4 Relationship to Recovery
+
+The saga recovery mechanism (RecoveryStack, CompensateX methods) is
+designed for undoing side effects. A `mem.Resource` itself is pure data
+— creating one has no side effects to undo.
+
+What IS compensable is the work performed USING a memory resource:
+
+| Layer | Compensable? | Example |
+|---|---|---|
+| Creating a `mem.Resource` | No | Extracting a callable — pure computation |
+| Storing it in a slot | No | Immutable graph definition |
+| Persisting it to disk | Trivially | Delete the checkpoint file |
+| **Invoking its content** | **Yes** | WalkTree's Reducer pushes operations onto the RecoveryStack |
+
+The recovery mechanism is relevant to `mem.Resource` in two ways:
+
+1. **Checkpoint persistence**: The recovery stack can persist `mem.Resource`
+   data to disk as part of its checkpoint state, ensuring the graph is
+   self-contained for resumption after failure.
+2. **Cleanup**: If temporary files were written for the checkpoint, the
+   recovery stack cleans them up on successful completion.
+
+The substantive compensation happens at the action level, not the
+resource level. WalkTree's `CompensateWalkTree` unwinds the Reducer's
+effects — the callable resource itself is just the code that was
+executed, not the effects it produced.
+
+## 3. Callable — First Application
+
+The first concrete `mem.Resource` is a Starlark callable: a lambda or
+`def` function extracted from the Starlark VM into a self-contained,
+compilable, serializable resource.
+
+### 3.1 The Callable Problem
+
+Provider methods like `file.WalkTree` accept Go function parameters
+(`Reducer`). In Starlark, the user passes a lambda or named function.
+The current system cannot:
+
+- Store a `starlark.Callable` in a slot (not serializable)
+- Invoke a Starlark function from `Do()` (no thread available)
+- Transfer a callable to another machine (it's a VM pointer)
+
+### 3.2 Solution: Extract, Compile, Serialize
+
+At plan time, extract the callable into a self-contained synthetic
+source file. Compile it to bytecode. Store both representations.
+
+#### Extraction
+
+Given a `*starlark.Function`, the extraction step:
+
+1. **Introspects parameters**: `NumParams()`, `Param(i)`,
+   `ParamDefault(i)`, `HasVarargs()`, `HasKwargs()`.
+
+2. **Captures closure bindings**: `NumFreeVars()`, `FreeVar(i)` returns
+   `(Binding, Value)` — the name and frozen value of each captured
+   variable. Frozen values are serialized as Starlark literals.
+
+3. **Extracts function source**: `Position()` provides the filename,
+   line, and column. The source file is read and the function text
+   extracted. Lambdas are transformed to `def` form.
+
+4. **Emits a synthetic file**:
+
+   ```starlark
+   # Extracted callable — from recipe.star:42
+   # Closure bindings:
+   ext = ".py"
+   threshold = 100
+
+   def _callable(initial, resource, path):
+       if path.endswith(ext) and resource.Size > threshold:
+           return initial + [resource]
+       return initial
+   ```
+
+The synthetic file is **self-contained**. All closure bindings are
+inlined as module-level constants. No imports, no external script
+references.
+
+#### Three-Tier Storage
+
+| Tier | Content | Purpose |
+|---|---|---|
+| **Source** | Synthetic `.star` file text | Human-readable, recompilable, version-independent |
+| **Compiled** | `Program.Write` bytecode | Fast load, no parse/compile cost, version-pinned |
+| **Live** | `starlark.Callable` in process | Zero-cost invocation, populated by `Init()` |
+
+Source is always present as the authoritative representation. Compiled
+bytecode is an optimization — fast to load, but pinned to a specific
+`starlark.CompilerVersion`. If the version mismatches at load time,
+the source is recompiled transparently.
+
+```go
+type Callable struct {
+    Resource // embeds mem.Resource — source text in Data
+
+    Compiled        []byte   // Program.Write bytecode
+    FuncName        string   // function name in synthetic file
+    ParamNames      []string // for validation
+    CompilerVersion uint32   // starlark.CompilerVersion at compile time
+    OriginalPos     string   // "recipe.star:42" for diagnostics
+
+    fn starlark.Callable     // live — populated by Init(), not serialized
+}
+```
+
+#### Compilation
+
+```go
+// Compile: source text → bytecode (called at extraction time)
+func (c *Callable) Compile() error
+
+// Init: bytecode → live callable (called at execution time)
+func (c *Callable) Init(thread *starlark.Thread) error
+
+// Fn: returns the live callable (panics if Init not called)
+func (c *Callable) Fn() starlark.Callable
+```
+
+`Init()` loads the compiled bytecode via `starlark.CompiledProgram`,
+runs `prog.Init(thread, predeclared)` to execute the synthetic module,
+and extracts the named function from the resulting globals. If the
+compiler version mismatches, it falls back to recompiling from source.
+
+#### Version Pinning
+
+`starlark.CompilerVersion` is stored alongside the bytecode. At load
+time:
+
+- **Version matches**: `CompiledProgram(bytecode)` — instant load.
+- **Version mismatches**: `SourceProgramOptions(source)` — recompile.
+  The source is always present, so version drift is transparent.
+
+Applications should incorporate `CompilerVersion` into cache keys when
+storing compiled callables externally (disk cache, remote store).
+
+### 3.3 Closure Binding Serialization
+
+Free variables captured by a lambda are frozen after `ExecFile` returns.
+The extraction step serializes each as a Starlark source literal:
+
+| Starlark Type | Literal Form | Example |
+|---|---|---|
+| `String` | Quoted string | `ext = ".py"` |
+| `Int` | Integer | `threshold = 100` |
+| `Float` | Float | `ratio = 3.14` |
+| `Bool` | `True` / `False` | `verbose = True` |
+| `NoneType` | `None` | `default = None` |
+| `List` | List literal | `items = [1, 2, 3]` |
+| `Dict` | Dict literal | `config = {"a": 1}` |
+| `Tuple` | Tuple literal | `pair = (1, 2)` |
+
+Non-primitive types (Resources, custom structs) that lack a natural
+Starlark literal form produce an extraction error. In practice, closure
+bindings are almost always primitives and containers.
+
+### 3.4 Signature Validation
+
+At extraction time, the callable's parameters are validated against the
+target action's expected arity using `*starlark.Function` introspection:
+
+- `NumParams()` — total parameters
+- `Param(i)` — parameter name and position
+- `ParamDefault(i)` — default value (nil if required)
+- `NumKwonlyParams()` — keyword-only count
+- `HasVarargs()` / `HasKwargs()` — variadic acceptance
+
+`starlark.Builtin` callables (Go functions exposed to Starlark) cannot
+be introspected — they lack parameter metadata. Validation is deferred
+to invocation time.
+
+### 3.5 Adapter Pattern
+
+Adapters convert a `mem.Callable` into a concrete Go function type.
+Each callable-accepting action defines its own adapter:
+
+```
+mem.Callable
+    │
+    ├─ ReducerAdapter    → file.Reducer (WalkTree)
+    ├─ PredicateAdapter  → func(any) (bool, error) (Choose, WaitUntil)
+    ├─ FilterAdapter     → func(any) (bool, error) (Gather where clause)
+    └─ TransformAdapter  → func(any) (any, error) (custom transforms)
+```
+
+The adapter handles:
+- **Argument marshaling**: Go values → Starlark values for the call
+- **Return unmarshaling**: Starlark result → Go value
+- **Swallowed params**: Internal params (e.g., `stack` in Reducer) are
+  provided by the Go caller, not the Starlark function
+
+### 3.6 Unification
+
+`mem.Callable` is the single type for all execution-time callables.
+There is no separate `RuntimePredicate` type. The orchestration
+primitives (Choose, WaitUntil, Gather) use `PredicateAdapter` over
+the same `mem.Callable`:
+
+| Use Case | Before | After |
+|---|---|---|
+| WalkTree Reducer | Not exposed to Starlark | `mem.Callable` + `ReducerAdapter` |
+| Choose predicate | `RuntimePredicate` (separate type, not serializable) | `mem.Callable` + `PredicateAdapter` |
+| WaitUntil condition | `RuntimePredicate` | `mem.Callable` + `PredicateAdapter` |
+| Gather filter | Not designed | `mem.Callable` + `FilterAdapter` |
+
+One type, one serialization format, one compilation path, N adapters.
+
+## 4. Thread Management
+
+Actions invoke callables at execution time. This requires a Starlark
+thread — the execution context for `starlark.Call`.
+
+```go
+// pkg/op/context.go
+type Context struct {
+    // ... existing fields ...
+    Thread *starlark.Thread
+}
+```
+
+The executor creates a fresh `starlark.Thread` before running the graph
+and sets it on `op.Context`. The thread's print handler writes to
+`ctx.Writer`. Actions that invoke callables use `ctx.Thread`. Actions
+that don't need it ignore the field.
+
+Starlark's freeze semantics guarantee thread safety: after `ExecFile`,
+all module-level values are frozen. The callable's closure bindings are
+frozen. The executor's thread is fresh, but the callable's frozen data
+is safe to read from any goroutine.
+
+## 5. Serialization
+
+### What Serializes
+
+| Field | Format | Notes |
+|---|---|---|
+| `Data` (source text) | UTF-8 string | Always present, authoritative |
+| `Compiled` (bytecode) | Base64-encoded bytes | Optional optimization |
+| `ContentType` | String | `"callable"`, `"json"`, etc. |
+| `FuncName` | String | Function name in synthetic file |
+| `ParamNames` | String list | For validation without compilation |
+| `CompilerVersion` | Integer | For version-match check on load |
+| `OriginalPos` | String | Diagnostics only |
+
+### What Doesn't Serialize
+
+| Field | Reason |
+|---|---|
+| `fn` (live callable) | VM pointer — reconstructed by `Init()` |
+
+The live callable is transient. It's created by `Init()` at execution
+time and discarded when the execution completes. The source and bytecode
+are the durable representations.
+
+## 6. Supersession Table
+
+| Existing Document | Section | Status | Notes |
+|---|---|---|---|
+| [devlore-resource-management.md](devlore-resource-management.md) | §3.3 Resource Types | **Extended** | `mem:` scheme now implemented; row updated from "Planned" to "Implemented" |
+| [devlore-orchestration-primitives.md](devlore-orchestration-primitives.md) | Runtime Predicates | **Superseded** | `RuntimePredicate` type replaced by `mem.Callable` + `PredicateAdapter` |
+| [devlore-orchestration-primitives.md](devlore-orchestration-primitives.md) | Serialization §"What Doesn't Serialize" | **Superseded** | Callables now serialize via source text + compiled bytecode |
+| [devlore-typed-slots.md](devlore-typed-slots.md) | Slot Types | **Extended** | `mem.Callable` flows through existing immediate slot path as a Resource |
+
+## 7. Related Documents
+
+- [devlore-resource-management.md](devlore-resource-management.md) — Resource lifecycle, catalog, URI scheme table
+- [devlore-orchestration-primitives.md](devlore-orchestration-primitives.md) — RuntimePredicate (superseded by callable)
+- [devlore-typed-slots.md](devlore-typed-slots.md) — Slot model and resolution
+- [devlore-phase-execution.md](devlore-phase-execution.md) — Saga pattern, recovery stack
+- [mem-resource plan](../plans/mem-resource.md) — Implementation plan

--- a/docs/architecture/devlore-resource-identity.md
+++ b/docs/architecture/devlore-resource-identity.md
@@ -1,0 +1,407 @@
+# Resource Identity
+
+This document defines how resources are identified across the system.
+Every resource has a URI — a single string that uniquely identifies it
+within the resource catalog. The URI is the only identity contract
+between a resource and the rest of the system.
+
+See also:
+- [devlore-resource-management.md](devlore-resource-management.md) — catalog, shadows, tombstones, resolution lifecycle
+- [devlore-mem-resource.md](devlore-mem-resource.md) — `mem:` scheme and callables
+- [mem-resource plan](../plans/mem-resource.md) — implementation plan (Phase 0: interface change)
+
+## 1. URI as the Single Identity
+
+A resource's identity is its URI. The catalog keys on it. The slot
+system passes it. Pre-flight validation checks it. Receipt serialization
+records it. No other method on the Resource interface participates in
+identity — the URI string is the sole contract.
+
+```go
+type Resource interface {
+    URI() string
+    Resolve() error
+    resourceBase() *ResourceBase
+}
+```
+
+`URI()` returns a cached string. It does not recompute on every call.
+Each concrete type constructs its URI at creation time (or after
+`Resolve()` mutates identity-bearing fields) and caches the result.
+
+`Resolve()` populates provider-specific metadata via I/O (e.g.,
+`os.Stat` for files, compilation for callables). If resolution changes
+identity-bearing fields (e.g., path canonicalization), the cached URI
+is updated.
+
+`resourceBase()` is the interface seal — it returns a pointer to the
+embedded `ResourceBase`, allowing the catalog to stamp `id` and
+`originID`. Not part of the identity contract.
+
+## 2. URI Syntax — RFC 3986
+
+All resource URIs conform to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).
+
+```
+URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+
+hier-part = "//" authority path-abempty     ← authority form
+          / path-absolute                   ← no authority, starts with /
+          / path-rootless                   ← no authority, no leading /
+          / path-empty                      ← nothing after scheme:
+
+authority = [ userinfo "@" ] host [ ":" port ]
+```
+
+**Key rules:**
+
+1. **Scheme** is mandatory — `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`
+2. **Authority** is optional — present only after `://`
+3. **Path** is always present (can be empty)
+4. When authority is present, path must start with `/` or be empty
+5. When authority is absent, path cannot start with `//`
+
+Each scheme defines its own syntax within these rules. The system does
+not impose a single decomposition (scheme + host + path) on all
+resources. The URI is an opaque string to the catalog; only the resource
+type that produced it understands its internal structure.
+
+### Hierarchical vs Opaque URIs
+
+RFC 3986 distinguishes two URI forms:
+
+- **Hierarchical**: starts with `//` after the scheme. Go's `url.Parse`
+  populates `Host` and `Path`. Used when the URI references a host or
+  filesystem path: `file:///etc/foo`.
+
+- **Opaque**: no `//` after the scheme. Go's `url.Parse` populates the
+  `Opaque` field; `Host` and `Path` are empty. Used when the URI names
+  a registry entry or wraps an inner URI: `pkg:brew/jq`,
+  `mem:callable/file.Reducer/myfn`, `appnet:https%3A//example.com/path`,
+  `svc:nginx`.
+
+The choice is per-scheme. Resources that reference external systems
+with hosts or paths use hierarchical URIs. Resources that name entries
+in a local registry use opaque URIs.
+
+Go's `url.URL` struct reflects this:
+
+| Field | Hierarchical (`file:///etc/foo`) | Opaque (`pkg:brew/jq@1.7`) |
+|---|---|---|
+| `Scheme` | `file` | `pkg` |
+| `Opaque` | (empty) | `brew/jq@1.7` |
+| `Host` | (empty) | (empty) |
+| `Path` | `/etc/foo` | (empty) |
+| `Fragment` | (empty) | (empty) |
+
+For opaque URIs, the `Opaque` field carries the full identity after the
+scheme colon. The `Fragment` (after `#`) is metadata — it identifies a
+specific instance or usage context but is NOT part of the catalog key.
+The catalog strips the fragment when keying; two URIs that differ only
+in fragment resolve to the same resource.
+
+### Fragment as Instance Context
+
+The fragment component (`#...`) identifies a specific usage of a
+resource without changing its identity. For `mem:` resources, the
+fragment carries the graph node ID where the resource was created:
+
+```
+mem:callable/file.Reducer/myfn#node1
+mem:callable/file.Reducer/myfn#node2
+```
+
+Both resolve to the same catalog entry (`mem:callable/file.Reducer/myfn`).
+The fragment tells the resolution layer which instance is being
+referenced. This supports:
+
+- **Deduplication**: same callable used at multiple nodes shares one
+  catalog entry.
+- **Instance tracking**: the fragment distinguishes specific usages for
+  diagnostics, logging, and slot resolution.
+
+### Content Hash as Metadata
+
+For `mem:` resources, a content hash (SHA-256 of the `Data` field) is
+stored as a field on the resource struct, NOT in the URI. The hash
+serves two purposes:
+
+1. **Change detection**: when a resource with the same URI appears with
+   a different hash, the catalog knows the content changed and creates
+   a shadow.
+2. **Integrity verification**: the hash can be checked after transfer
+   or deserialization to confirm the content is intact.
+
+Putting the hash in the URI would mean the URI changes whenever the
+content changes — defeating the catalog's ability to track that the
+"same" resource mutated. A stable URI with a mutable hash is the
+correct model for shadowing.
+
+### mem:callable URI Structure
+
+The `mem:callable` URI has three segments:
+
+```
+mem:callable/<function-type>/<instance-name>
+```
+
+| Segment | Meaning | Example |
+|---|---|---|
+| `callable` | Content type — maps to `callable.Resource` | Always `callable` |
+| `<function-type>` | The named Go function type the callable adapts to | `file.Reducer`, `file.Actor`, `Predicate` |
+| `<instance-name>` | The callable's identity within its function type | `count_python_files`, `file.walk_tree.fn` |
+
+**Function type** — the named type annotated with `+devlore:callable`.
+For anonymous function types (bare `func(...)` parameters without a
+named type), the fallback is `<action>.<param>` — the action method
+name and the parameter name that receives the callable. Named types
+are the primary path.
+
+**Instance name** — for named `def` functions, the function name is the
+default. For lambdas, the instance name is derived from the call site:
+`<action>.<param>`.
+
+```
+mem:callable/file.Reducer/count_python_files     ← named def
+mem:callable/file.Reducer/file.walk_tree.fn      ← lambda at walk_tree's fn param
+mem:callable/Predicate/is_ready                  ← named predicate
+```
+
+**Name collisions**: two functions with the same name and function type
+produce the same base URI. If their content hashes differ, the second
+shadows the first in the catalog. This is intentional — the catalog
+treats it as a newer version of the same callable. Slot data is carried
+inline, so no data is lost at the node level.
+
+## 3. Scheme Registry
+
+| Scheme | Form | URI Examples | Notes |
+|---|---|---|---|
+| `file` | Hierarchical | `file:///etc/foo`, `file:///usr/local/bin/jq` | [RFC 8089](https://datatracker.ietf.org/doc/html/rfc8089). Empty authority, absolute path. |
+| `pkg` | Opaque | `pkg:brew/jq`, `pkg:deb/curl@1.7`, `pkg:winget/Microsoft/VSCode` | [Package URL (purl)](https://github.com/package-url/purl-spec) compliant. `URI()` and `Purl()` converge. |
+| `svc` | Opaque | `svc:nginx`, `svc:postgresql` | Service name. Fragment reserved for future instance disambiguation (e.g., `svc:postgresql#port-5433`). |
+| `appnet` | Opaque | `appnet:https%3A//example.com/path` | Wraps an inner URI with targeted escaping (`#` and `?` escaped). Renamed from `net`. |
+| `git` | Opaque | `git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Fmain.go#abc123` | Opaque repo URL, optional path query, commit hash as fragment. |
+| `mem` | Opaque | `mem:callable/file.Reducer/myfn`, `mem:json/config` | `content-type/[qualifier/]name`. Hash is metadata, not identity. |
+
+Schemes are registered as constants in `pkg/op/resource.go`:
+
+```go
+const (
+    SchemeFile    = "file"
+    SchemeGit     = "git"
+    SchemePackage = "pkg"
+    SchemeService = "svc"
+    SchemeMem     = "mem"
+    SchemeAppNet  = "appnet"    // renamed from "net"
+)
+```
+
+## 4. URI Construction
+
+Each concrete resource type owns its URI construction. There is no
+shared `NewURI(r Resource)` method that dispatches through virtual
+calls. Each type builds its URI from its own fields using whatever
+logic fits its scheme.
+
+```go
+// file: RFC 8089 — hierarchical, empty authority, absolute path
+func (r *Resource) buildURI() string {
+    return "file://" + r.SourcePath // SourcePath is always absolute
+}
+
+// pkg: purl-compliant opaque URI — URI() and Purl() converge
+func (r *Resource) buildURI() string {
+    s := "pkg:" + r.Type + "/" + r.Name
+    if r.Version != "" {
+        s += "@" + r.Version
+    }
+    return s
+}
+
+// svc: opaque, service name only
+func (r *Resource) buildURI() string {
+    return "svc:" + r.Name
+}
+
+// appnet: opaque, wraps inner URI with targeted escaping
+func (r *Resource) buildURI() string {
+    return "appnet:" + escapeInnerURI(r.URL)
+}
+
+// mem: opaque — content-type/function-type/instance-name
+func (r *Resource) buildURI() string {
+    return "mem:" + r.ContentType + "/" + r.FuncType + "/" + r.Name
+}
+
+// git: opaque repo URL, optional path query, commit fragment
+func (r *Resource) buildURI() string {
+    s := "git:" + url.PathEscape(r.RepoURL)
+    if r.Path != "" {
+        s += "?path=" + url.QueryEscape(r.Path)
+    }
+    if r.Commit != "" {
+        s += "#" + r.Commit
+    }
+    return s
+}
+```
+
+The URI is computed once and cached. `URI()` returns the cached string:
+
+```go
+func (r *Resource) URI() string { return r.uri }
+```
+
+If `Resolve()` changes identity-bearing fields (e.g., `filepath.Abs`
+canonicalizes a relative path), the cached URI is updated.
+
+## 5. What Changed — Interface Simplification
+
+The original Resource interface exposed four URI-related methods:
+
+```go
+// Before — shoehorned URI decomposition
+type Resource interface {
+    URI() string
+    Scheme() string   // "file", "git", "pkg", ...
+    Host() string     // authority component
+    Path() string     // path component
+    Resolve() error
+    resourceBase() *ResourceBase
+}
+```
+
+`Scheme()`, `Host()`, and `Path()` existed to serve `NewURI(r Resource)`
+in `ResourceBase`, which assembled them into a `url.URL` on every
+`URI()` call. This imposed a single `scheme://host/path` decomposition
+on all resources — a decomposition that didn't fit:
+
+| Resource | Host() meant | Path() meant | Actual form |
+|---|---|---|---|
+| file | empty string | filesystem path | Hierarchical — fits |
+| git | empty string | clone path | Opaque — never fit |
+| net (now appnet) | hostname | URL path | Moving to opaque wrapper |
+| pkg | package manager type | package name | Opaque purl — never fit |
+| service | empty string | service name | Opaque — never fit |
+| mem | (N/A) | (N/A) | Opaque — never fit |
+
+`Host()` and `Path()` had no consistent semantics — they were just
+"the two fields that go into `url.URL{Host, Path}`." Code that called
+`r.Host()` couldn't know what it meant without knowing the concrete
+type. And `NewURI()` recomputed a `url.URL` struct on every call,
+which is unnecessary work for an immutable identity string.
+
+The simplified interface:
+
+```go
+// After — URI is the only identity contract
+type Resource interface {
+    URI() string
+    Resolve() error
+    resourceBase() *ResourceBase
+}
+```
+
+- `URI()` returns a cached string (no recomputation)
+- Each type constructs its URI from its own fields
+- `ResourceBase` retains parsing helpers (`Scheme()`, `Host()`, `Path()`)
+  for code that needs to decompose a URI after the fact — but these are
+  not interface methods
+
+## 6. ResourceBase Helpers
+
+`ResourceBase` provides fallback methods that parse the stored `uri`
+field via `net/url.Parse`. These are available to any code that holds
+a `ResourceBase` (i.e., any resource type), but they are NOT part of
+the `Resource` interface:
+
+```go
+// Convenience parsers — NOT interface methods.
+func (b *ResourceBase) Scheme() string   { /* parse b.uri */ }
+func (b *ResourceBase) Opaque() string   { /* parse b.uri — non-empty for opaque URIs */ }
+func (b *ResourceBase) Host() string     { /* parse b.uri — non-empty for hierarchical URIs */ }
+func (b *ResourceBase) Path() string     { /* parse b.uri — non-empty for hierarchical URIs */ }
+func (b *ResourceBase) Fragment() string { /* parse b.uri */ }
+```
+
+For opaque URIs (`pkg:`, `svc:`, `appnet:`, `mem:`), `Opaque()` returns
+the data after the scheme colon; `Host()` and `Path()` return empty.
+For hierarchical URIs (`file:`), `Opaque()` returns empty; `Host()` and
+`Path()` return the authority and path components.
+
+These are useful for generic code that needs to decompose an unknown
+resource's URI (e.g., display, logging, routing by scheme). They parse
+on every call — callers that need repeated access should cache the
+result.
+
+### git: URI Structure
+
+```
+git:<encoded-repo-url>[?path=<path>[&mode=blob|tree]]#<commit-hash>
+```
+
+The `git` scheme uses the opaque form. The repository URL is the base
+identity. The commit hash in the fragment pins an immutable version.
+
+| Component | `url.URL` Field | Role | Example |
+|---|---|---|---|
+| `git:` | `Scheme` | Routes to git resolver | Always `git` |
+| `<encoded-repo-url>` | `Opaque` | Base resource — the repository | `https%3A%2F%2Fgithub.com%2Forg%2Frepo` |
+| `?path=<path>` | `RawQuery` | Optional: file or directory within the repo | `path=src%2Fmain.go` |
+| `&mode=blob\|tree` | `RawQuery` | Optional: file or directory | `mode=blob` |
+| `#<commit-hash>` | `Fragment` | Immutable version pin — shadow key | `e5a4f3b22c1d...` |
+
+**Catalog keying**: the catalog strips the fragment. Two URIs that
+differ only in commit hash resolve to the same catalog entry — the
+newer commit shadows the older one. The query (`?path=...`) IS part
+of the catalog key, so different files in the same repo are distinct
+resources. A URI with no `?path=` references the repo root.
+
+```
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Fmain.go#abc123
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Fmain.go#def456
+  → same catalog entry, def456 shadows abc123
+
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Fmain.go#abc123
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Futil.go#abc123
+  → different catalog entries (different files)
+
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo#abc123
+  → repo root (no path query)
+```
+
+**Why fragment for commit hash**: RFC 3986 defines the fragment as
+client-side state identification — not sent to the server. A commit
+hash identifies a specific snapshot (state) of the repository. The
+catalog uses it as the shadow/version key, consistent with how `mem:`
+uses the fragment for instance context.
+
+**Mutable references**: branch names and tags are mutable — they can
+move to a new commit. For resources that should track "latest on main"
+rather than pinning a commit, the `ref` query parameter provides a
+resolution-time lookup:
+
+```
+git:https%3A%2F%2Fgithub.com%2Forg%2Frepo?path=src%2Fmain.go&ref=main
+```
+
+`Resolve()` resolves the mutable ref to a commit hash and updates the
+cached URI with the `#<commit>` fragment. Before resolution, the URI
+has no fragment (unpinned). After resolution, the fragment is set
+(pinned). This mirrors how `file:` resources resolve relative paths
+to absolute paths.
+
+**Local repos**: use the `file:` scheme as the inner URL, following
+the same encoding as `appnet:`:
+
+```
+git:file%3A%2F%2F%2Fhome%2Fuser%2Frepo?path=src%2Fmain.go#abc123
+```
+
+## 8. Supersession Table
+
+| Existing Document | Section | Status | Notes |
+|---|---|---|---|
+| [devlore-resource-management.md](devlore-resource-management.md) | §3.3 Resource Types by URI Scheme | **Extended** | Scheme table updated; URI construction model changed |
+| [devlore-resource-management.md](devlore-resource-management.md) | §2 Architectural Summary | **Extended** | Resource interface simplified |

--- a/docs/plans/mem-resource.md
+++ b/docs/plans/mem-resource.md
@@ -1,0 +1,838 @@
+---
+title: "Memory Resources and Callables"
+issue: TBD
+status: draft
+created: 2026-03-07
+updated: 2026-03-08
+---
+
+# Plan: Memory Resources and Callables
+
+## Summary
+
+Implement the `mem:` resource scheme and its first application:
+serializable Starlark callables.
+
+`mem.Resource` is a typed byte buffer with a semantically-named opaque
+URI — the first resource type backed by in-memory data rather than an
+external system. It serializes fully, can be persisted to disk or
+transferred to another machine, and compiles on demand at the execution
+site.
+
+`mem.Callable` is a `mem.Resource` that holds a Starlark function
+extracted into a self-contained synthetic source file, compiled
+to bytecode. It can be persisted to disk,
+transferred to another machine, and compiled on demand at execution time.
+
+The motivating use case is `file.WalkTree`, whose `Reducer` parameter is
+a per-file callback. The same mechanism serves RuntimePredicate, filters,
+validators, transformers — any action that needs user-supplied logic.
+
+**Unification requirement**: RuntimePredicate and all other callable
+patterns share one type, one serialization format, one compilation path,
+and one execution path. Adapters convert the unified callable to specific
+Go function types.
+
+## Goals
+
+1. **Unified callable type**: One resource type (`mem.Callable`) for all
+   execution-time callables — reducers, predicates, filters, transforms.
+   RuntimePredicate becomes an adapter over `mem.Callable`, not a separate
+   type.
+2. **Serializable**: Callables serialize as source text and compiled
+   bytecode. A graph containing callables can be written to disk, shipped
+   to another machine, and executed there.
+3. **Self-contained extraction**: At plan time, extract the callable into
+   a synthetic single-function file. Closure bindings are captured via
+   `*starlark.Function.FreeVar(i)` and inlined as module-level constants.
+   The synthetic file has no external dependencies.
+4. **Three-tier storage**: Source text (human-readable, recompilable),
+   compiled bytecode (fast load, version-pinned), and live callable
+   (in-process, zero-cost invocation). All three tiers stored in the
+   `mem.Resource`.
+5. **Unblock WalkTree**: `file.walk_tree(root, fn)` works in immediate
+   mode. `plan.file.walk_tree(root, fn)` works in planned mode. Resolves
+   BUGS.md #170.
+
+## URI Scheme Summary
+
+Phase 0 corrects all resource URI schemes. See
+[devlore-resource-identity.md](../architecture/devlore-resource-identity.md)
+for the full design.
+
+| Scheme | Form | Catalog Key | Shadow Key |
+|---|---|---|---|
+| `file` | Hierarchical | `file:///absolute/path` | N/A (external) |
+| `pkg` | Opaque | `pkg:type/name` | Version via `@version` |
+| `svc` | Opaque | `svc:name` | Fragment reserved for future instances |
+| `appnet` | Opaque | `appnet:<escaped-url>` | N/A (external) |
+| `git` | Opaque | `git:<encoded-repo>[?path=...]` | `#<commit-hash>` |
+| `mem` | Opaque | `mem:callable/type/name` | Content hash as metadata field |
+
+## Current State
+
+| Component | Status | Notes |
+|---|---|---|
+| `mem:` scheme | Declared | `SchemeMem = "mem"` in `pkg/op/resource.go`; `package mem` is empty |
+| `mem.Resource` | Missing | Architecture doc plans it for "in-memory data (template payloads, JSON content)" |
+| WalkTree Go method | Working | Accepts `Reducer` callable, compensable |
+| WalkTree Starlark binding | Missing | BUGS.md #170 — reflection bridge can't handle callable params |
+| Reflection bridge | No callable support | `buildMethodBridge` and `buildPlannedBridge` skip callable-typed params |
+| Slot system | Immediate / Promise / Proxy | Callables flow as immediate Resource values |
+| `op.Context` | No Starlark thread | Actions can't call Starlark functions at execution time |
+| `+devlore:callable` annotation | Exists on `Reducer` | Used by codegen for `swallow` — not for bridge generation |
+| RuntimePredicate | Designed, not implemented | Orchestration-primitives plan Step 3 |
+| Starlark `Program.Write` | Available upstream | `go.starlark.net` supports compiled bytecode serialization |
+| `*starlark.Function.FreeVar` | Available upstream | Full closure introspection: name + frozen value |
+
+## Design
+
+### Unified Callable Model
+
+Every execution-time callable — regardless of purpose — follows the same
+lifecycle:
+
+```
+Plan time:
+  *starlark.Function
+      │
+      ▼
+  Extract: introspect params, free vars, source position
+      │
+      ▼
+  Synthesize: generate self-contained .star source file
+      │
+      ▼
+  Compile: SourceProgramOptions → Program
+      │
+      ▼
+  Store: mem.Callable{Source, Compiled, Metadata}
+      │
+      ▼
+  Slot: stored as immediate Resource value in graph node
+
+Serialization:
+  mem.Callable → YAML/JSON/disk (source text + bytecode + metadata)
+
+Execution time (any machine):
+  Load: CompiledProgram(bytecode) → Program
+      │ (or recompile from source if CompilerVersion mismatches)
+      ▼
+  Init: prog.Init(thread, predeclared) → globals["_callable"]
+      │
+      ▼
+  Adapt: ReducerAdapter / PredicateAdapter / custom → Go func type
+      │
+      ▼
+  Invoke: action.Do() calls the adapted function
+```
+
+### Two Kinds of Callables
+
+The system already has **plan-time callables** — Starlark functions that
+execute during graph construction to build nodes. Choose's `then` callback
+is the canonical example. These don't need slot storage or serialization;
+they run immediately in the Starlark thread and are done.
+
+This plan adds **execution-time callables** — Starlark functions extracted
+into a `mem.Callable` resource and invoked from a Go action's `Do()`.
+
+| | Plan-time callable | Execution-time callable |
+|---|---|---|
+| When it runs | During Starlark script execution | During `Do()` in the executor |
+| What it does | Builds graph structure | Computes a value, filters, transforms |
+| Storage | Not stored — ephemeral | `mem.Callable` resource in slot |
+| Serializable | N/A | Yes — source text + compiled bytecode |
+| Thread | Starlark's own thread | Thread from `op.Context` |
+| Example | `plan.choose(when=p, then=lambda: ...)` | `file.walk_tree(root, lambda i, r, p: ...)` |
+
+### mem.Resource — Foundation
+
+`mem.Resource` is the first resource type backed by in-memory data rather
+than an external system. It serves callables now and template payloads,
+JSON content, and other in-memory artifacts later.
+
+```go
+// pkg/op/provider/mem/resource.go
+
+type Resource struct {
+    op.ResourceBase
+    ContentType string // "callable", "json", "template", etc.
+    Data        []byte // raw content (source text, JSON, template)
+    Hash        string // SHA-256 of Data — metadata, NOT part of URI
+}
+
+func (r Resource) String() string { return r.Format(r) }
+```
+
+URI uses the opaque form (no `//`): `mem:callable/file.Reducer/myfn`,
+`mem:json/config`. The content hash is stored as a field for change
+detection and integrity verification, not in the URI. See
+[devlore-resource-identity.md §mem:callable URI Structure](../architecture/devlore-resource-identity.md#memcallable-uri-structure).
+
+The recovery mechanism can persist `mem.Resource` to disk — it's just
+bytes with a content type. This is the first use case for `mem:` with
+a materialization path to durable storage.
+
+### mem.Callable — The Unified Callable
+
+```go
+// pkg/op/provider/mem/callable.go
+
+type Callable struct {
+    Resource // embeds mem.Resource (source text in Data)
+
+    // Compiled bytecode — Program.Write output. Nil until Compile.
+    // Persisted alongside source for fast reload.
+    Compiled []byte
+
+    // URI identity fields — these compose the opaque URI:
+    // mem:callable/<FuncType>/<Name>
+    FuncType string // named Go type: "file.Reducer", "Predicate"
+    Name     string // function name or <action>.<param> for lambdas
+
+    // Metadata captured at extraction time.
+    FuncName        string   // function name in synthetic file ("_callable" or original)
+    ParamNames      []string // parameter names (excluding swallowed)
+    NumParams       int      // total params (for validation)
+    CompilerVersion uint32   // starlark.CompilerVersion at compile time
+    OriginalPos     string   // "recipe.star:42" (diagnostics only)
+
+    // Live state — populated by Init(), not serialized.
+    fn starlark.Callable
+}
+```
+
+`Callable` IS a `mem.Resource` (embeds it). The `Data` field holds the
+synthetic source text. The `Compiled` field holds bytecode. Both are
+`[]byte` — serializable, transferable, persistable.
+
+URI: `mem:callable/file.Reducer/count_python_files` (named def),
+`mem:callable/file.Reducer/file.walk_tree.fn` (lambda). The `FuncType`
+and `Name` fields compose the opaque URI segments. The content hash on
+the embedded `Resource` detects when a callable with the same URI has
+different content (triggering a catalog shadow).
+
+### Extraction — Synthetic File Generation
+
+At plan time, when a `*starlark.Function` is passed to an action:
+
+```go
+// pkg/op/provider/mem/extract.go
+
+func Extract(fn *starlark.Function) (*Callable, error)
+```
+
+1. **Introspect parameters**: `fn.NumParams()`, `fn.Param(i)`,
+   `fn.ParamDefault(i)`, `fn.HasVarargs()`, `fn.HasKwargs()`.
+
+2. **Capture closure bindings**: `fn.NumFreeVars()`, `fn.FreeVar(i)` →
+   `(Binding, Value)`. Each free variable is a frozen Starlark value.
+   Serialize each value as a Starlark literal for the synthetic file
+   preamble.
+
+3. **Extract function source**: `fn.Position()` → filename, line, col.
+   Read the source file and extract the function text. For lambdas,
+   transform `lambda args: expr` → `def _callable(args): return expr`.
+   For `def` functions, preserve the body as-is.
+
+4. **Emit synthetic file**:
+   ```starlark
+   # Extracted callable — from recipe.star:42
+   # Closure bindings:
+   ext = ".py"
+   threshold = 100
+   config = {"verbose": True, "mode": "strict"}
+
+   def _callable(initial, resource, path):
+       if path.endswith(ext) and resource.Size > threshold:
+           return initial + [resource]
+       return initial
+   ```
+
+5. **Compile**: `SourceProgramOptions(opts, "<callable>", source, isPredeclared)`
+   → `*Program`.
+
+6. **Serialize bytecode**: `prog.Write(&buf)` → `Compiled` field.
+
+7. **Store**: Source text in `Data`, bytecode in `Compiled`, metadata
+   in the struct fields.
+
+The synthetic file is **self-contained** — all closure bindings are
+inlined. No external imports, no script re-execution needed.
+
+### Value Serialization for Closure Bindings
+
+Frozen Starlark values must be serialized as valid Starlark literals
+in the synthetic file preamble:
+
+| Starlark Type | Serialization | Example |
+|---|---|---|
+| `String` | Quoted string | `ext = ".py"` |
+| `Int` | Integer literal | `threshold = 100` |
+| `Float` | Float literal | `ratio = 3.14` |
+| `Bool` | `True` / `False` | `verbose = True` |
+| `NoneType` | `None` | `default = None` |
+| `List` | List literal | `items = [1, 2, 3]` |
+| `Dict` | Dict literal | `config = {"a": 1}` |
+| `Tuple` | Tuple literal | `pair = (1, 2)` |
+
+Complex types (Resources, custom structs) that don't have a natural
+Starlark literal representation are serialized via `value.String()` and
+wrapped in a comment noting the original type. The extraction step
+reports a warning for non-primitive bindings. In practice, closure
+bindings are almost always primitives and containers.
+
+### Compilation and Initialization
+
+```go
+// pkg/op/provider/mem/callable.go
+
+// Compile compiles the source text and stores the bytecode.
+// Called once at extraction time. Idempotent.
+func (c *Callable) Compile() error {
+    _, prog, err := starlark.SourceProgramOptions(
+        &syntax.FileOptions{}, "<callable>", c.Data, isPredeclared,
+    )
+    if err != nil {
+        return err
+    }
+    var buf bytes.Buffer
+    if err := prog.Write(&buf); err != nil {
+        return err
+    }
+    c.Compiled = buf.Bytes()
+    c.CompilerVersion = starlark.CompilerVersion
+    return nil
+}
+
+// Init loads the compiled program (or recompiles from source on version
+// mismatch) and extracts the callable function. Must be called before
+// Invoke.
+func (c *Callable) Init(thread *starlark.Thread) error {
+    var prog *starlark.Program
+    var err error
+
+    if c.Compiled != nil && c.CompilerVersion == starlark.CompilerVersion {
+        prog, err = starlark.CompiledProgram(bytes.NewReader(c.Compiled))
+    } else {
+        _, prog, err = starlark.SourceProgramOptions(
+            &syntax.FileOptions{}, "<callable>", c.Data, isPredeclared,
+        )
+    }
+    if err != nil {
+        return fmt.Errorf("callable init: %w", err)
+    }
+
+    globals, err := prog.Init(thread, predeclared)
+    if err != nil {
+        return fmt.Errorf("callable init: %w", err)
+    }
+
+    fn, ok := globals[c.FuncName]
+    if !ok {
+        return fmt.Errorf("callable init: function %q not found", c.FuncName)
+    }
+    callable, ok := fn.(starlark.Callable)
+    if !ok {
+        return fmt.Errorf("callable init: %q is %s, not callable", c.FuncName, fn.Type())
+    }
+    c.fn = callable
+    return nil
+}
+
+// Fn returns the live callable. Panics if Init has not been called.
+func (c *Callable) Fn() starlark.Callable {
+    if c.fn == nil {
+        panic("callable: Init not called")
+    }
+    return c.fn
+}
+```
+
+### Thread on Context
+
+```go
+// pkg/op/context.go — add field:
+Thread *starlark.Thread
+```
+
+The executor creates a fresh `starlark.Thread` before running the graph
+and sets it on `op.Context`. The thread's print handler writes to
+`ctx.Writer`.
+
+### Adapter Pattern
+
+Adapters convert a `mem.Callable` into a concrete Go function type.
+Each callable-accepting action defines its own adapter. The adapter
+handles argument marshaling, swallowed params, and return unmarshaling.
+
+```go
+// pkg/op/provider/file/callable_adapter.go
+
+func ReducerAdapter(c *mem.Callable, thread *starlark.Thread) Reducer {
+    return func(initial any, resource Resource, relativePath string, stack *op.RecoveryStack) (any, error) {
+        starInitial, _ := op.MarshalValue(initial)
+        starResource, _ := op.MarshalValue(resource)
+        starPath := starlark.String(relativePath)
+
+        result, err := starlark.Call(thread, c.Fn(), starlark.Tuple{
+            starInitial, starResource, starPath,
+        }, nil)
+        if err != nil {
+            return nil, err
+        }
+
+        var goResult any
+        op.UnmarshalValue(result, &goResult)
+        return goResult, nil
+    }
+}
+```
+
+RuntimePredicate becomes an adapter, not a type:
+
+```go
+// internal/execution/predicate.go
+
+func PredicateAdapter(c *mem.Callable, thread *starlark.Thread) func(any) (bool, error) {
+    return func(input any) (bool, error) {
+        starInput, _ := op.MarshalValue(input)
+        result, err := starlark.Call(thread, c.Fn(), starlark.Tuple{starInput}, nil)
+        if err != nil {
+            return false, err
+        }
+        return bool(result.Truth()), nil
+    }
+}
+```
+
+### Signature Validation
+
+At extraction time, validate the callable against the target action's
+expected arity. Uses `*starlark.Function` introspection:
+
+```go
+// pkg/op/provider/mem/extract.go
+
+func ValidateArity(fn *starlark.Function, minParams, maxParams int) error {
+    numRequired := 0
+    for i := range fn.NumParams() {
+        if fn.ParamDefault(i) == nil {
+            numRequired++
+        }
+    }
+    if numRequired > maxParams {
+        return fmt.Errorf("%s requires %d args but target accepts at most %d",
+            fn.Name(), numRequired, maxParams)
+    }
+    if fn.NumParams() < minParams {
+        return fmt.Errorf("%s accepts %d args but target requires at least %d",
+            fn.Name(), fn.NumParams(), minParams)
+    }
+    return nil
+}
+```
+
+For `starlark.Builtin` callables (Go functions exposed to Starlark),
+introspection is not possible — builtins don't carry parameter metadata.
+Validation is skipped; arity errors surface at call time.
+
+### Slot Flow
+
+`mem.Callable` is a Resource. Resources already flow through the slot
+system as immediate values. No new slot variant needed — callables use
+the existing `SetSlotImmediate` path. `FillSlot` already handles
+Resources via the constructor registry.
+
+At execution time, `ResolvedSlots` returns the `mem.Callable` as an
+immediate value. The action's `Do()` method calls `Init(ctx.Thread)`
+to populate the live callable, then adapts it.
+
+### Immediate Mode Flow
+
+```
+Starlark: file.walk_tree(root, lambda i, r, p: ..., True)
+    │
+    ▼
+buildMethodBridge: recognizes callable param type
+    │
+    ├─ Extract: *starlark.Function → mem.Callable (source + bytecode)
+    ├─ Validate arity
+    ├─ Init(thread) → live callable
+    ├─ ReducerAdapter(callable, thread) → Reducer
+    │
+    ▼
+Provider.WalkTree(root, reducer, true) → (result, stack, error)
+    │
+    ▼
+classifyReturn → Starlark value
+```
+
+In immediate mode, extraction and compilation happen inline. The
+compiled bytecode is discarded after use (no slot storage needed).
+
+### Planned Mode Flow
+
+```
+Starlark: plan.file.walk_tree(root, lambda i, r, p: ..., True)
+    │
+    ▼
+buildPlannedBridge: recognizes callable param type
+    │
+    ├─ Extract: *starlark.Function → mem.Callable (source + bytecode)
+    ├─ Validate arity
+    ├─ FillSlot stores mem.Callable as immediate Resource
+    │
+    ▼
+Graph node with slots: {root: ..., fn: mem.Callable, honor_gitignore: true}
+    │
+    ▼  (serialization / transfer / checkpoint)
+    │
+    ▼  (execution time — same or different machine)
+    │
+executor.executeNode:
+    ├─ ResolvedSlots returns mem.Callable in "fn" slot
+    ├─ ctx.Thread set by executor
+    │
+    ▼
+Action.Do(ctx, slots):
+    ├─ callable := slots["fn"].(*mem.Callable)
+    ├─ callable.Init(ctx.Thread)  // loads bytecode → live function
+    ├─ reducer := ReducerAdapter(callable, ctx.Thread)
+    ├─ Provider.WalkTree(root, reducer, honorGitignore)
+    │
+    ▼
+Result + RecoveryStack
+```
+
+### Serialization
+
+`mem.Callable` serializes fully:
+
+```yaml
+# In a serialized graph node's slot:
+fn:
+  uri: "mem:callable/file.Reducer/count_python_files"
+  content_type: callable
+  hash: "a1b2c3..."
+  func_type: file.Reducer
+  name: count_python_files
+  source: |
+    # Extracted callable — from recipe.star:42
+    ext = ".py"
+    def _callable(initial, resource, path):
+        if path.endswith(ext):
+            return initial + [resource]
+        return initial
+  compiled: <base64-encoded bytecode>
+  compiler_version: 14
+  func_name: _callable
+  param_names: [initial, resource, path]
+  original_pos: "recipe.star:42"
+```
+
+On load:
+- If `compiler_version` matches → `CompiledProgram(compiled)` (fast)
+- If version mismatch → `SourceProgramOptions(source)` (recompile)
+- Source is always present as the authoritative fallback
+
+### Recovery, Persistence, and Compensation
+
+**Is saga recovery real for a callable?**
+
+The callable itself is immutable code — source text and bytecode. It has
+no side effects to undo. You can't "un-compile" or "un-extract" a
+function. In the saga sense, a `mem.Callable` is not compensable. There's
+nothing to roll back.
+
+What IS compensable is **what the callable does when invoked**. WalkTree's
+Reducer can push operations onto the RecoveryStack — those get unwound by
+`CompensateWalkTree`. But that's the Reducer's effects being compensated,
+not the callable resource itself.
+
+The recovery framing has two distinct meanings here:
+
+| Concern | Real? | Mechanism |
+|---|---|---|
+| Undo the callable's invocation effects | Yes | Existing RecoveryStack (WalkTree already does this) |
+| Undo "creating" the callable | No | Immutable data — nothing to undo |
+| Persist callable for resumption after crash | Yes | Checkpoint to disk — but this is **persistence**, not compensation |
+| Clean up checkpoint files after success | Trivially yes | Recovery stack can remove temp files |
+
+The real benefits of `mem.Resource` for callables are **serialization**
+(anywhere to anywhere) and **self-containment** (graph carries its own
+code). The recovery mechanism is a convenient vehicle for persisting
+state to disk, but the callable itself doesn't exercise the compensation
+path.
+
+Where recovery IS real for `mem.Resource` in general: template payloads,
+generated JSON content, intermediate computation results — in-memory data
+that was produced by a compensable action and needs to be undone if a
+downstream node fails. But for callables specifically, recovery is about
+persistence and portability, not about undoing effects.
+
+**Compensation for WalkTree**: The `Reducer` callback can push operations
+onto the `RecoveryStack` during traversal. On error, `CompensateWalkTree`
+unwinds the stack in LIFO order. The adapter passes the Go-side `stack`
+to the Reducer; the Starlark function never sees it
+(`+devlore:callable swallow=stack`). This is unchanged — callables don't
+alter the existing compensation mechanism.
+
+## Implementation Phases
+
+|     | Phase | Name | Description |
+|-----|-------|------|-------------|
+| [ ] | 0 | [Resource identity](mem-resource/phase-0.md) | Slim `Resource` interface to `URI() + Resolve()`, correct URI schemes, rename net→appnet |
+| [ ] | 1 | [mem.Resource + Callable](mem-resource/phase-1.md) | `mem.Resource` type, `mem.Callable` with source/bytecode storage |
+| [ ] | 2 | [Extraction](mem-resource/phase-2.md) | `Extract(*starlark.Function)`, closure capture, synthetic file generation |
+| [ ] | 3 | [Compilation](mem-resource/phase-3.md) | `Compile()`, `Init(thread)`, `CompiledProgram` round-trip, version fallback |
+| [ ] | 4 | [Thread + bridge](mem-resource/phase-4.md) | Thread on Context, immediate + planned bridge callable detection |
+| [ ] | 5 | [WalkTree action](mem-resource/phase-5.md) | Registered action with ReducerAdapter, compensation |
+| [ ] | 6 | [E2E tests](mem-resource/phase-6.md) | Starlark test scripts for immediate and planned WalkTree |
+| [ ] | 7 | [Codegen](mem-resource/phase-7.md) | `star` recognizes callable params, generates adapter + bridge code |
+
+### Phase 0: Resource Identity
+
+Simplify the `Resource` interface from 6 methods to 3. Correct URI
+schemes to match their proper forms (opaque vs hierarchical). Rename
+`net` → `appnet`. See [devlore-resource-identity.md](../architecture/devlore-resource-identity.md).
+
+**Interface change** — `pkg/op/resource.go`:
+
+- Remove `Scheme()`, `Host()`, `Path()` from `Resource` interface
+- Keep them on `ResourceBase` as parsing helpers (not interface methods)
+- Add `Opaque()` and `Fragment()` parsing helpers to `ResourceBase`
+- Remove `NewURI(r Resource) string` method
+- Rename `SchemeNet` → `SchemeAppNet`, value `"net"` → `"appnet"`
+- `ResourceBase.URI()` returns the cached `uri` field (already does)
+
+**Per-provider URI changes:**
+
+- `pkg/op/provider/file/resource.go`:
+  - Remove `Scheme()`, `Host()`, `Path()` methods
+  - Cached `file://` + `SourcePath` construction (no change to URI format)
+
+- `pkg/op/provider/pkg/resource.go`:
+  - Remove `Scheme()`, `Host()`, `Path()` methods
+  - URI becomes purl-compliant: `pkg:<type>/<name>[@<version>]`
+  - `URI()` and `Purl()` converge — `Purl()` may become unnecessary
+  - Remove `NewURI` dispatch
+
+- `pkg/op/provider/service/resource.go`:
+  - Remove `Scheme()`, `Host()`, `Path()` methods
+  - URI becomes opaque: `svc:<name>` (was `svc:///<name>`)
+
+- `pkg/op/provider/net/` → `pkg/op/provider/appnet/`:
+  - Rename package `net` → `appnet`
+  - Remove `Scheme()`, `Host()`, `Path()` methods
+  - URI becomes opaque wrapper: `appnet:<escaped-inner-uri>`
+  - Targeted escaping: `#` and `?` in inner URI are percent-encoded
+  - Update all imports and references
+
+- `pkg/op/provider/git/resource.go`:
+  - Remove `Scheme()`, `Host()`, `Path()` methods
+  - URI becomes opaque: `git:<encoded-repo-url>[?path=<path>]#<commit>`
+  - Repo URL percent-encoded, optional path query, commit as fragment
+  - `Resolve()` pins mutable refs (branch/tag) to commit hash in fragment
+  - Cached construction (remove `NewURI` dispatch)
+
+- Update all test files that call `Scheme()`, `Host()`, `Path()` on
+  the interface — change to call on concrete type or use `ResourceBase`
+  parsing helpers
+
+- Update `DESIGN-DISCUSSION.md` references to `NewURI`
+
+**Tests:**
+
+- Each resource type: URI is correct after construction
+- Each resource type: URI updates after `Resolve()` if path changes
+- `pkg`: URI matches purl spec (`pkg:brew/jq`, `pkg:brew/jq@1.7`)
+- `svc`: opaque URI (`svc:nginx`, not `svc:///nginx`)
+- `appnet`: inner URI escaping round-trips correctly (`#` and `?` escaped)
+- `git`: opaque URI with encoded repo URL, optional path query, commit fragment
+- `git`: `Resolve()` pins mutable ref to commit hash in fragment
+- `ResourceBase` parsing helpers: `Scheme()`, `Opaque()`, `Host()`,
+  `Path()`, `Fragment()` work on cached URI strings
+- Catalog operations still work with cached URIs
+- `MarshalStarvalue` / round-trip tests still pass
+
+### Phase 1: mem.Resource + Callable
+
+- `pkg/op/provider/mem/resource.go` — `mem.Resource` type: `ContentType`,
+  `Data`, `Hash`, opaque URI construction (`mem:<content-type>/...`),
+  `String()` via `ResourceBase.Format`
+- `pkg/op/provider/mem/callable.go` — `mem.Callable` type: embeds
+  `mem.Resource`, adds `FuncType`, `Name` (URI identity), `Compiled`,
+  `FuncName`, `ParamNames`, `CompilerVersion`, `OriginalPos`,
+  unexported `fn`. URI: `mem:callable/<FuncType>/<Name>`
+- `pkg/op/provider/mem/callable_test.go` — construction, opaque URI
+  generation, JSON serialization round-trip, hash as metadata
+- Register `mem.Resource` constructor in `init()`
+
+### Phase 2: Extraction
+
+- `pkg/op/provider/mem/extract.go` — `Extract(*starlark.Function) (*Callable, error)`:
+  - Introspect params via `NumParams`, `Param`, `ParamDefault`
+  - Capture closure via `NumFreeVars`, `FreeVar`
+  - Serialize bindings as Starlark literals
+  - Extract function source from file using `Position()`
+  - Transform lambda → `def _callable`
+  - Emit synthetic file as `Data`
+- `pkg/op/provider/mem/extract_test.go`:
+  - Extract simple lambda (no closure)
+  - Extract lambda with closure bindings (string, int, list, dict)
+  - Extract named `def` function
+  - Extract function with default parameter values
+  - Validate round-trip: extract → synthetic source → parse → execute → same result
+- `pkg/op/provider/mem/literals.go` — `FormatStarlarkLiteral(starlark.Value) string`:
+  serializes frozen Starlark values as source-level literals
+
+### Phase 3: Compilation
+
+- `pkg/op/provider/mem/callable.go` — `Compile()` and `Init(thread)` methods
+- `pkg/op/provider/mem/callable_test.go`:
+  - Compile produces non-empty bytecode
+  - Init with matching CompilerVersion loads bytecode (no recompile)
+  - Init with mismatched version falls back to source recompilation
+  - Init extracts named function from globals
+  - Init rejects missing function name
+  - Bytecode round-trip: `Write` → `CompiledProgram` → `Init` → same result
+
+### Phase 4: Thread + Bridge
+
+- `pkg/op/context.go` — add `Thread *starlark.Thread` field
+- `internal/execution/executor.go` — create thread, set on context
+- `pkg/op/receiver_reflect.go` — extend `buildMethodBridge` to detect
+  `func`-typed params. Extract callable, Init, adapt, call.
+- `pkg/op/planned_reflect.go` — extend `buildPlannedBridge` to detect
+  `func`-typed params. Extract callable, store as slot immediate.
+- `pkg/op/action_reflect.go` — `validateSlotType` accepts `*mem.Callable`
+  for `func`-typed params
+- `pkg/op/provider/mem/extract.go` — `ValidateArity` function
+
+### Phase 5: WalkTree Action
+
+- `pkg/op/provider/file/callable_adapter.go` — `ReducerAdapter`
+- `pkg/op/provider/file/walk_tree_action.go` — registered
+  `CompensableAction` for `file.walk_tree`. `Do()` extracts
+  `mem.Callable` from slots, calls `Init(ctx.Thread)`, adapts to
+  `Reducer`, delegates to `Provider.WalkTree()`.
+- `pkg/op/provider/file/callable_adapter_test.go` — adapter unit tests
+
+### Phase 6: E2E Tests
+
+- `test_walk_tree.star` — immediate mode: walk temp dir, collect paths
+- `test_walk_tree_planned.star` — planned mode: `plan.file.walk_tree`
+- `test_walk_tree_gitignore.star` — `.gitignore` filtering
+- `test_walk_tree_skip.star` — `SkipDir` / `SkipAll` from callable
+- `test_walk_tree_closure.star` — lambda with closure bindings
+- `runner_test.go` — test functions
+
+### Phase 7: Codegen
+
+- Teach `star` to recognize `+devlore:callable` on function types
+- Generate adapter functions (like `ReducerAdapter`)
+- Generate bridge code that wraps `starlark.Callable` → `Extract` → adapter
+- Generate param registration with callable marker
+- This phase is in the `star` tool (noblefactor-ops)
+
+## Files to Create/Modify
+
+**Phase 0 — Resource Identity:**
+
+| File | Action | Purpose |
+|---|---|---|
+| `pkg/op/resource.go` | Modify | Slim interface, remove `NewURI`, add `Opaque`/`Fragment` helpers, rename `SchemeNet` → `SchemeAppNet` |
+| `pkg/op/provider/file/resource.go` | Modify | Remove `Scheme`/`Host`/`Path`, cached URI construction |
+| `pkg/op/provider/pkg/resource.go` | Modify | Purl-compliant opaque URI, converge `URI()` and `Purl()` |
+| `pkg/op/provider/service/resource.go` | Modify | Opaque `svc:<name>` URI |
+| `pkg/op/provider/net/` → `pkg/op/provider/appnet/` | Rename + Modify | Package rename, opaque `appnet:` URI with targeted escaping |
+| `pkg/op/provider/git/resource.go` | Modify | Opaque `git:` URI with encoded repo URL, query, fragment |
+| Test files | Modify | Update for new URI formats and removed interface methods |
+
+**Phases 1–7 — mem.Resource and Callables:**
+
+| File | Action | Purpose |
+|---|---|---|
+| `pkg/op/provider/mem/resource.go` | Rewrite | `mem.Resource` type with ContentType, Data, Hash |
+| `pkg/op/provider/mem/callable.go` | Create | `mem.Callable` — unified callable resource |
+| `pkg/op/provider/mem/extract.go` | Create | Extraction, closure capture, synthetic file generation |
+| `pkg/op/provider/mem/literals.go` | Create | Starlark value → source literal serializer |
+| `pkg/op/provider/mem/callable_test.go` | Create | Callable tests |
+| `pkg/op/provider/mem/extract_test.go` | Create | Extraction tests |
+| `pkg/op/context.go` | Modify | Add Thread field |
+| `pkg/op/receiver_reflect.go` | Modify | Callable detection in immediate bridge |
+| `pkg/op/planned_reflect.go` | Modify | Callable detection in planned bridge |
+| `pkg/op/action_reflect.go` | Modify | validateSlotType accepts Callable |
+| `pkg/op/provider/file/callable_adapter.go` | Create | ReducerAdapter |
+| `pkg/op/provider/file/walk_tree_action.go` | Create | Registered action for planned WalkTree |
+| `pkg/op/provider/file/callable_adapter_test.go` | Create | Adapter tests |
+| `internal/execution/executor.go` | Modify | Create thread, set on context |
+| `internal/e2e/testrunner/data/test_walk_tree*.star` | Create | E2E test scripts |
+| `internal/e2e/testrunner/runner_test.go` | Modify | Test functions |
+
+## Relationship to Other Plans
+
+**RuntimePredicate** (orchestration-primitives Step 3) becomes an adapter
+over `mem.Callable` — `PredicateAdapter`. The orchestration-primitives
+plan should build on the callable infrastructure from this plan. The
+`RuntimePredicate` type is eliminated; its functionality is:
+
+```go
+predicate := PredicateAdapter(callable, ctx.Thread)
+result, err := predicate(input)
+```
+
+**mem.Resource** is introduced here as the first `mem:` resource. The
+architecture doc's other planned uses (template payloads, JSON content)
+build on the same foundation — they're `mem.Resource` instances with
+different `ContentType` values.
+
+## Related Documents
+
+- [Architecture: Resource Identity](../architecture/devlore-resource-identity.md) — URI schemes, opaque vs hierarchical, interface simplification
+- [Architecture: Memory Resources](../architecture/devlore-mem-resource.md) — `mem:` scheme, callable design
+- [Architecture: Resource Management](../architecture/devlore-resource-management.md) — Resource lifecycle, `mem:` scheme table
+- [Architecture: Orchestration Primitives](../architecture/devlore-orchestration-primitives.md) — RuntimePredicate (superseded by callable)
+- [Orchestration Primitives](orchestration-primitives.md) — RuntimePredicate, WaitUntil
+- [Resource Management](resource-management.md) — Resource lifecycle, catalog
+- [Terminal Flow Control](terminal-flow-control.md) — Flow actions pattern
+- [Codegen Extraction](codegen-extraction.md) — Star tool, `+devlore:` annotations
+- [Provider Registration](provider-registration.md) — Action registration model
+- BUGS.md #170 — WalkTree binding gap
+
+## Open Questions
+
+- [ ] Should the adapter support arity adaptation (calling a 2-param
+  function where the Go type expects 3)? The `Actor` convenience wrapper
+  suggests users often don't need `initial`. Introspecting
+  `*starlark.Function.NumParams()` enables this.
+
+  Yes. The adapter inspects arity and omits trailing params when the
+  callable accepts fewer. The `+devlore:callable` annotation specifies
+  the minimum required arity. The Actor pattern validates this idiom.
+
+- [ ] For closure bindings of non-primitive types (e.g., a Resource
+  captured in a lambda), what serialization format should the synthetic
+  file use? `value.String()` works for display but may not produce a
+  valid Starlark literal for all types.
+
+  For now, restrict to primitive types + containers. Report a clear error
+  at extraction time if a free variable holds a non-serializable type.
+  Extend later if a real use case demands it.
+
+- [ ] Should `mem.Callable.Init()` cache the live callable across
+  multiple invocations (e.g., WalkTree calls the reducer per-file)?
+
+  Yes — `Init()` is called once per execution. The live `fn` field is
+  reused for all invocations within that execution. The adapter closes
+  over `c.Fn()` which returns the cached callable.
+
+- [ ] Should the compiled bytecode be stored in the resource catalog,
+  or only in the slot value?
+
+  Both. The catalog tracks the `mem:callable/<FuncType>/<Name>` URI
+  for deduplication. If two nodes reference the same callable (same
+  function type and name), they share one catalog entry. The content
+  hash detects when the callable's content has changed.


### PR DESCRIPTION
## Summary

Architecture docs and implementation plan for the mem-resource epic.

- **devlore-resource-identity.md** — URI as single identity contract; corrects all 6 resource URI schemes to proper RFC 3986 forms (hierarchical vs opaque); simplifies Resource interface to `URI() + Resolve()`; renames `net` → `appnet`
- **devlore-mem-resource.md** — `mem:` scheme architecture; typed byte buffer with opaque URI; content hash as metadata (not identity); callable design with three-tier storage, extraction, adapters, recovery analysis
- **mem-resource.md** — 8-phase plan: Phase 0 (resource identity refactor), Phases 1-7 (mem.Resource, extraction, compilation, bridge, WalkTree, E2E, codegen)

### URI Scheme Summary

| Scheme | Form | Catalog Key | Shadow Key |
|---|---|---|---|
| `file` | Hierarchical | `file:///absolute/path` | N/A (external) |
| `pkg` | Opaque | `pkg:type/name` | Version via `@version` |
| `svc` | Opaque | `svc:name` | Fragment reserved for instances |
| `appnet` | Opaque | `appnet:<escaped-url>` | N/A (external) |
| `git` | Opaque | `git:<encoded-repo>[?path=...]` | `#<commit-hash>` |
| `mem` | Opaque | `mem:callable/type/name` | Content hash as metadata |

## Test plan

- [x] Docs only — no code changes
- [x] `make build` unaffected
- [x] `make test` unaffected