### PR TITLE
feature(op): Generic callable→func coercion in reflection layer (Phase 5)

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -22,10 +22,17 @@ jobs:
           app-id: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.NOBLEFACTOR_AUTOMATION_APP_PRIVATE_KEY }}
           owner: NobleFactor
-          repositories: devlore.noblefactor.com
+          repositories: noblefactor-ops,devlore.noblefactor.com
 
       - name: Checkout CLI repo
         uses: actions/checkout@v4
+
+      - name: Clone noblefactor-ops
+        uses: actions/checkout@v4
+        with:
+          repository: NobleFactor/noblefactor-ops
+          path: noblefactor-ops
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -39,7 +46,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate CLI docs
-        run: go run ./cmd/docgen --output-dir=generated-docs/cli --version=${{ steps.version.outputs.version }}
+        run: make docs STAR_REPO=./noblefactor-ops DEVLORE_VERSION=${{ steps.version.outputs.version }}
 
       - name: Checkout site repo
         uses: actions/checkout@v4
@@ -51,7 +58,7 @@ jobs:
       - name: Update site content
         run: |
           rm -rf site/src/content/cli/
-          cp -r generated-docs/cli/ site/src/content/cli/
+          cp -r docs/cli/ site/src/content/cli/
           rm -rf site/src/content/guides/
           cp -r docs/guides/ site/src/content/guides/
 

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ dev:
 	git config core.hooksPath .githooks
 	@echo "Hooks activated: .githooks/pre-commit"
 
-docs:
+docs: generate
 	go run ./cmd/docgen --output-dir=docs/cli --version=$(VERSION)
 
 # Build distribution archives for all platforms

--- a/docs/plans/mem-resource.md
+++ b/docs/plans/mem-resource.md
@@ -1,7 +1,7 @@
 ---
 title: "Memory Resources and Callables"
 issue: TBD
-status: draft
+status: in-progress
 created: 2026-03-07
 updated: 2026-03-08
 ---
@@ -69,21 +69,24 @@ for the full design.
 | `git` | Opaque | `git:<encoded-repo>[?path=...]` | `#<commit-hash>` |
 | `mem` | Opaque | `mem:callable/type/name` | Content hash as metadata field |
 
-## Current State
+## Current State (updated after Phase 5)
 
 | Component | Status | Notes |
 |---|---|---|
-| `mem:` scheme | Declared | `SchemeMem = "mem"` in `pkg/op/resource.go`; `package mem` is empty |
-| `mem.Resource` | Missing | Architecture doc plans it for "in-memory data (template payloads, JSON content)" |
+| `mem:` scheme | Implemented | `SchemeMem = "mem"` in `pkg/op/resource.go`; `mem.Resource` type complete |
+| `mem.Resource` | Done (Phase 1) | ContentType, Qualifier, Data, Hash, opaque URI, constructor registered |
+| `mem.Callable` | Done (Phases 1–4) | Embeds `mem.Resource`. Extract, Compile, Init, Fn lifecycle complete |
+| Extraction | Done (Phase 2) | Lambda + def extraction, closure capture, synthetic file generation |
+| Compilation | Done (Phase 3) | `Compile()` → bytecode, `Init(thread)` with version fallback |
+| `CallableResource` interface | Done (Phase 4) | In `pkg/op/callable.go`, with extractor registry |
+| `op.Context.Thread` | Done (Phase 4) | Starlark thread on context, created by executor |
+| Planned bridge callable | Done (Phase 4) | `buildPlannedBridge` detects func-typed params, extracts callable |
 | WalkTree Go method | Working | Accepts `Reducer` callable, compensable |
-| WalkTree Starlark binding | Missing | BUGS.md #170 — reflection bridge can't handle callable params |
-| Reflection bridge | No callable support | `buildMethodBridge` and `buildPlannedBridge` skip callable-typed params |
-| Slot system | Immediate / Promise / Proxy | Callables flow as immediate Resource values |
-| `op.Context` | No Starlark thread | Actions can't call Starlark functions at execution time |
-| `+devlore:callable` annotation | Exists on `Reducer` | Used by codegen for `swallow` — not for bridge generation |
-| RuntimePredicate | Designed, not implemented | Orchestration-primitives plan Step 3 |
-| Starlark `Program.Write` | Available upstream | `go.starlark.net` supports compiled bytecode serialization |
-| `*starlark.Function.FreeVar` | Available upstream | Full closure introspection: name + frozen value |
+| Generic callable coercion | Done (Phase 5) | `initCallableSlots` + `buildCallableFunc` in reflection layer |
+| WalkTree Starlark binding | Partial | Action created; gen integration needs Phase 7 (code generator) |
+| `+devlore:callable` annotation | Exists on `Reducer` | Used by codegen for `swallow` — bridge generation in Phase 7 |
+| RuntimePredicate | Designed, not implemented | Will become `PredicateAdapter` over `mem.Callable` |
+| E2E tests | Pending (Phase 6) | Starlark test scripts for immediate and planned WalkTree |
 
 ## Design
 
@@ -121,7 +124,7 @@ Execution time (any machine):
   Init: prog.Init(thread, predeclared) → globals["_callable"]
       │
       ▼
-  Adapt: ReducerAdapter / PredicateAdapter / custom → Go func type
+  Adapt: initCallableSlots + buildCallableFunc → Go func type
       │
       ▼
   Invoke: action.Do() calls the adapted function
@@ -361,51 +364,48 @@ The executor creates a fresh `starlark.Thread` before running the graph
 and sets it on `op.Context`. The thread's print handler writes to
 `ctx.Writer`.
 
-### Adapter Pattern
+### Generic Callable Coercion
 
