### PR TITLE
Extract shared root command factory

### DIFF
--- a/docs/plans/root-command-factory.md
+++ b/docs/plans/root-command-factory.md
@@ -1,0 +1,59 @@
+---
+title: "Root Command Factory"
+status: complete
+created: 2026-03-10
+updated: 2026-03-10
+---
+
+# Plan: Root Command Factory
+
+## Summary
+
+Extract duplicated cobra root command setup from `internal/lore/root.go` and
+`internal/writ/root.go` into a shared `cli.NewRootCmd(cfg RootConfig)` factory.
+Eliminates structural drift between the two CLI entry points.
+
+## Goals
+
+1. **Single source of truth** for shared flags, Viper init, and metadata commands
+2. **Prevent drift** between lore and writ CLI configuration
+3. **Fix existing drift bugs** discovered during analysis
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| `lore/root.go` | 154 lines | Duplicated setup, missing `cmd.Root()` in BindFlags |
+| `writ/root.go` | 145 lines | Duplicated setup, missing `DisableAutoGenTag` |
+| Shared factory | Missing | No shared abstraction exists |
+
+## Implementation Phases
+
+### Phase 1: Extract factory (complete)
+
+- [x] Create `internal/cli/root.go` with `RootConfig` struct and `NewRootCmd` factory
+- [x] Move `initConfig` into factory as `initRootConfig` (unexported)
+- [x] Simplify `internal/lore/root.go` to call factory + add tool-specific flag and subcommands
+- [x] Simplify `internal/writ/root.go` to call factory + add tool-specific flag and subcommands
+- [x] Fix writ missing `DisableAutoGenTag: true`
+- [x] Fix lore using `cmd` instead of `cmd.Root()` in BindFlags
+- [x] Apply Go style guidelines (doc comments with Parameters/Returns)
+- [x] `make build`, `make test`, `make vet` pass
+
+**Files**:
+
+- `internal/cli/root.go` - Create (shared factory + initRootConfig)
+- `internal/lore/root.go` - Rewrite (154 -> 68 lines)
+- `internal/writ/root.go` - Rewrite (145 -> 59 lines)
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `internal/cli/root.go` | Create | Shared `NewRootCmd` factory and `initRootConfig` |
+| `internal/lore/root.go` | Rewrite | Tool-specific flag + subcommands only |
+| `internal/writ/root.go` | Rewrite | Tool-specific flag + subcommands only |
+
+## Related Documents
+
+- [CODE-CONSOLIDATION-ANALYSIS.md](../../CODE-CONSOLIDATION-ANALYSIS.md) - Item 2.1: Root Command Initialization

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/NobleFactor/devlore-cli/schema"
+)
+
+// ──────────────────────────────────────────────────────────────────
+// RootConfig
+// ──────────────────────────────────────────────────────────────────
+
+// RootConfig configures a root CLI command for lore or writ.
+type RootConfig struct {
+	Name          string // Command name ("lore" or "writ")
+	Short         string // One-line description
+	Long          string // Multi-line description
+	DefaultConfig []byte // Schema default config (e.g., schema.LoreDefaultConfig)
+	Version       string // Semantic version, set via ldflags
+	Commit        string // Git commit hash, set via ldflags
+	BuildDate     string // Build timestamp, set via ldflags
+}
+
+// ──────────────────────────────────────────────────────────────────
+// NewRootCmd
+// ──────────────────────────────────────────────────────────────────
+
+// NewRootCmd creates a root cobra command with all shared flags, metadata
+// commands, and Viper configuration. The caller adds tool-specific flags
+// and subcommands to the returned command.
+func NewRootCmd(cfg RootConfig) *cobra.Command {
+	SetProgramName(cfg.Name)
+
+	rootCmd := &cobra.Command{
+		Use:               cfg.Name,
+		Short:             cfg.Short,
+		Long:              cfg.Long,
+		DisableAutoGenTag: true,
+		CompletionOptions: cobra.CompletionOptions{
+			HiddenDefaultCmd: true,
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return initRootConfig(cmd, cfg.Name)
+		},
+	}
+
+	// ── Standard flags ───────────────────────────────────────────
+	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
+	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
+	AddSilentFlag(rootCmd)
+
+	// ── Deployment mode flags (ADR-033) ──────────────────────────
+	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts, rich output)")
+	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
+	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
+
+	// ── Model configuration flags ────────────────────────────────
+	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
+	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
+	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
+	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
+	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
+
+	// ── Shared metadata commands ─────────────────────────────────
+	capitalized := strings.ToUpper(cfg.Name[:1]) + cfg.Name[1:]
+
+	manHeader := ManHeader{
+		Title:   strings.ToUpper(cfg.Name),
+		Section: "1",
+		Source:  capitalized + " " + cfg.Version,
+		Manual:  capitalized + " Manual",
+	}
+	configInfo := ConfigInfo{
+		Name:          cfg.Name,
+		Schema:        schema.DevloreSchema,
+		DefaultConfig: cfg.DefaultConfig,
+	}
+
+	rootCmd.SetHelpCommand(NewHelpCmd(rootCmd, manHeader))
+	rootCmd.AddCommand(NewVersionCmd(VersionInfo{
+		Version:   cfg.Version,
+		Commit:    cfg.Commit,
+		BuildDate: cfg.BuildDate,
+	}))
+	rootCmd.AddCommand(NewManCmd(rootCmd, manHeader))
+	rootCmd.AddCommand(NewConfigCmd(configInfo))
+	rootCmd.AddCommand(NewSelfInstallCmd(rootCmd, SelfInstallInfo{
+		Name:       cfg.Name,
+		ManHeader:  manHeader,
+		ConfigInfo: configInfo,
+	}))
+
+	return rootCmd
+}
+
+// ──────────────────────────────────────────────────────────────────
+// initRootConfig
+// ──────────────────────────────────────────────────────────────────
+
+// initRootConfig initializes Viper configuration for a root command.
+// Precedence (lowest to highest): config file → environment variables → flags.
+func initRootConfig(cmd *cobra.Command, name string) error {
+	if err := InitViper(ViperConfig{
+		Name:            name,
+		EnvPrefix:       strings.ToUpper(name),
+		UseSharedConfig: true,
+	}); err != nil {
+		return err
+	}
+
+	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
+		viper.SetConfigFile(cfgFile)
+		if err := viper.ReadInConfig(); err != nil {
+			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
+		}
+	}
+
+	if err := BindFlags(cmd.Root(), name, true); err != nil {
+		return err
+	}
+
+	if viper.GetBool(name + ".verbose") {
+		Note("Using config: %s", viper.ConfigFileUsed())
+	}
+
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/NobleFactor/devlore-cli/schema"
+)
+
+// RootConfig configures a root CLI command for lore or writ.
+type RootConfig struct {
+	Name          string // Command name ("lore" or "writ")
+	Short         string // One-line description
+	Long          string // Multi-line description
+	DefaultConfig []byte // Schema default config (e.g., schema.LoreDefaultConfig)
+	Version       string // Semantic version, set via ldflags
+	Commit        string // Git commit hash, set via ldflags
+	BuildDate     string // Build timestamp, set via ldflags
+}
+
+// NewRootCmd creates a root cobra command with all shared flags, metadata
+// commands, and Viper configuration. The caller adds tool-specific flags
+// and subcommands to the returned command.
+//
+// Parameters:
+//   - cfg: root command configuration (name, descriptions, version info)
+//
+// Returns:
+//   - *cobra.Command: configured root command with shared flags and metadata commands
+func NewRootCmd(cfg RootConfig) *cobra.Command {
+	SetProgramName(cfg.Name)
+
+	rootCmd := &cobra.Command{
+		Use:               cfg.Name,
+		Short:             cfg.Short,
+		Long:              cfg.Long,
+		DisableAutoGenTag: true,
+		CompletionOptions: cobra.CompletionOptions{
+			HiddenDefaultCmd: true,
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return initRootConfig(cmd, cfg.Name)
+		},
+	}
+
+	// Standard flags
+	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
+	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
+	AddSilentFlag(rootCmd)
+
+	// Deployment mode flags (ADR-033)
+	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts, rich output)")
+	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
+	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
+
+	// Model configuration flags
+	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
+	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
+	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
+	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
+	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
+
+	// Shared metadata commands
+	capitalized := strings.ToUpper(cfg.Name[:1]) + cfg.Name[1:]
+
+	manHeader := ManHeader{
+		Title:   strings.ToUpper(cfg.Name),
+		Section: "1",
+		Source:  capitalized + " " + cfg.Version,
+		Manual:  capitalized + " Manual",
+	}
+	configInfo := ConfigInfo{
+		Name:          cfg.Name,
+		Schema:        schema.DevloreSchema,
+		DefaultConfig: cfg.DefaultConfig,
+	}
+
+	rootCmd.SetHelpCommand(NewHelpCmd(rootCmd, manHeader))
+	rootCmd.AddCommand(NewVersionCmd(VersionInfo{
+		Version:   cfg.Version,
+		Commit:    cfg.Commit,
+		BuildDate: cfg.BuildDate,
+	}))
+	rootCmd.AddCommand(NewManCmd(rootCmd, manHeader))
+	rootCmd.AddCommand(NewConfigCmd(configInfo))
+	rootCmd.AddCommand(NewSelfInstallCmd(rootCmd, SelfInstallInfo{
+		Name:       cfg.Name,
+		ManHeader:  manHeader,
+		ConfigInfo: configInfo,
+	}))
+
+	return rootCmd
+}
+
+// initRootConfig initializes Viper configuration for a root command.
+// Precedence (lowest to highest): config file → environment variables → flags.
+//
+// Parameters:
+//   - cmd: the cobra command triggering initialization
+//   - name: tool name ("lore" or "writ"), used as Viper prefix and env prefix
+//
+// Returns:
+//   - error: configuration, config file read, or flag binding failure
+func initRootConfig(cmd *cobra.Command, name string) error {
+	if err := InitViper(ViperConfig{
+		Name:            name,
+		EnvPrefix:       strings.ToUpper(name),
+		UseSharedConfig: true,
+	}); err != nil {
+		return err
+	}
+
+	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
+		viper.SetConfigFile(cfgFile)
+		if err := viper.ReadInConfig(); err != nil {
+			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
+		}
+	}
+
+	if err := BindFlags(cmd.Root(), name, true); err != nil {
+		return err
+	}
+
+	if viper.GetBool(name + ".verbose") {
+		Note("Using config: %s", viper.ConfigFileUsed())
+	}
+
+	return nil
+}

