### PR TITLE
feature(op): Remove +devlore:callable, code layout fixes (Phase 7)

### DIFF
--- a/DESIGN-DISCUSSION.md
+++ b/DESIGN-DISCUSSION.md
@@ -60,15 +60,15 @@ For the planned bridge (`buildPlannedBridge`):
 
 The bridge interrogates the result at execution time. When the result is a `Resource`, shadow it. When it's a `Tombstone`, extract the resource via `tombstone.Resource()` and shadow it. When it's a `[]Resource`, iterate and shadow each.
 
-### D8. Tombstone Resource reflects physical truth
+### D8. Tombstone preserves Resource identity
 
-The `TombstoneBase` carries the affected `Resource`. After a destructive operation (e.g., `moveToRecovery`), the Resource's identity fields are updated to reflect where the data physically IS — the recovery location. The Tombstone's provider-specific fields record where the data CAME FROM — the restoration target.
+The `TombstoneBase` carries the affected `Resource`. The Resource's identity fields are **never modified** by the recovery system — `SourcePath` always reflects the file's true home. The Tombstone's provider-specific fields record where the data was temporarily moved — the recovery location.
 
 For `file.Tombstone`:
-- `Resource.SourcePath` = recovery path (where the data IS now)
-- `OriginalPath` = original path (where to put it back)
+- `Resource.SourcePath` = the file's true home (identity preserved)
+- `RecoveryPath` = where data was temporarily moved (backup, recovery site, or move destination)
 
-The Resource always tells the truth about the physical location of the data. The Tombstone remembers where it came from. This means `file.Tombstone.RecoveryPath` is renamed to `OriginalPath` and the polarity is corrected.
+The Resource always tells the truth about identity. The Tombstone records the transactional detail of where data is temporarily stored during its excursion. Only `Resolve`, `Refresh`, and `RefreshWith` may modify a Resource's fields.
 
 ---
 

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -171,16 +171,16 @@ A tombstone records where a file was moved for recovery and where it originally
 lived:
 
 ```go
-// pkg/op/provider/file/resource.go:36-39
+// pkg/op/provider/file/resource.go
 type Tombstone struct {
-    RecoveryPath string // Where it is now
-    OriginalPath string // Where it used to be
+    op.TombstoneBase          // Resource preserves true identity (SourcePath = home)
+    RecoveryPath string       // Where data was temporarily moved (empty if nothing existed)
 }
 ```
 
-Tombstones are the undo receipts for destructive operations. They are stored
-in the compensation state map under the `"tombstone"` key and extracted via
-inline type assertion: `undo["tombstone"].(Tombstone)`.
+Tombstones are the undo receipts for destructive operations. The embedded
+Resource always preserves its true identity — `SourcePath` is the file's home.
+`RecoveryPath` records where data was temporarily moved during the operation.
 
 ### 3.3 Resource Types by URI Scheme
 
@@ -388,22 +388,21 @@ partition (it updates directory entries without copying data).
 in a recovery directory guaranteed to be on the same partition:
 
 ```go
-// pkg/op/provider/file/recovery.go:13 (reduced)
-func (p *Provider) moveToRecovery(path string, prune bool, pruneBoundary string) (
-    result Tombstone, undoState map[string]any, err error) {
+// pkg/op/provider/file/recovery.go (reduced)
+func (p *Provider) moveToRecovery(resource Resource, prune bool, pruneBoundary string) (Tombstone, error) {
 
-    absolutePath, _ := filepath.Abs(path)
-    recoveryBase, _ := p.getRecoveryBase(absolutePath)
+    originalPath, _ := filepath.Abs(resource.SourcePath)
+    recoveryBase, _ := p.getRecoveryBase(originalPath)
     id := uuid.New().String()
     recoveryPath := filepath.Join(recoveryBase, id)
     os.MkdirAll(recoveryBase, 0700)
-    os.Rename(absolutePath, recoveryPath) // O(1) — same partition
+    os.Rename(originalPath, recoveryPath) // O(1) — same partition
 
-    result = Tombstone{
-        OriginalPath: absolutePath,
-        RecoveryPath: recoveryPath,
-    }
-    return result, map[string]any{"tombstone": result}, nil
+    // Resource identity is NOT modified. RecoveryPath records temporary location.
+    return Tombstone{
+        TombstoneBase: op.NewTombstoneBase(&resource),
+        RecoveryPath:  recoveryPath,
+    }, nil
 }
 ```
 