-Adapters convert a `mem.Callable` into a concrete Go function type.
-Each callable-accepting action defines its own adapter. The adapter
-handles argument marshaling, swallowed params, and return unmarshaling.
+The reflection layer handles callable→func conversion generically. No
+per-action adapter code is needed. `initCallableSlots` runs in every
+reflected action's `Do()` before `coerceArgs`:
 
 ```go
-// pkg/op/provider/file/callable_adapter.go
+// pkg/op/callable.go
 
-func ReducerAdapter(c *mem.Callable, thread *starlark.Thread) Reducer {
-    return func(initial any, resource Resource, relativePath string, stack *op.RecoveryStack) (any, error) {
-        starInitial, _ := op.MarshalValue(initial)
-        starResource, _ := op.MarshalValue(resource)
-        starPath := starlark.String(relativePath)
-
-        result, err := starlark.Call(thread, c.Fn(), starlark.Tuple{
-            starInitial, starResource, starPath,
-        }, nil)
-        if err != nil {
-            return nil, err
+func initCallableSlots(ctx *Context, slots map[string]any, methodType reflect.Type, paramNames []string) error {
+    for i, name := range paramNames {
+        callable, ok := slots[name].(CallableResource)
+        if !ok {
+            continue
         }
-
-        var goResult any
-        op.UnmarshalValue(result, &goResult)
-        return goResult, nil
+        paramIdx := i + 1 // skip receiver
+        paramType := methodType.In(paramIdx)
+        if paramType.Kind() != reflect.Func {
+            continue
+        }
+        if err := callable.Init(ctx.Thread); err != nil {
+            return fmt.Errorf("param %s: init callable: %w", name, err)
+        }
+        adapted, err := buildCallableFunc(callable.Fn(), ctx.Thread, paramType)
+        if err != nil {
+            return fmt.Errorf("param %s: adapt callable: %w", name, err)
+        }
+        slots[name] = adapted
     }
+    return nil
 }
 ```
 
-RuntimePredicate becomes an adapter, not a type:
+`buildCallableFunc` uses `reflect.MakeFunc` to create a Go function
+matching the target type. It inspects the Starlark function's
+`NumParams()` and truncates Go args to the callable's arity — this
+handles `+devlore:callable swallow=stack` generically without per-action
+knowledge. The adapter marshals Go→Starlark, calls the function, and
+unmarshals Starlark→Go returns.
 
-```go
-// internal/execution/predicate.go
-
-func PredicateAdapter(c *mem.Callable, thread *starlark.Thread) func(any) (bool, error) {
-    return func(input any) (bool, error) {
-        starInput, _ := op.MarshalValue(input)
-        result, err := starlark.Call(thread, c.Fn(), starlark.Tuple{starInput}, nil)
-        if err != nil {
-            return false, err
-        }
-        return bool(result.Truth()), nil
-    }
-}
-```
+RuntimePredicate, ReducerAdapter, and any future callable-typed params
+all work through this single mechanism — no adapter code per action.
 
 ### Signature Validation
 
@@ -460,10 +460,10 @@ buildMethodBridge: recognizes callable param type
     ├─ Extract: *starlark.Function → mem.Callable (source + bytecode)
     ├─ Validate arity
     ├─ Init(thread) → live callable
-    ├─ ReducerAdapter(callable, thread) → Reducer
+    ├─ buildCallableFunc(fn, thread, targetType) → Go func (arity-truncated)
     │
     ▼
-Provider.WalkTree(root, reducer, true) → (result, stack, error)
+Provider.WalkTree(root, adaptedFn, true) → (result, stack, error)
     │
     ▼
 classifyReturn → Starlark value
@@ -497,10 +497,9 @@ executor.executeNode:
     │
     ▼
 Action.Do(ctx, slots):
-    ├─ callable := slots["fn"].(*mem.Callable)
-    ├─ callable.Init(ctx.Thread)  // loads bytecode → live function
-    ├─ reducer := ReducerAdapter(callable, ctx.Thread)
-    ├─ Provider.WalkTree(root, reducer, honorGitignore)
+    ├─ initCallableSlots: Init(ctx.Thread) + buildCallableFunc → Go func
+    ├─ coerceArgs: adapted func assigned to method param
+    ├─ Provider.WalkTree(root, adaptedFn, honorGitignore)
     │
     ▼
 Result + RecoveryStack
@@ -581,16 +580,16 @@ alter the existing compensation mechanism.
 
 ## Implementation Phases
 
-|     | Phase | Name | Description |
-|-----|-------|------|-------------|
-| [ ] | 0 | [Resource identity](mem-resource/phase-0.md) | Slim `Resource` interface to `URI() + Resolve()`, correct URI schemes, rename net→appnet |
-| [ ] | 1 | [mem.Resource + Callable](mem-resource/phase-1.md) | `mem.Resource` type, `mem.Callable` with source/bytecode storage |
-| [ ] | 2 | [Extraction](mem-resource/phase-2.md) | `Extract(*starlark.Function)`, closure capture, synthetic file generation |
-| [ ] | 3 | [Compilation](mem-resource/phase-3.md) | `Compile()`, `Init(thread)`, `CompiledProgram` round-trip, version fallback |
-| [ ] | 4 | [Thread + bridge](mem-resource/phase-4.md) | Thread on Context, immediate + planned bridge callable detection |
-| [ ] | 5 | [WalkTree action](mem-resource/phase-5.md) | Registered action with ReducerAdapter, compensation |
-| [ ] | 6 | [E2E tests](mem-resource/phase-6.md) | Starlark test scripts for immediate and planned WalkTree |
-| [ ] | 7 | [Codegen](mem-resource/phase-7.md) | `star` recognizes callable params, generates adapter + bridge code |
+|     | Phase | Name | Description | PR |
+|-----|-------|------|-------------|----|
+| [x] | 0 | [Resource identity](mem-resource/phase-0.md) | Slim `Resource` interface to `URI() + Resolve()`, correct URI schemes, rename net→appnet | #192–#197 |
+| [x] | 1 | [mem.Resource + Callable](mem-resource/phase-1.md) | `mem.Resource` type, `mem.Callable` with source/bytecode storage | #197 |
+| [x] | 2 | [Extraction](mem-resource/phase-2.md) | `Extract(*starlark.Function)`, closure capture, synthetic file generation | #198 |
+| [x] | 3 | [Compilation](mem-resource/phase-3.md) | `Compile()`, `Init(thread)`, `CompiledProgram` round-trip, version fallback | #199 |
+| [x] | 4 | [Thread + bridge](mem-resource/phase-4.md) | Thread on Context, immediate + planned bridge callable detection | #200 |
+| [x] | 5 | [WalkTree action](mem-resource/phase-5.md) | Generic callable→func coercion in reflection layer | pending |
+| [ ] | 6 | [E2E tests](mem-resource/phase-6.md) | Starlark test scripts for immediate and planned WalkTree | |
+| [ ] | 7 | [Codegen](mem-resource/phase-7.md) | `star` recognizes callable params, generates adapter + bridge code | |
 
 ### Phase 0: Resource Identity
 
