### PR TITLE
feature(op): Thread on context, callable bridge infrastructure (Phase 4)

### DIFF
--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"go.starlark.net/starlark"
+
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -113,6 +115,17 @@ func NewGraphExecutor(opts ExecutorOptions) *GraphExecutor {
 	}
 }
 
+// newThread creates a Starlark thread for callable initialization during
+// execution. Print output goes to the executor's writer.
+func (e *GraphExecutor) newThread() *starlark.Thread {
+	return &starlark.Thread{
+		Name: "executor",
+		Print: func(_ *starlark.Thread, msg string) {
+			_, _ = fmt.Fprintln(e.options.Writer, msg)
+		},
+	}
+}
+
 // SetHooks sets the lifecycle hook registry for this executor.
 func (e *GraphExecutor) SetHooks(hooks *HookRegistry) {
 	e.hooks = hooks
@@ -146,6 +159,7 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 		Data:     e.options.Data,
 		Graph:    g,
 		Platform: e.options.Platform,
+		Thread:   e.newThread(),
 	}
 
 	// Create a fresh ActionRegistry with per-graph provider instances
@@ -199,6 +213,7 @@ func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) error { //no
 		Data:     e.options.Data,
 		Graph:    g,
 		Platform: e.options.Platform,
+		Thread:   e.newThread(),
 	}
 
 	// Create a fresh ActionRegistry with per-graph provider instances
@@ -416,6 +431,7 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*op.Node, edges []
 		Writer:   e.options.Writer,
 		Data:     e.options.Data,
 		Platform: e.options.Platform,
+		Thread:   e.newThread(),
 	}
 
 	// Hydrate stub actions and inject context into provider-backed actions.

--- a/pkg/op/action_reflect.go
+++ b/pkg/op/action_reflect.go
@@ -197,6 +197,11 @@ func validateSlotType(goVal any, targetType reflect.Type) error {
 		return nil
 	}
 
+	// CallableResource → func type coercion.
+	if isCallableResource(goVal) && isFuncType(targetType) {
+		return nil
+	}
+
 	return fmt.Errorf("cannot coerce %T to %s", goVal, targetType)
 }
 

--- a/pkg/op/callable.go
+++ b/pkg/op/callable.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.starlark.net/starlark"
+)
+
+// CallableResource is the interface that mem.Callable satisfies.
+// It allows pkg/op to work with callables without importing the mem package.
+type CallableResource interface {
+	Resource
+	Init(thread *starlark.Thread) error
+	Fn() starlark.Callable
+	FuncTypeName() string
+}
+
+// callableExtractorFn is the registered function that extracts a
+// *starlark.Function into a CallableResource. Registered by the mem
+// package in init(). Returns the extracted, compiled callable.
+var callableExtractorFn func(fn *starlark.Function, funcType string) (CallableResource, error)
+
+// RegisterCallableExtractor registers the function that extracts a
+// *starlark.Function into a CallableResource. Called by the mem package
+// during init().
+func RegisterCallableExtractor(fn func(*starlark.Function, string) (CallableResource, error)) {
+	callableExtractorFn = fn
+}
+
+// ExtractCallable extracts a *starlark.Function into a CallableResource
+// using the registered extractor. Returns an error if no extractor is
+// registered.
+func ExtractCallable(fn *starlark.Function, funcType string) (CallableResource, error) {
+	if callableExtractorFn == nil {
+		return nil, fmt.Errorf("no callable extractor registered (mem package not imported?)")
+	}
+	return callableExtractorFn(fn, funcType)
+}
+
+// isCallableResource returns true if the value implements CallableResource.
+func isCallableResource(v any) bool {
+	_, ok := v.(CallableResource)
+	return ok
+}
+
+// isFuncType returns true if the reflect.Type is a function type.
+func isFuncType(t reflect.Type) bool {
+	return t.Kind() == reflect.Func
+}