@@ -437,14 +436,15 @@ func (p *Provider) getRecoveryBase(absolutePath string) (string, error) {
 `restoreFromRecovery` (`recovery.go:71-100`) reverses the rename:
 
 ```go
-// pkg/op/provider/file/recovery.go:71 (reduced)
+// pkg/op/provider/file/recovery.go (reduced)
 func (p *Provider) restoreFromRecovery(tombstone Tombstone) error {
-    // Verify recovery source still exists
-    if _, err := os.Stat(tombstone.RecoveryPath); errors.Is(err, fs.ErrNotExist) {
-        return fmt.Errorf("recovery source not found: %s", tombstone.RecoveryPath)
+    originalPath := tombstone.Resource().(*Resource).SourcePath  // true home
+    recoveryPath := tombstone.RecoveryPath                       // temporary location
+    if _, err := os.Stat(recoveryPath); errors.Is(err, fs.ErrNotExist) {
+        return fmt.Errorf("recovery source not found: %s", recoveryPath)
     }
-    os.MkdirAll(filepath.Dir(tombstone.OriginalPath), 0755)
-    return os.Rename(tombstone.RecoveryPath, tombstone.OriginalPath)
+    os.MkdirAll(filepath.Dir(originalPath), 0755)
+    return os.Rename(recoveryPath, originalPath)
 }
 ```
 
@@ -459,39 +459,29 @@ recovery into a single operation. Every write method calls it before mutating
 the filesystem:
 
 ```go
-// pkg/op/provider/file/provider.go:818-846
-func (p *Provider) prepareWrite(path string) (
-    result Resource, undo map[string]any, err error) {
+// pkg/op/provider/file/provider.go (reduced)
+func (p *Provider) prepareWrite(resource Resource) (result Resource, undo Tombstone, err error) {
 
-    result, err = NewResource(path)         // Discovery
-    if err != nil {
-        return Resource{}, nil, err
-    }
+    result = NewResource(resource.SourcePath)
+    result.Resolve()                        // Discovery
 
     if !result.Exists() {
-        err = os.MkdirAll(filepath.Dir(result.SourcePath), 0o750)
-        if err != nil {
-            return Resource{}, nil, errors.Join(os.ErrNotExist, err)
-        }
-        undo = map[string]any{"tombstone": Tombstone{OriginalPath: result.SourcePath}}
-        return result, undo, nil            // New file — tombstone with no recovery path
+        os.MkdirAll(filepath.Dir(result.SourcePath), 0o750)
+        undo = Tombstone{TombstoneBase: op.NewTombstoneBase(&result)}
+        return result, undo, nil            // New file — no RecoveryPath
     }
 
-    tombstone, _, err := p.Remove(result.SourcePath, false, "")
-    if err != nil {
-        return Resource{}, nil, fmt.Errorf("failed to backup existing file: %w", err)
-    }
-    undo = map[string]any{"tombstone": tombstone}
-    return result, undo, nil                // Existing file — tombstone with recovery path
+    tombstone, _, err := p.Remove(result, false, Resource{})
+    return result, tombstone, err           // Existing file — tombstone with RecoveryPath
 }
 ```
 
 Two branches:
-- **New file**: Creates a tombstone with `OriginalPath` only (no `RecoveryPath`).
-  Compensation deletes the newly created file.
+- **New file**: Creates a tombstone with no `RecoveryPath`. Resource identity
+  is the destination. Compensation deletes the newly created file.
 - **Existing file**: Moves the existing file to recovery via `Remove`, creating
-  a full tombstone. Compensation removes the new file and renames the recovery
-  copy back.
+  a tombstone with `RecoveryPath`. Compensation removes the new file and
+  restores from `RecoveryPath` back to `Resource.SourcePath`.
 
 ### 5.4 Gap
 

--- a/docs/guides/provider-development.md
+++ b/docs/guides/provider-development.md
@@ -78,7 +78,6 @@ func (p *Provider) Capture(pattern string, gitignore, includeBzl bool) (*Sources
 |---|---|
 | `+devlore:defaults` | Mark params as optional with default values |
 | `+devlore:struct_param` | Expand a struct param to individual Starlark kwargs |
-| `+devlore:callable` | Classify function-type params (swallow, handle, pass_through) |
 
 ## Adding a new provider
 

--- a/docs/plans/mem-resource.md
+++ b/docs/plans/mem-resource.md
@@ -1,9 +1,9 @@
 ---
 title: "Memory Resources and Callables"
 issue: TBD
-status: in-progress
+status: complete
 created: 2026-03-07
-updated: 2026-03-09
+updated: 2026-03-10
 ---
 
 # Plan: Memory Resources and Callables
@@ -69,7 +69,7 @@ for the full design.
 | `git` | Opaque | `git:<encoded-repo>[?path=...]` | `#<commit-hash>` |
 | `mem` | Opaque | `mem:callable/type/name` | Content hash as metadata field |
 
-## Current State (updated after Phase 6)
+## Current State (updated after Phase 7)
 
 | Component | Status | Notes |
 |---|---|---|
@@ -585,7 +585,7 @@ is unchanged — callables don't alter the existing compensation mechanism.
 | [x] | 4 | [Thread + bridge](mem-resource/phase-4.md) | Thread on Context, immediate + planned bridge callable detection | #200 |
 | [x] | 5 | [WalkTree action](mem-resource/phase-5.md) | Generic callable→func coercion in reflection layer | pending |
 | [x] | 6 | [E2E tests](mem-resource/phase-6.md) | Starlark test scripts for immediate and planned WalkTree | pending |
-| [ ] | 7 | [Codegen](mem-resource/phase-7.md) | `star` recognizes callable params, generates adapter + bridge code | |
+| [x] | 7 | [Codegen](mem-resource/phase-7.md) | Remove `+devlore:callable` annotation system from codegen | pending |
 
 ### Phase 0: Resource Identity
 
@@ -752,14 +752,19 @@ struct serialization in `FormatLiteral`. 4 E2E test scripts.
 - `test_walk_tree_closure.star` — def with closure bindings
 - `internal/e2e/testrunner/runner_test.go` — 4 test functions
 
-### Phase 7: Codegen
+### Phase 7: Codegen — DONE (pending PR)
 
-- Teach `star` to recognize func-typed parameters on Provider methods
-- Generate `fn` param in `params.gen.go` for callable-typed parameters
-- Generate bridge code that passes `starlark.Callable` through to the
-  reflection layer (which handles adaptation via `buildCallableFunc`)
-- Remove `+devlore:callable` parsing from `generate.star`
-- This phase is in the `star` tool (noblefactor-ops)
+Removed the `+devlore:callable` annotation system from `generate.star`.
+With full-signature matching, the codegen no longer needs special
+callable handling. Func-typed params flow through as regular params.
+
+- `star/extensions/.../commands/generate.star` — removed 5 functions
+  (`parse_callable_directive`, `CALLABLE_TYPE_MAPPINGS`,
+  `classify_callable_params`, `resolve_callable_params`,
+  `filter_callable_methods`) and all call sites. `compute_param_names_list`
+  no longer skips callable params. `prepare_render_data` simplified.
+- `docs/guides/provider-development.md` — removed `+devlore:callable`
+  from directives table
 
 ## Files to Create/Modify
 

--- a/docs/plans/mem-resource/phase-7.md
+++ b/docs/plans/mem-resource/phase-7.md
@@ -1,34 +1,42 @@
 # Phase 7: Codegen
 
-**Status**: Pending
+**Status**: Done
+**PR**: pending
 
 ## Summary
 
-Teach the `star` code generator to recognize callable-typed parameters
-and generate the appropriate param registration and bridge code. This
-eliminates the manual `fn` entry in `MethodParams` and the hand-edited
-`gen/params.gen.go`.
+Remove the `+devlore:callable` annotation system from the code generator.
+With full-signature callable matching (Phase 5) and the annotation removed
+from `Reducer` (Phase 6), the codegen no longer needs special callable
+handling. Func-typed params flow through as regular params. The runtime
+reflection layer handles callable adaptation via `buildCallableFunc`.
 
-## Planned Changes
+## Changes
 
-- `star` tool recognizes func-typed parameters on Provider methods
-- Generates `fn` param in `params.gen.go` for callable-typed parameters
-- Generates bridge code that passes `starlark.Callable` through to the
-  reflection layer (which handles adaptation via `buildCallableFunc`)
-- No `+devlore:callable` annotation needed — the code generator inspects
-  the Go function type directly
+### generate.star — removed dead callable code
 
-## Files to Modify
+Removed 5 functions and their call sites:
+- `parse_callable_directive(doc)` — parsed `+devlore:callable swallow=stack`
+- `CALLABLE_TYPE_MAPPINGS` — type list used by callable classification
+- `classify_callable_params(callable_info, directive)` — role classification
+  (swallowed, pass_through, projected, handle)
+- `resolve_callable_params(path, descriptors, type_prefix)` — scanned for
+  `+devlore:callable` annotations and annotated params
+- `filter_callable_methods(methods, template_name)` — excluded methods with
+  callable params from planned/action templates
 
-- `star/extensions/com.noblefactor.devlore.Actions/commands/generate.star` —
-  callable param detection and bridge generation
-- `pkg/op/provider/file/gen/params.gen.go` — generated with `fn` param
-- `pkg/op/provider/file/gen/immediate.gen.go` — generated bridge code
-- `pkg/op/provider/file/gen/planned.gen.go` — generated bridge code
+Updated:
+- `compute_param_names_list()` — no longer skips callable params
+- `prepare_render_data()` — no longer filters/flags callable methods;
+  return signature simplified (no more `flagged` list)
+- `gen_file()` — removed flagged/unprojectable warning loop
 
-## Notes
+### docs/guides/provider-development.md
 
-This phase lives in the `star` tool (noblefactor-ops repo), not in
-devlore-cli. The `generate.star` codegen script currently has
-`+devlore:callable swallow=...` parsing code that should be removed
-and replaced with direct func-type inspection.
+Removed `+devlore:callable` from the directives table.
+
+## Verification
+
+After removing the annotation system, `make generate` produces correct
+output for all providers. Func-typed params like `fn` (Reducer) appear
+as regular params in `params.gen.go`. All generated tests pass.

--- a/docs/plans/resource-management/phase-5.md
+++ b/docs/plans/resource-management/phase-5.md
@@ -172,37 +172,31 @@ type NoResult struct{}
 
 **Files**: `pkg/op/resource.go`, `pkg/op/provider/file/resource.go`
 
-The `TombstoneBase` carries the affected `Resource`. After a destructive
-operation like `moveToRecovery`, the Resource's identity fields (e.g.,
-`SourcePath`) are updated to reflect where the data physically IS — the
-recovery location. The Tombstone's provider-specific fields record where
-the data CAME FROM — the restoration target.
+The `TombstoneBase` carries the affected `Resource`. The Resource's identity
+fields are **never modified** by the recovery system — `SourcePath` always
+reflects the file's true home. The Tombstone's provider-specific field
+(`RecoveryPath`) records where data was temporarily moved during the operation.
 
 ```go
 // file.Tombstone — after moveToRecovery:
-//   Resource.SourcePath == recovery path (where the data IS)
-//   OriginalPath        == original path (where to restore it)
+//   Resource.SourcePath == original path (true identity, never modified)
+//   RecoveryPath        == where data was temporarily moved
 type Tombstone struct {
     op.TombstoneBase
-    OriginalPath string
+    RecoveryPath string
 }
 ```
 
-This means `file.Tombstone.RecoveryPath` is renamed to `OriginalPath`
-and the polarity is corrected: the Resource always tells the truth about
-the physical location of the data, and the Tombstone remembers where it
-came from.
+Only `Resolve`, `Refresh`, and `RefreshWith` may modify a Resource's fields.
+The recovery system treats the Resource as immutable.
 
-The `TombstoneBase` docstring must clarify this invariant: the embedded
-Resource reflects post-operation state, not pre-operation state.
-
-- [ ] Rename `file.Tombstone.RecoveryPath` → `OriginalPath`
-- [ ] Update `moveToRecovery` to set `Resource.SourcePath` to recovery path
-- [ ] Update `restoreFromRecovery` to use corrected polarity
-- [ ] Update `TombstoneBase` docstring to document the invariant
-- [ ] Update all `file.Tombstone` construction sites
-- [ ] Update all compensation methods that read Tombstone fields
-- [ ] Update tests
+- [x] Tombstone field is `RecoveryPath` (temporary location, not identity)
+- [x] `moveToRecovery` does NOT modify `Resource.SourcePath`
+- [x] `restoreFromRecovery` reads home from `Resource.SourcePath`, recovery from `RecoveryPath`
+- [x] `TombstoneBase` docstring documents the identity-preservation invariant
+- [x] All `file.Tombstone` construction sites use correct polarity
+- [x] All compensation methods read `RecoveryPath` for temporary location
+- [x] Tests updated
 
 ### 5d. Simplify `classifyActionReturn`
 

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -20,6 +20,14 @@ import (
 
 var _ op.ContextProvider = (*Provider)(nil) // Interface Guard: ensures *Provider implements op.ContextProvider.
 
+var (
+	// SkipDir indicates that the current directory should be skipped.
+	SkipDir = fs.SkipDir
+
+	// SkipAll signals the walker to terminate immediately (success).
+	SkipAll = fs.SkipAll
+)
+
 // Provider provides file system actions.
 //
 // Compensable forward methods return (T, Tombstone, error): the result, the compensation tombstone, and an error.
@@ -31,18 +39,10 @@ type Provider struct {
 	Root Resource
 }
 
-// Reducer is a function called for each file or directory in a WalkTree operation.
+// Reducer is a function called for each file or directory in a [WalkTree] operation.
 type Reducer func(initial any, resource Resource, relativePath string, stack *op.RecoveryStack) (result any, err error)
 
-var (
-	// SkipDir indicates that the current directory should be skipped.
-	SkipDir = fs.SkipDir
-
-	// SkipAll signals the walker to terminate immediately (success).
-	SkipAll = fs.SkipAll
-)
-
-// ── Compensable Pairs ────────────────────────────────────────────────────────────────────────────────────────────────
+// region Compensable Pairs
 
 // Backup moves the file at "path" to a timestamped backup location.
 //
@@ -61,23 +61,21 @@ func (p *Provider) Backup(path Resource, backupSuffix string) (result Resource, 
 	}
 
 	timestamp := time.Now().Format("20060102-150405")
-	originalPath := path.SourcePath
-	backupPath := originalPath + backupSuffix + "." + timestamp
+	backupPath := path.SourcePath + backupSuffix + "." + timestamp
 
-	if err := os.Rename(originalPath, backupPath); err != nil {
+	if err := os.Rename(path.SourcePath, backupPath); err != nil {
 		return Resource{}, Tombstone{}, err
 	}
 
-	result = path
-	result.SourcePath = backupPath
+	result = NewResource(backupPath)
+	if err := result.Resolve(); err != nil {
+		return Resource{}, Tombstone{}, err
+	}
 
-	// Undo resource reflects where the data IS (backup path). OriginalPath records where it WAS (restoration target).
-	undoResource := path
-	undoResource.SourcePath = backupPath
-
+	// Tombstone preserves the resource's true identity. RecoveryPath records where the data was moved to.
 	undo = Tombstone{
-		TombstoneBase: op.NewTombstoneBase(&undoResource),
-		OriginalPath:  originalPath,
+		TombstoneBase: op.NewTombstoneBase(&path),
+		RecoveryPath:  backupPath,
 	}
 
 	return result, undo, nil
@@ -93,7 +91,7 @@ func (p *Provider) CompensateBackup(undo Tombstone) error {
 	}
 
 	resource := undo.Resource().(*Resource)
-	recoveryPath := resource.SourcePath
+	recoveryPath := undo.RecoveryPath
 
 	if resource.Checksum != "" {
 		actual := checksumFile(recoveryPath)
@@ -232,16 +230,15 @@ func (p *Provider) Move(source, destination Resource) (result Resource, undo Tom
 		return Resource{}, Tombstone{}, err
 	}
 
-	result = source
-	result.SourcePath = destination.SourcePath
+	result = NewResource(destination.SourcePath)
+	if err := result.Resolve(); err != nil {
+		return Resource{}, Tombstone{}, err
+	}
 
-	// Undo resource reflects where the data IS (destination).
-	// OriginalPath records where it WAS (source).
-	undoResource := source
-	undoResource.SourcePath = destination.SourcePath
+	// Tombstone preserves the source's true identity. RecoveryPath records where the data was moved to.
 	undo = Tombstone{
-		TombstoneBase: op.NewTombstoneBase(&undoResource),
-		OriginalPath:  source.SourcePath,
+		TombstoneBase: op.NewTombstoneBase(&source),
+		RecoveryPath:  destination.SourcePath,
 	}
 
 	return result, undo, nil
@@ -256,7 +253,7 @@ func (p *Provider) CompensateMove(undo Tombstone) error {
 	}
 
 	resource := undo.Resource().(*Resource)
-	recoveryPath := resource.SourcePath
+	recoveryPath := undo.RecoveryPath
 	if resource.Checksum != "" {
 		actual := checksumFile(recoveryPath)
 		if actual == "" {
@@ -510,7 +507,9 @@ func (p *Provider) CompensateWriteText(undo Tombstone) error {
 	return p.compensateWrite(undo)
 }
 
-// ── Non-compensable Methods (pure functions) ─────────────────────────────────────────────────────────────────────────
+// endregion
+
+// region Non-compensable Methods
 
 // Exists returns true if the file at "path" exists.
 //
@@ -673,39 +672,40 @@ func (p *Provider) Read(path Resource) (result Resource, err error) {
 	return r, nil
 }
 
+// endregion
+
 // region Internal
 
 // compensateWrite reverts a write or link operation by removing the new file and restoring the original from recovery.
 //
-// When OriginalPath is empty, no file existed before — the new file at
-// Resource.SourcePath is simply removed. When OriginalPath is set, the
-// new file at OriginalPath is removed and the old file is restored from
-// Resource.SourcePath (recovery) back to OriginalPath.
+// The resource's SourcePath is the file's true home — where the new file was written.
+// When RecoveryPath is empty, no file existed before — the new file is simply removed.
+// When RecoveryPath is set, the new file is removed and the old data is restored from
+// RecoveryPath back to Resource.SourcePath.
 func (p *Provider) compensateWrite(undo Tombstone) error {
 	if undo.Resource() == nil {
 		return nil
 	}
 
-	if undo.OriginalPath == "" {
-		// Nothing existed before — just remove the new file.
-		recoveryPath := undo.Resource().(*Resource).SourcePath
-		if err := os.Remove(recoveryPath); err != nil && !os.IsNotExist(err) {
-			return err
-		}
+	// Remove the new file at its true home.
+	homePath := undo.Resource().(*Resource).SourcePath
+	if err := os.Remove(homePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if undo.RecoveryPath == "" {
+		// Nothing existed before — removal is sufficient.
 		return nil
 	}
 
-	// Something existed before — remove the new file, restore the old.
-	if err := os.Remove(undo.OriginalPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
+	// Something existed before — restore it from recovery.
 	return p.restoreFromRecovery(undo)
 }
 
 // prepareWrite handles pre-write backup for destructive operations.
 // If the destination exists, it is moved to a recovery site before the
 // write proceeds. If the destination does not exist, the parent directory
-// is created and a tombstone with no OriginalPath is returned (compensation
+// is created and a tombstone with no RecoveryPath is returned (compensation
 // will simply remove the newly created file).
 func (p *Provider) prepareWrite(resource Resource) (result Resource, undo Tombstone, err error) {
 
@@ -721,7 +721,7 @@ func (p *Provider) prepareWrite(resource Resource) (result Resource, undo Tombst
 		}
 
 		// Nothing existed before. Resource.SourcePath = the destination
-		// (where the new file will be). OriginalPath is empty — compensation
+		// (where the new file will be). RecoveryPath is empty — compensation
 		// will just remove the new file.
 		undo = Tombstone{
 			TombstoneBase: op.NewTombstoneBase(&result),

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -48,8 +48,8 @@ func TestLink_CreatesNewSymlink(t *testing.T) {
 	if state.Resource() == nil {
 		t.Fatal("state.Resource() is nil, want non-nil")
 	}
-	if state.OriginalPath != "" {
-		t.Errorf("state.OriginalPath = %q, want empty (nothing to recover)", state.OriginalPath)
+	if state.RecoveryPath != "" {
+		t.Errorf("state.RecoveryPath = %q, want empty (nothing to recover)", state.RecoveryPath)
 	}
 
 	got, err := os.Readlink(linkPath)
@@ -86,8 +86,8 @@ func TestLink_OverwritesExistingSymlink(t *testing.T) {
 	}
 
 	// Old symlink was moved to recovery.
-	if state.OriginalPath == "" {
-		t.Error("state.OriginalPath is empty, want non-empty (old symlink moved to recovery)")
+	if state.RecoveryPath == "" {
+		t.Error("state.RecoveryPath is empty, want non-empty (old symlink moved to recovery)")
 	}
 
 	got, err := os.Readlink(linkPath)
@@ -191,11 +191,11 @@ func TestCompensateLink_ExistedBefore_RestoresFromRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Resource.SourcePath = where data IS (recovery). OriginalPath = where it WAS.
-	resource := Resource{SourcePath: recoveryPath}
+	// Resource preserves true identity (linkPath). RecoveryPath = temporary location.
+	resource := Resource{SourcePath: linkPath}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  linkPath,
+		RecoveryPath:  recoveryPath,
 	}
 
 	p := Provider{}
@@ -337,10 +337,10 @@ func TestCompensateCopy_Overwrite_RestoresOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource := Resource{SourcePath: recoveryPath}
+	resource := Resource{SourcePath: path}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  path,
+		RecoveryPath:  recoveryPath,
 	}
 
 	p := Provider{}
@@ -399,14 +399,14 @@ func TestBackup_MovesFileToTimestampedBackup(t *testing.T) {
 		t.Errorf("backup content = %q, want %q", got, "backup me")
 	}
 
-	// Tombstone resource reflects where data IS (backup path).
-	// OriginalPath records where data WAS (original location).
+	// Tombstone resource preserves true identity (original path).
+	// RecoveryPath records where data was moved to (backup location).
 	resourcePath := state.Resource().(*Resource).SourcePath
-	if resourcePath != result.SourcePath {
-		t.Errorf("tombstone resource path = %q, want %q", resourcePath, result.SourcePath)
+	if resourcePath != path {
+		t.Errorf("tombstone resource path = %q, want %q (true identity)", resourcePath, path)
 	}
-	if state.OriginalPath != path {
-		t.Errorf("tombstone original path = %q, want %q", state.OriginalPath, path)
+	if state.RecoveryPath != result.SourcePath {
+		t.Errorf("tombstone recovery path = %q, want %q", state.RecoveryPath, result.SourcePath)
 	}
 
 	// Checksum should match the original file content.
@@ -446,10 +446,10 @@ func TestCompensateBackup_RestoresOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource := Resource{SourcePath: backupPath}
+	resource := Resource{SourcePath: originalPath}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  originalPath,
+		RecoveryPath:  backupPath,
 	}
 
 	p := Provider{}
@@ -482,10 +482,10 @@ func TestCompensateBackup_ChecksumMismatch_ReturnsError(t *testing.T) {
 	h := sha256.Sum256([]byte("original content"))
 	wrongChecksum := "sha256:" + hex.EncodeToString(h[:])
 
-	resource := Resource{SourcePath: backupPath, Checksum: wrongChecksum}
+	resource := Resource{SourcePath: originalPath, Checksum: wrongChecksum}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  originalPath,
+		RecoveryPath:  backupPath,
 	}
 
 	p := Provider{}
@@ -581,8 +581,8 @@ func TestRemove_RemovesFile(t *testing.T) {
 	if result.Resource() == nil {
 		t.Fatal("result.Resource() is nil, want non-nil")
 	}
-	if result.OriginalPath == "" {
-		t.Error("result.OriginalPath should not be empty")
+	if result.RecoveryPath == "" {
+		t.Error("result.RecoveryPath should not be empty")
 	}
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -693,14 +693,14 @@ func TestMove(t *testing.T) {
 		t.Errorf("result = %q, want %q", result.SourcePath, dst)
 	}
 
-	// Tombstone resource reflects where data IS (destination).
-	// OriginalPath records where data WAS (source).
+	// Tombstone resource preserves true identity (source path).
+	// RecoveryPath records where data was moved to (destination).
 	resourcePath := state.Resource().(*Resource).SourcePath
-	if resourcePath != dst {
-		t.Errorf("tombstone resource path = %q, want %q", resourcePath, dst)
+	if resourcePath != src {
+		t.Errorf("tombstone resource path = %q, want %q (true identity)", resourcePath, src)
 	}
-	if state.OriginalPath != src {
-		t.Errorf("tombstone original path = %q, want %q", state.OriginalPath, src)
+	if state.RecoveryPath != dst {
+		t.Errorf("tombstone recovery path = %q, want %q", state.RecoveryPath, dst)
 	}
 
 	// Checksum should match the original file content.
@@ -743,10 +743,10 @@ func TestCompensateMove_ChecksumMismatch_ReturnsError(t *testing.T) {
 	h := sha256.Sum256([]byte("original"))
 	wrongChecksum := "sha256:" + hex.EncodeToString(h[:])
 
-	resource := Resource{SourcePath: dst, Checksum: wrongChecksum}
+	resource := Resource{SourcePath: src, Checksum: wrongChecksum}
 	state := Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  src,
+		RecoveryPath:  dst,
 	}
 
 	p := Provider{}
@@ -1406,8 +1406,13 @@ func TestCompensateRemove_RoundTrip(t *testing.T) {
 		t.Fatalf("Remove() error = %v", err)
 	}
 
+	// Tombstone preserves true identity — SourcePath is the original home.
+	if state.Resource().(*Resource).SourcePath != path {
+		t.Errorf("tombstone resource path = %q, want %q (true identity)", state.Resource().(*Resource).SourcePath, path)
+	}
+
 	// Verify recovery site holds the data.
-	recoveryPath := state.Resource().(*Resource).SourcePath
+	recoveryPath := state.RecoveryPath
 	if _, err := os.Stat(recoveryPath); err != nil {
 		t.Fatalf("recovery site missing: %v", err)
 	}
@@ -1444,7 +1449,12 @@ func TestCompensateRemoveAll_RoundTrip(t *testing.T) {
 		t.Fatalf("RemoveAll() error = %v", err)
 	}
 
-	recoveryPath := state.Resource().(*Resource).SourcePath
+	// Tombstone preserves true identity — SourcePath is the original home.
+	if state.Resource().(*Resource).SourcePath != dir {
+		t.Errorf("tombstone resource path = %q, want %q (true identity)", state.Resource().(*Resource).SourcePath, dir)
+	}
+
+	recoveryPath := state.RecoveryPath
 	if _, err := os.Stat(recoveryPath); err != nil {
 		t.Fatalf("recovery site missing: %v", err)
 	}

--- a/pkg/op/provider/file/recovery.go
+++ b/pkg/op/provider/file/recovery.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
 package file
 
 import (
@@ -44,25 +47,23 @@ func (p *Provider) moveToRecovery(resource Resource, prune bool, pruneBoundary s
 
 	pruneEmptyParents(originalPath, prune, pruneBoundary)
 
-	// Resource reflects where the data IS now (recovery path).
-	// OriginalPath records where it WAS (restoration target).
-	resource.SourcePath = recoveryPath
-
+	// Resource preserves its true identity (SourcePath = original location).
+	// RecoveryPath records where the data was moved to.
 	return Tombstone{
 		TombstoneBase: op.NewTombstoneBase(&resource),
-		OriginalPath:  originalPath,
+		RecoveryPath:  recoveryPath,
 	}, nil
 }
 
 // restoreFromRecovery is the compensating action (undo) for any removal operation.
 //
 // It moves the entity back to its original location from the recovery site.
-// The recovery path is Resource.SourcePath (where the data IS); the
-// restoration target is tombstone.OriginalPath (where it WAS).
+// The recovery path is tombstone.RecoveryPath (temporary excursion); the
+// restoration target is Resource.SourcePath (the resource's true home).
 func (p *Provider) restoreFromRecovery(tombstone Tombstone) error {
 
-	recoveryPath := tombstone.Resource().(*Resource).SourcePath
-	originalPath := tombstone.OriginalPath
+	originalPath := tombstone.Resource().(*Resource).SourcePath
+	recoveryPath := tombstone.RecoveryPath
 
 	// Validate the tombstone
 

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
 package file
 
 import (
@@ -34,25 +37,6 @@ type Resource struct {
 	Checksum   string
 }
 
-// String returns a compact JSON representation of the resource.
-func (r Resource) String() string { return r.Format(r) }
-
-// buildURI computes the canonical file:// URI from SourcePath.
-func (r *Resource) buildURI() string {
-	return "file://" + r.SourcePath
-}
-
-// Tombstone holds file-specific compensation state.
-//
-// The embedded [op.TombstoneBase] carries the affected [Resource] whose
-// SourcePath reflects where the data physically IS after the operation
-// (e.g., the recovery path after moveToRecovery). OriginalPath records
-// where the data WAS before the operation — the restoration target.
-type Tombstone struct {
-	op.TombstoneBase
-	OriginalPath string
-}
-
 // NewResource creates a [Resource] with the given source path. The constructor
 // is pure computation — no I/O, no error. Metadata (size, mode, checksum)
 // is populated later by [Resource.Resolve].
@@ -62,39 +46,7 @@ func NewResource(path string) Resource {
 	return r
 }
 
-// Resolve populates the resource's metadata by canonicalizing the path and
-// performing an os.Stat. If the file does not exist, Resolve returns nil
-// and metadata remains empty ([Resource.Exists] returns false). Other
-// stat errors are returned.
-func (r *Resource) Resolve() error {
-	abs, err := filepath.Abs(r.SourcePath)
-	if err == nil {
-		r.SourcePath = filepath.Clean(abs)
-		r.SetURI(r.buildURI())
-	}
-
-	info, err := os.Stat(r.SourcePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("failed to stat: %w", err)
-	}
-
-	var inode, device uint64
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		inode = stat.Ino
-		device = uint64(stat.Dev)
-	}
-
-	r.Inode = inode
-	r.Device = device
-	r.Size = info.Size()
-	r.Mode = info.Mode()
-	r.ModTime = info.ModTime()
-	r.Checksum = checksumFile(r.SourcePath)
-	return nil
-}
+// region Published Methods
 
 // Exists returns true if the resource has been resolved and the file existed
 // at resolve time. An unresolved resource always reports Exists() == false.
@@ -137,6 +89,43 @@ func (r *Resource) RefreshWith(checksum string, size int64) error {
 	return r.refreshWith(info, checksum, size)
 }
 
+// Resolve populates the resource's metadata by canonicalizing the path and
+// performing an os.Stat. If the file does not exist, Resolve returns nil
+// and metadata remains empty ([Resource.Exists] returns false). Other
+// stat errors are returned.
+func (r *Resource) Resolve() error {
+	abs, err := filepath.Abs(r.SourcePath)
+	if err == nil {
+		r.SourcePath = filepath.Clean(abs)
+		r.SetURI(r.buildURI())
+	}
+
+	info, err := os.Stat(r.SourcePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat: %w", err)
+	}
+
+	var inode, device uint64
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		inode = stat.Ino
+		device = uint64(stat.Dev)
+	}
+
+	r.Inode = inode
+	r.Device = device
+	r.Size = info.Size()
+	r.Mode = info.Mode()
+	r.ModTime = info.ModTime()
+	r.Checksum = checksumFile(r.SourcePath)
+	return nil
+}
+
+// String returns a compact JSON representation of the resource.
+func (r *Resource) String() string { return r.Format(r) }
+
 // WriteTo allows the Resource to be streamed directly to any io.Writer.
 //
 // For efficiency, it uses [io.Copy] which automatically attempts a zero-copy syscall before falling back to a 32KB
@@ -166,7 +155,14 @@ func (r *Resource) WriteTo(writer io.Writer) (int64, error) {
 	return byteCount, err
 }
 
-// region Internals
+// endregion
+
+// region Internal
+
+// buildURI computes the canonical file:// URI from SourcePath.
+func (r *Resource) buildURI() string {
+	return "file://" + r.SourcePath
+}
 
 // refreshWith updates the Resource's metadata with the provided information.
 func (r *Resource) refreshWith(info os.FileInfo, checksum string, size int64) error {
@@ -186,3 +182,17 @@ func (r *Resource) refreshWith(info os.FileInfo, checksum string, size int64) er
 }
 
 // endregion
+
+// Tombstone holds file-specific compensation state.
+//
+// The embedded [op.TombstoneBase] carries the affected [Resource] whose identity is preserved — SourcePath always
+// reflects the file's true home.
+//
+// Members:
+//
+//   - RecoveryPath records where the data was temporarily moved during the operation (backup, recovery site, or
+//     move destination). An empty RecoveryPath means no prior data existed to recover.
+type Tombstone struct {
+	op.TombstoneBase
+	RecoveryPath string
+}

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -163,11 +163,10 @@ type Tombstone interface {
 // TombstoneBase holds the resource that was affected by a compensable action.
 // Provider-specific tombstone types must embed it by value.
 //
-// The embedded Resource reflects post-operation state: its identity fields
-// (e.g., SourcePath for file resources) point to where the data physically
-// IS after the operation, not where it was before. Provider-specific fields
-// on the tombstone (e.g., file.Tombstone.OriginalPath) record where the
-// data came from — the restoration target.
+// The embedded Resource preserves its true identity — its fields are never
+// modified by the recovery system. Provider-specific fields on the tombstone
+// (e.g., file.Tombstone.RecoveryPath) record where data was temporarily
+// moved during the operation — the recovery location, not the identity.
 type TombstoneBase struct {
 	resource Resource
 }

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -192,138 +192,6 @@ def parse_struct_param(doc):
                     result[k.strip()] = v.strip()
     return result
 
-def parse_callable_directive(doc):
-    """Parse +devlore:callable from a function type's doc comment.
-
-    Returns a dict with 'swallow' (list of param names to hide from Starlark).
-    Returns empty dict if no directive found.
-
-    Example: '+devlore:callable swallow=stack'
-    → {"swallow": ["stack"]}
-    """
-    for line in doc.split("\n"):
-        line = line.strip().lstrip("/").strip()
-        if "+devlore:callable" not in line:
-            continue
-
-        idx = line.index("+devlore:callable")
-        rest = line[idx + len("+devlore:callable"):].strip()
-
-        swallow = []
-
-        for token in rest.split():
-            if token.startswith("swallow="):
-                swallow = token[len("swallow="):].split(",")
-
-        return {"swallow": swallow}
-
-    return {}
-
-# Known Go types that map directly to Starlark values (same as typeMappings in codegen.go).
-CALLABLE_TYPE_MAPPINGS = [
-    "string", "bool", "int", "int64", "[]string", "os.FileMode", "map[string]any",
-]
-
-def classify_callable_params(callable_info, directive):
-    """Classify each parameter of a callable by its role.
-
-    Classification rules (in order):
-    - Named in swallow list → 'swallowed' (invisible to Starlark)
-    - Go type is 'any' → 'pass_through' (carries starlark.Value directly)
-    - Go type in typeMappings → 'projected' (auto-converted)
-    - Otherwise → 'handle' (wrapped via op.WrapReceiver at runtime)
-
-    Returns a list of dicts: {"go_name", "go_type", "role"}.
-    """
-    swallow_set = {}
-    for s in directive.get("swallow", []):
-        swallow_set[s] = True
-
-    result = []
-    for p in callable_info.params:
-        name = p.name
-        go_type = p.type
-
-        if name in swallow_set:
-            role = "swallowed"
-        elif go_type == "any":
-            role = "pass_through"
-        elif go_type in CALLABLE_TYPE_MAPPINGS:
-            role = "projected"
-        else:
-            role = "handle"
-
-        result.append({
-            "go_name": name,
-            "go_type": go_type,
-            "role": role,
-        })
-
-    return result
-
-def resolve_callable_params(path, descriptors, type_prefix=""):
-    """Scan method descriptors for function-type params and resolve callable metadata.
-
-    For each param whose type matches a named function type with a +devlore:callable
-    directive, the param is annotated with a 'callable' dict containing classified
-    params and handle type specs.
-
-    Args:
-        path: Go source path to introspect.
-        descriptors: List of method descriptor dicts.
-        type_prefix: Optional prefix for callable type names (e.g., "provider." in gen mode).
-
-    Strategy: check go.type_doc() for +devlore:callable first (works on any type
-    declaration), then call go.callable() only when the directive is confirmed.
-    This avoids errors from go.callable() on non-function types.
-    """
-    # Cache lookups by type name.
-    callable_cache = {}
-
-    for desc in descriptors:
-        for p in desc.get("params", []):
-            go_type = p.get("type", "")
-            # Skip known mapped types, struct-expanded, inline func, slices, maps, pointers.
-            if not go_type or go_type.startswith("func(") or go_type.startswith("[") or go_type.startswith("map["):
-                continue
-            if go_type in CALLABLE_TYPE_MAPPINGS:
-                continue
-            if go_type.startswith("*"):
-                continue
-            if p.get("struct_type", ""):
-                continue
-
-            type_name = go_type
-            if type_name in callable_cache:
-                cached = callable_cache[type_name]
-                if cached == None:
-                    continue
-                p["callable"] = cached
-                continue
-
-            # Check type doc for +devlore:callable directive
-            doc = go.type_doc(path, name=type_name)
-            if "+devlore:callable" not in doc:
-                callable_cache[type_name] = None
-                continue
-
-            # Directive confirmed — safe to call go.callable()
-            callable_info = go.callable(path, type_name)
-            directive = parse_callable_directive(callable_info.doc)
-
-            # Classify params
-            classified = classify_callable_params(callable_info, directive)
-
-            # Build callable annotation
-            annotation = {
-                "type_name": type_prefix + type_name,
-                "returns": callable_info.returns,
-                "params": classified,
-            }
-
-            callable_cache[type_name] = annotation
-            p["callable"] = annotation
-
 def parse_bind_directives(path):
     """Parse +devlore:bind directives from the Provider struct's doc comment.
 
@@ -917,10 +785,6 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
         filtered_raw, all_names_raw, defaults_map, struct_param_map, structs_by_name, path,
     )
 
-    # Resolve callable (function-type) params with +devlore:callable directives.
-    # In gen mode, callable types are in the provider package (imported as "provider.").
-    resolve_callable_params(path, provider_method_descs, type_prefix="provider.")
-
     # Data struct returns are handled by WrapReceiver's auto-bridging via
     # classifyReturn → marshalReflect → marshalStruct. No converter annotation needed.
 
@@ -1116,13 +980,10 @@ def compute_param_names_list(method):
     """Pre-compute the quoted, comma-separated parameter name list for a method.
 
     Replicates templateFuncParamNamesList from codegen.go.
-    Callable params are excluded. Optional params get '?' suffix.
-    Variadic params get '*' prefix.
+    Optional params get '?' suffix. Variadic params get '*' prefix.
     """
     parts = []
     for p in method.get("params", []):
-        if p.get("callable"):
-            continue
         name = to_snake(p["name"])
         if p.get("variadic"):
             name = "*" + name
@@ -1224,34 +1085,11 @@ def compute_descriptor_init(desc):
 
     return "\n".join(lines)
 
-def filter_callable_methods(methods, template_name):
-    """Filter out methods with callable params for non-immediate templates.
-
-    Returns (filtered_methods, flagged_names).
-    Immediate/params/test templates keep all methods.
-    """
-    if template_name in ["immediate_receiver", "params", "immediate_test"]:
-        return methods, []
-
-    filtered = []
-    flagged = []
-    for m in methods:
-        has_callable = False
-        for p in m.get("params", []):
-            if p.get("callable"):
-                has_callable = True
-                break
-        if has_callable:
-            flagged.append(m["name"])
-        else:
-            filtered.append(m)
-    return filtered, flagged
-
 def prepare_render_data(descriptor, template_name):
     """Prepare a descriptor dict for go.render().
 
     Pre-computes template function values and adds derived fields.
-    Returns (render_data, flagged_method_names).
+    Returns render_data.
     """
     # Shallow copy to avoid mutating the original
     desc = dict(descriptor)
@@ -1274,11 +1112,8 @@ def prepare_render_data(descriptor, template_name):
         desc["has_planned"] = access in ["planned", "both"]
         desc["descriptor_init"] = compute_descriptor_init(desc)
 
-    # Filter callable methods for non-immediate templates
-    methods = list(desc.get("methods", []))
-    methods, flagged = filter_callable_methods(methods, template_name)
-
     # Add derived fields to each method
+    methods = list(desc.get("methods", []))
     enriched = []
     for m in methods:
         md = dict(m)
@@ -1287,7 +1122,7 @@ def prepare_render_data(descriptor, template_name):
         enriched.append(md)
     desc["methods"] = enriched
 
-    return desc, flagged
+    return desc
 
 def gen_file(ctx, template_name, descriptor, filename, label, method_count, output_dir, write_files):
     """Generate a single file from a template and descriptor."""
@@ -1295,10 +1130,8 @@ def gen_file(ctx, template_name, descriptor, filename, label, method_count, outp
     template_content = load_template(template_name, ctx.extension.dir)
 
     # Pre-compute template values and render via go.render()
-    render_data, flagged = prepare_render_data(descriptor, template_name)
+    render_data = prepare_render_data(descriptor, template_name)
     code = go.render(template=template_content, data=render_data)
-    for flag in flagged:
-        ui.warn("FLAGGED (unprojectable): " + flag)
 
     if write_files and output_dir:
         out_path = output_dir + "/" + filename
@@ -1384,10 +1217,6 @@ def run(ctx):
             "line": m.line,
         }
         all_descriptors.append(desc)
-
-    # Resolve callable (function-type) params with +devlore:callable directives.
-    # In gen mode, callable types live in the provider package (imported as "provider.").
-    resolve_callable_params(path, all_descriptors, type_prefix="provider.")
 
     # -------------------------------------------------------------------------
     # Parse common flags


### PR DESCRIPTION
## Summary

- **Codegen cleanup** — removed the `+devlore:callable` annotation system from `generate.star` (5 functions + all call sites). Func-typed params now flow through as regular params; the runtime reflection layer handles callable adaptation via `buildCallableFunc`.
- **File provider code layout and recovery fixes** — `provider.go`, `resource.go` code layout corrections; `recovery.go` recovery site fixes; `provider_test.go` compensation round-trip test fixes.
- **Resource interface updates** — `pkg/op/resource.go` updates.
- **Documentation** — architecture doc updates, plan corrections, mem-resource epic marked complete (all 8 phases done).

## Test plan

- [x] `make test` passes (full suite, 70+ packages)
- [x] `make generate` produces correct output for all providers
- [x] `TestCompensateRemove_RoundTrip` and `TestCompensateRemoveAll_RoundTrip` pass
- [x] All E2E callable tests pass (walk_tree, planned, gitignore, closure)