@@ -657,68 +656,88 @@ schemes to match their proper forms (opaque vs hierarchical). Rename
 - Catalog operations still work with cached URIs
 - `MarshalStarvalue` / round-trip tests still pass
 
-### Phase 1: mem.Resource + Callable
+### Phase 1: mem.Resource + Callable — DONE (PR #197)
 
 - `pkg/op/provider/mem/resource.go` — `mem.Resource` type: `ContentType`,
-  `Data`, `Hash`, opaque URI construction (`mem:<content-type>/...`),
-  `String()` via `ResourceBase.Format`
+  `Qualifier`, `Data`, `Hash`, opaque URI construction (`mem:<content-type>/...`),
+  `String()` via `ResourceBase.Format`, `NewResource`, `NewResourceWithData`,
+  constructor registration in `init()`
 - `pkg/op/provider/mem/callable.go` — `mem.Callable` type: embeds
   `mem.Resource`, adds `FuncType`, `Name` (URI identity), `Compiled`,
   `FuncName`, `ParamNames`, `CompilerVersion`, `OriginalPos`,
   unexported `fn`. URI: `mem:callable/<FuncType>/<Name>`
 - `pkg/op/provider/mem/callable_test.go` — construction, opaque URI
-  generation, JSON serialization round-trip, hash as metadata
-- Register `mem.Resource` constructor in `init()`
+  generation, hash as metadata
 
-### Phase 2: Extraction
+### Phase 2: Extraction — DONE (PR #198)
 
-- `pkg/op/provider/mem/extract.go` — `Extract(*starlark.Function) (*Callable, error)`:
-  - Introspect params via `NumParams`, `Param`, `ParamDefault`
-  - Capture closure via `NumFreeVars`, `FreeVar`
-  - Serialize bindings as Starlark literals
-  - Extract function source from file using `Position()`
-  - Transform lambda → `def _callable`
-  - Emit synthetic file as `Data`
-- `pkg/op/provider/mem/extract_test.go`:
-  - Extract simple lambda (no closure)
-  - Extract lambda with closure bindings (string, int, list, dict)
-  - Extract named `def` function
-  - Extract function with default parameter values
-  - Validate round-trip: extract → synthetic source → parse → execute → same result
-- `pkg/op/provider/mem/literals.go` — `FormatStarlarkLiteral(starlark.Value) string`:
-  serializes frozen Starlark values as source-level literals
+- `pkg/op/provider/mem/extract.go` — `Extract`, `ExtractWithName`,
+  `synthesize`, `extractLambdaBody`, `extractDefSource`, `extractSpan`,
+  `ValidateArity`. Uses `syntax.Walk` for recursive AST search.
+- `pkg/op/provider/mem/extract_test.go` — 13 tests: simple lambda,
+  closure capture, named def, nested def with closure, custom naming,
+  3 round-trips, 5 arity checks. `execScript` helper.
+- `pkg/op/provider/mem/literals.go` — `FormatLiteral` serializes frozen
+  Starlark values (None, Bool, Int, Float, String, List, Dict, Tuple)
+  as source literals. Depth limit 20. Rejects Set.
+- `pkg/op/provider/mem/literals_test.go` — 14 tests covering all literal
+  types, escaping, nesting, unsupported type rejection.
 
-### Phase 3: Compilation
+### Phase 3: Compilation — DONE (PR #199)
 
-- `pkg/op/provider/mem/callable.go` — `Compile()` and `Init(thread)` methods
-- `pkg/op/provider/mem/callable_test.go`:
-  - Compile produces non-empty bytecode
-  - Init with matching CompilerVersion loads bytecode (no recompile)
-  - Init with mismatched version falls back to source recompilation
-  - Init extracts named function from globals
-  - Init rejects missing function name
-  - Bytecode round-trip: `Write` → `CompiledProgram` → `Init` → same result
+- `pkg/op/provider/mem/callable.go` — `Compile()` and `Init(thread)` methods.
+  `Compile` uses `SourceProgramOptions` + `Program.Write`. `Init` loads via
+  `CompiledProgram` (fast path) or recompiles from source (version mismatch).
+- `pkg/op/provider/mem/callable_test.go` — 12 tests added: Compile (4),
+  Init (6), BytecodeRoundTrip, ExtractCompileInitRoundTrip.
 
-### Phase 4: Thread + Bridge
+### Phase 4: Thread + Bridge — DONE (PR #200)
 
-- `pkg/op/context.go` — add `Thread *starlark.Thread` field
-- `internal/execution/executor.go` — create thread, set on context
-- `pkg/op/receiver_reflect.go` — extend `buildMethodBridge` to detect
-  `func`-typed params. Extract callable, Init, adapt, call.
-- `pkg/op/planned_reflect.go` — extend `buildPlannedBridge` to detect
-  `func`-typed params. Extract callable, store as slot immediate.
-- `pkg/op/action_reflect.go` — `validateSlotType` accepts `*mem.Callable`
-  for `func`-typed params
-- `pkg/op/provider/mem/extract.go` — `ValidateArity` function
+- `pkg/op/context.go` — added `Thread *starlark.Thread` field
+- `internal/execution/executor.go` — `newThread()` creates thread with
+  print→writer; set on context in `runFlat`, `RunPhased`, `RunNodes`
+- `pkg/op/callable.go` — **new file**: `CallableResource` interface
+  (`Resource` + `Init` + `Fn` + `FuncTypeName`), `RegisterCallableExtractor`/
+  `ExtractCallable` callback registry, `isCallableResource`, `isFuncType`
+- `pkg/op/callable_test.go` — 6 tests: interface compliance, extractor
+  registry, isCallableResource, isFuncType, validateSlotType for callable→func
+- `pkg/op/planned_reflect.go` — `buildPlannedBridge` intercepts
+  `*starlark.Function` for func-typed params, extracts to `CallableResource`,
+  stores via `SetSlotImmediate`
+- `pkg/op/action_reflect.go` — `validateSlotType` accepts `CallableResource`
+  for func-typed targets
+- `pkg/op/provider/mem/resource.go` — registered callable extractor in
+  `init()` (Extract + Compile → CallableResource)
+- `pkg/op/provider/mem/callable.go` — added `FuncTypeName()` method
 