--- a/pkg/op/callable_test.go
+++ b/pkg/op/callable_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"reflect"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+// mockCallableResource implements CallableResource for testing.
+type mockCallableResource struct {
+	ResourceBase
+	funcType string
+	initErr  error
+	fn       starlark.Callable
+}
+
+func (m *mockCallableResource) String() string                { return "mock" }
+func (m *mockCallableResource) Init(_ *starlark.Thread) error { return m.initErr }
+func (m *mockCallableResource) Fn() starlark.Callable         { return m.fn }
+func (m *mockCallableResource) FuncTypeName() string          { return m.funcType }
+
+func TestCallableResourceInterface(t *testing.T) {
+	var _ CallableResource = (*mockCallableResource)(nil)
+}
+
+func TestExtractCallable_NoExtractor(t *testing.T) {
+	// Save and restore the extractor.
+	saved := callableExtractorFn
+	callableExtractorFn = nil
+	defer func() { callableExtractorFn = saved }()
+
+	_, err := ExtractCallable(nil, "TestType")
+	if err == nil {
+		t.Fatal("expected error when no extractor registered")
+	}
+}
+
+func TestExtractCallable_WithExtractor(t *testing.T) {
+	saved := callableExtractorFn
+	defer func() { callableExtractorFn = saved }()
+
+	called := false
+	RegisterCallableExtractor(func(fn *starlark.Function, funcType string) (CallableResource, error) {
+		called = true
+		if funcType != "file.Reducer" {
+			t.Errorf("funcType = %q, want %q", funcType, "file.Reducer")
+		}
+		m := &mockCallableResource{funcType: funcType}
+		m.SetURI("mem:callable/file.Reducer/test")
+		return m, nil
+	})
+
+	cr, err := ExtractCallable(nil, "file.Reducer")
+	if err != nil {
+		t.Fatalf("ExtractCallable: %v", err)
+	}
+	if !called {
+		t.Error("extractor was not called")
+	}
+	if cr.FuncTypeName() != "file.Reducer" {
+		t.Errorf("FuncTypeName = %q, want %q", cr.FuncTypeName(), "file.Reducer")
+	}
+}
+
+func TestIsCallableResource(t *testing.T) {
+	m := &mockCallableResource{}
+	if !isCallableResource(m) {
+		t.Error("mockCallableResource should satisfy isCallableResource")
+	}
+	if isCallableResource("not a callable") {
+		t.Error("string should not satisfy isCallableResource")
+	}
+}
+
+func TestIsFuncType(t *testing.T) {
+	type Reducer func(int) int
+	if !isFuncType(reflect.TypeOf(Reducer(nil))) {
+		t.Error("Reducer should be a func type")
+	}
+	if isFuncType(reflect.TypeOf("string")) {
+		t.Error("string should not be a func type")
+	}
+}
+
+func TestValidateSlotType_CallableToFunc(t *testing.T) {
+	type Reducer func(int) int
+	m := &mockCallableResource{funcType: "file.Reducer"}
+	err := validateSlotType(m, reflect.TypeOf(Reducer(nil)))
+	if err != nil {
+		t.Errorf("validateSlotType should accept CallableResource for func type: %v", err)
+	}
+}

--- a/pkg/op/context.go
+++ b/pkg/op/context.go
@@ -3,6 +3,8 @@ package op
 import (
 	"context"
 	"io"
+
+	"go.starlark.net/starlark"
 )
 
 // Context provides execution context to actions.