--- a/internal/lore/root.go
+++ b/internal/lore/root.go
@@ -5,10 +5,7 @@
 package lore
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -22,13 +19,13 @@ var (
 )
 
 // NewRootCmd creates the root lore command with all subcommands.
+//
+// Returns:
+//   - *cobra.Command: configured lore command with registry flag and all subcommands
 func NewRootCmd() *cobra.Command {
-	cli.SetProgramName("lore")
-
-	rootCmd := &cobra.Command{
-		Use:               "lore",
-		Short:             "The tribal knowledge package deployer",
-		DisableAutoGenTag: true,
+	rootCmd := cli.NewRootCmd(cli.RootConfig{
+		Name:  "lore",
+		Short: "The tribal knowledge package deployer",
 		Long: `Lore is a cross-platform package deployment tool that captures tribal
 knowledge about installing software.
 
@@ -43,35 +40,14 @@ anywhere.
 
 Lore captures this knowledge once and shares it forever.
 What took someone hours to figure out, you get in minutes.`,
-		CompletionOptions: cobra.CompletionOptions{
-			HiddenDefaultCmd: true, // Hide from help, but still available (like Docker)
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initConfig(cmd)
-		},
-	}
+		DefaultConfig: schema.LoreDefaultConfig,
+		Version:       version,
+		Commit:        commit,
+		BuildDate:     buildDate,
+	})
 
-	// Global flags
-	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
 	rootCmd.PersistentFlags().String("registry", "", "Registry path")
-	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
-	cli.AddSilentFlag(rootCmd)
 
-	// Deployment mode flags (ADR-033)
-	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts, rich output)")
-	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
-	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
-
-	// Model configuration flags (override env/config)
-	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
-	// See internal/model/config.go for full documentation.
-	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
-	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
-	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
-	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
-
-	// Add subcommands
 	rootCmd.AddCommand(newDeployCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newDecommissionCmd())
