### PR TITLE
feature(op): mem.Resource and mem.Callable types — Phase 1

### DIFF
--- a/pkg/op/provider/mem/callable.go
+++ b/pkg/op/provider/mem/callable.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package mem
+
+import (
+	"go.starlark.net/starlark"
+)
+
+// Callable is a mem.Resource that holds a Starlark function extracted into
+// a self-contained synthetic source file with compiled bytecode.
+//
+// The URI is opaque: mem:callable/<FuncType>/<Name>. FuncType is the named
+// Go type the callable satisfies (e.g., "file.Reducer", "Predicate"). Name
+// is the function name or <action>.<param> for lambdas.
+//
+// The Data field (inherited from Resource) holds the synthetic source text.
+// The Compiled field holds serialized bytecode from Program.Write. Both are
+// []byte — serializable, transferable, persistable.
+//
+// Lifecycle:
+//  1. Extract(*starlark.Function) → Callable (Phase 2)
+//  2. Compile() → populates Compiled bytecode (Phase 3)
+//  3. Init(thread) → loads bytecode, extracts live fn (Phase 3)
+//  4. Fn() → returns live callable for adapter invocation
+type Callable struct {
+	Resource // embeds mem.Resource (source text in Data)
+
+	// Compiled bytecode — Program.Write output. Nil until Compile.
+	Compiled []byte
+
+	// URI identity fields — compose the opaque URI:
+	// mem:callable/<FuncType>/<Name>
+	FuncType string // named Go type: "file.Reducer", "Predicate"
+	Name     string // function name or <action>.<param> for lambdas
+
+	// Metadata captured at extraction time.
+	FuncName        string   // function name in synthetic file ("_callable" or original)
+	ParamNames      []string // parameter names (excluding swallowed)
+	NumParams       int      // total params (for validation)
+	CompilerVersion uint32   // starlark.CompilerVersion at compile time
+	OriginalPos     string   // "recipe.star:42" (diagnostics only)
+
+	// Live state — populated by Init(), not serialized.
+	fn starlark.Callable
+}
+
+// NewCallable creates a Callable with the given function type and name.
+// The source text (Data) and compiled bytecode should be set by the extraction
+// and compilation phases.
+func NewCallable(funcType, name string) *Callable {
+	c := &Callable{
+		Resource: NewResource("callable", funcType+"/"+name),
+		FuncType: funcType,
+		Name:     name,
+		FuncName: "_callable",
+	}
+	// Override URI to use the callable-specific format.
+	c.SetURI(c.callableURI())
+	return c
+}
+
+// callableURI computes the opaque mem:callable URI.
+func (c *Callable) callableURI() string {
+	return "mem:callable/" + c.FuncType + "/" + c.Name
+}
+
+// SetSource sets the synthetic source text and recomputes the hash.
+func (c *Callable) SetSource(source []byte) {
+	c.Data = source
+	c.ComputeHash()
+}
+
+// Fn returns the live callable. Panics if Init has not been called.
+func (c *Callable) Fn() starlark.Callable {
+	if c.fn == nil {
+		panic("callable: Init not called")
+	}
+	return c.fn
+}