@@ -34,6 +36,11 @@ type Context struct {
 	// manager) to action providers. Nil when running in environments
 	// where host access is not needed (e.g., pure data transforms).
 	Platform *Platform
+
+	// Thread is a Starlark execution thread for callable initialization.
+	// Created by the executor at execution time. Actions that need to
+	// invoke mem.Callable functions call Init(ctx.Thread) before Fn().
+	Thread *starlark.Thread
 
 	// Writer receives user-facing output messages.
 	Writer io.Writer

--- a/pkg/op/planned_reflect.go
+++ b/pkg/op/planned_reflect.go
@@ -151,6 +151,20 @@ func buildPlannedBridge(
 			if sv == nil {
 				continue // Optional param not provided.
 			}
+
+			// Callable extraction: when a *starlark.Function is passed
+			// to a func-typed parameter, extract it into a compiled
+			// CallableResource and store as a slot immediate.
+			if starFn, ok := sv.(*starlark.Function); ok && i+1 < mt.NumIn() && isFuncType(mt.In(i+1)) {
+				funcType := providerName + "." + mt.In(i+1).Name()
+				callable, err := ExtractCallable(starFn, funcType)
+				if err != nil {
+					return nil, fmt.Errorf("%s: param %s: extract callable: %w", snakeName, cleanName, err)
+				}
+				node.SetSlotImmediate(cleanName, callable)
+				continue
+			}
+
 			if err := FillSlot(node, graph, cleanName, sv); err != nil {
 				return nil, fmt.Errorf("%s: %w", cleanName, err)
 			}

--- a/pkg/op/provider/mem/callable.go
+++ b/pkg/op/provider/mem/callable.go
@@ -131,6 +131,12 @@ func (c *Callable) Init(thread *starlark.Thread) error {
 	return nil
 }
 
+// FuncTypeName returns the Go type name this callable satisfies.
+// Implements op.CallableResource.
+func (c *Callable) FuncTypeName() string {
+	return c.FuncType
+}
+
 // Fn returns the live callable. Panics if Init has not been called.
 func (c *Callable) Fn() starlark.Callable {
 	if c.fn == nil {

--- a/pkg/op/provider/mem/callable_test.go
+++ b/pkg/op/provider/mem/callable_test.go
@@ -15,6 +15,10 @@ func TestCallableImplementsResource(t *testing.T) {
 	var _ op.Resource = (*Callable)(nil)
 }
 
+func TestCallableImplementsCallableResource(t *testing.T) {
+	var _ op.CallableResource = (*Callable)(nil)
+}
+
 func TestNewCallable(t *testing.T) {
 	c := NewCallable("file.Reducer", "count_python_files")
 	if c.FuncType != "file.Reducer" {

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 
+	"go.starlark.net/starlark"
+
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -77,6 +79,18 @@ func NewResourceWithData(contentType, qualifier string, data []byte) Resource {
 }
 
 func init() {
+	// Register callable extractor for the bridge layer.
+	op.RegisterCallableExtractor(func(fn *starlark.Function, funcType string) (op.CallableResource, error) {
+		c, err := Extract(fn, funcType)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.Compile(); err != nil {
+			return nil, err
+		}
+		return c, nil
+	})
+
 	op.RegisterConstructor(func(v any) (Resource, error) {
 		s, ok := v.(string)
 		if !ok {


### PR DESCRIPTION
## Summary

- **`op.CallableResource` interface**: Allows `pkg/op` to work with callables without importing `mem` — defines `Init(thread)`, `Fn()`, `FuncTypeName()` methods
- **Callable extractor registry**: `RegisterCallableExtractor`/`ExtractCallable` callback pattern; `mem` registers `Extract` + `Compile` in `init()`
- **Thread on Context**: `op.Context.Thread` holds a `*starlark.Thread` for callable initialization at execution time
- **Executor thread creation**: `newThread()` creates a Starlark thread with print→writer; set on context in `runFlat`, `RunPhased`, `RunNodes`
- **Planned bridge callable support**: `buildPlannedBridge` intercepts `*starlark.Function` values targeting func-typed params, extracts and compiles via `ExtractCallable`, stores as slot immediate
- **Slot validation**: `validateSlotType` accepts `CallableResource` for func-typed targets
- **`mem.Callable`**: Added `FuncTypeName()`, registered extractor in `init()`, interface compliance test

## Test plan

- [x] `CallableResource` interface compliance (mock + `mem.Callable`)
- [x] Extractor registry: no extractor error, with extractor callback
- [x] `isCallableResource` and `isFuncType` helpers
- [x] `validateSlotType` accepts `CallableResource` for func-typed targets
- [x] `make build` passes
- [x] `make test` passes (full suite)
- [x] `make vet` clean