@@ -87,67 +63,5 @@ What took someone hours to figure out, you get in minutes.`,
 	rootCmd.AddCommand(newAuditCmd())
 	rootCmd.AddCommand(newInspectCmd())
 
-	// Shared metadata
-	manHeader := cli.ManHeader{
-		Title:   "LORE",
-		Section: "1",
-		Source:  "Lore " + version,
-		Manual:  "Lore Manual",
-	}
-	configInfo := cli.ConfigInfo{
-		Name:          "lore",
-		Schema:        schema.DevloreSchema,
-		DefaultConfig: schema.LoreDefaultConfig,
-	}
-
-	// Add shared commands from cli
-	// Replace Cobra's built-in help with git-style help (prefers man pages)
-	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewVersionCmd(cli.VersionInfo{
-		Version:   version,
-		Commit:    commit,
-		BuildDate: buildDate,
-	}))
-	rootCmd.AddCommand(cli.NewManCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewConfigCmd(configInfo))
-	rootCmd.AddCommand(cli.NewSelfInstallCmd(rootCmd, cli.SelfInstallInfo{
-		Name:       "lore",
-		ManHeader:  manHeader,
-		ConfigInfo: configInfo,
-	}))
-
 	return rootCmd
-}
-
-// initConfig initializes Viper configuration.
-// Precedence (lowest to highest): config file → environment variables → flags
-func initConfig(cmd *cobra.Command) error {
-	// Initialize Viper with shared devlore config
-	if err := cli.InitViper(cli.ViperConfig{
-		Name:            "lore",
-		EnvPrefix:       "LORE",
-		UseSharedConfig: true,
-	}); err != nil {
-		return err
-	}
-
-	// Check for custom config file via flag
-	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
-		viper.SetConfigFile(cfgFile)
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
-		}
-	}
-
-	// Bind flags to viper (flag values override config/env)
-	if err := cli.BindFlags(cmd, "lore", true); err != nil {
-		return err
-	}
-
-	// Debug output if verbose
-	if viper.GetBool("lore.verbose") {
-		cli.Note("Using config: %s", viper.ConfigFileUsed())
-	}
-
-	return nil
 }

--- a/internal/lore/root.go
+++ b/internal/lore/root.go
@@ -5,10 +5,7 @@
 package lore
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -23,12 +20,9 @@ var (
 
 // NewRootCmd creates the root lore command with all subcommands.
 func NewRootCmd() *cobra.Command {
-	cli.SetProgramName("lore")
-
-	rootCmd := &cobra.Command{
-		Use:               "lore",
-		Short:             "The tribal knowledge package deployer",
-		DisableAutoGenTag: true,
+	rootCmd := cli.NewRootCmd(cli.RootConfig{
+		Name:  "lore",
+		Short: "The tribal knowledge package deployer",
 		Long: `Lore is a cross-platform package deployment tool that captures tribal
 knowledge about installing software.
 
