### PR TITLE
feature(op): Resource interface simplification — Phase 0

### DIFF
--- a/DESIGN-DISCUSSION.md
+++ b/DESIGN-DISCUSSION.md
@@ -119,29 +119,11 @@ Down the road, pre-flight will also check prerequisites (e.g., must run on syste
 
 ### O4. URI construction
 
-**Status**: RESOLVED (correctness bug, needs implementation)
+**Status**: RESOLVED (implemented in Phase 0 of mem-resource epic)
 
-`file.NewResource` uses `fmt.Sprintf("file://%s", path)` instead of canonical URI construction. Relative paths produce wrong URIs, breaking catalog deduplication.
+**Decision**: Each concrete resource type owns its URI construction via a private `buildURI()` method. The URI is cached in `ResourceBase.uri` at construction time via `SetURI()`. There is no shared dispatch (`NewURI` is removed). If `Resolve()` changes identity-bearing fields (e.g., path canonicalization), the concrete type calls `SetURI(buildURI())` to update the cache.
 
-**Decision**: The `Resource` interface gains three component methods following `net/url.URL` naming: `Scheme()`, `Host()`, `Path()`. Each provider implements them — `Scheme()` and `Host()` are typically constants, `Path()` returns the provider-specific identifier (e.g., `file.Resource.Path()` returns the canonicalized `SourcePath`).
-
-`ResourceBase.NewURI(r Resource)` builds the URI from the three components via `net/url.URL`:
-
-```go
-func (b *ResourceBase) NewURI(r Resource) string {
-    return (&url.URL{Scheme: r.Scheme(), Host: r.Host(), Path: r.Path()}).String()
-}
-```
-
-Each provider implements `URI()` as a one-liner that passes itself:
-
-```go
-func (r *Resource) URI() string { return r.NewURI(r) }
-```
-
-`ResourceBase` stores nothing about scheme/host/path — those come from the concrete type. Canonicalization happens in the provider (e.g., `file.Resource.Path()` returns `filepath.Abs` + `filepath.Clean`). The standalone `ResourceURI` helper is removed.
-
-All URIs use the standard authority form: `scheme://host/path` (with host, e.g., `git://github.com/org/repo`) or `scheme:///path` (without host, e.g., `file:///usr/local/bin`, `svc:///nginx`).
+URIs follow RFC 3986 — hierarchical for file resources (`file:///path`), opaque for all others (`pkg:brew/jq`, `svc:nginx`, `appnet:host/path`, `git:repo-url#ref`, `mem:callable/type/name`). See `docs/architecture/devlore-resource-identity.md` for the full scheme registry.
 
 ### O5. `refreshMetadataWith` ignores the checksum parameter
 

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ $(P)/git/gen/planned.gen.go \
 $(P)/git/gen/provider.gen.go &: $(P)/git/provider.go | star
 	$(STAR) devlore actions generate --source=$(P)/git --gen=true --write=true --output=$(P)/git
 
-$(P)/net/gen/actions_gen_test.go \
-$(P)/net/gen/immediate.gen.go \
-$(P)/net/gen/immediate_gen_test.go \
-$(P)/net/gen/params.gen.go \
-$(P)/net/gen/planned.gen.go \
-$(P)/net/gen/provider.gen.go &: $(P)/net/provider.go | star
-	$(STAR) devlore actions generate --source=$(P)/net --gen=true --write=true --output=$(P)/net
+$(P)/appnet/gen/actions_gen_test.go \
+$(P)/appnet/gen/immediate.gen.go \
+$(P)/appnet/gen/immediate_gen_test.go \
+$(P)/appnet/gen/params.gen.go \
+$(P)/appnet/gen/planned.gen.go \
+$(P)/appnet/gen/provider.gen.go &: $(P)/appnet/provider.go | star
+	$(STAR) devlore actions generate --source=$(P)/appnet --gen=true --write=true --output=$(P)/appnet
 
 $(P)/pkg/gen/actions_gen_test.go \
 $(P)/pkg/gen/immediate.gen.go \
@@ -182,7 +182,7 @@ GEN_PROVIDERS := \
 	$(P)/file/gen/immediate.gen.go \
 	$(P)/git/gen/immediate.gen.go \
 	$(P)/json/gen/immediate.gen.go \
-	$(P)/net/gen/immediate.gen.go \
+	$(P)/appnet/gen/immediate.gen.go \
 	$(P)/pkg/gen/immediate.gen.go \
 	$(P)/regexp/gen/immediate.gen.go \
 	$(P)/service/gen/immediate.gen.go \

--- a/docs/architecture/devlore-execution-topology.md
+++ b/docs/architecture/devlore-execution-topology.md
@@ -1,4 +1,4 @@
-# Draft: Elevation Model
+# Execution Topology
 
 Design topic for a future plan. Not yet approved for implementation.
 
@@ -81,7 +81,9 @@ type ElevationAware interface {
 }
 ```
 
-**Instance-level** — node annotation overrides the type-level default:
+**Instance-level** — node annotation overrides the type-level default.
+`Node.Annotations` (`map[string]string`) is already implemented and serialized
+to JSON/YAML receipts:
 
 ```go
 node.Annotations["elevate"] = "true"   // force elevation for this node
@@ -121,8 +123,16 @@ type ElevationProvider interface {
 
 ### flow.elevate Integration
 
+`flow.elevate` exists as a registered flow action (`internal/execution/flow/elevate.go`)
+alongside `flow.choose`, `flow.gather`, `flow.complete`, `flow.degraded`,
+`flow.fatal`, and `flow.wait_until`. It is currently a passthrough stub that
+makes privilege boundaries visible in the graph. The full privilege provider
+wiring is the subject of this design.
+
+The action signatures use `Complement` (the current undo state type alias):
+
 ```go
-func (a *Elevate) Do(ctx *Context, slots map[string]any) (Result, UndoState, error) {
+func (a *Elevate) Do(ctx *op.Context, slots map[string]any) (op.Result, op.Complement, error) {
     provider := elevationProviderFromContext(ctx)
     if provider == nil {
         return nil, nil, fmt.Errorf("elevation required but no provider configured")
@@ -130,12 +140,12 @@ func (a *Elevate) Do(ctx *Context, slots map[string]any) (Result, UndoState, err
     if err := provider.Start(ctx); err != nil {
         return nil, nil, fmt.Errorf("failed to acquire elevation: %w", err)
     }
-    // Provider is the undo state — Undo calls Stop
+    // Provider is the complement — Undo calls Stop
     return nil, provider, nil
 }
 
-func (a *Elevate) Undo(ctx *Context, slots map[string]any, state UndoState) error {
-    if provider, ok := state.(ElevationProvider); ok {
+func (a *Elevate) Undo(ctx *op.Context, complement op.Complement) error {
+    if provider, ok := complement.(ElevationProvider); ok {
         return provider.Stop()
     }
     return nil
@@ -145,6 +155,14 @@ func (a *Elevate) Undo(ctx *Context, slots map[string]any, state UndoState) erro
 The `flow.elevate` node in the graph makes privilege acquisition visible in the
 plan and receipt. Phase boundary = child lifetime. The receipt records when
 elevation was acquired and released.
+
+### Context Integration
+
+`op.Context` currently carries: `context.Context` (embedded), `Catalog`,
+`Data map[string]any`, `DryRun`, `Graph`, `NodeID`, `Platform`, and `Writer`.
+The elevation provider would be accessed via `ctx.Data` or a dedicated field.
+The `Platform` field (added for host abstraction) already provides OS detection
+needed for platform-specific elevation dispatch.
 
 ---
 
@@ -160,6 +178,28 @@ elevation was acquired and released.
   scenarios.
 - **Named pipes**: Native IPC mechanism on Windows — better fit than
   stdin/stdout pipes for the elevated child.
+
+---
+
+## Prior Art: Persistent PowerShell Session
+
+The `internal/pwsh` package implements the persistent child process + pipe IPC
+pattern for PowerShell on Windows. This is the same architectural shape proposed
+for elevation:
+
+- A single `pwsh -NoProfile -NonInteractive -Command -` process is spawned once
+- Commands are streamed to stdin; output is read from stdout until a marker
+- Variables, module imports, and session state persist across calls
+- The session is closed explicitly (or on process exit)
+
+This exists because PowerShell modules (Az, ActiveDirectory, PackageManagement)
+establish authenticated sessions on import, and COM/.NET objects (WMI, Registry,
+IIS) are expensive to instantiate. Spawning `pwsh -Command` per operation loses
+all state.
+
+The elevation worker generalizes this pattern: instead of PowerShell-specific
+stdin/marker protocol, the worker uses a structured IPC protocol (ndjson) for
+arbitrary `(command, args, env) → (stdout, stderr, exit_code)` exchanges.
 
 ---
 
@@ -251,11 +291,12 @@ type Executor interface {
 
 ### Graph Lifecycle Over SSH
 
-1. **Transfer:** Coordinator SCP/SFTPs the graph (JSON) and the runner binary
-   to the target.
+1. **Transfer:** Coordinator SCP/SFTPs the graph (JSON or YAML) and the runner
+   binary to the target.
 2. **Trigger:** Coordinator calls `session.Start("./runner --graph=task.json")`.
 3. **Hydration:** On the target, the runner loads the graph, reconciles against
-   local system state, and begins execution.
+   local system state (using the `RecoveryStack` with drift detection and
+   reconcile functions), and begins execution.
 4. **Persistence:** The runner saves the result graph (receipt) to a local file.
 5. **Retrieval:** Coordinator detects process exit, downloads the result graph.
 
@@ -280,7 +321,8 @@ For "chunky" workloads (minutes to hours):
   coordinator monitors.
 - **Detached pattern:** For very long workloads, start via `nohup` or a systemd
   transient unit. Disconnect and re-attach later to check exit status. This
-  maps to the Recovery Stack restart capability (see `draft.md`).
+  maps to the Recovery Stack restart capability (see
+  [devlore-recovery-serialization](devlore-recovery-serialization.md) — planned).
 
 ---
 

--- a/docs/architecture/devlore-operation-namespaces.md
+++ b/docs/architecture/devlore-operation-namespaces.md
@@ -50,7 +50,7 @@ The execution engine processes a directed acyclic graph (DAG) of nodes, where ea
 | pkg | `pkg.install`, `pkg.upgrade`, `pkg.remove`, `pkg.update` | `provider/pkg` |
 | shell | `shell.exec`, `shell.powershell` | `provider/shell` |
 | service | `service.start`, `service.stop`, `service.restart`, `service.enable`, `service.disable` | `provider/service` |
-| net | `net.download` | `provider/net` |
+| appnet | `appnet.download` | `provider/appnet` |
 | archive | `archive.extract` | `provider/archive` |
 | git | `git.clone`, `git.checkout`, `git.pull` | `provider/git` |
 | flow | `flow.choose`, `flow.gather`, `flow.elevate` | `flow/` |

--- a/docs/architecture/devlore-recovery-serialization.md
+++ b/docs/architecture/devlore-recovery-serialization.md
@@ -1,4 +1,6 @@
-# Next Design Topic: Recovery Stack Serialization & Restart
+# Recovery Stack Serialization & Restart
+
+Design topic for a future plan. Not yet approved for implementation.
 
 ## Problem
 

--- a/internal/e2e/testrunner/data/test_net.star
+++ b/internal/e2e/testrunner/data/test_net.star
@@ -1,6 +1,6 @@
-# test_net.star — Dry-run: net.download creates a graph node.
+# test_net.star — Dry-run: appnet.download creates a graph node.
 #
-# Validates: plan.net.download (registration + node creation)
+# Validates: plan.appnet.download (registration + node creation)
 
-plan.net.download(url="https://example.com/file.txt")
+plan.appnet.download(url="https://example.com/file.txt")
 t.expect_node_count(1)

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -100,7 +100,7 @@ func TestAllProvidersCount(t *testing.T) {
 		"pkg.install", "pkg.upgrade", "pkg.remove", "pkg.update", "pkg.installed", "pkg.not_installed", "pkg.version_gte",
 		"shell.exec", "shell.power_shell",
 		"service.start", "service.stop", "service.restart", "service.enable", "service.disable", "service.exists", "service.running", "service.enabled",
-		"net.download",
+		"appnet.download",
 		"archive.extract",
 		"git.clone", "git.checkout", "git.pull",
 	}

--- a/internal/execution/provider_test.go
+++ b/internal/execution/provider_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/archive"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/git"
-	"github.com/NobleFactor/devlore-cli/pkg/op/provider/net"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/pkg"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/service"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/shell"
@@ -340,23 +340,23 @@ func TestGitPullDryRun(t *testing.T) {
 	}
 }
 
-// --- net action tests ---
+// --- appnet action tests ---
 
-func TestNetDownload(t *testing.T) {
+func TestAppnetDownload(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "downloaded content")
 	}))
 	defer ts.Close()
 
 	ctx := &op.Context{Context: context.Background()}
-	action := &net.Download{Impl: &net.Provider{}}
+	action := &appnet.Download{Impl: &appnet.Provider{}}
 	slots := map[string]any{
 		"url": ts.URL,
 	}
 
 	result, _, err := action.Do(ctx, slots)
 	if err != nil {
-		t.Fatalf("net.download: %v", err)
+		t.Fatalf("appnet.download: %v", err)
 	}
 
 	data, ok := result.([]byte)
@@ -368,21 +368,21 @@ func TestNetDownload(t *testing.T) {
 	}
 }
 
-func TestNetDownloadReturnsContent(t *testing.T) {
+func TestAppnetDownloadReturnsContent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "file content")
 	}))
 	defer ts.Close()
 
 	ctx := &op.Context{Context: context.Background()}
-	action := &net.Download{Impl: &net.Provider{}}
+	action := &appnet.Download{Impl: &appnet.Provider{}}
 	slots := map[string]any{
 		"url": ts.URL,
 	}
 
 	result, _, err := action.Do(ctx, slots)
 	if err != nil {
-		t.Fatalf("net.download: %v", err)
+		t.Fatalf("appnet.download: %v", err)
 	}
 
 	data, ok := result.([]byte)
@@ -394,19 +394,19 @@ func TestNetDownloadReturnsContent(t *testing.T) {
 	}
 }
 
-func TestNetDownloadDryRun(t *testing.T) {
+func TestAppnetDownloadDryRun(t *testing.T) {
 	var buf bytes.Buffer
 	ctx := &op.Context{Context: context.Background(), DryRun: true, Writer: &buf}
-	action := &net.Download{Impl: &net.Provider{}}
+	action := &appnet.Download{Impl: &appnet.Provider{}}
 	slots := map[string]any{
 		"url": "https://example.com/test.tar.gz",
 	}
 
 	_, _, err := action.Do(ctx, slots)
 	if err != nil {
-		t.Fatalf("net.download dry-run: %v", err)
+		t.Fatalf("appnet.download dry-run: %v", err)
 	}
-	if !strings.Contains(buf.String(), "[dry-run] net.download") {
+	if !strings.Contains(buf.String(), "[dry-run] appnet.download") {
 		t.Errorf("expected dry-run download log, got %q", buf.String())
 	}
 }

--- a/pkg/op/action_reflect_test.go
+++ b/pkg/op/action_reflect_test.go
@@ -47,10 +47,11 @@ type actionResource struct {
 	SourcePath string
 }
 
-func (r *actionResource) URI() string    { return r.NewURI(r) }
-func (r *actionResource) Scheme() string { return SchemeFile }
-func (r *actionResource) Host() string   { return "" }
-func (r *actionResource) Path() string   { return r.SourcePath }
+func newActionResource(path string) *actionResource {
+	r := &actionResource{SourcePath: path}
+	r.SetURI("file://" + path)
+	return r
+}
 
 // actionProvider exercises all action patterns.
 type actionProvider struct{}
@@ -97,7 +98,9 @@ func (p *actionProvider) Configure(name string, cfg actionConfig) (string, error
 
 // Returns a Resource by value — tests shadowResult.
 func (p *actionProvider) Create(path string) (actionResource, string, error) {
-	return actionResource{SourcePath: path}, "undo:" + path, nil
+	r := actionResource{SourcePath: path}
+	r.SetURI("file://" + path)
+	return r, "undo:" + path, nil
 }
 
 func (p *actionProvider) CompensateCreate(state string) error {

--- a/pkg/op/output.go
+++ b/pkg/op/output.go
@@ -164,7 +164,7 @@ func (o *Output) Path() string {
 }
 
 // retryBuiltin sets the retry policy on this output's node.
-// Usage: node = plan.net.download(...); node.retry(max_attempts=5, backoff="linear")
+// Usage: node = plan.appnet.download(...); node.retry(max_attempts=5, backoff="linear")
 func (o *Output) retryBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var maxAttempts int
 	var backoff, initialDelay, maxDelay string

--- a/pkg/op/output_test.go
+++ b/pkg/op/output_test.go
@@ -242,7 +242,7 @@ func TestOutputAttr(t *testing.T) {
 }
 
 func TestOutputAttrRetry(t *testing.T) {
-	n := makeTestNode("r1", "net.download")
+	n := makeTestNode("r1", "appnet.download")
 	g := makeTestGraph()
 	out := NewOutput(n, g, "")
 
@@ -628,20 +628,18 @@ type testFileResource struct {
 	SourcePath string
 }
 
-func (r *testFileResource) URI() string    { return r.NewURI(r) }
-func (r *testFileResource) Scheme() string { return SchemeFile }
-func (r *testFileResource) Host() string   { return "" }
-func (r *testFileResource) Path() string   { return r.SourcePath }
+func newTestFileResource(path string) *testFileResource {
+	r := &testFileResource{SourcePath: path}
+	r.SetURI("file://" + path)
+	return r
+}
 
 func TestFillSlotImplicitEdge_ResourceWithOrigin(t *testing.T) {
 	g := makeTestGraph()
 	consumer := makeTestNode("reader", "file.read")
 
 	// A resource produced by "writer" node — FillSlot should create an implicit edge.
-	res := &testFileResource{
-		ResourceBase: NewResourceBase("file:///foo"),
-		SourcePath:   "/foo",
-	}
+	res := newTestFileResource("/foo")
 	if _, err := g.Catalog.Shadow(res, "writer"); err != nil {
 		t.Fatalf("Shadow error: %v", err)
 	}
@@ -669,10 +667,7 @@ func TestFillSlotImplicitEdge_ResourceWithoutOrigin(t *testing.T) {
 	consumer := makeTestNode("reader", "file.read")
 
 	// A discovered resource (no origin) — FillSlot should NOT create an edge.
-	res := &testFileResource{
-		ResourceBase: NewResourceBase("file:///bar"),
-		SourcePath:   "/bar",
-	}
+	res := newTestFileResource("/bar")
 	// Resolve creates a discovery entry with no origin.
 	g.Catalog.Resolve("file:///bar")
 
@@ -797,7 +792,7 @@ func TestOutputRetryBuiltin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := makeTestNode("r1", "net.download")
+			n := makeTestNode("r1", "appnet.download")
 			out := NewOutput(n, makeTestGraph(), "")
 
 			val, err := out.Attr("retry")
@@ -845,7 +840,7 @@ func TestOutputRetryBuiltin(t *testing.T) {
 }
 
 func TestOutputRetryBuiltinDelays(t *testing.T) {
-	n := makeTestNode("r1", "net.download")
+	n := makeTestNode("r1", "appnet.download")
 	out := NewOutput(n, makeTestGraph(), "")
 
 	val, err := out.Attr("retry")

--- a/pkg/op/planned_reflect_test.go
+++ b/pkg/op/planned_reflect_test.go
@@ -254,7 +254,9 @@ func TestWrapPlanned_ResolvesResourceParams(t *testing.T) {
 		if !ok {
 			return actionResource{}, fmt.Errorf("expected string, got %T", v)
 		}
-		return actionResource{SourcePath: s}, nil
+		r := actionResource{SourcePath: s}
+		r.SetURI("file://" + s)
+		return r, nil
 	})
 	defer constructorRegistry.Delete(reflect.TypeOf(actionResource{}))
 
@@ -334,7 +336,9 @@ func TestWrapPlanned_ShadowsOutputResource(t *testing.T) {
 		if !ok {
 			return actionResource{}, fmt.Errorf("expected string, got %T", v)
 		}
-		return actionResource{SourcePath: s}, nil
+		r := actionResource{SourcePath: s}
+		r.SetURI("file://" + s)
+		return r, nil
 	})
 	defer constructorRegistry.Delete(reflect.TypeOf(actionResource{}))
 
@@ -402,7 +406,9 @@ func TestWrapPlanned_ShadowsSingleResourceOutput(t *testing.T) {
 		if !ok {
 			return actionResource{}, fmt.Errorf("expected string, got %T", v)
 		}
-		return actionResource{SourcePath: s}, nil
+		r := actionResource{SourcePath: s}
+		r.SetURI("file://" + s)
+		return r, nil
 	})
 	defer constructorRegistry.Delete(reflect.TypeOf(actionResource{}))
 
@@ -457,7 +463,9 @@ func TestWrapPlanned_ConflictDetection(t *testing.T) {
 		if !ok {
 			return actionResource{}, fmt.Errorf("expected string, got %T", v)
 		}
-		return actionResource{SourcePath: s}, nil
+		r := actionResource{SourcePath: s}
+		r.SetURI("file://" + s)
+		return r, nil
 	})
 	defer constructorRegistry.Delete(reflect.TypeOf(actionResource{}))
 
@@ -559,7 +567,9 @@ func TestWrapPlanned_TypeValidation_AcceptsConstructable(t *testing.T) {
 		if !ok {
 			return actionResource{}, fmt.Errorf("expected string, got %T", v)
 		}
-		return actionResource{SourcePath: s}, nil
+		r := actionResource{SourcePath: s}
+		r.SetURI("file://" + s)
+		return r, nil
 	})
 	defer constructorRegistry.Delete(reflect.TypeOf(actionResource{}))
 

--- a/pkg/op/provider/appnet/provider.go
+++ b/pkg/op/provider/appnet/provider.go
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
-// Package net provides network actions for the operation graph.
-package net //nolint:revive // package name is domain-specific
+// Package appnet provides network actions for the operation graph.
+package appnet
 
 import (
 	"context"

--- a/pkg/op/provider/appnet/provider_test.go
+++ b/pkg/op/provider/appnet/provider_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
-package net //nolint:revive // package name is domain-specific
+package appnet
 
 import (
 	"bytes"

--- a/pkg/op/provider/appnet/resource.go
+++ b/pkg/op/provider/appnet/resource.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
-package net //nolint:revive // package name is domain-specific
+package appnet
 
 import (
 	"fmt"
@@ -15,22 +15,24 @@ func init() {
 	op.RegisterConstructor(func(v any) (Resource, error) {
 		s, ok := v.(string)
 		if !ok {
-			return Resource{}, fmt.Errorf("net.Resource: expected string URL, got %T", v)
+			return Resource{}, fmt.Errorf("appnet.Resource: expected string URL, got %T", v)
 		}
 		u, err := url.Parse(s)
 		if err != nil {
-			return Resource{}, fmt.Errorf("net.Resource: invalid URL %q: %w", s, err)
+			return Resource{}, fmt.Errorf("appnet.Resource: invalid URL %q: %w", s, err)
 		}
-		return Resource{SourceURL: u}, nil
+		r := Resource{SourceURL: u}
+		r.SetURI(r.buildURI())
+		return r, nil
 	})
 }
 
 // Resource represents a network resource identified by a URL.
 //
 // The SourceURL holds the original URL as provided (with transport scheme,
-// original casing, etc.). The canonical URI produced by [URI] strips the
-// transport scheme and normalizes the authority and path components for
-// catalog deduplication.
+// original casing, etc.). The canonical URI produced by [URI] is an opaque
+// appnet: URI wrapping the normalized, transport-independent URL with
+// targeted escaping of # and ? characters.
 type Resource struct {
 	op.ResourceBase
 	SourceURL *url.URL
@@ -39,21 +41,28 @@ type Resource struct {
 // String returns a compact JSON representation of the resource.
 func (r Resource) String() string { return r.Format(r) }
 
-// URI returns the canonical net:// URI for catalog lookups.
-//
-// The URI is transport-independent: http://example.com/f and
-// https://example.com/f produce the same URI. The original transport
-// scheme is available via SourceURL.Scheme.
-func (r *Resource) URI() string { return "net://" + r.canonicalAuthority() }
+// buildURI computes the opaque appnet: URI.
+// The inner URL is normalized and wrapped with targeted escaping.
+func (r *Resource) buildURI() string {
+	return "appnet:" + escapeInnerURI(r.canonicalAuthority())
+}
 
-// Scheme returns "net".
-func (r *Resource) Scheme() string { return op.SchemeNet }
-
-// Host returns the lowercased hostname from the source URL.
-func (r *Resource) Host() string { return strings.ToLower(r.SourceURL.Hostname()) }
-
-// Path returns the raw path from the source URL.
-func (r *Resource) Path() string { return r.SourceURL.Path }
+// escapeInnerURI percent-encodes # and ? so they don't interfere with
+// the outer URI's fragment and query parsing.
+func escapeInnerURI(s string) string {
+	var b []byte
+	for i := range len(s) {
+		switch s[i] {
+		case '#':
+			b = append(b, '%', '2', '3')
+		case '?':
+			b = append(b, '%', '3', 'F')
+		default:
+			b = append(b, s[i])
+		}
+	}
+	return string(b)
+}
 
 // canonicalAuthority produces the canonical host+path+query string.
 //

--- a/pkg/op/provider/appnet/resource_test.go
+++ b/pkg/op/provider/appnet/resource_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: SSPL-1.0
 // Copyright (c) 2025-2026 Noble Factor. All rights reserved.
 
-package net //nolint:revive // package name is domain-specific
+package appnet
 
 import (
 	"testing"
@@ -11,27 +11,6 @@ import (
 
 func TestResourceImplementsInterface(t *testing.T) {
 	var _ op.Resource = (*Resource)(nil)
-}
-
-func TestResourceScheme(t *testing.T) {
-	r := mustParse(t, "https://example.com/path")
-	if r.Scheme() != op.SchemeNet {
-		t.Errorf("Scheme() = %q, want %q", r.Scheme(), op.SchemeNet)
-	}
-}
-
-func TestResourceHost(t *testing.T) {
-	r := mustParse(t, "https://Example.COM/path")
-	if r.Host() != "example.com" {
-		t.Errorf("Host() = %q, want %q", r.Host(), "example.com")
-	}
-}
-
-func TestResourcePath(t *testing.T) {
-	r := mustParse(t, "https://example.com/some/path")
-	if r.Path() != "/some/path" {
-		t.Errorf("Path() = %q, want %q", r.Path(), "/some/path")
-	}
 }
 
 func TestConstructorRoundTrip(t *testing.T) {
@@ -66,6 +45,16 @@ func TestURITransportIndependent(t *testing.T) {
 	}
 }
 
+func TestURIOpaqueScheme(t *testing.T) {
+	r := mustParse(t, "https://example.com/path")
+	if r.Scheme() != "appnet" {
+		t.Errorf("Scheme() = %q, want %q", r.Scheme(), "appnet")
+	}
+	if r.Opaque() == "" {
+		t.Error("Opaque() is empty — expected opaque URI")
+	}
+}
+
 func TestURICanonicalization(t *testing.T) {
 	tests := []struct {
 		name string
@@ -75,72 +64,67 @@ func TestURICanonicalization(t *testing.T) {
 		{
 			name: "lowercase host",
 			raw:  "https://Example.COM/path",
-			want: "net://example.com/path",
+			want: "appnet:example.com/path",
 		},
 		{
 			name: "strip default https port",
 			raw:  "https://example.com:443/path",
-			want: "net://example.com/path",
+			want: "appnet:example.com/path",
 		},
 		{
 			name: "strip default http port",
 			raw:  "http://example.com:80/path",
-			want: "net://example.com/path",
+			want: "appnet:example.com/path",
 		},
 		{
 			name: "keep non-default port",
 			raw:  "https://example.com:8443/path",
-			want: "net://example.com:8443/path",
+			want: "appnet:example.com:8443/path",
 		},
 		{
 			name: "strip trailing slash",
 			raw:  "https://example.com/path/",
-			want: "net://example.com/path",
+			want: "appnet:example.com/path",
 		},
 		{
 			name: "collapse double slashes",
 			raw:  "https://example.com/a//b///c",
-			want: "net://example.com/a/b/c",
+			want: "appnet:example.com/a/b/c",
 		},
 		{
 			name: "uppercase percent encoding",
 			raw:  "https://example.com/p%61th",
-			want: "net://example.com/path",
+			want: "appnet:example.com/path",
 		},
 		{
 			name: "keep reserved chars encoded",
 			raw:  "https://example.com/path%20with%20spaces",
-			want: "net://example.com/path%20with%20spaces",
+			want: "appnet:example.com/path%20with%20spaces",
 		},
 		{
 			name: "uppercase hex digits",
 			raw:  "https://example.com/%2f%2F",
-			want: "net://example.com/%2F%2F",
+			want: "appnet:example.com/%2F%2F",
 		},
 		{
-			name: "sort query parameters",
+			name: "sort query parameters escaped",
 			raw:  "https://example.com/path?z=1&a=2&m=3",
-			want: "net://example.com/path?a=2&m=3&z=1",
+			want: "appnet:example.com/path%3Fa=2&m=3&z=1",
 		},
 		{
 			name: "root path stays",
 			raw:  "https://example.com",
-			want: "net://example.com/",
+			want: "appnet:example.com/",
 		},
 		{
 			name: "all rules combined",
 			raw:  "HTTPS://Example.COM:443/A//B/%7e/?z=1&a=2",
-			want: "net://example.com/A/B/~?a=2&z=1",
+			want: "appnet:example.com/A/B/~%3Fa=2&z=1",
 		},
 		{
 			name: "ftp default port stripped",
 			raw:  "ftp://files.example.com:21/pub/file.txt",
-			want: "net://files.example.com/pub/file.txt",
-		},
-		{
-			name: "file scheme accepted",
-			raw:  "file:///etc/hosts",
-			want: "net:///etc/hosts",
+			want: "appnet:files.example.com/pub/file.txt",
 		},
 	}
 

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -37,20 +37,9 @@ type Resource struct {
 // String returns a compact JSON representation of the resource.
 func (r Resource) String() string { return r.Format(r) }
 
-// URI returns the canonical file:// URI for this resource.
-func (r *Resource) URI() string { return r.NewURI(r) }
-
-// Scheme returns "file".
-func (r *Resource) Scheme() string { return op.SchemeFile }
-
-// Host returns empty string — file URIs have no authority.
-func (r *Resource) Host() string { return "" }
-
-// Path returns the resource's source path. Before Resolve(), this is the
-// raw path as given to the constructor. After Resolve(), it is the
-// canonicalized absolute path on the target machine.
-func (r *Resource) Path() string {
-	return r.SourcePath
+// buildURI computes the canonical file:// URI from SourcePath.
+func (r *Resource) buildURI() string {
+	return "file://" + r.SourcePath
 }
 
 // Tombstone holds file-specific compensation state.
@@ -68,7 +57,9 @@ type Tombstone struct {
 // is pure computation — no I/O, no error. Metadata (size, mode, checksum)
 // is populated later by [Resource.Resolve].
 func NewResource(path string) Resource {
-	return Resource{SourcePath: path}
+	r := Resource{SourcePath: path}
+	r.SetURI(r.buildURI())
+	return r
 }
 
 // Resolve populates the resource's metadata by canonicalizing the path and
@@ -79,6 +70,7 @@ func (r *Resource) Resolve() error {
 	abs, err := filepath.Abs(r.SourcePath)
 	if err == nil {
 		r.SourcePath = filepath.Clean(abs)
+		r.SetURI(r.buildURI())
 	}
 
 	info, err := os.Stat(r.SourcePath)

--- a/pkg/op/provider/git/provider.go
+++ b/pkg/op/provider/git/provider.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
+	netprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
-	netprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/net"
 )
 
 // Provider provides git actions.

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
+	netprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
-	netprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/net"
 )
 
 func TestCloneViaHook(t *testing.T) {

--- a/pkg/op/provider/git/resource.go
+++ b/pkg/op/provider/git/resource.go
@@ -5,6 +5,7 @@ package git
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -16,7 +17,9 @@ func init() {
 		if !ok {
 			return Resource{}, fmt.Errorf("git.Resource: expected string path, got %T", v)
 		}
-		return Resource{ClonePath: s}, nil
+		r := Resource{ClonePath: s}
+		r.SetURI(r.buildURI())
+		return r, nil
 	})
 }
 
@@ -31,24 +34,58 @@ type Resource struct {
 // String returns a compact JSON representation of the resource.
 func (r Resource) String() string { return r.Format(r) }
 
-// URI returns the canonical git:// URI for this resource.
-func (r *Resource) URI() string { return r.NewURI(r) }
+// buildURI computes the opaque git: URI.
+//
+// Format: git:<encoded-repo-url>[?path=<path>]#<commit>
+// When URL is empty (local clone), the clone path is used as the opaque data.
+func (r *Resource) buildURI() string {
+	var opaque string
+	if r.URL != "" {
+		opaque = escapeInnerURI(r.URL)
+	} else {
+		opaque = escapeInnerURI(r.ClonePath)
+	}
+	s := "git:" + opaque
+	if r.Ref != "" {
+		s += "#" + r.Ref
+	}
+	return s
+}
 
-// Scheme returns "git".
-func (r *Resource) Scheme() string { return op.SchemeGit }
+// escapeInnerURI percent-encodes # and ? in an inner URI so they don't
+// interfere with the outer URI's fragment and query parsing.
+func escapeInnerURI(s string) string {
+	// url.PathEscape is too aggressive (encodes /). We only need to
+	// escape the characters that would be consumed by url.Parse.
+	var b []byte
+	for i := range len(s) {
+		switch s[i] {
+		case '#':
+			b = append(b, '%', '2', '3')
+		case '?':
+			b = append(b, '%', '3', 'F')
+		default:
+			b = append(b, s[i])
+		}
+	}
+	return string(b)
+}
 
-// Host returns empty string — git URIs use path-only identification.
-func (r *Resource) Host() string { return "" }
+// unescapeInnerURI reverses the targeted escaping of escapeInnerURI.
+func unescapeInnerURI(s string) string {
+	u, err := url.PathUnescape(s)
+	if err != nil {
+		return s
+	}
+	return u
+}
 
-// Path returns the clone path. Before Resolve(), this is the raw path as
-// given. After Resolve(), it is the canonicalized absolute path.
-func (r *Resource) Path() string { return r.ClonePath }
-
-// Resolve canonicalizes the clone path to an absolute path.
+// Resolve canonicalizes the clone path to an absolute path and updates the URI.
 func (r *Resource) Resolve() error {
 	abs, err := filepath.Abs(r.ClonePath)
 	if err == nil {
 		r.ClonePath = filepath.Clean(abs)
+		r.SetURI(r.buildURI())
 	}
 	return nil
 }

--- a/pkg/op/provider/git/resource_test.go
+++ b/pkg/op/provider/git/resource_test.go
@@ -9,14 +9,75 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-func TestResourceURI(t *testing.T) {
-	r := &Resource{ClonePath: "/tmp/repo"}
-	uri := r.URI()
-	if uri == "" {
-		t.Error("URI() returned empty string")
+func TestResourceURI_LocalClone(t *testing.T) {
+	r, err := op.Construct[Resource]("/tmp/repo")
+	if err != nil {
+		t.Fatalf("Construct: %v", err)
 	}
-	if r.Scheme() != op.SchemeGit {
-		t.Errorf("Scheme() = %q, want %q", r.Scheme(), op.SchemeGit)
+	want := "git:/tmp/repo"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceURI_RemoteURL(t *testing.T) {
+	r := Resource{URL: "https://github.com/org/repo", ClonePath: "/tmp/repo"}
+	r.SetURI(r.buildURI())
+	want := "git:https://github.com/org/repo"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceURI_WithRef(t *testing.T) {
+	r := Resource{URL: "https://github.com/org/repo", Ref: "abc123"}
+	r.SetURI(r.buildURI())
+	want := "git:https://github.com/org/repo#abc123"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceURI_EscapesFragment(t *testing.T) {
+	r := Resource{URL: "https://github.com/org/repo#readme", Ref: "main"}
+	r.SetURI(r.buildURI())
+	want := "git:https://github.com/org/repo%23readme#main"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceURI_EscapesQuery(t *testing.T) {
+	r := Resource{URL: "https://github.com/org/repo?token=abc"}
+	r.SetURI(r.buildURI())
+	want := "git:https://github.com/org/repo%3Ftoken=abc"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceURI_LocalCloneScheme(t *testing.T) {
+	r, err := op.Construct[Resource]("/tmp/repo")
+	if err != nil {
+		t.Fatalf("Construct: %v", err)
+	}
+	if r.Scheme() != "git" {
+		t.Errorf("Scheme() = %q, want %q", r.Scheme(), "git")
+	}
+	// Local absolute paths produce hierarchical URIs (path starts with /)
+	if r.Path() != "/tmp/repo" {
+		t.Errorf("Path() = %q, want %q", r.Path(), "/tmp/repo")
+	}
+}
+
+func TestResourceURI_RemoteOpaqueScheme(t *testing.T) {
+	r := Resource{URL: "https://github.com/org/repo"}
+	r.SetURI(r.buildURI())
+	if r.Scheme() != "git" {
+		t.Errorf("Scheme() = %q, want %q", r.Scheme(), "git")
+	}
+	if r.Opaque() != "https://github.com/org/repo" {
+		t.Errorf("Opaque() = %q, want %q", r.Opaque(), "https://github.com/org/repo")
 	}
 }
 
@@ -35,5 +96,40 @@ func TestConstructorRoundTrip(t *testing.T) {
 	}
 	if r.ClonePath != "/tmp/myrepo" {
 		t.Errorf("ClonePath = %q, want %q", r.ClonePath, "/tmp/myrepo")
+	}
+}
+
+func TestEscapeInnerURI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://example.com/path", "https://example.com/path"},
+		{"https://example.com/path?q=1", "https://example.com/path%3Fq=1"},
+		{"https://example.com/repo#readme", "https://example.com/repo%23readme"},
+		{"https://example.com/r?q=1#frag", "https://example.com/r%3Fq=1%23frag"},
+	}
+	for _, tt := range tests {
+		got := escapeInnerURI(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeInnerURI(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestUnescapeInnerURI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://example.com/path", "https://example.com/path"},
+		{"https://example.com/path%3Fq=1", "https://example.com/path?q=1"},
+		{"https://example.com/repo%23readme", "https://example.com/repo#readme"},
+	}
+	for _, tt := range tests {
+		got := unescapeInnerURI(tt.input)
+		if got != tt.want {
+			t.Errorf("unescapeInnerURI(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }

--- a/pkg/op/provider/pkg/resource.go
+++ b/pkg/op/provider/pkg/resource.go
@@ -23,12 +23,16 @@ func init() {
 // NewResource creates a Resource with the given package name.
 // The Type is left empty for auto-detection at Resolve() time.
 func NewResource(name string) Resource {
-	return Resource{Name: name}
+	r := Resource{Name: name}
+	r.SetURI(r.buildURI())
+	return r
 }
 
 // NewTypedResource creates a Resource with explicit package name and type.
 func NewTypedResource(name, typ string) Resource {
-	return Resource{Name: name, Type: typ}
+	r := Resource{Name: name, Type: typ}
+	r.SetURI(r.buildURI())
+	return r
 }
 
 // Resource represents a system package.
@@ -42,21 +46,8 @@ type Resource struct {
 // String returns a compact JSON representation of the resource.
 func (r Resource) String() string { return r.Format(r) }
 
-// URI returns the canonical pkg:// URI for this resource.
-func (r *Resource) URI() string { return r.NewURI(r) }
-
-// Scheme returns "pkg".
-func (r *Resource) Scheme() string { return op.SchemePackage }
-
-// Host returns the package type (manager), used as the URI authority.
-// With type: pkg://brew/jq. Without type: pkg:///jq.
-func (r *Resource) Host() string { return r.Type }
-
-// Path returns the package name with a leading slash.
-func (r *Resource) Path() string { return "/" + r.Name }
-
-// Purl returns the canonical package-url string (ECMA-427).
-func (r *Resource) Purl() string {
+// buildURI computes the purl-compliant opaque URI.
+func (r *Resource) buildURI() string {
 	if r.Type == "winget" {
 		// Split "Microsoft.VisualStudioCode" → namespace "Microsoft" / name "VisualStudioCode"
 		if ns, name, ok := strings.Cut(r.Name, "."); ok {
@@ -72,6 +63,12 @@ func (r *Resource) Purl() string {
 		s += "@" + r.Version
 	}
 	return s
+}
+
+// Purl returns the canonical package-url string. For this implementation,
+// URI() and Purl() produce the same string.
+func (r *Resource) Purl() string {
+	return r.URI()
 }
 
 // Resolve populates Type from the platform's default package manager

--- a/pkg/op/provider/pkg/resource_test.go
+++ b/pkg/op/provider/pkg/resource_test.go
@@ -33,59 +33,59 @@ func TestNewTypedResource(t *testing.T) {
 }
 
 func TestResourceURI_WithType(t *testing.T) {
-	r := &Resource{Name: "jq", Type: "brew"}
-	want := "pkg://brew/jq"
+	r := NewTypedResource("jq", "brew")
+	want := "pkg:brew/jq"
 	if got := r.URI(); got != want {
 		t.Errorf("URI() = %q, want %q", got, want)
 	}
 }
 
 func TestResourceURI_WithoutType(t *testing.T) {
-	r := &Resource{Name: "jq"}
-	want := "pkg:///jq"
+	r := NewResource("jq")
+	want := "pkg:/jq"
 	if got := r.URI(); got != want {
 		t.Errorf("URI() = %q, want %q", got, want)
 	}
 }
 
-func TestResourceScheme(t *testing.T) {
-	r := &Resource{Name: "jq"}
-	if r.Scheme() != op.SchemePackage {
-		t.Errorf("Scheme() = %q, want %q", r.Scheme(), op.SchemePackage)
+func TestResourceURI_WithVersion(t *testing.T) {
+	r := Resource{Name: "jq", Type: "brew", Version: "1.7"}
+	r.SetURI(r.buildURI())
+	want := "pkg:brew/jq@1.7"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
 	}
 }
 
-func TestResourceHost(t *testing.T) {
-	r := &Resource{Name: "jq", Type: "brew"}
-	if r.Host() != "brew" {
-		t.Errorf("Host() = %q, want %q", r.Host(), "brew")
+func TestResourceURI_Winget(t *testing.T) {
+	r := Resource{Name: "Microsoft.VisualStudioCode", Type: "winget"}
+	r.SetURI(r.buildURI())
+	want := "pkg:winget/Microsoft/VisualStudioCode"
+	if got := r.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
 	}
 }
 
-func TestResourceHost_Empty(t *testing.T) {
-	r := &Resource{Name: "jq"}
-	if r.Host() != "" {
-		t.Errorf("Host() = %q, want empty", r.Host())
+func TestResourceURI_ParsesAsOpaque(t *testing.T) {
+	r := NewTypedResource("jq", "brew")
+	if r.Scheme() != "pkg" {
+		t.Errorf("Scheme() = %q, want pkg", r.Scheme())
+	}
+	if r.Opaque() != "brew/jq" {
+		t.Errorf("Opaque() = %q, want brew/jq", r.Opaque())
 	}
 }
 
-func TestResourcePath(t *testing.T) {
-	r := &Resource{Name: "jq"}
-	if r.Path() != "/jq" {
-		t.Errorf("Path() = %q, want %q", r.Path(), "/jq")
-	}
-}
-
-func TestPurl_Simple(t *testing.T) {
-	r := &Resource{Name: "jq", Type: "brew"}
-	want := "pkg:brew/jq"
-	if got := r.Purl(); got != want {
-		t.Errorf("Purl() = %q, want %q", got, want)
+func TestPurl_ConvergesWithURI(t *testing.T) {
+	r := NewTypedResource("jq", "brew")
+	if r.URI() != r.Purl() {
+		t.Errorf("URI() = %q != Purl() = %q — should converge", r.URI(), r.Purl())
 	}
 }
 
 func TestPurl_WithVersion(t *testing.T) {
-	r := &Resource{Name: "jq", Type: "brew", Version: "1.7"}
+	r := Resource{Name: "jq", Type: "brew", Version: "1.7"}
+	r.SetURI(r.buildURI())
 	want := "pkg:brew/jq@1.7"
 	if got := r.Purl(); got != want {
 		t.Errorf("Purl() = %q, want %q", got, want)
@@ -93,7 +93,8 @@ func TestPurl_WithVersion(t *testing.T) {
 }
 
 func TestPurl_Winget(t *testing.T) {
-	r := &Resource{Name: "Microsoft.VisualStudioCode", Type: "winget"}
+	r := Resource{Name: "Microsoft.VisualStudioCode", Type: "winget"}
+	r.SetURI(r.buildURI())
 	want := "pkg:winget/Microsoft/VisualStudioCode"
 	if got := r.Purl(); got != want {
 		t.Errorf("Purl() = %q, want %q", got, want)
@@ -101,7 +102,8 @@ func TestPurl_Winget(t *testing.T) {
 }
 
 func TestPurl_WingetWithVersion(t *testing.T) {
-	r := &Resource{Name: "Microsoft.VisualStudioCode", Type: "winget", Version: "1.85"}
+	r := Resource{Name: "Microsoft.VisualStudioCode", Type: "winget", Version: "1.85"}
+	r.SetURI(r.buildURI())
 	want := "pkg:winget/Microsoft/VisualStudioCode@1.85"
 	if got := r.Purl(); got != want {
 		t.Errorf("Purl() = %q, want %q", got, want)
@@ -109,8 +111,8 @@ func TestPurl_WingetWithVersion(t *testing.T) {
 }
 
 func TestPurl_WingetNoDot(t *testing.T) {
-	// Winget package without namespace dot falls back to regular format.
-	r := &Resource{Name: "curl", Type: "winget"}
+	r := Resource{Name: "curl", Type: "winget"}
+	r.SetURI(r.buildURI())
 	want := "pkg:winget/curl"
 	if got := r.Purl(); got != want {
 		t.Errorf("Purl() = %q, want %q", got, want)

--- a/pkg/op/provider/service/resource.go
+++ b/pkg/op/provider/service/resource.go
@@ -15,7 +15,9 @@ func init() {
 		if !ok {
 			return Resource{}, fmt.Errorf("service.Resource: expected string name, got %T", v)
 		}
-		return Resource{Name: s}, nil
+		r := Resource{Name: s}
+		r.SetURI(r.buildURI())
+		return r, nil
 	})
 }
 
@@ -28,17 +30,10 @@ type Resource struct {
 // String returns a compact JSON representation of the resource.
 func (r Resource) String() string { return r.Format(r) }
 
-// URI returns the canonical svc:// URI for this resource.
-func (r *Resource) URI() string { return r.NewURI(r) }
-
-// Scheme returns "svc".
-func (r *Resource) Scheme() string { return op.SchemeService }
-
-// Host returns empty string.
-func (r *Resource) Host() string { return "" }
-
-// Path returns the service name.
-func (r *Resource) Path() string { return r.Name }
+// buildURI computes the opaque svc: URI.
+func (r *Resource) buildURI() string {
+	return "svc:" + r.Name
+}
 
 // Tombstone holds service-specific compensation state.
 type Tombstone struct {

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -17,18 +17,11 @@ import (
 // Every provider-specific resource (e.g., file.Resource) must embed [ResourceBase] to satisfy it. The unexported
 // resourceBase method seals the interface to package op. Only types embedding [ResourceBase] can implement [Resource].
 //
-// Concrete types must implement [Scheme], [Host], and [Path] to provide URI components. [URI] should be implemented
-// as a one-liner delegating to [ResourceBase.NewURI]:
-//
-//	func (r *Resource) URI() string { return r.NewURI(r) }
-//
-// [ResourceBase] provides default implementations of all four methods by parsing the stored uri field. Concrete types
-// shadow these with efficient, component-based implementations.
+// URI() returns a cached string computed at construction time. Each concrete type owns its URI construction —
+// there is no shared dispatch. If Resolve() changes identity-bearing fields (e.g., path canonicalization),
+// the concrete type updates the cached URI via [ResourceBase.SetURI].
 type Resource interface {
 	URI() string
-	Scheme() string
-	Host() string
-	Path() string
 	Resolve() error
 	resourceBase() *ResourceBase
 }
@@ -50,14 +43,19 @@ func NewResourceBase(uri string) ResourceBase {
 	return ResourceBase{uri: uri}
 }
 
-// URI returns the canonical URI of this resource. Concrete types should
-// shadow this with: func (r *Resource) URI() string { return r.NewURI(r) }
+// URI returns the cached canonical URI of this resource.
 func (b *ResourceBase) URI() string {
 	return b.uri
 }
 
-// Scheme returns the URI scheme by parsing the stored uri. Concrete types
-// should shadow this with a constant (e.g., "file").
+// SetURI updates the cached URI. Concrete types call this after Resolve()
+// when identity-bearing fields change (e.g., path canonicalization).
+func (b *ResourceBase) SetURI(uri string) {
+	b.uri = uri
+}
+
+// Scheme returns the URI scheme by parsing the stored uri.
+// Convenience helper — NOT an interface method.
 func (b *ResourceBase) Scheme() string {
 	u, err := url.Parse(b.uri)
 	if err != nil {
@@ -66,8 +64,20 @@ func (b *ResourceBase) Scheme() string {
 	return u.Scheme
 }
 
-// Host returns the URI host by parsing the stored uri. Concrete types
-// should shadow this with their authority component (often empty).
+// Opaque returns the opaque data component of the URI (non-empty for
+// opaque URIs like pkg:, svc:, mem:, appnet:). For hierarchical URIs
+// (file://), returns empty. Convenience helper — NOT an interface method.
+func (b *ResourceBase) Opaque() string {
+	u, err := url.Parse(b.uri)
+	if err != nil {
+		return ""
+	}
+	return u.Opaque
+}
+
+// Host returns the URI host by parsing the stored uri. Non-empty for
+// hierarchical URIs with an authority (e.g., net://host/path). Empty
+// for opaque URIs. Convenience helper — NOT an interface method.
 func (b *ResourceBase) Host() string {
 	u, err := url.Parse(b.uri)
 	if err != nil {
@@ -76,8 +86,9 @@ func (b *ResourceBase) Host() string {
 	return u.Host
 }
 
-// Path returns the URI path by parsing the stored uri. Concrete types
-// should shadow this with their provider-specific identifier.
+// Path returns the URI path by parsing the stored uri. Non-empty for
+// hierarchical URIs. Empty for opaque URIs. Convenience helper — NOT
+// an interface method.
 func (b *ResourceBase) Path() string {
 	u, err := url.Parse(b.uri)
 	if err != nil {
@@ -86,12 +97,14 @@ func (b *ResourceBase) Path() string {
 	return u.Path
 }
 
-// NewURI builds a canonical URI from a concrete Resource's component methods.
-// Concrete types call this to implement URI():
-//
-//	func (r *Resource) URI() string { return r.NewURI(r) }
-func (b *ResourceBase) NewURI(r Resource) string {
-	return (&url.URL{Scheme: r.Scheme(), Host: r.Host(), Path: r.Path()}).String()
+// Fragment returns the URI fragment by parsing the stored uri.
+// Convenience helper — NOT an interface method.
+func (b *ResourceBase) Fragment() string {
+	u, err := url.Parse(b.uri)
+	if err != nil {
+		return ""
+	}
+	return u.Fragment
 }
 
 // Resolve populates provider-specific metadata via I/O (e.g., os.Stat for
@@ -124,7 +137,7 @@ const (
 	SchemePackage = "pkg"
 	SchemeService = "svc"
 	SchemeMem     = "mem"
-	SchemeNet     = "net"
+	SchemeAppNet  = "appnet"
 )
 
 // MarshalStarvalue implements [starvalue.Marshaler]. It serializes the

--- a/pkg/op/resource_test.go
+++ b/pkg/op/resource_test.go
@@ -4,8 +4,6 @@
 package op
 
 import (
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -16,7 +14,15 @@ func TestResourceBase_URI(t *testing.T) {
 	}
 }
 
-func TestResourceBase_ComponentsParsedFromURI(t *testing.T) {
+func TestResourceBase_SetURI(t *testing.T) {
+	base := NewResourceBase("file:///foo")
+	base.SetURI("file:///bar")
+	if base.URI() != "file:///bar" {
+		t.Errorf("URI() = %q, want file:///bar", base.URI())
+	}
+}
+
+func TestResourceBase_ParseHierarchicalURI(t *testing.T) {
 	base := NewResourceBase("file:///usr/local/bin")
 	if base.Scheme() != "file" {
 		t.Errorf("Scheme() = %q, want file", base.Scheme())
@@ -27,56 +33,34 @@ func TestResourceBase_ComponentsParsedFromURI(t *testing.T) {
 	if base.Path() != "/usr/local/bin" {
 		t.Errorf("Path() = %q, want /usr/local/bin", base.Path())
 	}
-}
-
-func TestResourceBase_ComponentsWithHost(t *testing.T) {
-	base := NewResourceBase("git://github.com/org/repo")
-	if base.Scheme() != "git" {
-		t.Errorf("Scheme() = %q, want git", base.Scheme())
-	}
-	if base.Host() != "github.com" {
-		t.Errorf("Host() = %q, want github.com", base.Host())
-	}
-	if base.Path() != "/org/repo" {
-		t.Errorf("Path() = %q, want /org/repo", base.Path())
+	if base.Opaque() != "" {
+		t.Errorf("Opaque() = %q, want empty (hierarchical URI)", base.Opaque())
 	}
 }
 
-func TestResourceBase_NewURI(t *testing.T) {
-	base := NewResourceBase("")
-	r := &testResource{scheme: "svc", host: "", path: "/nginx"}
-	uri := base.NewURI(r)
-	if uri != "svc:///nginx" {
-		t.Errorf("NewURI() = %q, want svc:///nginx", uri)
+func TestResourceBase_ParseOpaqueURI(t *testing.T) {
+	base := NewResourceBase("pkg:brew/jq@1.7")
+	if base.Scheme() != "pkg" {
+		t.Errorf("Scheme() = %q, want pkg", base.Scheme())
+	}
+	if base.Opaque() != "brew/jq@1.7" {
+		t.Errorf("Opaque() = %q, want brew/jq@1.7", base.Opaque())
+	}
+	if base.Host() != "" {
+		t.Errorf("Host() = %q, want empty (opaque URI)", base.Host())
+	}
+	if base.Path() != "" {
+		t.Errorf("Path() = %q, want empty (opaque URI)", base.Path())
 	}
 }
 
-func TestResourceBase_NewURI_WithHost(t *testing.T) {
-	base := NewResourceBase("")
-	r := &testResource{scheme: "git", host: "github.com", path: "/org/repo"}
-	uri := base.NewURI(r)
-	if uri != "git://github.com/org/repo" {
-		t.Errorf("NewURI() = %q, want git://github.com/org/repo", uri)
+func TestResourceBase_ParseFragment(t *testing.T) {
+	base := NewResourceBase("mem:callable/file.Reducer/myfn#node1")
+	if base.Scheme() != "mem" {
+		t.Errorf("Scheme() = %q, want mem", base.Scheme())
 	}
-}
-
-func TestResourceBase_NewURI_File(t *testing.T) {
-	base := NewResourceBase("")
-	r := &testResource{scheme: "file", host: "", path: "/usr/local/bin"}
-	uri := base.NewURI(r)
-	if uri != "file:///usr/local/bin" {
-		t.Errorf("NewURI() = %q, want file:///usr/local/bin", uri)
-	}
-}
-
-func TestResourceBase_NewURI_RelativeFilePath(t *testing.T) {
-	// A testResource that returns a relative path gets a relative URI.
-	// Real file.Resource.Path() always canonicalizes via filepath.Abs.
-	base := NewResourceBase("")
-	r := &testResource{scheme: "file", host: "", path: "/etc/foo"}
-	uri := base.NewURI(r)
-	if !strings.HasPrefix(uri, "file:///") {
-		t.Errorf("NewURI() = %q, want file:/// prefix", uri)
+	if base.Fragment() != "node1" {
+		t.Errorf("Fragment() = %q, want node1", base.Fragment())
 	}
 }
 
@@ -88,60 +72,22 @@ func TestResourceBase_SatisfiesInterface(t *testing.T) {
 	}
 }
 
-// testResource is a concrete Resource implementation for testing NewURI.
-type testResource struct {
-	ResourceBase
-	scheme string
-	host   string
-	path   string
-}
-
-func (r *testResource) URI() string    { return r.NewURI(r) }
-func (r *testResource) Scheme() string { return r.scheme }
-func (r *testResource) Host() string   { return r.host }
-func (r *testResource) Path() string   { return r.path }
-
-func TestConcreteResource_URI(t *testing.T) {
-	r := &testResource{scheme: "file", host: "", path: "/usr/local/bin"}
-	if r.URI() != "file:///usr/local/bin" {
-		t.Errorf("URI() = %q, want file:///usr/local/bin", r.URI())
-	}
-
-	// Verify it satisfies the Resource interface
-	var iface Resource = r
-	if iface.URI() != "file:///usr/local/bin" {
-		t.Errorf("Resource.URI() = %q, want file:///usr/local/bin", iface.URI())
+func TestResourceBase_ParseInvalidURI(t *testing.T) {
+	base := NewResourceBase("://bad")
+	if base.Scheme() != "" {
+		t.Errorf("Scheme() = %q, want empty for invalid URI", base.Scheme())
 	}
 }
 
-// testEmbeddingResource embeds ResourceBase, like file.Resource does.
+// testEmbeddingResource is a minimal Resource used by resource_catalog_test.go.
 type testEmbeddingResource struct {
 	ResourceBase
 	SourcePath string
 }
 
-func (r *testEmbeddingResource) URI() string    { return r.NewURI(r) }
-func (r *testEmbeddingResource) Scheme() string { return SchemeFile }
-func (r *testEmbeddingResource) Host() string   { return "" }
-func (r *testEmbeddingResource) Path() string {
-	abs, err := filepath.Abs(r.SourcePath)
-	if err != nil {
-		return r.SourcePath
+func (r *testEmbeddingResource) URI() string {
+	if r.ResourceBase.URI() == "" {
+		r.SetURI("file://" + r.SourcePath)
 	}
-	return abs
-}
-
-func TestEmbeddingResource_URIComputedFromComponents(t *testing.T) {
-	r := &testEmbeddingResource{SourcePath: "/etc/foo"}
-	if r.URI() != "file:///etc/foo" {
-		t.Errorf("URI() = %q, want file:///etc/foo", r.URI())
-	}
-	if r.Scheme() != "file" {
-		t.Errorf("Scheme() = %q, want file", r.Scheme())
-	}
-
-	var iface Resource = r
-	if iface.URI() != "file:///etc/foo" {
-		t.Errorf("Resource.URI() = %q, want file:///etc/foo", iface.URI())
-	}
+	return r.ResourceBase.URI()
 }


### PR DESCRIPTION
## Summary

- Slim Resource interface from 6 methods to 3 (`URI`, `Resolve`, `resourceBase`)
- Each concrete type owns URI construction via `buildURI()` + `SetURI()` — no shared `NewURI` dispatch
- URI schemes corrected per RFC 3986: file (hierarchical), pkg/svc/git/appnet (opaque)
- Rename `provider/net` → `provider/appnet` (eliminates Go stdlib shadowing)
- Action namespace `net.download` → `appnet.download`
- Architecture docs promoted from draft to `docs/architecture/`

### URI Scheme Summary

| Scheme | Form | Example |
|---|---|---|
| `file` | Hierarchical | `file:///usr/local/bin` |
| `pkg` | Opaque (purl) | `pkg:brew/jq@1.7` |
| `svc` | Opaque | `svc:nginx` |
| `git` | Opaque/Hierarchical | `git:https://github.com/org/repo#ref` |
| `appnet` | Opaque | `appnet:example.com/path` |

### Files changed

**Core interface** — `pkg/op/resource.go` (slim interface, SetURI, Opaque/Fragment helpers, SchemeAppNet)

**Per-provider URI** — `file/resource.go`, `pkg/resource.go`, `service/resource.go`, `git/resource.go`, `appnet/resource.go`

**net → appnet rename** — directory, package declarations, imports, Makefile, register.go, Starlark scripts

**Tests** — all resource tests rewritten for new URI format; mock constructors set URI

**Docs** — `devlore-execution-topology.md`, `devlore-recovery-serialization.md` (renamed from drafts), `devlore-operation-namespaces.md`, `DESIGN-DISCUSSION.md`

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all packages pass
- [x] URI format verified for all 5 resource types (file, pkg, svc, git, appnet)
- [x] Purl convergence: `pkg.Resource.URI() == Purl()`
- [x] Appnet canonical URI: transport-independent, normalized
- [x] Git URI: targeted escaping of # and ? in inner URLs
- [x] No backward-compatibility code introduced (grep verified)