--- a/pkg/op/provider/mem/callable_test.go
+++ b/pkg/op/provider/mem/callable_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package mem
+
+import (
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+func TestCallableImplementsResource(t *testing.T) {
+	var _ op.Resource = (*Callable)(nil)
+}
+
+func TestNewCallable(t *testing.T) {
+	c := NewCallable("file.Reducer", "count_python_files")
+	if c.FuncType != "file.Reducer" {
+		t.Errorf("FuncType = %q, want %q", c.FuncType, "file.Reducer")
+	}
+	if c.Name != "count_python_files" {
+		t.Errorf("Name = %q, want %q", c.Name, "count_python_files")
+	}
+	if c.FuncName != "_callable" {
+		t.Errorf("FuncName = %q, want %q", c.FuncName, "_callable")
+	}
+	if c.ContentType != "callable" {
+		t.Errorf("ContentType = %q, want %q", c.ContentType, "callable")
+	}
+}
+
+func TestCallableURI(t *testing.T) {
+	c := NewCallable("file.Reducer", "count_python_files")
+	want := "mem:callable/file.Reducer/count_python_files"
+	if got := c.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestCallableURI_Lambda(t *testing.T) {
+	c := NewCallable("file.Reducer", "file.walk_tree.fn")
+	want := "mem:callable/file.Reducer/file.walk_tree.fn"
+	if got := c.URI(); got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestCallableURI_OpaqueScheme(t *testing.T) {
+	c := NewCallable("Predicate", "is_large")
+	if c.Scheme() != "mem" {
+		t.Errorf("Scheme() = %q, want %q", c.Scheme(), "mem")
+	}
+	if c.Opaque() != "callable/Predicate/is_large" {
+		t.Errorf("Opaque() = %q, want %q", c.Opaque(), "callable/Predicate/is_large")
+	}
+}
+
+func TestCallableSetSource(t *testing.T) {
+	c := NewCallable("file.Reducer", "myfn")
+	source := []byte(`def _callable(initial, resource, path):
+    return initial + [resource]
+`)
+	c.SetSource(source)
+	if string(c.Data) != string(source) {
+		t.Errorf("Data = %q, want %q", c.Data, source)
+	}
+	if c.Hash == "" {
+		t.Error("Hash is empty after SetSource")
+	}
+}
+
+func TestCallableSetSource_HashChanges(t *testing.T) {
+	c := NewCallable("file.Reducer", "myfn")
+	c.SetSource([]byte("version 1"))
+	hash1 := c.Hash
+	c.SetSource([]byte("version 2"))
+	hash2 := c.Hash
+	if hash1 == hash2 {
+		t.Error("hash did not change after SetSource with different data")
+	}
+}
+
+func TestCallableFn_PanicsBeforeInit(t *testing.T) {
+	c := NewCallable("file.Reducer", "myfn")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Fn() did not panic before Init")
+		}
+	}()
+	c.Fn()
+}

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -1,1 +1,102 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
 package mem
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// Resource represents an in-memory data resource identified by a mem: URI.
+//
+// Unlike file or git resources that reference external systems, a mem.Resource
+// holds its content directly. The Data field contains the raw bytes (source text,
+// JSON, template content, etc.). The ContentType field classifies the content
+// for dispatch (e.g., "callable", "json", "template").
+//
+// The URI is opaque: mem:<content-type>/<qualifier>. The content hash is stored
+// as a metadata field for change detection — NOT part of the URI. Two resources
+// with the same URI but different hashes trigger a catalog shadow.
+type Resource struct {
+	op.ResourceBase
+	ContentType string // "callable", "json", "template", etc.
+	Qualifier   string // type-specific qualifier (e.g., "file.Reducer/myfn" for callables)
+	Data        []byte // raw content
+	Hash        string // SHA-256 of Data — metadata, NOT part of URI
+}
+
+// String returns a compact JSON representation of the resource.
+func (r Resource) String() string { return r.Format(r) }
+
+// buildURI computes the opaque mem: URI.
+//
+// Format: mem:<content-type>/<qualifier>
+func (r *Resource) buildURI() string {
+	if r.Qualifier != "" {
+		return "mem:" + r.ContentType + "/" + r.Qualifier
+	}
+	return "mem:" + r.ContentType
+}
+
+// ComputeHash calculates the SHA-256 hash of Data and stores it in Hash.
+func (r *Resource) ComputeHash() {
+	if len(r.Data) == 0 {
+		r.Hash = ""
+		return
+	}
+	h := sha256.Sum256(r.Data)
+	r.Hash = hex.EncodeToString(h[:])
+}
+
+// NewResource creates a mem.Resource with the given content type and qualifier.
+// Data must be set separately; Hash is computed when ComputeHash is called.
+func NewResource(contentType, qualifier string) Resource {
+	r := Resource{
+		ContentType: contentType,
+		Qualifier:   qualifier,
+	}
+	r.SetURI(r.buildURI())
+	return r
+}
+
+// NewResourceWithData creates a mem.Resource with content and computes the hash.
+func NewResourceWithData(contentType, qualifier string, data []byte) Resource {
+	r := Resource{
+		ContentType: contentType,
+		Qualifier:   qualifier,
+		Data:        data,
+	}
+	r.SetURI(r.buildURI())
+	r.ComputeHash()
+	return r
+}
+
+func init() {
+	op.RegisterConstructor(func(v any) (Resource, error) {
+		s, ok := v.(string)
+		if !ok {
+			return Resource{}, fmt.Errorf("mem.Resource: expected string URI, got %T", v)
+		}
+		// Parse a mem: URI back into ContentType and Qualifier.
+		// Expected format: mem:<content-type>[/<qualifier>]
+		if !strings.HasPrefix(s, "mem:") {
+			return Resource{}, fmt.Errorf("mem.Resource: expected mem: URI, got %q", s)
+		}
+		opaque := s[len("mem:"):]
+		contentType, qualifier, _ := strings.Cut(opaque, "/")
+		if contentType == "" {
+			return Resource{}, fmt.Errorf("mem.Resource: empty content type in %q", s)
+		}
+		r := Resource{
+			ContentType: contentType,
+			Qualifier:   qualifier,
+		}
+		r.SetURI(r.buildURI())
+		return r, nil
+	})
+}

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package mem
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+func TestResourceImplementsInterface(t *testing.T) {
+	var _ op.Resource = (*Resource)(nil)
+}
+
+func TestNewResource(t *testing.T) {
+	r := NewResource("callable", "file.Reducer/myfn")
+	if r.ContentType != "callable" {
+		t.Errorf("ContentType = %q, want %q", r.ContentType, "callable")
+	}
+	if r.Qualifier != "file.Reducer/myfn" {
+		t.Errorf("Qualifier = %q, want %q", r.Qualifier, "file.Reducer/myfn")
+	}
+	if r.URI() != "mem:callable/file.Reducer/myfn" {
+		t.Errorf("URI() = %q, want %q", r.URI(), "mem:callable/file.Reducer/myfn")
+	}
+}
+
+func TestNewResource_NoQualifier(t *testing.T) {
+	r := NewResource("json", "")
+	if r.URI() != "mem:json" {
+		t.Errorf("URI() = %q, want %q", r.URI(), "mem:json")
+	}
+}
+
+func TestNewResourceWithData(t *testing.T) {
+	data := []byte("hello world")
+	r := NewResourceWithData("template", "greeting", data)
+	if string(r.Data) != "hello world" {
+		t.Errorf("Data = %q, want %q", r.Data, "hello world")
+	}
+	if r.Hash == "" {
+		t.Error("Hash is empty after NewResourceWithData")
+	}
+	// Verify hash is correct.
+	h := sha256.Sum256(data)
+	want := hex.EncodeToString(h[:])
+	if r.Hash != want {
+		t.Errorf("Hash = %q, want %q", r.Hash, want)
+	}
+}
+
+func TestComputeHash_Empty(t *testing.T) {
+	r := NewResource("json", "config")
+	r.ComputeHash()
+	if r.Hash != "" {
+		t.Errorf("Hash = %q, want empty for nil Data", r.Hash)
+	}
+}
+
+func TestComputeHash_Deterministic(t *testing.T) {
+	r1 := NewResourceWithData("json", "a", []byte("same"))
+	r2 := NewResourceWithData("json", "b", []byte("same"))
+	if r1.Hash != r2.Hash {
+		t.Errorf("same data different hash: %q vs %q", r1.Hash, r2.Hash)
+	}
+}
+
+func TestComputeHash_DifferentData(t *testing.T) {
+	r1 := NewResourceWithData("json", "a", []byte("one"))
+	r2 := NewResourceWithData("json", "a", []byte("two"))
+	if r1.Hash == r2.Hash {
+		t.Error("different data produced same hash")
+	}
+}
+
+func TestResourceURI_OpaqueScheme(t *testing.T) {
+	r := NewResource("callable", "file.Reducer/myfn")
+	if r.Scheme() != "mem" {
+		t.Errorf("Scheme() = %q, want %q", r.Scheme(), "mem")
+	}
+	if r.Opaque() != "callable/file.Reducer/myfn" {
+		t.Errorf("Opaque() = %q, want %q", r.Opaque(), "callable/file.Reducer/myfn")
+	}
+}
+
+func TestConstructorRoundTrip(t *testing.T) {
+	r, err := op.Construct[Resource]("mem:callable/file.Reducer/myfn")
+	if err != nil {
+		t.Fatalf("Construct: %v", err)
+	}
+	if r.ContentType != "callable" {
+		t.Errorf("ContentType = %q, want %q", r.ContentType, "callable")
+	}
+	if r.Qualifier != "file.Reducer/myfn" {
+		t.Errorf("Qualifier = %q, want %q", r.Qualifier, "file.Reducer/myfn")
+	}
+	if r.URI() != "mem:callable/file.Reducer/myfn" {
+		t.Errorf("URI() = %q, want %q", r.URI(), "mem:callable/file.Reducer/myfn")
+	}
+}
+
+func TestConstructorInvalidPrefix(t *testing.T) {
+	_, err := op.Construct[Resource]("file:///tmp/foo")
+	if err == nil {
+		t.Fatal("expected error for non-mem URI")
+	}
+}
+
+func TestConstructorEmptyContentType(t *testing.T) {
+	_, err := op.Construct[Resource]("mem:")
+	if err == nil {
+		t.Fatal("expected error for empty content type")
+	}
+}
+
+func TestConstructorWrongType(t *testing.T) {
+	_, err := op.Construct[Resource](42)
+	if err == nil {
+		t.Fatal("expected error for non-string")
+	}
+}
+
+func TestConstructorSimpleContentType(t *testing.T) {
+	r, err := op.Construct[Resource]("mem:json")
+	if err != nil {
+		t.Fatalf("Construct: %v", err)
+	}
+	if r.ContentType != "json" {
+		t.Errorf("ContentType = %q, want %q", r.ContentType, "json")
+	}
+	if r.Qualifier != "" {
+		t.Errorf("Qualifier = %q, want empty", r.Qualifier)
+	}
+}


### PR DESCRIPTION
## Summary

- `mem.Resource` — typed byte buffer with opaque `mem:` URI, SHA-256 hash as metadata
- `mem.Callable` — embeds `mem.Resource`, adds `FuncType`/`Name` (URI identity), `Compiled` bytecode field, extraction metadata, live `fn` field
- Constructor registered for slot system integration (`op.Construct[mem.Resource]`)
- 20 tests across `resource_test.go` and `callable_test.go`

### URI Examples

| Type | URI |
|---|---|
| Named callable | `mem:callable/file.Reducer/count_python_files` |
| Lambda callable | `mem:callable/file.Reducer/file.walk_tree.fn` |
| JSON content | `mem:json/config` |
| Simple type | `mem:template` |

### Files

| File | Action | Purpose |
|---|---|---|
| `pkg/op/provider/mem/resource.go` | Rewrite | `mem.Resource` type, constructor, hash |
| `pkg/op/provider/mem/callable.go` | Create | `mem.Callable` unified callable type |
| `pkg/op/provider/mem/resource_test.go` | Create | Resource tests |
| `pkg/op/provider/mem/callable_test.go` | Create | Callable tests |

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all packages pass (20 new tests in `pkg/op/provider/mem`)
- [x] `mem.Resource` implements `op.Resource` interface
- [x] `mem.Callable` implements `op.Resource` interface (via embedding)
- [x] Opaque URI format: `mem:callable/file.Reducer/myfn`
- [x] Constructor round-trip: `op.Construct[mem.Resource]("mem:callable/...")`
- [x] SHA-256 hash: deterministic, changes with data, empty for nil
- [x] `Fn()` panics before `Init()` (guard for Phase 3)