@@ -43,35 +37,14 @@ anywhere.
 
 Lore captures this knowledge once and shares it forever.
 What took someone hours to figure out, you get in minutes.`,
-		CompletionOptions: cobra.CompletionOptions{
-			HiddenDefaultCmd: true, // Hide from help, but still available (like Docker)
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initConfig(cmd)
-		},
-	}
+		DefaultConfig: schema.LoreDefaultConfig,
+		Version:       version,
+		Commit:        commit,
+		BuildDate:     buildDate,
+	})
 
-	// Global flags
-	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
 	rootCmd.PersistentFlags().String("registry", "", "Registry path")
-	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
-	cli.AddSilentFlag(rootCmd)
 
-	// Deployment mode flags (ADR-033)
-	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts, rich output)")
-	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
-	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
-
-	// Model configuration flags (override env/config)
-	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
-	// See internal/model/config.go for full documentation.
-	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
-	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
-	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
-	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
-
-	// Add subcommands
 	rootCmd.AddCommand(newDeployCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newDecommissionCmd())
@@ -87,67 +60,5 @@ What took someone hours to figure out, you get in minutes.`,
 	rootCmd.AddCommand(newAuditCmd())
 	rootCmd.AddCommand(newInspectCmd())
 
-	// Shared metadata
-	manHeader := cli.ManHeader{
-		Title:   "LORE",
-		Section: "1",
-		Source:  "Lore " + version,
-		Manual:  "Lore Manual",
-	}
-	configInfo := cli.ConfigInfo{
-		Name:          "lore",
-		Schema:        schema.DevloreSchema,
-		DefaultConfig: schema.LoreDefaultConfig,
-	}
-
-	// Add shared commands from cli
-	// Replace Cobra's built-in help with git-style help (prefers man pages)
-	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewVersionCmd(cli.VersionInfo{
-		Version:   version,
-		Commit:    commit,
-		BuildDate: buildDate,
-	}))
-	rootCmd.AddCommand(cli.NewManCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewConfigCmd(configInfo))
-	rootCmd.AddCommand(cli.NewSelfInstallCmd(rootCmd, cli.SelfInstallInfo{
-		Name:       "lore",
-		ManHeader:  manHeader,
-		ConfigInfo: configInfo,
-	}))
-
 	return rootCmd
