### PR TITLE
chore(op): Rename regexp provider param s → text

### DIFF
--- a/internal/e2e/testrunner/data/test_imm_regexp.star
+++ b/internal/e2e/testrunner/data/test_imm_regexp.star
@@ -3,30 +3,30 @@
 # Validates: regexp.match, regexp.find, regexp.find_all, regexp.find_submatch,
 #            regexp.find_all_submatch, regexp.replace, regexp.replace_literal, regexp.split
 
-t.expect_equal(regexp.match(pattern="^hello", s="hello world"), True)
-t.expect_equal(regexp.match(pattern="^world", s="hello world"), False)
+t.expect_equal(regexp.match(pattern="^hello", text="hello world"), True)
+t.expect_equal(regexp.match(pattern="^world", text="hello world"), False)
 
-t.expect_equal(regexp.find(pattern="[0-9]+", s="abc123def"), "123")
+t.expect_equal(regexp.find(pattern="[0-9]+", text="abc123def"), "123")
 
-found = regexp.find_all(pattern="[0-9]+", s="a1b2c3", count=-1)
+found = regexp.find_all(pattern="[0-9]+", text="a1b2c3", count=-1)
 t.expect_equal(len(found), 3)
 
-sub = regexp.find_submatch(pattern="([a-z]+)([0-9]+)", s="abc123")
+sub = regexp.find_submatch(pattern="([a-z]+)([0-9]+)", text="abc123")
 t.expect_equal(sub[0], "abc123")
 t.expect_equal(sub[1], "abc")
 t.expect_equal(sub[2], "123")
 
-all_sub = regexp.find_all_submatch(pattern="([0-9]+)", s="a1b2c3", count=-1)
+all_sub = regexp.find_all_submatch(pattern="([0-9]+)", text="a1b2c3", count=-1)
 t.expect_equal(len(all_sub), 3)
 
-replaced = regexp.replace(pattern="[0-9]+", s="a1b2c3", replacement="X")
+replaced = regexp.replace(pattern="[0-9]+", text="a1b2c3", replacement="X")
 t.expect_equal(replaced, "aXbXcX")
 
 # replace_literal does not interpret $ expansions in replacement
-lit = regexp.replace_literal(pattern="[0-9]+", s="a1b2", replacement="$1")
+lit = regexp.replace_literal(pattern="[0-9]+", text="a1b2", replacement="$1")
 t.expect_equal(lit, "a$1b$1")
 
-parts = regexp.split(pattern=",", s="a,b,c", count=-1)
+parts = regexp.split(pattern=",", text="a,b,c", count=-1)
 t.expect_equal(len(parts), 3)
 t.expect_equal(parts[0], "a")
 

--- a/internal/e2e/testrunner/data/test_regexp.star
+++ b/internal/e2e/testrunner/data/test_regexp.star
@@ -4,12 +4,12 @@
 #            plan.regexp.find_submatch, plan.regexp.find_all_submatch,
 #            plan.regexp.replace, plan.regexp.replace_literal, plan.regexp.split
 
-plan.regexp.match(pattern="foo", s="foobar")
-plan.regexp.find(pattern="foo", s="foobar")
-plan.regexp.find_all(pattern="o", s="foobar", count=-1)
-plan.regexp.find_submatch(pattern="f(o+)", s="foobar")
-plan.regexp.find_all_submatch(pattern="o", s="foobar", count=-1)
-plan.regexp.replace(pattern="foo", s="foobar", replacement="baz")
-plan.regexp.replace_literal(pattern="foo", s="foobar", replacement="baz")
-plan.regexp.split(pattern=",", s="a,b,c", count=-1)
+plan.regexp.match(pattern="foo", text="foobar")
+plan.regexp.find(pattern="foo", text="foobar")
+plan.regexp.find_all(pattern="o", text="foobar", count=-1)
+plan.regexp.find_submatch(pattern="f(o+)", text="foobar")
+plan.regexp.find_all_submatch(pattern="o", text="foobar", count=-1)
+plan.regexp.replace(pattern="foo", text="foobar", replacement="baz")
+plan.regexp.replace_literal(pattern="foo", text="foobar", replacement="baz")
+plan.regexp.split(pattern=",", text="a,b,c", count=-1)
 t.expect_node_count(8)