-### Phase 5: WalkTree Action
+### Phase 5: WalkTree Action — DONE (pending PR)
 
-- `pkg/op/provider/file/callable_adapter.go` — `ReducerAdapter`
-- `pkg/op/provider/file/walk_tree_action.go` — registered
-  `CompensableAction` for `file.walk_tree`. `Do()` extracts
-  `mem.Callable` from slots, calls `Init(ctx.Thread)`, adapts to
-  `Reducer`, delegates to `Provider.WalkTree()`.
-- `pkg/op/provider/file/callable_adapter_test.go` — adapter unit tests
+Generic callable→func coercion in the reflection layer. No per-action
+custom code needed — the reflected action infrastructure handles
+`CallableResource` slots automatically.
+
+- `pkg/op/callable.go` — added `initCallableSlots` (pre-processes slots
+  in `Do()` before `coerceArgs`), `buildCallableFunc` (creates Go func
+  adapter via `reflect.MakeFunc` with arity truncation for swallowed
+  params), `makeErrorReturn`, `unmarshalReturn`. Generic — works for any
+  action with callable-typed parameters.
+- `pkg/op/action_reflect.go` — wired `initCallableSlots` into all three
+  `Do()` methods: `reflectedPureAction`, `reflectedFallibleAction`,
+  `reflectedCompensableAction`. Runs before `coerceArgs` so standard
+  coercion sees a directly-assignable func value.
+- `pkg/op/callable_test.go` — 5 new tests: `BuildCallableFunc_SimpleReturn`,
+  `BuildCallableFunc_ArityTruncation` (4-param Go func, 3-param Starlark fn),
+  `BuildCallableFunc_StarlarkError`, `InitCallableSlots_ReplacesCallable`,
+  `InitCallableSlots_SkipsNonCallable`.
+- `pkg/op/provider/file/callable_test.go` — 2 integration tests through
+  reflected actions: `TestWalkTreeAction_Integration` (full walk of temp
+  dir with Starlark callable, path collection, Undo(nil), RecoveryStack),
+  `TestWalkTreeAction_DryRun`.
+- `pkg/op/starvalue_marshal.go` — added exported `MarshalValue` and
+  `UnmarshalAny` wrappers for provider package access.
+
+**Gen integration note**: The generated `params.gen.go` needs `"fn"` added
+to `WalkTree` params. This is deferred to Phase 7 (code generator update).
 
 ### Phase 6: E2E Tests
 
@@ -732,8 +751,8 @@ schemes to match their proper forms (opaque vs hierarchical). Rename
 ### Phase 7: Codegen
 
 - Teach `star` to recognize `+devlore:callable` on function types
-- Generate adapter functions (like `ReducerAdapter`)
-- Generate bridge code that wraps `starlark.Callable` → `Extract` → adapter
+- Generate `fn` param in `params.gen.go` for callable-typed parameters
+- Generate bridge code that wraps `starlark.Callable` → `Extract` → `CallableResource`
 - Generate param registration with callable marker
 - This phase is in the `star` tool (noblefactor-ops)
 
@@ -753,24 +772,25 @@ schemes to match their proper forms (opaque vs hierarchical). Rename
 
 **Phases 1–7 — mem.Resource and Callables:**
 
-| File | Action | Purpose |
-|---|---|---|
-| `pkg/op/provider/mem/resource.go` | Rewrite | `mem.Resource` type with ContentType, Data, Hash |
-| `pkg/op/provider/mem/callable.go` | Create | `mem.Callable` — unified callable resource |
-| `pkg/op/provider/mem/extract.go` | Create | Extraction, closure capture, synthetic file generation |
-| `pkg/op/provider/mem/literals.go` | Create | Starlark value → source literal serializer |
-| `pkg/op/provider/mem/callable_test.go` | Create | Callable tests |
-| `pkg/op/provider/mem/extract_test.go` | Create | Extraction tests |
-| `pkg/op/context.go` | Modify | Add Thread field |
-| `pkg/op/receiver_reflect.go` | Modify | Callable detection in immediate bridge |
-| `pkg/op/planned_reflect.go` | Modify | Callable detection in planned bridge |
-| `pkg/op/action_reflect.go` | Modify | validateSlotType accepts Callable |
-| `pkg/op/provider/file/callable_adapter.go` | Create | ReducerAdapter |
-| `pkg/op/provider/file/walk_tree_action.go` | Create | Registered action for planned WalkTree |
-| `pkg/op/provider/file/callable_adapter_test.go` | Create | Adapter tests |
-| `internal/execution/executor.go` | Modify | Create thread, set on context |
-| `internal/e2e/testrunner/data/test_walk_tree*.star` | Create | E2E test scripts |
-| `internal/e2e/testrunner/runner_test.go` | Modify | Test functions |
+| File | Action | Purpose | Phase | Status |
+|---|---|---|---|---|
+| `pkg/op/provider/mem/resource.go` | Rewrite | `mem.Resource` type with ContentType, Data, Hash | 1 | Done |
+| `pkg/op/provider/mem/callable.go` | Create | `mem.Callable` — unified callable resource | 1,3,4 | Done |
+| `pkg/op/provider/mem/extract.go` | Create | Extraction, closure capture, synthetic file generation | 2 | Done |
+| `pkg/op/provider/mem/literals.go` | Create | Starlark value → source literal serializer | 2 | Done |
+| `pkg/op/provider/mem/callable_test.go` | Create | Callable tests | 1,3,4 | Done |
+| `pkg/op/provider/mem/extract_test.go` | Create | Extraction tests | 2 | Done |
+| `pkg/op/provider/mem/literals_test.go` | Create | Literal serialization tests | 2 | Done |
+| `pkg/op/callable.go` | Create | `CallableResource` interface, extractor registry, generic callable→func coercion | 4,5 | Done |
+| `pkg/op/callable_test.go` | Create | Interface, registry, type-check, coercion tests | 4,5 | Done |
+| `pkg/op/context.go` | Modify | Add Thread field | 4 | Done |
+| `pkg/op/planned_reflect.go` | Modify | Callable detection in planned bridge | 4 | Done |
+| `pkg/op/action_reflect.go` | Modify | validateSlotType accepts Callable; initCallableSlots in Do() | 4,5 | Done |
+| `pkg/op/starvalue_marshal.go` | — | No changes needed (generic code uses unexported funcs directly) | — | — |
+| `pkg/op/provider/file/callable_test.go` | Create | Integration tests for WalkTree through reflected actions | 5 | Done |
+| `internal/execution/executor.go` | Modify | Create thread, set on context | 4 | Done |
+| `internal/e2e/testrunner/data/test_walk_tree*.star` | Create | E2E test scripts | 6 | Pending |
+| `internal/e2e/testrunner/runner_test.go` | Modify | Test functions | 6 | Pending |
 
 ## Relationship to Other Plans
 