-}
-
-// initConfig initializes Viper configuration.
-// Precedence (lowest to highest): config file → environment variables → flags
-func initConfig(cmd *cobra.Command) error {
-	// Initialize Viper with shared devlore config
-	if err := cli.InitViper(cli.ViperConfig{
-		Name:            "lore",
-		EnvPrefix:       "LORE",
-		UseSharedConfig: true,
-	}); err != nil {
-		return err
-	}
-
-	// Check for custom config file via flag
-	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
-		viper.SetConfigFile(cfgFile)
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
-		}
-	}
-
-	// Bind flags to viper (flag values override config/env)
-	if err := cli.BindFlags(cmd, "lore", true); err != nil {
-		return err
-	}
-
-	// Debug output if verbose
-	if viper.GetBool("lore.verbose") {
-		cli.Note("Using config: %s", viper.ConfigFileUsed())
-	}
-
-	return nil
 }

--- a/internal/writ/root.go
+++ b/internal/writ/root.go
@@ -5,10 +5,7 @@
 package writ
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -22,11 +19,12 @@ var (
 )
 
 // NewRootCmd creates the root writ command with all subcommands.
+//
+// Returns:
+//   - *cobra.Command: configured writ command with target flag and all subcommands
 func NewRootCmd() *cobra.Command {
-	cli.SetProgramName("writ")
-
-	rootCmd := &cobra.Command{
-		Use:   "writ",
+	rootCmd := cli.NewRootCmd(cli.RootConfig{
+		Name:  "writ",
 		Short: "Environment manager with platform-aware symlinks",
 		Long: `Writ orchestrates your portable environment—configuration, scripts, utilities,
 templates, and software manifests. Lore is a component that writ delegates to
@@ -38,35 +36,14 @@ automatically. Templates handle machine-specific values.
 Writ exists because environment management shouldn't require manual symlink
 creation, platform-specific scripts, or secret leakage into git.
 Declare your environment once — writ deploys it everywhere you work.`,
-		CompletionOptions: cobra.CompletionOptions{
-			HiddenDefaultCmd: true, // Hide from help, but still available (like Docker)
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initConfig(cmd)
-		},
-	}
+		DefaultConfig: schema.WritDefaultConfig,
+		Version:       version,
+		Commit:        commit,
+		BuildDate:     buildDate,
+	})
 
-	// Global flags
-	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
 	rootCmd.PersistentFlags().String("target", "Home", "Target to operate on")
-	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
-	cli.AddSilentFlag(rootCmd)
 
-	// Deployment mode flags (mirrors lore ADR-033)
-	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts for conflicts)")
-	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
-	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
-
-	// Model configuration flags (override env/config)
-	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
-	// See internal/ai/config.go for full documentation.
-	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
-	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
-	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
-	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
-
-	// Add subcommands
 	rootCmd.AddCommand(newDeployCmd())
 	rootCmd.AddCommand(newDecommissionCmd())
 	rootCmd.AddCommand(newReconcileCmd())