--- a/pkg/op/provider/regexp/provider.go
+++ b/pkg/op/provider/regexp/provider.go
@@ -32,81 +32,81 @@ func (p *Provider) compile(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// Match reports whether the string contains any match of the pattern.
-func (p *Provider) Match(pattern, s string) (bool, error) {
+// Match reports whether the text contains any match of the pattern.
+func (p *Provider) Match(pattern, text string) (bool, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return false, err
 	}
-	return re.MatchString(s), nil
+	return re.MatchString(text), nil
 }
 
-// Find returns the first match of the pattern in the string.
+// Find returns the first match of the pattern in the text.
 // Returns an empty string if no match is found.
-func (p *Provider) Find(pattern, s string) (string, error) {
+func (p *Provider) Find(pattern, text string) (string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return "", err
 	}
-	return re.FindString(s), nil
+	return re.FindString(text), nil
 }
 
 // FindAll returns all non-overlapping matches of the pattern.
 // The count parameter limits the number of matches; -1 means no limit.
-func (p *Provider) FindAll(pattern, s string, count int) ([]string, error) {
+func (p *Provider) FindAll(pattern, text string, count int) ([]string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return re.FindAllString(s, count), nil
+	return re.FindAllString(text, count), nil
 }
 
 // FindSubmatch returns the first match and its submatches.
 // Returns nil if no match is found.
-func (p *Provider) FindSubmatch(pattern, s string) ([]string, error) {
+func (p *Provider) FindSubmatch(pattern, text string) ([]string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return re.FindStringSubmatch(s), nil
+	return re.FindStringSubmatch(text), nil
 }
 
 // FindAllSubmatch returns all matches with their submatches.
 // The count parameter limits the number of matches; -1 means no limit.
-func (p *Provider) FindAllSubmatch(pattern, s string, count int) ([][]string, error) {
+func (p *Provider) FindAllSubmatch(pattern, text string, count int) ([][]string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return re.FindAllStringSubmatch(s, count), nil
+	return re.FindAllStringSubmatch(text, count), nil
 }
 
 // Replace replaces all matches of the pattern with the replacement string.
 // The replacement can include $1, $2, etc. for submatch references.
-func (p *Provider) Replace(pattern, s, replacement string) (string, error) {
+func (p *Provider) Replace(pattern, text, replacement string) (string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return "", err
 	}
-	return re.ReplaceAllString(s, replacement), nil
+	return re.ReplaceAllString(text, replacement), nil
 }
 
 // ReplaceLiteral replaces all matches with the literal replacement string
 // (no submatch expansion).
-func (p *Provider) ReplaceLiteral(pattern, s, replacement string) (string, error) {
+func (p *Provider) ReplaceLiteral(pattern, text, replacement string) (string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return "", err
 	}
-	return re.ReplaceAllLiteralString(s, replacement), nil
+	return re.ReplaceAllLiteralString(text, replacement), nil
 }
 
-// Split splits the string around matches of the pattern.
+// Split splits the text around matches of the pattern.
 // The count parameter limits the number of substrings; -1 means no limit.
-func (p *Provider) Split(pattern, s string, count int) ([]string, error) {
+func (p *Provider) Split(pattern, text string, count int) ([]string, error) {
 	re, err := p.compile(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return re.Split(s, count), nil
+	return re.Split(text, count), nil
 }


### PR DESCRIPTION
## Summary

- Rename Starlark parameter `s` → `text` in all 8 regexp provider methods
- Update e2e test scripts (`test_regexp.star`, `test_imm_regexp.star`) keyword args
- Aligns with noblefactor-ops naming convention and Python's `re` module

Prerequisite for shared provider receivers work (noblefactor-ops reuse of devlore-cli providers).

## Test plan

- [x] `make build` — all binaries compile, codegen regenerates with `text` params
- [x] `make test` — all tests pass including regexp e2e tests