--- a/draft-op-capability-taxonomy.md
+++ b/draft-op-capability-taxonomy.md
@@ -1,0 +1,63 @@
+Your current structure—`op/provider/<domain>`—is a solid foundation, but the friction you are feeling with `callable` and `encryption` suggests you are conflating **"Domain of Authority"** (who owns the resource) with **"Operational Capability"** (what the resource can do).
+
+In system architecture, when a domain feels "awkward," it’s usually because it is a **Cross-Cutting Concern** masquerading as a **Vertical Domain**.
+
+### 1. The Strategy: Separate "Origins" from "Traits"
+
+Stop treating every directory in `provider` as an equal domain. Instead, distinguish between:
+
+* **Origin Domains (The "Where"):** `git`, `file`, `mem`, `service`. These represent *where* the data lives.
+* **Trait/Capability Domains (The "What"):** `callable`, `encryption`, `schema`. These represent *how* the data behaves, regardless of its origin.
+
+### 2. Proposed Restructure: The "Trait-Based" Model
+
+Move your "oddball" domains into a specific hierarchy that signals they are modifiers, not data sources.
+
+```text
+op/
+  provider/
+    origin/       # Where data lives
+      git/
+      file/
+      mem/
+      appnet/
+    trait/        # Capabilities that wrap/modify resources
+      callable/   # A trait that allows execution
+      encrypt/    # A trait that adds security
+      validate/   # A trait that enforces schema
+
+```
+
+### 3. Solving the "Callable" Awkwardness
+
+A `callable` isn't a domain—it's a **Functional Trait**. By moving it into a `trait` namespace, you change your mental model:
+
+* **Before:** I have a `callable.Resource`. (Feels like a separate bucket of things).
+* **After:** I have a `file.Resource` that has been **upgraded** with the `callable` trait.
+
+This allows you to implement a **Decorator Pattern** or **Mix-in Architecture**. Your graph engine doesn't need to know if a resource is `mem` or `git` if it just checks for the `Callable` interface.
+
+### 4. Handling Cross-Domain Operations (The "Encryption" Case)
+
+The fact that `encryption` operates on `file` and `mem` proves it is a **Coordinator Domain**.
+
+Don't put `encryption` inside `provider/`. Create a separate `op/security/` or `op/transform/` package.
+
+* **`op/provider`**: Should *only* contain things that fetch/produce base resources.
+* **`op/transform`**: Should contain things that take a `Resource` and return a new `Resource` (e.g., `Encrypt(file.Resource) -> EncryptedResource`).
+
+### Why this fixes the "Awkward" feeling:
+
+1. **Semantic Clarity:** When a developer sees `op/provider/origin/git`, they know exactly what it does. When they see `op/provider/trait/callable`, they know it's a behavior wrapper.
+2. **Scalability:** If you add a new provider (e.g., `s3`), you only touch `origin/`. If you add a new capability (e.g., `compress`), you only touch `trait/`.
+3. **Graph Construction:** Your graph engine can now plan actions based on **Capabilities**. A plan can now say: *"I need a `Callable` resource,"* and the system can find a `file.Resource` and satisfy the request by wrapping it in the `callable` trait.
+
+### Summary of the New Hierarchy
+
+* **`op/provider/origin/`**: The "leaves" of your graph (data sources).
+* **`op/provider/trait/`**: The "logic" of your graph (execution, crypto, validation).
+* **`op/transform/`**: The "glue" (the functions that bridge origins and traits).
+
+This separation prevents you from polluting your "domains" with cross-cutting logic.
+
+Does this "Trait vs. Origin" distinction help resolve why `callable` felt like a misplaced domain, or does it complicate your current codegen setup too much?