@@ -77,68 +54,5 @@ Declare your environment once — writ deploys it everywhere you work.`,
 	rootCmd.AddCommand(newInspectCmd())
 	rootCmd.AddCommand(newMigrateCmd())
 
-	// Shared metadata
-	manHeader := cli.ManHeader{
-		Title:   "WRIT",
-		Section: "1",
-		Source:  "Writ " + version,
-		Manual:  "Writ Manual",
-	}
-	configInfo := cli.ConfigInfo{
-		Name:          "writ",
-		Schema:        schema.DevloreSchema,
-		DefaultConfig: schema.WritDefaultConfig,
-	}
-
-	// Add shared commands from cli
-	// Replace Cobra's built-in help with git-style help (prefers man pages)
-	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewVersionCmd(cli.VersionInfo{
-		Version:   version,
-		Commit:    commit,
-		BuildDate: buildDate,
-	}))
-	rootCmd.AddCommand(cli.NewManCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewConfigCmd(configInfo))
-	rootCmd.AddCommand(cli.NewSelfInstallCmd(rootCmd, cli.SelfInstallInfo{
-		Name:       "writ",
-		ManHeader:  manHeader,
-		ConfigInfo: configInfo,
-	}))
-
 	return rootCmd
-}
-
-// initConfig initializes Viper configuration.
-// Precedence (lowest to highest): config file → environment variables → flags
-func initConfig(cmd *cobra.Command) error {
-	// Initialize Viper with shared devlore config
-	if err := cli.InitViper(cli.ViperConfig{
-		Name:            "writ",
-		EnvPrefix:       "WRIT",
-		UseSharedConfig: true,
-	}); err != nil {
-		return err
-	}
-
-	// Check for custom config file via flag
-	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
-		viper.SetConfigFile(cfgFile)
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
-		}
-	}
-
-	// Bind flags to viper (flag values override config/env)
-	// Use cmd.Root() to bind persistent flags defined on the root command
-	if err := cli.BindFlags(cmd.Root(), "writ", true); err != nil {
-		return err
-	}
-
-	// Debug output if verbose
-	if viper.GetBool("writ.verbose") {
-		cli.Note("Using config: %s", viper.ConfigFileUsed())
-	}
-
-	return nil
 }

--- a/internal/writ/root.go
+++ b/internal/writ/root.go
@@ -5,10 +5,7 @@
 package writ
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -23,10 +20,8 @@ var (
 
 // NewRootCmd creates the root writ command with all subcommands.
 func NewRootCmd() *cobra.Command {
-	cli.SetProgramName("writ")
-
-	rootCmd := &cobra.Command{
-		Use:   "writ",
+	rootCmd := cli.NewRootCmd(cli.RootConfig{
+		Name:  "writ",
 		Short: "Environment manager with platform-aware symlinks",
 		Long: `Writ orchestrates your portable environment—configuration, scripts, utilities,
 templates, and software manifests. Lore is a component that writ delegates to