--- a/pkg/op/action_reflect.go
+++ b/pkg/op/action_reflect.go
@@ -61,6 +61,10 @@ type reflectedPureAction struct {
 }
 
 func (a *reflectedPureAction) Do(ctx *Context, slots map[string]any) (Result, Complement, error) {
+	if err := initCallableSlots(ctx, slots, a.method.Type, a.paramNames); err != nil {
+		panic(fmt.Sprintf("%s: %v", a.name, err))
+	}
+
 	goArgs, err := a.coerceArgs(slots)
 	if err != nil {
 		// Pure actions cannot fail. Coercion errors indicate a framework bug.
@@ -92,6 +96,10 @@ type reflectedFallibleAction struct {
 }
 
 func (a *reflectedFallibleAction) Do(ctx *Context, slots map[string]any) (Result, Complement, error) {
+	if err := initCallableSlots(ctx, slots, a.method.Type, a.paramNames); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", a.name, err)
+	}
+
 	goArgs, err := a.coerceArgs(slots)
 	if err != nil {
 		return nil, nil, err
@@ -119,6 +127,10 @@ type reflectedCompensableAction struct {
 }
 
 func (a *reflectedCompensableAction) Do(ctx *Context, slots map[string]any) (Result, Complement, error) {
+	if err := initCallableSlots(ctx, slots, a.method.Type, a.paramNames); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", a.name, err)
+	}
+
 	goArgs, err := a.coerceArgs(slots)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/op/callable.go
+++ b/pkg/op/callable.go
@@ -51,3 +51,141 @@ func isCallableResource(v any) bool {
 func isFuncType(t reflect.Type) bool {
 	return t.Kind() == reflect.Func
 }
+
+// initCallableSlots finds CallableResource values in slots that target
+// func-typed method parameters, initializes them, and replaces the slot
+// value with an adapted Go function. This runs in Do() before coerceArgs
+// so the standard coercion path sees a directly-assignable func value.
+func initCallableSlots(ctx *Context, slots map[string]any, methodType reflect.Type, paramNames []string) error {
+	for i, name := range paramNames {
+		callable, ok := slots[name].(CallableResource)
+		if !ok {
+			continue
+		}
+		paramIdx := i + 1 // skip receiver
+		if paramIdx >= methodType.NumIn() {
+			continue
+		}
+		paramType := methodType.In(paramIdx)
+		if paramType.Kind() != reflect.Func {
+			continue
+		}
+
+		if err := callable.Init(ctx.Thread); err != nil {
+			return fmt.Errorf("param %s: init callable: %w", name, err)
+		}
+
+		adapted, err := buildCallableFunc(callable.Fn(), ctx.Thread, paramType)
+		if err != nil {
+			return fmt.Errorf("param %s: adapt callable: %w", name, err)
+		}
+		slots[name] = adapted
+	}
+	return nil
+}
+
+// buildCallableFunc creates a Go function value matching targetType that
+// delegates to the Starlark callable. Arguments are marshaled Go→Starlark,
+// truncated to the callable's arity (supporting swallowed trailing params).
+// Returns are unmarshaled Starlark→Go.
+//
+// Target func signature: func(p0 T0, p1 T1, ...) (R0, R1, ...)
+// The Starlark callable receives min(targetParams, callableArity) arguments.
+func buildCallableFunc(fn starlark.Callable, thread *starlark.Thread, targetType reflect.Type) (any, error) {
+	numIn := targetType.NumIn()
+	numOut := targetType.NumOut()
+
+	// Determine how many args the Starlark function accepts.
+	starArity := numIn // default: pass all
+	if starFn, ok := fn.(*starlark.Function); ok {
+		starArity = starFn.NumParams()
+		if starFn.HasVarargs() {
+			starArity = numIn // varargs: pass all
+		}
+	}
+	if starArity > numIn {
+		starArity = numIn
+	}
+
+	// Build adapter function via reflect.MakeFunc.
+	adapter := reflect.MakeFunc(targetType, func(args []reflect.Value) []reflect.Value {
+		// Marshal Go args → Starlark, truncated to callable arity.
+		starArgs := make(starlark.Tuple, starArity)
+		for i := range starArity {
+			sv, err := marshal(args[i].Interface())
+			if err != nil {
+				return makeErrorReturn(targetType, numOut,
+					fmt.Errorf("callable arg %d: marshal: %w", i, err))
+			}
+			starArgs[i] = sv
+		}
+
+		// Call the Starlark function.
+		result, err := starlark.Call(thread, fn, starArgs, nil)
+		if err != nil {
+			return makeErrorReturn(targetType, numOut,
+				fmt.Errorf("callable %s: %w", fn.Name(), err))
+		}
+
+		// Unmarshal return values.
+		return unmarshalReturn(targetType, numOut, result)
+	})
+
+	return adapter.Interface(), nil
+}
+
+// makeErrorReturn builds a reflect.Value slice for an error return.
+// Convention: the last return is error; preceding returns are zero values.
+func makeErrorReturn(funcType reflect.Type, numOut int, err error) []reflect.Value {
+	out := make([]reflect.Value, numOut)
+	for i := range numOut - 1 {
+		out[i] = reflect.Zero(funcType.Out(i))
+	}
+	if numOut > 0 {
+		out[numOut-1] = reflect.ValueOf(&err).Elem()
+	}
+	return out
+}
+
+// unmarshalReturn converts a Starlark result into the target func's return
+// values. Convention: first return is the result (via unmarshalToAny), last
+// return is error (nil on success). Middle returns are zero values.
+func unmarshalReturn(funcType reflect.Type, numOut int, result starlark.Value) []reflect.Value {
+	out := make([]reflect.Value, numOut)
+
+	if numOut == 0 {
+		return out
+	}
+
+	// Last return is error — set to nil.
+	if numOut > 0 && funcType.Out(numOut-1).Implements(errorType) {
+		out[numOut-1] = reflect.Zero(funcType.Out(numOut - 1))
+	}
+
+	// First return is the result value.
+	if numOut >= 1 {
+		goVal, err := unmarshalToAny(result)
+		if err != nil {
+			return makeErrorReturn(funcType, numOut, err)
+		}
+		if goVal == nil {
+			out[0] = reflect.Zero(funcType.Out(0))
+		} else {
+			rv := reflect.ValueOf(goVal)
+			if rv.Type().AssignableTo(funcType.Out(0)) {
+				out[0] = rv
+			} else if rv.Type().ConvertibleTo(funcType.Out(0)) {
+				out[0] = rv.Convert(funcType.Out(0))
+			} else {
+				out[0] = reflect.Zero(funcType.Out(0))
+			}
+		}
+	}
+
+	// Middle returns (between first result and last error) are zero.
+	for i := 1; i < numOut-1; i++ {
+		out[i] = reflect.Zero(funcType.Out(i))
+	}
+
+	return out
+}

--- a/pkg/op/callable_test.go
+++ b/pkg/op/callable_test.go
@@ -4,10 +4,13 @@
 package op
 
 import (
+	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 // mockCallableResource implements CallableResource for testing.
@@ -92,5 +95,184 @@ func TestValidateSlotType_CallableToFunc(t *testing.T) {
 	err := validateSlotType(m, reflect.TypeOf(Reducer(nil)))
 	if err != nil {
 		t.Errorf("validateSlotType should accept CallableResource for func type: %v", err)
+	}
+}
+
+// ── Generic callable adapter ─────────────────────────────────────────────────
+
+// compileStarlarkFn compiles a Starlark source and returns the named function.
+func compileStarlarkFn(t *testing.T, source, funcName string) *starlark.Function {
+	t.Helper()
+	thread := &starlark.Thread{Name: "test"}
+	_, prog, err := starlark.SourceProgramOptions(
+		&syntax.FileOptions{}, "<test>", source, func(string) bool { return false },
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	globals, err := prog.Init(thread, nil)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	fn, ok := globals[funcName]
+	if !ok {
+		t.Fatalf("function %q not found", funcName)
+	}
+	return fn.(*starlark.Function)
+}
+
+// liveCallableResource creates a mockCallableResource with a live function.
+func liveCallableResource(t *testing.T, source, funcName string) *mockCallableResource {
+	t.Helper()
+	fn := compileStarlarkFn(t, source, funcName)
+	return &mockCallableResource{
+		funcType: "TestType",
+		fn:       fn,
+	}
+}
+
+func TestBuildCallableFunc_SimpleReturn(t *testing.T) {
+	// Starlark function: def add(a, b): return a + b
+	fn := compileStarlarkFn(t, "def add(a, b):\n    return a + b\n", "add")
+	thread := &starlark.Thread{Name: "test"}
+
+	type addFunc func(any, any) (any, error)
+	targetType := reflect.TypeOf(addFunc(nil))
+
+	adapted, err := buildCallableFunc(fn, thread, targetType)
+	if err != nil {
+		t.Fatalf("buildCallableFunc: %v", err)
+	}
+
+	f := adapted.(addFunc)
+	result, err := f(3, 4)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result != 7 {
+		t.Errorf("result = %v, want 7", result)
+	}
+}
+
+func TestBuildCallableFunc_ArityTruncation(t *testing.T) {
+	// Starlark function accepts 3 params, Go func has 4.
+	// The 4th Go param should be silently dropped (swallowed).
+	fn := compileStarlarkFn(t, `
+def reducer(initial, resource, path):
+    if initial == None:
+        return [path]
+    return initial + [path]
+`, "reducer")
+	thread := &starlark.Thread{Name: "test"}
+
+	// Go target: func(any, any, string, *int) (any, error)
+	// The *int param (index 3) should be swallowed.
+	type reducerFunc func(any, any, string, *int) (any, error)
+	targetType := reflect.TypeOf(reducerFunc(nil))
+
+	adapted, err := buildCallableFunc(fn, thread, targetType)
+	if err != nil {
+		t.Fatalf("buildCallableFunc: %v", err)
+	}
+
+	f := adapted.(reducerFunc)
+	dummy := 42
+
+	result, err := f(nil, "res1", "a.txt", &dummy)
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+
+	result, err = f(result, "res2", "b.txt", &dummy)
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+
+	paths, ok := result.([]string)
+	if !ok {
+		t.Fatalf("result type = %T, want []string", result)
+	}
+	if len(paths) != 2 || paths[0] != "a.txt" || paths[1] != "b.txt" {
+		t.Errorf("result = %v, want [a.txt b.txt]", paths)
+	}
+}
+
+func TestBuildCallableFunc_StarlarkError(t *testing.T) {
+	fn := compileStarlarkFn(t, "def bad(x):\n    fail(\"boom\")\n", "bad")
+	thread := &starlark.Thread{Name: "test"}
+
+	type f func(any) (any, error)
+	adapted, err := buildCallableFunc(fn, thread, reflect.TypeOf(f(nil)))
+	if err != nil {
+		t.Fatalf("buildCallableFunc: %v", err)
+	}
+
+	_, err = adapted.(f)(42)
+	if err == nil {
+		t.Fatal("expected error from failing Starlark function")
+	}
+}
+
+func TestInitCallableSlots_ReplacesCallable(t *testing.T) {
+	m := liveCallableResource(t, "def double(x):\n    return x * 2\n", "double")
+	thread := &starlark.Thread{Name: "test"}
+
+	// Simulate a method type: func(receiver, fn func(any)(any,error))
+	type targetFunc func(any) (any, error)
+	type fakeProvider struct{}
+	type fakeMethod func(fakeProvider, targetFunc)
+	methodType := reflect.TypeOf(fakeMethod(nil))
+
+	ctx := &Context{
+		Context: context.Background(),
+		Thread:  thread,
+		Writer:  &bytes.Buffer{},
+	}
+
+	slots := map[string]any{"fn": m}
+	paramNames := []string{"fn"}
+
+	err := initCallableSlots(ctx, slots, methodType, paramNames)
+	if err != nil {
+		t.Fatalf("initCallableSlots: %v", err)
+	}
+
+	// The slot should now contain a Go func, not a CallableResource.
+	if _, ok := slots["fn"].(CallableResource); ok {
+		t.Fatal("slot still contains CallableResource after initCallableSlots")
+	}
+
+	// Call the adapted function.
+	adapted, ok := slots["fn"].(targetFunc)
+	if !ok {
+		t.Fatalf("slot type = %T, want targetFunc", slots["fn"])
+	}
+	result, err := adapted(5)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result != 10 {
+		t.Errorf("result = %v, want 10", result)
+	}
+}
+
+func TestInitCallableSlots_SkipsNonCallable(t *testing.T) {
+	ctx := &Context{
+		Context: context.Background(),
+		Thread:  &starlark.Thread{Name: "test"},
+		Writer:  &bytes.Buffer{},
+	}
+
+	// String slot targeting a string param — should be untouched.
+	type fakeMethod func(struct{}, string)
+	methodType := reflect.TypeOf(fakeMethod(nil))
+
+	slots := map[string]any{"path": "/tmp/foo"}
+	err := initCallableSlots(ctx, slots, methodType, []string{"path"})
+	if err != nil {
+		t.Fatalf("initCallableSlots: %v", err)
+	}
+	if slots["path"] != "/tmp/foo" {
+		t.Errorf("non-callable slot was modified: %v", slots["path"])
 	}
 }

--- a/pkg/op/provider/file/callable_test.go
+++ b/pkg/op/provider/file/callable_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package file
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/mem"
+)
+
+// makeCallableResource creates a compiled CallableResource from source.
+func makeCallableResource(t *testing.T, source string) op.CallableResource {
+	t.Helper()
+	c := mem.NewCallable("file.Reducer", "test_reducer")
+	c.SetSource([]byte(source))
+	if err := c.Compile(); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	return c
+}
+
+func TestWalkTreeAction_Integration(t *testing.T) {
+	// Create a temp directory with a few files.
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a callable that collects relative paths.
+	callable := makeCallableResource(t, `def _callable(initial, resource, relative_path):
+    if initial == None:
+        return [relative_path]
+    return initial + [relative_path]
+`)
+
+	// Register reflected actions with fn in params.
+	p := &Provider{}
+	reg := op.NewActionRegistry()
+	params := op.MethodParams{
+		"WalkTree":           {"root", "fn", "honor_gitignore"},
+		"CompensateWalkTree": nil, // needed to avoid orphan panic
+	}
+	op.RegisterReflectedActions(reg, "file", p, params)
+
+	action, ok := reg.Get("file.walk_tree")
+	if !ok {
+		t.Fatal("file.walk_tree not registered")
+	}
+
+	// Verify it's compensable.
+	ca, ok := action.(op.CompensableAction)
+	if !ok {
+		t.Fatal("file.walk_tree is not CompensableAction")
+	}
+
+	thread := &starlark.Thread{Name: "test"}
+	ctx := &op.Context{
+		Context: context.Background(),
+		Thread:  thread,
+		Writer:  &bytes.Buffer{},
+	}
+
+	result, complement, err := action.Do(ctx, map[string]any{
+		"root":            dir,
+		"fn":              callable,
+		"honor_gitignore": false,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	// Verify collected paths.
+	paths, ok := result.([]string)
+	if !ok {
+		t.Fatalf("result type = %T, want []string", result)
+	}
+	sort.Strings(paths)
+	want := []string{"a.txt", "b.txt", "c.txt"}
+	if len(paths) != len(want) {
+		t.Fatalf("paths = %v, want %v", paths, want)
+	}
+	for i, got := range paths {
+		if got != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+
+	// Verify Undo(nil) is safe.
+	if err := ca.Undo(ctx, nil); err != nil {
+		t.Errorf("Undo(nil) = %v, want nil", err)
+	}
+
+	// Verify complement is a RecoveryStack (or nil for no-ops).
+	if complement != nil {
+		if _, ok := complement.(*op.RecoveryStack); !ok {
+			t.Errorf("complement type = %T, want *op.RecoveryStack", complement)
+		}
+	}
+}
+
+func TestWalkTreeAction_DryRun(t *testing.T) {
+	p := &Provider{}
+	reg := op.NewActionRegistry()
+	params := op.MethodParams{
+		"WalkTree":           {"root", "fn", "honor_gitignore"},
+		"CompensateWalkTree": nil,
+	}
+	op.RegisterReflectedActions(reg, "file", p, params)
+
+	action, ok := reg.Get("file.walk_tree")
+	if !ok {
+		t.Fatal("file.walk_tree not registered")
+	}
+
+	callable := makeCallableResource(t, `def _callable(initial, resource, path):
+    return initial
+`)
+
+	var buf bytes.Buffer
+	ctx := &op.Context{
+		Context: context.Background(),
+		Thread:  &starlark.Thread{Name: "test"},
+		DryRun:  true,
+		Writer:  &buf,
+	}
+
+	result, _, err := action.Do(ctx, map[string]any{
+		"root":            "/tmp/test",
+		"fn":              callable,
+		"honor_gitignore": true,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != nil {
+		t.Errorf("dry-run result = %v, want nil", result)
+	}
+	if buf.Len() == 0 {
+		t.Error("dry-run produced no output")
+	}
+}


### PR DESCRIPTION
## Summary

- **`initCallableSlots`** — pre-processes slots in `Do()` before `coerceArgs`: finds `CallableResource` values targeting func-typed method params, calls `Init(thread)`, replaces with adapted Go functions via `buildCallableFunc`
- **`buildCallableFunc`** — `reflect.MakeFunc` adapter: marshals Go→Starlark args, calls with arity truncation (Starlark fn accepting fewer params than Go func type → trailing Go args silently dropped), unmarshals Starlark→Go returns
- **Wired into all three `Do()` methods** — `reflectedPureAction`, `reflectedFallibleAction`, `reflectedCompensableAction` all call `initCallableSlots` before `coerceArgs`
- **Generic approach** — no per-action adapter code; any action with a callable-typed parameter works automatically through the reflection layer

## Test plan

- [x] `BuildCallableFunc_SimpleReturn` — add(3,4)=7
- [x] `BuildCallableFunc_ArityTruncation` — 4-param Go func, 3-param Starlark fn, trailing param swallowed
- [x] `BuildCallableFunc_StarlarkError` — `fail()` propagates as Go error
- [x] `InitCallableSlots_ReplacesCallable` — callable in slot replaced with adapted Go func
- [x] `InitCallableSlots_SkipsNonCallable` — string slot untouched
- [x] `TestWalkTreeAction_Integration` — full walk of temp dir with Starlark callable through reflected `CompensableAction`
- [x] `TestWalkTreeAction_DryRun` — dry-run mode produces output, returns nil result
- [x] `make test` passes (full suite)
- [x] `make vet` clean