@@ -38,35 +33,14 @@ automatically. Templates handle machine-specific values.
 Writ exists because environment management shouldn't require manual symlink
 creation, platform-specific scripts, or secret leakage into git.
 Declare your environment once — writ deploys it everywhere you work.`,
-		CompletionOptions: cobra.CompletionOptions{
-			HiddenDefaultCmd: true, // Hide from help, but still available (like Docker)
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initConfig(cmd)
-		},
-	}
+		DefaultConfig: schema.WritDefaultConfig,
+		Version:       version,
+		Commit:        commit,
+		BuildDate:     buildDate,
+	})
 
-	// Global flags
-	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
 	rootCmd.PersistentFlags().String("target", "Home", "Target to operate on")
-	rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done without making changes")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
-	cli.AddSilentFlag(rootCmd)
 
-	// Deployment mode flags (mirrors lore ADR-033)
-	rootCmd.PersistentFlags().Bool("interactive", false, "Force interactive mode (prompts for conflicts)")
-	rootCmd.PersistentFlags().Bool("unattended", false, "Force unattended mode (no prompts, sensible defaults)")
-	rootCmd.MarkFlagsMutuallyExclusive("interactive", "unattended")
-
-	// Model configuration flags (override env/config)
-	// Resolution order: CLI flags → Environment → Config file → Keystore (api-key only)
-	// See internal/ai/config.go for full documentation.
-	rootCmd.PersistentFlags().String("model", "", "Model name (e.g., claude-sonnet-4-20250514, gpt-4o)")
-	rootCmd.PersistentFlags().String("model-api-key", "", "Model provider API key")
-	rootCmd.PersistentFlags().String("model-endpoint", "", "Model provider endpoint URL")
-	rootCmd.PersistentFlags().String("model-provider", "", "Model provider: anthropic, openai, azure-openai, ollama, github")
-
-	// Add subcommands
 	rootCmd.AddCommand(newDeployCmd())
 	rootCmd.AddCommand(newDecommissionCmd())
 	rootCmd.AddCommand(newReconcileCmd())
@@ -77,68 +51,5 @@ Declare your environment once — writ deploys it everywhere you work.`,
 	rootCmd.AddCommand(newInspectCmd())
 	rootCmd.AddCommand(newMigrateCmd())
 
-	// Shared metadata
-	manHeader := cli.ManHeader{
-		Title:   "WRIT",
-		Section: "1",
-		Source:  "Writ " + version,
-		Manual:  "Writ Manual",
-	}
-	configInfo := cli.ConfigInfo{
-		Name:          "writ",
-		Schema:        schema.DevloreSchema,
-		DefaultConfig: schema.WritDefaultConfig,
-	}
-
-	// Add shared commands from cli
-	// Replace Cobra's built-in help with git-style help (prefers man pages)
-	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewVersionCmd(cli.VersionInfo{
-		Version:   version,
-		Commit:    commit,
-		BuildDate: buildDate,
-	}))
-	rootCmd.AddCommand(cli.NewManCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewConfigCmd(configInfo))
-	rootCmd.AddCommand(cli.NewSelfInstallCmd(rootCmd, cli.SelfInstallInfo{
-		Name:       "writ",
-		ManHeader:  manHeader,
-		ConfigInfo: configInfo,
-	}))
-
 	return rootCmd
-}
-
-// initConfig initializes Viper configuration.
-// Precedence (lowest to highest): config file → environment variables → flags
-func initConfig(cmd *cobra.Command) error {
-	// Initialize Viper with shared devlore config
-	if err := cli.InitViper(cli.ViperConfig{
-		Name:            "writ",
-		EnvPrefix:       "WRIT",
-		UseSharedConfig: true,
-	}); err != nil {
-		return err
-	}
-
-	// Check for custom config file via flag
-	if cfgFile, _ := cmd.Flags().GetString("config"); cfgFile != "" { //nolint:errcheck // flag registered above
-		viper.SetConfigFile(cfgFile)
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("failed to read config %s: %w", cfgFile, err)
-		}
-	}
-
-	// Bind flags to viper (flag values override config/env)
-	// Use cmd.Root() to bind persistent flags defined on the root command
-	if err := cli.BindFlags(cmd.Root(), "writ", true); err != nil {
-		return err
-	}
-
-	// Debug output if verbose
-	if viper.GetBool("writ.verbose") {
-		cli.Note("Using config: %s", viper.ConfigFileUsed())
-	}
-
-	return nil
 }


### PR DESCRIPTION
## Summary

- Extract `cli.NewRootCmd(cfg RootConfig)` factory in `internal/cli/root.go`
- `initRootConfig` replaces duplicated `initConfig` in both packages
- `lore/root.go`: 154 → 65 lines (tool-specific flag + subcommands only)
- `writ/root.go`: 145 → 56 lines (tool-specific flag + subcommands only)
- Net reduction: 42 lines; eliminates structural drift between lore and writ

**Bug fixes:**
- writ now gets `DisableAutoGenTag: true` (was missing)
- lore now uses `cmd.Root()` in `BindFlags` (was using `cmd`, incorrect when invoked from subcommand)

## Test plan

- [x] `make build` — all four binaries compile
- [x] `make test` — all tests pass
- [x] `make vet` — clean