### PR TITLE
feature(op): Export Marshal/UnmarshalToAny, style compliance (Phase 4)

### DIFF
--- a/internal/e2e/testrunner/runner.go
+++ b/internal/e2e/testrunner/runner.go
@@ -36,26 +36,50 @@ type Result struct {
 type Option func(*Runner)
 
 // WithDryRun enables dry-run mode (plan only, no side effects).
+//
+// Returns:
+//   - Option: a runner option that sets dry-run mode.
 func WithDryRun() Option {
 	return func(r *Runner) { r.dryRun = true }
 }
 
 // WithTrace enables Starlark step-by-step trace logging.
+//
+// Returns:
+//   - Option: a runner option that enables tracing.
 func WithTrace() Option {
 	return func(r *Runner) { r.trace = true }
 }
 
 // WithProvider restricts execution to a specific provider.
+//
+// Parameters:
+//   - name: the provider name to restrict to.
+//
+// Returns:
+//   - Option: a runner option that sets the provider filter.
 func WithProvider(name string) Option {
 	return func(r *Runner) { r.provider = name }
 }
 
 // WithWriter sets the output writer for executor messages.
+//
+// Parameters:
+//   - w: the output writer.
+//
+// Returns:
+//   - Option: a runner option that sets the writer.
 func WithWriter(w io.Writer) Option {
 	return func(r *Runner) { r.writer = w }
 }
 
 // WithReceivers sets the Starlark namespaces to expose as globals.
+//
+// Parameters:
+//   - names: the receiver names to expose.
+//
+// Returns:
+//   - Option: a runner option that sets the receiver list.
 func WithReceivers(names ...string) Option {
 	return func(r *Runner) { r.receivers = names }
 }
@@ -72,11 +96,21 @@ type Runner struct {
 }
 
 // Graph returns the execution graph after Start completes. Returns nil before Start is called.
+//
+// Returns:
+//   - *op.Graph: the execution graph, or nil if Start has not been called.
 func (r *Runner) Graph() *op.Graph {
 	return r.graph
 }
 
 // New creates a Runner for the given script path.
+//
+// Parameters:
+//   - script: the path to the .star test script.
+//   - opts: functional options to configure the runner.
+//
+// Returns:
+//   - *Runner: the configured test runner.
 func New(script string, opts ...Option) *Runner {
 	r := &Runner{
 		script: script,
@@ -89,6 +123,13 @@ func New(script string, opts ...Option) *Runner {
 }
 
 // Start executes the test script and returns structured results.
+//
+// Parameters:
+//   - ctx: the execution context (used for cancellation).
+//
+// Returns:
+//   - *Result: the test outcome with pass/fail status and failures.
+//   - error: non-nil if script loading or graph execution fails unexpectedly.
 func (r *Runner) Start(ctx context.Context) (*Result, error) {
 	// 1. Create temp directory
 	tmpDir, err := os.MkdirTemp("", "devlore-test-*")
@@ -214,6 +255,15 @@ func (r *Runner) Start(ctx context.Context) (*Result, error) {
 }
 
 // buildResult evaluates expectations and constructs the Result.
+//
+// Parameters:
+//   - graph: the executed graph.
+//   - tc: the test context with expectations.
+//   - tracer: the trace collector.
+//   - execErr: the execution error (nil on success).
+//
+// Returns:
+//   - *Result: the structured test result.
 func (r *Runner) buildResult(graph *op.Graph, tc *TestContext, tracer *Tracer, execErr error) *Result {
 	failures := tc.Check(graph, execErr)
 	if failures == nil {
@@ -244,6 +294,12 @@ func (r *Runner) buildResult(graph *op.Graph, tc *TestContext, tracer *Tracer, e
 }
 
 // hasErrorExpectation returns true if any expectation is of kind "error".
+//
+// Parameters:
+//   - tc: the test context to check.
+//
+// Returns:
+//   - bool: true if at least one expectation has kind "error".
 func hasErrorExpectation(tc *TestContext) bool {
 	for _, exp := range tc.Expectations() {
 		if exp.Kind == "error" {

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -35,6 +35,9 @@ const (
 )
 
 // String returns a human-readable status label.
+//
+// Returns:
+//   - string: the status name.
 func (s ResultStatus) String() string {
 	switch s {
 	case ResultPending:
@@ -107,6 +110,12 @@ type GraphExecutor struct {
 }
 
 // NewGraphExecutor creates an executor with the given options.
+//
+// Parameters:
+//   - opts: the executor configuration.
+//
+// Returns:
+//   - *GraphExecutor: the configured executor.
 func NewGraphExecutor(opts ExecutorOptions) *GraphExecutor {
 	if opts.Writer == nil {
 		opts.Writer = os.Stdout
@@ -122,6 +131,13 @@ func NewGraphExecutor(opts ExecutorOptions) *GraphExecutor {
 // newContext creates an execution Context from the executor's options.
 // Root is mandatory — an op.Root is opened for OS-enforced confinement
 // and a RecoverySite is created. The caller must defer Root.Close().
+//
+// Parameters:
+//   - ctx: the parent context for cancellation.
+//
+// Returns:
+//   - *op.Context: the execution context.
+//   - error: non-nil if Root is empty or the confined root cannot be opened.
 func (e *GraphExecutor) newContext(ctx context.Context) (*op.Context, error) {
 
 	if e.options.Root == "" {
@@ -151,6 +167,9 @@ func (e *GraphExecutor) newContext(ctx context.Context) (*op.Context, error) {
 
 // newThread creates a Starlark thread for callable initialization during
 // execution. Print output goes to the executor's writer.
+//
+// Returns:
+//   - *starlark.Thread: the configured thread.
 func (e *GraphExecutor) newThread() *starlark.Thread {
 	return &starlark.Thread{
 		Name: "executor",
@@ -161,6 +180,9 @@ func (e *GraphExecutor) newThread() *starlark.Thread {
 }
 
 // SetHooks sets the lifecycle hook registry for this executor.
+//
+// Parameters:
+//   - hooks: the hook registry to install.
 func (e *GraphExecutor) SetHooks(hooks *HookRegistry) {
 	e.hooks = hooks
 }
@@ -169,6 +191,13 @@ func (e *GraphExecutor) SetHooks(hooks *HookRegistry) {
 // When the graph has phases, execution is delegated to RunPhased which
 // implements the saga pattern with retry and rollback. Otherwise, nodes
 // are processed in topological order (flat execution).
+//
+// Parameters:
+//   - ctx: the execution context for cancellation.
+//   - g: the execution graph to run.
+//
+// Returns:
+//   - error: non-nil if any node or phase fails.
 func (e *GraphExecutor) Run(ctx context.Context, g *op.Graph) error {
 	if g.State != op.StatePending {
 		return fmt.Errorf("graph already executed (state: %s)", g.State)
@@ -182,6 +211,13 @@ func (e *GraphExecutor) Run(ctx context.Context, g *op.Graph) error {
 }
 
 // runFlat executes all nodes in topological order without phase boundaries.
+//
+// Parameters:
+//   - ctx: the execution context for cancellation.
+//   - g: the execution graph.
+//
+// Returns:
+//   - error: non-nil if any node fails (when ConflictResolution is Stop).
 func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 	ordered := OrderNodes(g.Nodes, g.Edges)
 
@@ -235,6 +271,13 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 //
 // Phases referenced as compensating actions (via Compensate fields) are
 // skipped during the forward pass — they execute only during rollback.
+//
+// Parameters:
+//   - ctx: the execution context for cancellation.
+//   - g: the execution graph with phases.
+//
+// Returns:
+//   - error: non-nil if any phase fails (includes rollback errors).
 func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) error { //nolint:gocognit,gocyclo // complexity is inherent to the algorithm
 	execCtx, err := e.newContext(ctx)
 	if err != nil {
@@ -366,6 +409,16 @@ func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) error { //no
 }
 
 // executePhase runs a single phase with retry logic.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - g: the execution graph.
+//   - phase: the phase to execute.
+//   - results: the accumulated node results for promise resolution.
+//   - stack: the recovery stack for compensation.
+//
+// Returns:
+//   - error: non-nil if the phase fails after all retry attempts.
 func (e *GraphExecutor) executePhase(ctx *op.Context, g *op.Graph, phase *op.Phase, results map[string]any, stack *op.RecoveryStack) error {
 	maxAttempts := 1
 	if phase.Retry != nil {
@@ -415,6 +468,10 @@ func (e *GraphExecutor) executePhase(ctx *op.Context, g *op.Graph, phase *op.Pha
 }
 
 // resetPhaseNodes resets inner node statuses back to pending for retry.
+//
+// Parameters:
+//   - g: the execution graph.
+//   - phase: the phase whose nodes should be reset.
 func (e *GraphExecutor) resetPhaseNodes(g *op.Graph, phase *op.Phase) {
 	nodeSet := make(map[string]bool, len(phase.NodeIDs))
 	for _, id := range phase.NodeIDs {
@@ -430,6 +487,16 @@ func (e *GraphExecutor) resetPhaseNodes(g *op.Graph, phase *op.Phase) {
 }
 
 // ExecutePhaseInner runs the inner nodes of a phase.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - g: the execution graph.
+//   - phase: the phase to execute.
+//   - results: the accumulated node results for promise resolution.
+//   - stack: the recovery stack for compensation.
+//
+// Returns:
+//   - error: non-nil if any inner node fails.
 func (e *GraphExecutor) ExecutePhaseInner(ctx *op.Context, g *op.Graph, phase *op.Phase, results map[string]any, stack *op.RecoveryStack) error {
 	phaseNodes, phaseEdges := g.CollectPhaseNodes(phase)
 	ordered := OrderNodes(phaseNodes, phaseEdges)
@@ -450,6 +517,15 @@ func (e *GraphExecutor) ExecutePhaseInner(ctx *op.Context, g *op.Graph, phase *o
 
 // RunNodes executes a slice of nodes with the given edges.
 // This is a lower-level API for callers that don't have a full Graph.
+//
+// Parameters:
+//   - ctx: the execution context for cancellation.
+//   - nodes: the nodes to execute.
+//   - edges: the ordering edges between nodes.
+//
+// Returns:
+//   - []*NodeResult: the per-node execution results.
+//   - error: non-nil if context creation or a node fails (when ConflictResolution is Stop).
 func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*op.Node, edges []op.Edge) ([]*NodeResult, error) {
 	ordered := OrderNodes(nodes, edges)
 
@@ -493,6 +569,15 @@ func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*op.Node, edges []
 }
 
 // executeNode resolves slots, calls Do, stores the result, and pushes a recovery entry.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - node: the node to execute.
+//   - results: the accumulated results for promise resolution.
+//   - stack: the recovery stack for compensation.
+//
+// Returns:
+//   - *NodeResult: the execution outcome.
 func (e *GraphExecutor) executeNode(ctx *op.Context, node *op.Node, results map[string]any, stack *op.RecoveryStack) *NodeResult {
 	if node.Action == nil {
 		node.Status = op.StatusFailed
@@ -545,6 +630,10 @@ func (e *GraphExecutor) executeNode(ctx *op.Context, node *op.Node, results map[
 
 // FillSlotsFromData fills unfilled slots from Context.Data.
 // Slots already set by the caller or resolved from promises are not overwritten.
+//
+// Parameters:
+//   - slots: the slot map to fill (mutated in place).
+//   - data: the data map to fill from.
 func FillSlotsFromData(slots, data map[string]any) {
 	for key, value := range data {
 		if _, exists := slots[key]; !exists {
@@ -555,6 +644,13 @@ func FillSlotsFromData(slots, data map[string]any) {
 
 // OrderNodes returns nodes in execution order.
 // Nodes with edges are topologically sorted; nodes without edges are sorted by path depth.
+//
+// Parameters:
+//   - nodes: the nodes to order.
+//   - edges: the ordering constraints.
+//
+// Returns:
+//   - []*op.Node: the ordered nodes.
 func OrderNodes(nodes []*op.Node, edges []op.Edge) []*op.Node {
 	if len(edges) > 0 {
 		return topologicalSortNodes(nodes, edges)
@@ -563,6 +659,13 @@ func OrderNodes(nodes []*op.Node, edges []op.Edge) []*op.Node {
 }
 
 // topologicalSortNodes orders nodes respecting edge constraints (Kahn's algorithm).
+//
+// Parameters:
+//   - nodes: the nodes to sort.
+//   - edges: the directed edges expressing ordering constraints.
+//
+// Returns:
+//   - []*op.Node: the topologically sorted nodes (cycles broken by appending unsorted nodes).
 func topologicalSortNodes(nodes []*op.Node, edges []op.Edge) []*op.Node { //nolint:gocognit // complexity is inherent to the algorithm
 	nodeMap := make(map[string]*op.Node)
 	inDegree := make(map[string]int)
@@ -621,6 +724,12 @@ func topologicalSortNodes(nodes []*op.Node, edges []op.Edge) []*op.Node { //noli
 }
 
 // sortNodesByDepth sorts nodes by target path depth.
+//
+// Parameters:
+//   - nodes: the nodes to sort.
+//
+// Returns:
+//   - []*op.Node: the nodes sorted by ascending path depth.
 func sortNodesByDepth(nodes []*op.Node) []*op.Node {
 	sorted := make([]*op.Node, len(nodes))
 	copy(sorted, nodes)
@@ -641,6 +750,12 @@ func sortNodesByDepth(nodes []*op.Node) []*op.Node {
 }
 
 // pathDepth returns the directory depth of a path.
+//
+// Parameters:
+//   - path: the file path to measure.
+//
+// Returns:
+//   - int: the number of path separators (0 for empty paths).
 func pathDepth(path string) int {
 	if path == "" {
 		return 0
@@ -651,6 +766,13 @@ func pathDepth(path string) int {
 // hydrateProviders creates a fresh ActionRegistry with per-graph provider instances.
 // Stub actions (from deserialized graphs) are replaced with real actions.
 // Non-stub actions (from planning) get their provider's context updated.
+//
+// Parameters:
+//   - g: the execution graph.
+//   - ctx: the execution context for provider initialization.
+//
+// Returns:
+//   - error: non-nil if a stub action references an unknown action name.
 func (e *GraphExecutor) hydrateProviders(g *op.Graph, ctx op.Context) error {
 	freshReg := op.NewActionRegistry()
 	op.InitAll(freshReg, ctx)
@@ -674,6 +796,10 @@ func (e *GraphExecutor) hydrateProviders(g *op.Graph, ctx op.Context) error {
 }
 
 // ApplyResults updates node states from execution results.
+//
+// Parameters:
+//   - g: the execution graph whose nodes are updated.
+//   - results: the per-node execution results.
 func ApplyResults(g *op.Graph, results []*NodeResult) {
 	resultMap := make(map[string]*NodeResult)
 	for _, r := range results {

--- a/internal/execution/flow/gather.go
+++ b/internal/execution/flow/gather.go
@@ -45,12 +45,27 @@ type iterOutcome struct {
 type Gather struct{}
 
 // Name returns the dotted action name.
+//
+// Returns:
+//   - string: "flow.gather".
 func (a *Gather) Name() string { return "flow.gather" }
 
 // Params returns nil — Gather uses untyped slots.
+//
+// Returns:
+//   - []op.ParamInfo: always nil (untyped slots).
 func (a *Gather) Params() []op.ParamInfo { return nil }
 
 // Do executes the referenced phase once per item, with per-iteration isolation.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - slots: the slot map (items, do, limit).
+//
+// Returns:
+//   - result: []any of terminal node results, one per item.
+//   - complement: *gatherComplement for rollback.
+//   - err: non-nil if any iteration fails.
 func (a *Gather) Do(ctx *op.Context, slots map[string]any) (result op.Result, complement op.Complement, err error) { //nolint:gocyclo // validation + sequential/concurrent branching is inherent
 	items, err := extractItems(slots)
 	if err != nil {
@@ -121,6 +136,13 @@ func (a *Gather) Do(ctx *op.Context, slots map[string]any) (result op.Result, co
 }
 
 // Undo walks iterations in reverse and calls Action.Undo per entry.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - complement: the *gatherComplement from Do.
+//
+// Returns:
+//   - error: non-nil if any iteration rollback fails.
 func (a *Gather) Undo(ctx *op.Context, complement op.Complement) error {
 	gs, ok := complement.(*gatherComplement)
 	if !ok || gs == nil {
@@ -130,6 +152,12 @@ func (a *Gather) Undo(ctx *op.Context, complement op.Complement) error {
 }
 
 // undoCompleted unwinds all iterations that have recovery stacks.
+//
+// Parameters:
+//   - gs: the gather complement with per-iteration recovery stacks.
+//
+// Returns:
+//   - error: non-nil if any stack unwind fails (errors are joined).
 func (a *Gather) undoCompleted(_ *op.Context, gs *gatherComplement) error {
 	var errs []error
 	for i := len(gs.Iterations) - 1; i >= 0; i-- {
@@ -143,6 +171,14 @@ func (a *Gather) undoCompleted(_ *op.Context, gs *gatherComplement) error {
 }
 
 // executeConcurrent runs gather iterations with bounded concurrency.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - ordered: the topologically sorted phase body nodes.
+//   - gatherID: the gather node ID for slot resolution.
+//   - items: the list of items to iterate over.
+//   - limit: the maximum concurrent iterations.
+//   - outcomes: the pre-allocated slice to receive per-iteration results.
 func executeConcurrent(ctx *op.Context, ordered []*op.Node, gatherID string, items []any, limit int, outcomes []iterOutcome) {
 	iterCtxBase, cancel := context.WithCancel(ctx.Context)
 	defer cancel()
@@ -200,6 +236,15 @@ iterLoop:
 }
 
 // executeIteration runs the phase body for a single item.
+//
+// Parameters:
+//   - ctx: the execution context.
+//   - ordered: the topologically sorted phase body nodes.
+//   - gatherID: the gather node ID for slot resolution.
+//   - item: the current iteration item.
+//
+// Returns:
+//   - iterOutcome: the terminal result and undo state.
 func executeIteration(ctx *op.Context, ordered []*op.Node, gatherID string, item any) iterOutcome {
 	results := make(map[string]any)
 	stack := op.NewRecoveryStack()
@@ -250,6 +295,13 @@ func executeIteration(ctx *op.Context, ordered []*op.Node, gatherID string, item
 }
 
 // extractItems pulls the items list from slots.
+//
+// Parameters:
+//   - slots: the slot map to extract from.
+//
+// Returns:
+//   - []any: the items list.
+//   - error: non-nil if the items slot is missing or has the wrong type.
 func extractItems(slots map[string]any) ([]any, error) {
 	raw, ok := slots["items"]
 	if !ok {
@@ -263,6 +315,12 @@ func extractItems(slots map[string]any) ([]any, error) {
 }
 
 // extractLimit pulls the concurrency limit from slots (default 1).
+//
+// Parameters:
+//   - slots: the slot map to extract from.
+//
+// Returns:
+//   - int: the concurrency limit (minimum 1).
 func extractLimit(slots map[string]any) int {
 	if v, ok := slots["limit"]; ok {
 		switch n := v.(type) {

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -79,6 +79,14 @@ type Planner struct {
 
 // PlanPackages parses a packages-manifest file and adds installation nodes
 // to the graph. Returns the resolved package names.
+//
+// Parameters:
+//   - graph: the execution graph to populate.
+//   - manifestPath: the path to the packages-manifest file.
+//
+// Returns:
+//   - []string: the resolved package names.
+//   - error: non-nil if manifest parsing or package resolution fails.
 func (p *Planner) PlanPackages(graph *op.Graph, manifestPath string) ([]string, error) {
 	m, err := manifest.Load(manifestPath)
 	if err != nil {
@@ -116,6 +124,14 @@ func (p *Planner) PlanPackages(graph *op.Graph, manifestPath string) ([]string, 
 
 // PlanByName resolves explicit package names and adds installation nodes
 // to the graph. Returns the resolved package names.
+//
+// Parameters:
+//   - graph: the execution graph to populate.
+//   - packages: the package names to resolve and plan.
+//
+// Returns:
+//   - []string: the resolved package names.
+//   - error: non-nil if any package resolution or node building fails.
 func (p *Planner) PlanByName(graph *op.Graph, packages []string) ([]string, error) {
 	targetPlatform, reg, regClient, err := p.resolve()
 	if err != nil {
@@ -147,6 +163,12 @@ func (p *Planner) PlanByName(graph *op.Graph, packages []string) ([]string, erro
 
 // resolve returns the resolved platform, action registry, and registry client,
 // auto-creating any that are nil on the Planner.
+//
+// Returns:
+//   - resolvedPlatform: the target platform string.
+//   - resolvedReg: the action registry (created if nil on Planner).
+//   - resolvedRegistry: the package registry client (created if nil on Planner).
+//   - err: non-nil if creating the registry client fails.
 func (p *Planner) resolve() (resolvedPlatform string, resolvedReg *op.ActionRegistry, resolvedRegistry *lorepackage.Registry, err error) {
 	targetPlatform := p.Platform
 	if targetPlatform == "" {
@@ -172,6 +194,13 @@ func (p *Planner) resolve() (resolvedPlatform string, resolvedReg *op.ActionRegi
 }
 
 // Build creates an execution graph from the given configuration.
+//
+// Parameters:
+//   - cfg: the build configuration (manifest path or package list, platform, options).
+//
+// Returns:
+//   - *BuildResult: the execution graph and metadata.
+//   - error: non-nil if configuration is invalid or graph building fails.
 func Build(cfg BuildConfig) (*BuildResult, error) {
 	// Validate configuration
 	if cfg.ManifestPath != "" && len(cfg.Packages) > 0 {
@@ -224,6 +253,14 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 }
 
 // BuildFromManifest creates an execution graph from a packages-manifest.yaml file.
+//
+// Parameters:
+//   - manifestPath: the path to the packages-manifest file.
+//   - targetPlatform: the platform string (empty for auto-detect).
+//
+// Returns:
+//   - *BuildResult: the execution graph and metadata.
+//   - error: non-nil if graph building fails.
 func BuildFromManifest(manifestPath, targetPlatform string) (*BuildResult, error) {
 	return Build(BuildConfig{
 		ManifestPath: manifestPath,
@@ -232,6 +269,14 @@ func BuildFromManifest(manifestPath, targetPlatform string) (*BuildResult, error
 }
 
 // BuildFromPackages creates an execution graph from a list of package names.
+//
+// Parameters:
+//   - packages: the package names to resolve and install.
+//   - targetPlatform: the platform string (empty for auto-detect).
+//
+// Returns:
+//   - *BuildResult: the execution graph and metadata.
+//   - error: non-nil if graph building fails.
 func BuildFromPackages(packages []string, targetPlatform string) (*BuildResult, error) {
 	return Build(BuildConfig{
 		Packages: packages,
@@ -242,6 +287,16 @@ func BuildFromPackages(packages []string, targetPlatform string) (*BuildResult, 
 // buildPackageNodes adds execution nodes and phases for a package to the graph.
 // Each lifecycle phase becomes a Phase entry in the graph.
 // Compensation is handled by Action Do/Undo on the recovery stack — no Starlark-level compensation.
+//
+// Parameters:
+//   - graph: the execution graph to populate.
+//   - pkg: the resolved package release.
+//   - targetPlatform: the target platform string.
+//   - cfg: the build configuration.
+//   - reg: the action registry for resolving action names.
+//
+// Returns:
+//   - error: non-nil if script execution or node building fails.
 func buildPackageNodes(graph *op.Graph, pkg *lorepackage.Release, targetPlatform string, cfg BuildConfig, reg *op.ActionRegistry) error { //nolint:gocognit
 	action := lorepackage.Deploy
 	phases := lorepackage.PhaseOrder(action)
@@ -292,8 +347,20 @@ func buildPackageNodes(graph *op.Graph, pkg *lorepackage.Release, targetPlatform
 	return nil
 }
 
-// executeScriptAction runs a Starlark phase script's entry point function (named for the lifecycle phase, e.g.,
-// "install", "provision") and returns the retry policy if one was configured via phase.retry().
+// executeScriptAction runs a Starlark phase script's entry point function
+// (named for the lifecycle phase, e.g., "install", "provision") and returns
+// the retry policy if one was configured via phase.retry().
+//
+// Parameters:
+//   - graph: the execution graph.
+//   - pkg: the resolved package release.
+//   - action: the script action to execute.
+//   - cfg: the build configuration.
+//   - reg: the action registry.
+//
+// Returns:
+//   - *op.RetryPolicy: the retry policy if configured, or nil.
+//   - error: non-nil if script execution fails.
 func executeScriptAction(graph *op.Graph, pkg *lorepackage.Release, _ string, action *lorepackage.ScriptAction, cfg BuildConfig, reg *op.ActionRegistry) (*op.RetryPolicy, error) {
 	thread, globals, pkgContext, err := prepareScriptEnv(graph, pkg, action, cfg, reg)
 	if err != nil {
@@ -347,8 +414,21 @@ func executeScriptAction(graph *op.Graph, pkg *lorepackage.Release, _ string, ac
 	return phaseCtx.Retry, nil
 }
 
-// prepareScriptEnv creates the Starlark thread and globals needed to execute a phase script.
-// plan and ui are injected as globals via Runtime.
+// prepareScriptEnv creates the Starlark thread and globals needed to execute a
+// phase script. plan and ui are injected as globals via Runtime.
+//
+// Parameters:
+//   - graph: the execution graph.
+//   - pkg: the resolved package release.
+//   - action: the script action being prepared.
+//   - cfg: the build configuration.
+//   - reg: the action registry.
+//
+// Returns:
+//   - *starlark.Thread: the configured Starlark thread.
+//   - starlark.StringDict: the global namespace.
+//   - *loreStar.PackageContext: the package context for the script.
+//   - error: reserved for future use (currently always nil).
 func prepareScriptEnv(
 	graph *op.Graph,
 	pkg *lorepackage.Release,
@@ -396,8 +476,18 @@ func prepareScriptEnv(
 }
 
 // addNativePMNodes adds nodes for a native package manager action.
-// Uses namespaced action names (pkg.install, pkg.upgrade, pkg.remove) that work on all platforms.
-// The actual package manager is determined at execution time via op.Context.Platform.
+// Uses namespaced action names (pkg.install, pkg.upgrade, pkg.remove) that
+// work on all platforms. The actual package manager is determined at execution
+// time via op.Context.Platform.
+//
+// Parameters:
+//   - graph: the execution graph to populate.
+//   - pkg: the resolved package release.
+//   - action: the native package manager action.
+//   - reg: the action registry for resolving action names.
+//
+// Returns:
+//   - error: reserved for future use (currently always nil).
 func addNativePMNodes(graph *op.Graph, pkg *lorepackage.Release, action *lorepackage.NativePMAction, reg *op.ActionRegistry) error { //nolint:unparam // error return reserved for future use
 	// Determine the dotted action name
 	var actionName string
@@ -426,6 +516,9 @@ func addNativePMNodes(graph *op.Graph, pkg *lorepackage.Release, action *lorepac
 }
 
 // userHomeDir returns the user's home directory.
+//
+// Returns:
+//   - string: the home directory path, falling back to $HOME.
 func userHomeDir() string {
 	if home, err := os.UserHomeDir(); err == nil {
 		return home
@@ -434,6 +527,9 @@ func userHomeDir() string {
 }
 
 // detectPlatform converts platform info to registry platform string.
+//
+// Returns:
+//   - string: the registry platform string (e.g., "Darwin", "Linux.Debian").
 func detectPlatform() string {
 	p := platform.New()
 	switch p.OS {

--- a/internal/starlark/runtime.go
+++ b/internal/starlark/runtime.go
@@ -27,32 +27,49 @@ type loaderEntry struct {
 
 // NewRuntime creates a Runtime with the given configuration.
 // Receivers listed in cfg.Receivers are included as pre-injected globals.
+//
+// Parameters:
+//   - cfg: configuration specifying receivers, writer, and program name.
+//
+// Returns:
+//   - *Runtime: the initialized runtime.
 func NewRuntime(cfg op.BindingConfig) *Runtime {
+
 	return &Runtime{
 		StarlarkRuntime: op.NewStarlarkRuntime(cfg),
 		cache:           make(map[string]*loaderEntry),
 	}
 }
 
+// region EXPORTED METHODS
+
+// region Behaviors
+
 // RegisterActions registers all providers' actions with the registry.
 // All providers' actions are always registered regardless of Receivers selections — the action
 // registry is for the executor, not the script environment.
+//
+// Parameters:
+//   - reg: the action registry to populate.
+//   - ctx: the execution context for provider initialization.
 func (rt *Runtime) RegisterActions(reg *op.ActionRegistry, ctx op.Context) {
-	rt.Initialize(reg, ctx.ContextBase)
-}
 
-// NewPopulatedRegistry creates an ActionRegistry with all provider actions registered.
-// Shorthand for NewActionRegistry() + RegisterActions().
-func (rt *Runtime) NewPopulatedRegistry(ctx op.Context) *op.ActionRegistry {
-	reg := op.NewActionRegistry()
-	rt.RegisterActions(reg, ctx)
-	return reg
+	rt.Initialize(reg, ctx.ContextBase)
 }
 
 // BuildGlobals constructs the Starlark globals dict for a consumer.
 // Only providers listed in cfg.Receivers appear as globals.
 // If "plan" is listed, a PlanRoot is built from all announced PlannedProvider implementations.
+//
+// Parameters:
+//   - graph: the execution graph for plan namespace construction.
+//   - project: the project name passed to planned providers.
+//   - reg: the action registry for plan namespace construction.
+//
+// Returns:
+//   - starlark.StringDict: the complete globals dict for Starlark execution.
 func (rt *Runtime) BuildGlobals(graph *op.Graph, project string, reg *op.ActionRegistry) starlark.StringDict {
+
 	// Start with immediate receivers from the base runtime.
 	globals := rt.BuildReceivers()
 
@@ -70,12 +87,51 @@ func (rt *Runtime) BuildGlobals(graph *op.Graph, project string, reg *op.ActionR
 // ConfigureThread sets thread.Load to the @devlore// module loader.
 // The loader resolves provider names from the runtime and caches instances.
 // Must be called before starlark.ExecFileOptions.
+//
+// Parameters:
+//   - thread: the Starlark thread to configure.
+//   - graph: the execution graph for module resolution.
+//   - project: the project name for module resolution.
+//   - reg: the action registry for module resolution.
 func (rt *Runtime) ConfigureThread(thread *starlark.Thread, graph *op.Graph, project string, reg *op.ActionRegistry) {
+
 	thread.Load = rt.makeLoader(graph, project, reg)
 }
 
+// NewPopulatedRegistry creates an ActionRegistry with all provider actions registered.
+// Shorthand for NewActionRegistry() + RegisterActions().
+//
+// Parameters:
+//   - ctx: the execution context for provider initialization.
+//
+// Returns:
+//   - *op.ActionRegistry: the populated registry.
+func (rt *Runtime) NewPopulatedRegistry(ctx op.Context) *op.ActionRegistry {
+
+	reg := op.NewActionRegistry()
+	rt.RegisterActions(reg, ctx)
+	return reg
+}
+
+// endregion
+
+// endregion
+
+// region UNEXPORTED METHODS
+
+// region Behaviors
+
 // makeLoader creates the thread.Load function for @devlore// modules.
+//
+// Parameters:
+//   - graph: the execution graph for provider resolution.
+//   - project: the project name for provider resolution.
+//   - reg: the action registry for provider resolution.
+//
+// Returns:
+//   - func: a Starlark module loader function.
 func (rt *Runtime) makeLoader(graph *op.Graph, project string, reg *op.ActionRegistry) func(*starlark.Thread, string) (starlark.StringDict, error) {
+
 	return func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 		if !strings.HasPrefix(module, "@devlore//") {
 			return nil, fmt.Errorf("unknown module: %s (use @devlore// prefix)", module)
@@ -94,7 +150,18 @@ func (rt *Runtime) makeLoader(graph *op.Graph, project string, reg *op.ActionReg
 }
 
 // resolveProvider creates a Starlark module dict for a single provider.
+//
+// Parameters:
+//   - name: the provider name to resolve.
+//   - graph: the execution graph for plan module construction.
+//   - project: the project name for plan module construction.
+//   - reg: the action registry for plan module construction.
+//
+// Returns:
+//   - starlark.StringDict: the module globals.
+//   - error: non-nil if the provider is not found.
 func (rt *Runtime) resolveProvider(name string, graph *op.Graph, project string, reg *op.ActionRegistry) (starlark.StringDict, error) {
+
 	// Special case: plan aggregate
 	if name == "plan" {
 		return rt.buildPlanModule(graph, project, reg)
@@ -108,7 +175,17 @@ func (rt *Runtime) resolveProvider(name string, graph *op.Graph, project string,
 }
 
 // buildPlanModule constructs a plan module from all announced PlannedProvider implementations.
+//
+// Parameters:
+//   - graph: the execution graph for plan construction.
+//   - project: the project name for plan construction.
+//   - reg: the action registry for plan construction.
+//
+// Returns:
+//   - starlark.StringDict: the plan module globals.
+//   - error: non-nil if no planned providers are registered.
 func (rt *Runtime) buildPlanModule(graph *op.Graph, project string, reg *op.ActionRegistry) (starlark.StringDict, error) {
+
 	planned := collectPlannedProviders()
 	if len(planned) == 0 {
 		return nil, fmt.Errorf("no planned providers registered")
@@ -117,8 +194,16 @@ func (rt *Runtime) buildPlanModule(graph *op.Graph, project string, reg *op.Acti
 	return starlark.StringDict{"plan": plan}, nil
 }
 
+// endregion
+
+// endregion
+
 // collectPlannedProviders returns all announced PlannedProvider implementations.
+//
+// Returns:
+//   - map[string]op.PlannedProvider: provider name to PlannedProvider mapping.
 func collectPlannedProviders() map[string]op.PlannedProvider {
+
 	planned := make(map[string]op.PlannedProvider)
 	for _, p := range op.Providers() {
 		if pp, ok := p.(op.PlannedProvider); ok {

--- a/internal/writ/migrate/execute.go
+++ b/internal/writ/migrate/execute.go
@@ -31,6 +31,13 @@ type Rename struct {
 
 // Execute performs the directory renames specified in the execution graph.
 // It writes progress to stderr using standard cli output functions.
+//
+// Parameters:
+//   - graph: the execution graph containing rename nodes.
+//   - analysis: the migration analysis with source root and system info.
+//
+// Returns:
+//   - error: non-nil if any rename fails or a target directory already exists.
 func Execute(graph *op.Graph, analysis *MigrationAnalysis) error {
 	// Find rename nodes in the graph
 	var renameNodes []*op.Node
@@ -93,6 +100,14 @@ func Execute(graph *op.Graph, analysis *MigrationAnalysis) error {
 }
 
 // WriteMigratedMarker writes the .writ-migrated marker file.
+//
+// Parameters:
+//   - sourceRoot: the root directory where the marker file is written.
+//   - graph: the execution graph containing completed rename nodes.
+//   - analysis: the migration analysis with system metadata.
+//
+// Returns:
+//   - error: non-nil if marshaling or writing the marker fails.
 func WriteMigratedMarker(sourceRoot string, graph *op.Graph, analysis *MigrationAnalysis) error {
 	var renames []Rename
 	for _, node := range graph.Nodes {
@@ -119,6 +134,13 @@ func WriteMigratedMarker(sourceRoot string, graph *op.Graph, analysis *Migration
 	return nil
 }
 
+// joinWords concatenates words with spaces.
+//
+// Parameters:
+//   - words: the strings to join.
+//
+// Returns:
+//   - string: the space-separated result.
 func joinWords(words []string) string {
 	result := ""
 	for i, w := range words {

--- a/pkg/op/context.go
+++ b/pkg/op/context.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
 package op
 
 import (

--- a/pkg/op/output.go
+++ b/pkg/op/output.go
@@ -26,7 +26,16 @@ type Output struct {
 }
 
 // NewOutput creates a new Output (promise) representing a node's output.
+//
+// Parameters:
+//   - node: the producing node.
+//   - graph: the execution graph.
+//   - slot: which output slot this represents (empty for default).
+//
+// Returns:
+//   - *Output: the new promise handle.
 func NewOutput(node *Node, graph *Graph, slot string) *Output {
+
 	return &Output{
 		node:  node,
 		graph: graph,
@@ -34,23 +43,66 @@ func NewOutput(node *Node, graph *Graph, slot string) *Output {
 	}
 }
 
-// String implements starlark.Value.
-func (o *Output) String() string { return fmt.Sprintf("Output(%s)", o.node.ID) }
+// region EXPORTED METHODS
 
-// Type implements starlark.Value.
-func (o *Output) Type() string { return "Output" }
+// region State management
 
-// Freeze implements starlark.Value.
-func (o *Output) Freeze() {}
+// Graph returns the execution graph.
+//
+// Returns:
+//   - *Graph: the graph this output belongs to.
+func (o *Output) Graph() *Graph {
 
-// Truth implements starlark.Value.
-func (o *Output) Truth() starlark.Bool { return true }
+	return o.graph
+}
 
-// Hash implements starlark.Value.
-func (o *Output) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Output") }
+// Node returns the node that produces this output.
+//
+// Returns:
+//   - *Node: the producing node.
+func (o *Output) Node() *Node {
+
+	return o.node
+}
+
+// Path returns a path from the node's slots.
+//
+// Returns:
+//   - string: the path slot value, or empty string if not present or not a string.
+func (o *Output) Path() string {
+
+	path, ok := o.node.GetSlot("path").(string)
+	if !ok {
+		return ""
+	}
+	return path
+}
+
+// Slot returns which output slot this represents.
+//
+// Returns:
+//   - string: the slot identifier.
+func (o *Output) Slot() string {
+
+	return o.slot
+}
+
+// endregion
+
+// region Behaviors
+
+// Actions
 
 // Attr implements starlark.HasAttrs.
+//
+// Parameters:
+//   - name: the attribute name to look up.
+//
+// Returns:
+//   - starlark.Value: the attribute value.
+//   - error: non-nil if the attribute does not exist.
 func (o *Output) Attr(name string) (starlark.Value, error) {
+
 	switch name {
 	case "node_id":
 		return starlark.String(o.node.ID), nil
@@ -64,7 +116,7 @@ func (o *Output) Attr(name string) (starlark.Value, error) {
 		if slotVal == nil {
 			return nil, starlark.NoSuchAttrError(fmt.Sprintf("Output has no attribute %q", name))
 		}
-		sv, err := marshal(slotVal)
+		sv, err := Marshal(slotVal)
 		if err != nil {
 			return nil, fmt.Errorf("slot %q: %w", name, err)
 		}
@@ -73,7 +125,11 @@ func (o *Output) Attr(name string) (starlark.Value, error) {
 }
 
 // AttrNames implements starlark.HasAttrs.
+//
+// Returns:
+//   - []string: all available attribute names.
 func (o *Output) AttrNames() []string {
+
 	names := []string{"node_id", "retry", "slot"}
 	// Add slot names from the node
 	if o.node.Slots != nil {
@@ -84,24 +140,26 @@ func (o *Output) AttrNames() []string {
 	return names
 }
 
-// Node returns the node that produces this output.
-func (o *Output) Node() *Node {
-	return o.node
-}
+// DependOn creates an edge making the given node depend on this output's node.
+//
+// Parameters:
+//   - consumer: the node that should depend on this output's producer.
+func (o *Output) DependOn(consumer *Node) {
 
-// Graph returns the execution graph.
-func (o *Output) Graph() *Graph {
-	return o.graph
-}
-
-// Slot returns which output slot this represents.
-func (o *Output) Slot() string {
-	return o.slot
+	o.graph.Edges = append(o.graph.Edges, Edge{
+		From: o.node.ID,
+		To:   consumer.ID,
+	})
 }
 
 // FillSlot fills a slot in the consumer node with this promise, creating an edge.
 // This is called when a promise is passed to a plan function.
+//
+// Parameters:
+//   - consumer: the node receiving the promise.
+//   - slotName: the slot to fill.
 func (o *Output) FillSlot(consumer *Node, slotName string) {
+
 	// Set the slot to reference this output's node
 	consumer.SetSlotPromise(slotName, o.node.ID, o.slot)
 
@@ -112,60 +170,56 @@ func (o *Output) FillSlot(consumer *Node, slotName string) {
 	})
 }
 
-// FillSlot fills a slot in a node from a Starlark value.
+// Freeze implements starlark.Value.
+func (o *Output) Freeze() {}
+
+// Hash implements starlark.Value.
 //
-// Any slot accepts:
-//   - A promise (Output): creates an edge, value flows at runtime
-//   - A gather (Gather): creates edges from all members (parallel execution)
-//   - An immediate value: stored directly, known at analysis time
-func FillSlot(node *Node, graph *Graph, slotName string, value starlark.Value) error {
-	// Promise: create edge, value flows at runtime
-	if output, ok := value.(*Output); ok {
-		output.FillSlot(node, slotName)
-		return nil
-	}
+// Returns:
+//   - uint32: unused, always 0.
+//   - error: always non-nil (Output is unhashable).
+func (o *Output) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Output") }
 
-	// Gather: create edges from all members (parallel execution)
-	if gather, ok := value.(*Gather); ok {
-		gather.FillSlot(node, slotName)
-		return nil
-	}
+// String implements starlark.Value.
+//
+// Returns:
+//   - string: human-readable representation.
+func (o *Output) String() string { return fmt.Sprintf("Output(%s)", o.node.ID) }
 
-	// None: skip (optional parameter not provided)
-	if _, ok := value.(starlark.NoneType); ok {
-		return nil
-	}
+// Truth implements starlark.Value.
+//
+// Returns:
+//   - starlark.Bool: always true.
+func (o *Output) Truth() starlark.Bool { return true }
 
-	// Immediate: unmarshal Starlark value to native Go type
-	var goVal any
-	if err := unmarshal(value, &goVal); err != nil {
-		return fmt.Errorf("slot %q: %w", slotName, err)
-	}
+// Type implements starlark.Value.
+//
+// Returns:
+//   - string: the type name "Output".
+func (o *Output) Type() string { return "Output" }
 
-	// Resource identity: if the immediate value carries resource origin,
-	// create an implicit edge from the origin node to the consumer. This
-	// enables automatic dependency ordering when a resource produced by
-	// one node flows to another.
-	if originID, ok := extractResource(goVal); ok {
-		graph.Edges = append(graph.Edges, Edge{From: originID, To: node.ID})
-	}
+// endregion
 
-	node.SetSlotImmediate(slotName, goVal)
-	return nil
-}
+// endregion
 
-// Path returns a path from the node's slots.
-func (o *Output) Path() string {
-	path, ok := o.node.GetSlot("path").(string)
-	if !ok {
-		return ""
-	}
-	return path
-}
+// region UNEXPORTED METHODS
+
+// region Behaviors
 
 // retryBuiltin sets the retry policy on this output's node.
 // Usage: node = plan.appnet.download(...); node.retry(max_attempts=5, backoff="linear")
+//
+// Parameters:
+//   - thread: the Starlark thread (unused).
+//   - b: the builtin (unused).
+//   - args: positional arguments.
+//   - kwargs: keyword arguments (max_attempts, backoff?, initial_delay?, max_delay?).
+//
+// Returns:
+//   - starlark.Value: this Output (for chaining).
+//   - error: non-nil if arguments are invalid.
 func (o *Output) retryBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
 	var maxAttempts int
 	var backoff, initialDelay, maxDelay string
 
@@ -210,22 +264,81 @@ func (o *Output) retryBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args star
 	return o, nil
 }
 
-// DependOn creates an edge making the given node depend on this output's node.
-func (o *Output) DependOn(consumer *Node) {
-	o.graph.Edges = append(o.graph.Edges, Edge{
-		From: o.node.ID,
-		To:   consumer.ID,
-	})
+// endregion
+
+// endregion
+
+// ── Exported free functions ─────────────────────────────────────────────────
+
+// FillSlot fills a slot in a node from a Starlark value.
+//
+// Any slot accepts:
+//   - A promise (Output): creates an edge, value flows at runtime
+//   - A gather (Gather): creates edges from all members (parallel execution)
+//   - An immediate value: stored directly, known at analysis time
+//
+// Parameters:
+//   - node: the node whose slot to fill.
+//   - graph: the execution graph (for edge creation).
+//   - slotName: the slot to fill.
+//   - value: the Starlark value to assign.
+//
+// Returns:
+//   - error: non-nil if the value cannot be unmarshaled.
+func FillSlot(node *Node, graph *Graph, slotName string, value starlark.Value) error {
+
+	// Promise: create edge, value flows at runtime
+	if output, ok := value.(*Output); ok {
+		output.FillSlot(node, slotName)
+		return nil
+	}
+
+	// Gather: create edges from all members (parallel execution)
+	if gather, ok := value.(*Gather); ok {
+		gather.FillSlot(node, slotName)
+		return nil
+	}
+
+	// None: skip (optional parameter not provided)
+	if _, ok := value.(starlark.NoneType); ok {
+		return nil
+	}
+
+	// Immediate: unmarshal Starlark value to native Go type
+	var goVal any
+	if err := unmarshal(value, &goVal); err != nil {
+		return fmt.Errorf("slot %q: %w", slotName, err)
+	}
+
+	// Resource identity: if the immediate value carries resource origin,
+	// create an implicit edge from the origin node to the consumer. This
+	// enables automatic dependency ordering when a resource produced by
+	// one node flows to another.
+	if originID, ok := extractResource(goVal); ok {
+		graph.Edges = append(graph.Edges, Edge{From: originID, To: node.ID})
+	}
+
+	node.SetSlotImmediate(slotName, goVal)
+	return nil
 }
 
 // ResolveInput extracts an *Output from a Starlark value.
-// Returns an error if the value is not an Output.
+//
+// Parameters:
+//   - value: the Starlark value to extract from.
+//
+// Returns:
+//   - *Output: the extracted output.
+//   - error: non-nil if value is not an Output.
 func ResolveInput(value starlark.Value) (*Output, error) {
+
 	if output, ok := value.(*Output); ok {
 		return output, nil
 	}
 	return nil, fmt.Errorf("expected Output, got %s", value.Type())
 }
+
+// ── Gather ──────────────────────────────────────────────────────────────────
 
 // Gather represents a collection of outputs that can run in parallel.
 // When used as a slot input, it creates edges from ALL members to the consumer,
@@ -244,42 +357,48 @@ type Gather struct {
 }
 
 // NewGather creates a new Gather from multiple outputs.
+//
+// Parameters:
+//   - graph: the execution graph.
+//   - outputs: the outputs to gather.
+//
+// Returns:
+//   - *Gather: the new gather handle.
 func NewGather(graph *Graph, outputs ...*Output) *Gather {
+
 	return &Gather{
 		outputs: outputs,
 		graph:   graph,
 	}
 }
 
-// String implements starlark.Value.
-func (g *Gather) String() string {
-	ids := make([]string, len(g.outputs))
-	for i, o := range g.outputs {
-		ids[i] = o.node.ID
-	}
-	return fmt.Sprintf("Gather(%v)", ids)
-}
+// region EXPORTED METHODS
 
-// Type implements starlark.Value.
-func (g *Gather) Type() string { return "Gather" }
-
-// Freeze implements starlark.Value.
-func (g *Gather) Freeze() {}
-
-// Truth implements starlark.Value.
-func (g *Gather) Truth() starlark.Bool { return len(g.outputs) > 0 }
-
-// Hash implements starlark.Value.
-func (g *Gather) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Gather") }
+// region State management
 
 // Outputs returns the gathered outputs.
+//
+// Returns:
+//   - []*Output: the collected output promises.
 func (g *Gather) Outputs() []*Output {
+
 	return g.outputs
 }
 
+// endregion
+
+// region Behaviors
+
+// Actions
+
 // FillSlot fills a slot in the consumer node with all gathered promises,
 // creating edges from each member. This enables parallel execution.
+//
+// Parameters:
+//   - consumer: the node receiving the gathered promises.
+//   - slotName: the slot to fill.
 func (g *Gather) FillSlot(consumer *Node, slotName string) {
+
 	for i, output := range g.outputs {
 		// Set slot reference for each output
 		subSlot := fmt.Sprintf("%s[%d]", slotName, i)
@@ -294,3 +413,42 @@ func (g *Gather) FillSlot(consumer *Node, slotName string) {
 	// Store count for runtime
 	consumer.SetSlotImmediate(slotName+".len", len(g.outputs))
 }
+
+// Freeze implements starlark.Value.
+func (g *Gather) Freeze() {}
+
+// Hash implements starlark.Value.
+//
+// Returns:
+//   - uint32: unused, always 0.
+//   - error: always non-nil (Gather is unhashable).
+func (g *Gather) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: Gather") }
+
+// String implements starlark.Value.
+//
+// Returns:
+//   - string: human-readable representation.
+func (g *Gather) String() string {
+
+	ids := make([]string, len(g.outputs))
+	for i, o := range g.outputs {
+		ids[i] = o.node.ID
+	}
+	return fmt.Sprintf("Gather(%v)", ids)
+}
+
+// Truth implements starlark.Value.
+//
+// Returns:
+//   - starlark.Bool: true if the gather contains any outputs.
+func (g *Gather) Truth() starlark.Bool { return len(g.outputs) > 0 }
+
+// Type implements starlark.Value.
+//
+// Returns:
+//   - string: the type name "Gather".
+func (g *Gather) Type() string { return "Gather" }
+
+// endregion
+
+// endregion

--- a/pkg/op/output_test.go
+++ b/pkg/op/output_test.go
@@ -644,7 +644,7 @@ func TestFillSlotImplicitEdge_ResourceWithOrigin(t *testing.T) {
 		t.Fatalf("Shadow error: %v", err)
 	}
 
-	val, err := marshal(res)
+	val, err := Marshal(res)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
@@ -671,7 +671,7 @@ func TestFillSlotImplicitEdge_ResourceWithoutOrigin(t *testing.T) {
 	// Resolve creates a discovery entry with no origin.
 	g.Catalog.Resolve("file:///bar")
 
-	val, err := marshal(res)
+	val, err := Marshal(res)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
@@ -696,7 +696,7 @@ func TestFillSlotImplicitEdge_PlainResource(t *testing.T) {
 		t.Fatalf("Shadow error: %v", err)
 	}
 
-	val, err := marshal(res)
+	val, err := Marshal(res)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}

--- a/pkg/op/provider/regexp/provider.go
+++ b/pkg/op/provider/regexp/provider.go
@@ -19,8 +19,186 @@ type Provider struct {
 	cache sync.Map // pattern string → *regexp.Regexp
 }
 
+// region EXPORTED METHODS
+
+// region Behaviors
+
+// Fallible actions
+
+// Find returns the first match of the pattern in the text.
+// Returns an empty string if no match is found.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//
+// Returns:
+//   - string: the first match, or empty string if none.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) Find(pattern, text string) (string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	return re.FindString(text), nil
+}
+
+// FindAll returns all non-overlapping matches of the pattern.
+// The count parameter limits the number of matches; -1 means no limit.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//   - count: maximum number of matches (-1 for no limit).
+//
+// Returns:
+//   - []string: all matches found.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) FindAll(pattern, text string, count int) ([]string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return re.FindAllString(text, count), nil
+}
+
+// FindAllSubmatch returns all matches with their submatches.
+// The count parameter limits the number of matches; -1 means no limit.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//   - count: maximum number of matches (-1 for no limit).
+//
+// Returns:
+//   - [][]string: all matches with submatches.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) FindAllSubmatch(pattern, text string, count int) ([][]string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return re.FindAllStringSubmatch(text, count), nil
+}
+
+// FindSubmatch returns the first match and its submatches.
+// Returns nil if no match is found.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//
+// Returns:
+//   - []string: the match and submatches, or nil if none.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) FindSubmatch(pattern, text string) ([]string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return re.FindStringSubmatch(text), nil
+}
+
+// Match reports whether the text contains any match of the pattern.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//
+// Returns:
+//   - bool: true if the pattern matches.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) Match(pattern, text string) (bool, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(text), nil
+}
+
+// Replace replaces all matches of the pattern with the replacement string.
+// The replacement can include $1, $2, etc. for submatch references.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//   - replacement: the replacement string (supports submatch references).
+//
+// Returns:
+//   - string: the text with all matches replaced.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) Replace(pattern, text, replacement string) (string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	return re.ReplaceAllString(text, replacement), nil
+}
+
+// ReplaceLiteral replaces all matches with the literal replacement string
+// (no submatch expansion).
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to search.
+//   - replacement: the literal replacement string.
+//
+// Returns:
+//   - string: the text with all matches replaced literally.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) ReplaceLiteral(pattern, text, replacement string) (string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	return re.ReplaceAllLiteralString(text, replacement), nil
+}
+
+// Split splits the text around matches of the pattern.
+// The count parameter limits the number of substrings; -1 means no limit.
+//
+// Parameters:
+//   - pattern: the regular expression pattern.
+//   - text: the string to split.
+//   - count: maximum number of substrings (-1 for no limit).
+//
+// Returns:
+//   - []string: the substrings between matches.
+//   - error: non-nil if the pattern is invalid.
+func (p *Provider) Split(pattern, text string, count int) ([]string, error) {
+
+	re, err := p.compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return re.Split(text, count), nil
+}
+
+// endregion
+
+// endregion
+
+// region UNEXPORTED METHODS
+
+// region Behaviors
+
 // compile returns a compiled regexp, caching it for reuse.
+//
+// Parameters:
+//   - pattern: the regular expression pattern to compile.
+//
+// Returns:
+//   - *regexp.Regexp: the compiled pattern.
+//   - error: non-nil if the pattern is invalid.
 func (p *Provider) compile(pattern string) (*regexp.Regexp, error) {
+
 	if v, ok := p.cache.Load(pattern); ok {
 		return v.(*regexp.Regexp), nil
 	}
@@ -32,81 +210,6 @@ func (p *Provider) compile(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// Match reports whether the text contains any match of the pattern.
-func (p *Provider) Match(pattern, text string) (bool, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return false, err
-	}
-	return re.MatchString(text), nil
-}
+// endregion
 
-// Find returns the first match of the pattern in the text.
-// Returns an empty string if no match is found.
-func (p *Provider) Find(pattern, text string) (string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return "", err
-	}
-	return re.FindString(text), nil
-}
-
-// FindAll returns all non-overlapping matches of the pattern.
-// The count parameter limits the number of matches; -1 means no limit.
-func (p *Provider) FindAll(pattern, text string, count int) ([]string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-	return re.FindAllString(text, count), nil
-}
-
-// FindSubmatch returns the first match and its submatches.
-// Returns nil if no match is found.
-func (p *Provider) FindSubmatch(pattern, text string) ([]string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-	return re.FindStringSubmatch(text), nil
-}
-
-// FindAllSubmatch returns all matches with their submatches.
-// The count parameter limits the number of matches; -1 means no limit.
-func (p *Provider) FindAllSubmatch(pattern, text string, count int) ([][]string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-	return re.FindAllStringSubmatch(text, count), nil
-}
-
-// Replace replaces all matches of the pattern with the replacement string.
-// The replacement can include $1, $2, etc. for submatch references.
-func (p *Provider) Replace(pattern, text, replacement string) (string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return "", err
-	}
-	return re.ReplaceAllString(text, replacement), nil
-}
-
-// ReplaceLiteral replaces all matches with the literal replacement string
-// (no submatch expansion).
-func (p *Provider) ReplaceLiteral(pattern, text, replacement string) (string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return "", err
-	}
-	return re.ReplaceAllLiteralString(text, replacement), nil
-}
-
-// Split splits the text around matches of the pattern.
-// The count parameter limits the number of substrings; -1 means no limit.
-func (p *Provider) Split(pattern, text string, count int) ([]string, error) {
-	re, err := p.compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-	return re.Split(text, count), nil
-}
+// endregion

--- a/pkg/op/provider/starcode/provider.go
+++ b/pkg/op/provider/starcode/provider.go
@@ -32,6 +32,15 @@ type Provider struct {
 // If includeBzl is true, .bzl files are included alongside .star files.
 //
 // +devlore:defaults gitignore=true,includeBzl=true
+//
+// Parameters:
+//   - pattern: the glob pattern to match (supports **).
+//   - gitignore: when true, skip files excluded by .gitignore rules.
+//   - includeBzl: when true, include .bzl files alongside .star files.
+//
+// Returns:
+//   - *Sources: the captured file set with root and sorted paths.
+//   - error: non-nil if the root directory cannot be resolved or the walk fails.
 func (p *Provider) Capture(pattern string, gitignore, includeBzl bool) (*Sources, error) {
 	root := p.Root
 	if root == "" {
@@ -76,6 +85,9 @@ type Sources struct {
 }
 
 // Paths returns the file paths relative to Root.
+//
+// Returns:
+//   - []string: relative paths for all captured files.
 func (s *Sources) Paths() []string {
 	paths := make([]string, len(s.Files))
 	for i, f := range s.Files {
@@ -90,6 +102,9 @@ func (s *Sources) Paths() []string {
 }
 
 // Count returns the number of captured files.
+//
+// Returns:
+//   - int: the file count.
 func (s *Sources) Count() int {
 	return len(s.Files)
 }
@@ -99,6 +114,14 @@ func (s *Sources) Count() int {
 // If withGlobals is true, top-level assignments are captured.
 //
 // +devlore:defaults withDocstrings=true,withGlobals=true
+//
+// Parameters:
+//   - withDocstrings: when true, extract function docstrings.
+//   - withGlobals: when true, capture top-level assignments.
+//
+// Returns:
+//   - *starindex.Index: the parsed index with functions, loads, and globals.
+//   - error: non-nil if parsing fails.
 func (s *Sources) Index(withDocstrings, withGlobals bool) (*starindex.Index, error) {
 	return (&starindex.Provider{Root: s.Root}).IndexFiles(s.Files, withDocstrings, withGlobals)
 }
@@ -108,6 +131,14 @@ func (s *Sources) Index(withDocstrings, withGlobals bool) (*starindex.Index, err
 // If withLOC is true, line counts (LOC, SLOC, comments, blanks) are included.
 //
 // +devlore:defaults withBytes=true,withLOC=true
+//
+// Parameters:
+//   - withBytes: when true, include byte counts.
+//   - withLOC: when true, include line counts (LOC, SLOC, comments, blanks).
+//
+// Returns:
+//   - *starstats.Stats: the computed statistics.
+//   - error: non-nil if stat computation fails.
 func (s *Sources) Stats(withBytes, withLOC bool) (*starstats.Stats, error) {
 	return (&starstats.Provider{Root: s.Root}).ComputeStats(s.Files, withBytes, withLOC)
 }
@@ -115,11 +146,29 @@ func (s *Sources) Stats(withBytes, withLOC bool) (*starstats.Stats, error) {
 // Analyze performs a combined analysis of all captured files.
 //
 // +devlore:struct_param cfg=staranalysis.AnalysisConfig
+//
+// Parameters:
+//   - cfg: the analysis configuration.
+//
+// Returns:
+//   - *staranalysis.AnalysisReport: the combined analysis report.
+//   - error: non-nil if analysis fails.
 func (s *Sources) Analyze(cfg staranalysis.AnalysisConfig) (*staranalysis.AnalysisReport, error) {
 	return (&staranalysis.Provider{Root: s.Root}).Analyze(s.Files, cfg)
 }
 
-// captureRecursive walks the tree using file.Provider.WalkTree and matches files against the glob pattern.
+// captureRecursive walks the tree using file.Provider.WalkTree and matches
+// files against the glob pattern.
+//
+// Parameters:
+//   - absRoot: the absolute root directory to walk.
+//   - pattern: the glob pattern to match (may contain **).
+//   - honorGitignore: when true, skip files excluded by .gitignore.
+//   - includeBzl: when true, include .bzl files alongside .star files.
+//
+// Returns:
+//   - []string: absolute paths of matched files.
+//   - error: non-nil if the walk fails.
 func captureRecursive(absRoot, pattern string, honorGitignore, includeBzl bool) ([]string, error) {
 	var files []string
 
@@ -155,6 +204,16 @@ func captureRecursive(absRoot, pattern string, honorGitignore, includeBzl bool) 
 }
 
 // captureFlat uses filepath.Glob for non-recursive patterns.
+//
+// Parameters:
+//   - absRoot: the absolute root directory.
+//   - pattern: the glob pattern to match.
+//   - tracker: optional gitignore tracker (nil to disable filtering).
+//   - includeBzl: when true, include .bzl files alongside .star files.
+//
+// Returns:
+//   - []string: absolute paths of matched files.
+//   - error: non-nil if the glob fails.
 func captureFlat(absRoot, pattern string, tracker *ignore.Tracker, includeBzl bool) ([]string, error) {
 	fullPattern := filepath.Join(absRoot, pattern)
 	matches, err := filepath.Glob(fullPattern)
@@ -187,6 +246,13 @@ func captureFlat(absRoot, pattern string, tracker *ignore.Tracker, includeBzl bo
 }
 
 // isStarlarkFile returns true if the path has a .star extension (or .bzl if includeBzl is true).
+//
+// Parameters:
+//   - path: the file path to check.
+//   - includeBzl: when true, .bzl files are also accepted.
+//
+// Returns:
+//   - bool: true if the file is a Starlark source file.
 func isStarlarkFile(path string, includeBzl bool) bool {
 	ext := filepath.Ext(path)
 	if ext == ".star" {
@@ -195,15 +261,30 @@ func isStarlarkFile(path string, includeBzl bool) bool {
 	return includeBzl && ext == ".bzl"
 }
 
-// flattenDoubleStar converts "**/*.star" to a pattern usable with filepath.Match by replacing "**/" with any prefix match.
-// This is a simplistic approach; matchRecursivePattern handles the more general case.
+// flattenDoubleStar converts "**/*.star" to a pattern usable with filepath.Match
+// by stripping the "**/" prefix. This is a simplistic approach;
+// matchRecursivePattern handles the more general case.
+//
+// Parameters:
+//   - pattern: the glob pattern containing **.
+//
+// Returns:
+//   - string: the flattened pattern.
 func flattenDoubleStar(pattern string) string {
 	// filepath.Match doesn't support **; strip the ** prefix and match only the base pattern portion.
 	return strings.ReplaceAll(pattern, "**/", "")
 }
 
-// matchRecursivePattern checks if relPath matches a ** glob pattern by matching the suffix portion after ** against
-// the path's suffix.
+// matchRecursivePattern checks if relPath matches a ** glob pattern by
+// matching the suffix portion after ** against the path's suffix.
+//
+// Parameters:
+//   - pattern: the glob pattern containing **.
+//   - relPath: the relative path to test.
+//
+// Returns:
+//   - bool: true if the path matches the pattern suffix.
+//   - error: non-nil if filepath.Match fails.
 func matchRecursivePattern(pattern, relPath string) (bool, error) {
 	// Split on ** and match the suffix
 	parts := strings.SplitN(pattern, "**", 2)

--- a/pkg/op/provider/ui/provider.go
+++ b/pkg/op/provider/ui/provider.go
@@ -45,45 +45,30 @@ type Provider struct {
 	Color bool
 }
 
-func (p *Provider) writer() io.Writer {
-	if p.Writer != nil {
-		return p.Writer
-	}
-	return os.Stderr
-}
+// region EXPORTED METHODS
 
-func (p *Provider) programName() string {
-	if p.ProgramName != "" {
-		return p.ProgramName
-	}
-	return "devlore"
-}
+// region Behaviors
 
-func (p *Provider) colorize(color, text string) string {
-	if p.Color {
-		return color + text + colorReset
-	}
-	return text
-}
+// Actions
 
 // Error reports a non-fatal problem to the user.
+//
+// Parameters:
+//   - msg: the error message to display.
 func (p *Provider) Error(msg string) {
+
 	if p.Silent {
 		return
 	}
 	fmt.Fprintf(p.writer(), "[%s] [%s] %s\n", p.programName(), p.colorize(colorRed, symbolError), msg) //nolint:errcheck // write to stderr
 }
 
-// Fail prints an error message and returns an error.
-func (p *Provider) Fail(msg string) error {
-	if !p.Silent {
-		fmt.Fprintf(p.writer(), "[%s] [%s] %s\n", p.programName(), p.colorize(colorRed, symbolError), msg) //nolint:errcheck // write to stderr
-	}
-	return fmt.Errorf("%s", msg)
-}
-
 // Note informs the user of progress.
+//
+// Parameters:
+//   - msg: the informational message to display.
 func (p *Provider) Note(msg string) {
+
 	if p.Silent {
 		return
 	}
@@ -91,7 +76,11 @@ func (p *Provider) Note(msg string) {
 }
 
 // Success confirms completion to the user.
+//
+// Parameters:
+//   - msg: the success message to display.
 func (p *Provider) Success(msg string) {
+
 	if p.Silent {
 		return
 	}
@@ -99,9 +88,82 @@ func (p *Provider) Success(msg string) {
 }
 
 // Warn alerts the user to a potential issue.
+//
+// Parameters:
+//   - msg: the warning message to display.
 func (p *Provider) Warn(msg string) {
+
 	if p.Silent {
 		return
 	}
 	fmt.Fprintf(p.writer(), "[%s] [%s] %s\n", p.programName(), p.colorize(colorYellow, symbolWarn), msg) //nolint:errcheck // write to stderr
 }
+
+// Fallible actions
+
+// Fail prints an error message and returns an error.
+//
+// Parameters:
+//   - msg: the error message to display and return.
+//
+// Returns:
+//   - error: an error wrapping msg.
+func (p *Provider) Fail(msg string) error {
+
+	if !p.Silent {
+		fmt.Fprintf(p.writer(), "[%s] [%s] %s\n", p.programName(), p.colorize(colorRed, symbolError), msg) //nolint:errcheck // write to stderr
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// endregion
+
+// endregion
+
+// region UNEXPORTED METHODS
+
+// region Behaviors
+
+// colorize wraps text in ANSI color codes when Color is enabled.
+//
+// Parameters:
+//   - color: the ANSI color escape sequence.
+//   - text: the text to colorize.
+//
+// Returns:
+//   - string: the colorized text, or plain text if Color is disabled.
+func (p *Provider) colorize(color, text string) string {
+
+	if p.Color {
+		return color + text + colorReset
+	}
+	return text
+}
+
+// programName returns the configured program name, defaulting to "devlore".
+//
+// Returns:
+//   - string: the program name prefix for messages.
+func (p *Provider) programName() string {
+
+	if p.ProgramName != "" {
+		return p.ProgramName
+	}
+	return "devlore"
+}
+
+// writer returns the configured writer, defaulting to os.Stderr.
+//
+// Returns:
+//   - io.Writer: the output destination.
+func (p *Provider) writer() io.Writer {
+
+	if p.Writer != nil {
+		return p.Writer
+	}
+	return os.Stderr
+}
+
+// endregion
+
+// endregion

--- a/pkg/op/receiver_reflect.go
+++ b/pkg/op/receiver_reflect.go
@@ -33,22 +33,7 @@ type ReflectedReceiver struct {
 	stack         *RecoveryStack   // optional; set via SetStack
 }
 
-// SetCatalog sets the resource catalog for immediate-mode dispatch.
-// When set, Resource results are shadowed in the catalog after each
-// successful method call.
-func (r *ReflectedReceiver) SetCatalog(c *ResourceCatalog) { r.catalog = c }
-
-// SetContext injects the execution Context into the receiver's underlying provider.
-// This allows immediate receivers to access Context-scoped services like RecoverySite.
-func (r *ReflectedReceiver) SetContext(ctx Context) {
-	if r.providerValue.Kind() == reflect.Ptr && !r.providerValue.IsNil() {
-		InitProvider(r.providerValue.Interface(), ctx)
-	}
-}
-
-// SetStack sets the recovery stack for immediate-mode dispatch.
-func (r *ReflectedReceiver) SetStack(s *RecoveryStack) { r.stack = s }
-
+// methodBridge pairs a snake_case method name with its Starlark bridge function.
 type methodBridge struct {
 	name   string
 	bridge builtinFunc
@@ -58,7 +43,15 @@ type methodBridge struct {
 // Params are looked up from the receiver params registry (populated by
 // RegisterReflectedActions during InitAll). Only methods listed in the
 // registered params are exposed. Compensate* methods are excluded.
+//
+// Parameters:
+//   - name: the receiver name exposed to Starlark.
+//   - provider: the Go struct to wrap (must be a pointer).
+//
+// Returns:
+//   - *ReflectedReceiver: the wrapped receiver with method bridges.
 func WrapReceiver(name string, provider any) *ReflectedReceiver {
+
 	entry, ok := lookupReceiverParams(reflect.TypeOf(provider))
 	if !ok {
 		panic(fmt.Sprintf("WrapReceiver(%s): no params registered — was RegisterReflectedActions called?", name))
@@ -100,10 +93,76 @@ func WrapReceiver(name string, provider any) *ReflectedReceiver {
 	return r
 }
 
+// region EXPORTED METHODS
+
+// region State management
+
+// SetCatalog sets the resource catalog for immediate-mode dispatch.
+// When set, Resource results are shadowed in the catalog after each
+// successful method call.
+//
+// Parameters:
+//   - c: the resource catalog to use.
+func (r *ReflectedReceiver) SetCatalog(c *ResourceCatalog) { r.catalog = c }
+
+// SetContext injects the execution Context into the receiver's underlying provider.
+// This allows immediate receivers to access Context-scoped services like RecoverySite.
+//
+// Parameters:
+//   - ctx: the execution context to inject.
+func (r *ReflectedReceiver) SetContext(ctx Context) {
+
+	if r.providerValue.Kind() == reflect.Ptr && !r.providerValue.IsNil() {
+		InitProvider(r.providerValue.Interface(), ctx)
+	}
+}
+
+// SetStack sets the recovery stack for immediate-mode dispatch.
+//
+// Parameters:
+//   - s: the recovery stack to use.
+func (r *ReflectedReceiver) SetStack(s *RecoveryStack) { r.stack = s }
+
+// endregion
+
+// region Behaviors
+
+// Actions
+
+// Attr implements starlark.HasAttrs.
+//
+// Parameters:
+//   - name: the attribute name to look up.
+//
+// Returns:
+//   - starlark.Value: the method builtin.
+//   - error: non-nil if the attribute does not exist.
+func (r *ReflectedReceiver) Attr(name string) (starlark.Value, error) {
+
+	if m, ok := r.methods[name]; ok {
+		return MakeAttr(r.Receiver.name+"."+name, m.bridge), nil
+	}
+	return nil, NoSuchAttrError(r.Receiver.name, name)
+}
+
+// AttrNames implements starlark.HasAttrs.
+//
+// Returns:
+//   - []string: sorted list of available method names.
+func (r *ReflectedReceiver) AttrNames() []string {
+
+	return r.attrList
+}
+
 // Override replaces a method's auto-generated bridge with a custom one.
 // Used for methods with unusual signatures (Callable params, variadic
 // args, non-zero defaults).
+//
+// Parameters:
+//   - name: the snake_case method name to override.
+//   - fn: the custom bridge function.
 func (r *ReflectedReceiver) Override(name string, fn builtinFunc) {
+
 	r.methods[name] = &methodBridge{
 		name:   name,
 		bridge: fn,
@@ -115,18 +174,11 @@ func (r *ReflectedReceiver) Override(name string, fn builtinFunc) {
 	}
 }
 
-// Attr implements starlark.HasAttrs.
-func (r *ReflectedReceiver) Attr(name string) (starlark.Value, error) {
-	if m, ok := r.methods[name]; ok {
-		return MakeAttr(r.Receiver.name+"."+name, m.bridge), nil
-	}
-	return nil, NoSuchAttrError(r.Receiver.name, name)
-}
+// endregion
 
-// AttrNames implements starlark.HasAttrs.
-func (r *ReflectedReceiver) AttrNames() []string {
-	return r.attrList
-}
+// endregion
+
+// ── Unexported free functions ───────────────────────────────────────────────
 
 // buildMethodBridge creates a builtinFunc that bridges a Go method to Starlark.
 // The receiver parameter provides optional catalog/stack integration —
@@ -136,6 +188,17 @@ func (r *ReflectedReceiver) AttrNames() []string {
 // Remaining positional Starlark args are collected into the variadic slot.
 // The keyword form (parts=["a","b"]) is also accepted as a fallback.
 // Supplying both positional and keyword args for a variadic param is an error.
+//
+// Parameters:
+//   - receiverName: the qualified receiver name for error messages.
+//   - providerVal: the reflected provider value.
+//   - method: the Go method to bridge.
+//   - snakeName: the snake_case method name.
+//   - paramNames: Starlark parameter names (with "?" for optional, "*" for variadic).
+//   - receiver: the ReflectedReceiver for catalog/stack integration.
+//
+// Returns:
+//   - builtinFunc: the Starlark-callable bridge function.
 func buildMethodBridge(
 	receiverName string,
 	providerVal reflect.Value,
@@ -144,6 +207,7 @@ func buildMethodBridge(
 	paramNames []string,
 	receiver *ReflectedReceiver,
 ) builtinFunc {
+
 	methodType := method.Type
 
 	// Separate named params from the variadic param (at most one, always last).
@@ -269,6 +333,23 @@ func buildMethodBridge(
 }
 
 // callNonVariadic handles the common case: no variadic params.
+//
+// Parameters:
+//   - receiverName: the qualified receiver name for error messages.
+//   - providerVal: the reflected provider value.
+//   - method: the Go method to call.
+//   - methodType: the method's reflect.Type.
+//   - snakeName: the snake_case method name.
+//   - paramNames: Starlark parameter names.
+//   - numParams: the number of parameters.
+//   - receiver: the ReflectedReceiver for catalog/stack integration.
+//   - thread: the Starlark thread.
+//   - args: positional Starlark arguments.
+//   - kwargs: keyword Starlark arguments.
+//
+// Returns:
+//   - starlark.Value: the marshaled return value.
+//   - error: non-nil if the call fails.
 func callNonVariadic(
 	receiverName string,
 	providerVal reflect.Value,
@@ -282,6 +363,7 @@ func callNonVariadic(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	// 1. Unpack Starlark args into starlark.Value slots.
 	vals := make([]starlark.Value, numParams)
 	pairs := make([]any, 0, numParams*2)
@@ -353,12 +435,20 @@ func callNonVariadic(
 //
 //	()                         → None
 //	(error)                    → None or error
-//	(T)                        → marshal(T)
-//	(T, error)                 → marshal(T) or error
-//	(T, map[string]any, error) → marshal(T), discard undo state, or error
-//	(T, *RecoveryStack, error) → marshal(T), discard stack, or error
+//	(T)                        → Marshal(T)
+//	(T, error)                 → Marshal(T) or error
+//	(T, map[string]any, error) → Marshal(T), discard undo state, or error
+//	(T, *RecoveryStack, error) → Marshal(T), discard stack, or error
 //	(NoResult, ...)            → None (sentinel for no-output methods)
+//
+// Parameters:
+//   - results: the Go method return values.
+//
+// Returns:
+//   - starlark.Value: the marshaled first return value (or None).
+//   - error: non-nil if the method returned an error.
 func classifyReturn(results []reflect.Value) (starlark.Value, error) {
+
 	n := len(results)
 	if n == 0 {
 		return starlark.None, nil

--- a/pkg/op/receiver_reflect_test.go
+++ b/pkg/op/receiver_reflect_test.go
@@ -345,7 +345,7 @@ func TestCall_CompensableReturn(t *testing.T) {
 	r := wrapTestReceiver("test", &testProvider{}, testParams)
 	result := callMethod(t, r, "write", starlark.String("/tmp/f"), starlark.String("data"))
 
-	// Compensable methods return (T, map, error). Bridge returns marshal(T),
+	// Compensable methods return (T, map, error). Bridge returns Marshal(T),
 	// discarding the compensation state.
 	s, ok := starlark.AsString(result)
 	if !ok || s != "/tmp/f" {

--- a/pkg/op/starlark_runtime.go
+++ b/pkg/op/starlark_runtime.go
@@ -17,7 +17,14 @@ type StarlarkRuntime struct {
 
 // NewStarlarkRuntime creates a runtime with the given configuration.
 // Receivers listed in cfg.Receivers are included when BuildReceivers is called.
+//
+// Parameters:
+//   - cfg: configuration specifying which receivers to include.
+//
+// Returns:
+//   - *StarlarkRuntime: the initialized runtime.
 func NewStarlarkRuntime(cfg BindingConfig) *StarlarkRuntime {
+
 	included := make(map[string]bool, len(cfg.Receivers))
 	for _, name := range cfg.Receivers {
 		included[name] = true
@@ -28,32 +35,48 @@ func NewStarlarkRuntime(cfg BindingConfig) *StarlarkRuntime {
 	}
 }
 
+// region EXPORTED METHODS
+
+// region State management
+
+// Included reports whether the named provider is in the receiver set.
+//
+// Parameters:
+//   - name: the provider name to check.
+//
+// Returns:
+//   - bool: true if the provider is included in this runtime's receiver set.
+func (rt *StarlarkRuntime) Included(name string) bool {
+
+	return rt.included[name]
+}
+
+// endregion
+
+// region Behaviors
+
 // Initialize registers all providers' actions with the registry and stores the context
 // for later receiver initialization.
+//
+// Parameters:
+//   - reg: the action registry to populate.
+//   - ctx: the base execution context for provider initialization.
 func (rt *StarlarkRuntime) Initialize(reg *ActionRegistry, ctx ContextBase) {
+
 	rt.ctx = Context{ContextBase: ctx}
 	InitAll(reg, rt.ctx)
 }
 
-// BuildReceivers constructs immediate receivers for providers listed in cfg.Receivers.
-// Returns a StringDict suitable for merging into Starlark globals.
-func (rt *StarlarkRuntime) BuildReceivers() starlark.StringDict {
-	globals := starlark.StringDict{}
-	for _, p := range Providers() {
-		if !rt.included[p.Name()] {
-			continue
-		}
-		if recv := rt.buildOne(p); recv != nil {
-			globals[p.Name()] = recv
-		}
-	}
-	return globals
-}
-
 // BuildReceiver constructs a single immediate receiver by provider name.
-// Returns the receiver and true, or nil and false if the provider is not
-// found or does not implement ImmediateProvider.
+//
+// Parameters:
+//   - name: the provider name to build.
+//
+// Returns:
+//   - starlark.Value: the constructed receiver, or nil if not found.
+//   - bool: true if the provider was found and implements ImmediateProvider.
 func (rt *StarlarkRuntime) BuildReceiver(name string) (starlark.Value, bool) {
+
 	for _, p := range Providers() {
 		if p.Name() != name {
 			continue
@@ -66,13 +89,41 @@ func (rt *StarlarkRuntime) BuildReceiver(name string) (starlark.Value, bool) {
 	return nil, false
 }
 
-// Included reports whether the named provider is in the receiver set.
-func (rt *StarlarkRuntime) Included(name string) bool {
-	return rt.included[name]
+// BuildReceivers constructs immediate receivers for providers listed in cfg.Receivers.
+//
+// Returns:
+//   - starlark.StringDict: receiver map suitable for merging into Starlark globals.
+func (rt *StarlarkRuntime) BuildReceivers() starlark.StringDict {
+
+	globals := starlark.StringDict{}
+	for _, p := range Providers() {
+		if !rt.included[p.Name()] {
+			continue
+		}
+		if recv := rt.buildOne(p); recv != nil {
+			globals[p.Name()] = recv
+		}
+	}
+	return globals
 }
 
+// endregion
+
+// endregion
+
+// region UNEXPORTED METHODS
+
+// region Behaviors
+
 // buildOne constructs an immediate receiver from a provider, injecting context if available.
+//
+// Parameters:
+//   - p: the provider to construct a receiver from.
+//
+// Returns:
+//   - starlark.Value: the constructed receiver, or nil if the provider is not immediate.
 func (rt *StarlarkRuntime) buildOne(p Provider) starlark.Value {
+
 	ip, ok := p.(ImmediateProvider)
 	if !ok {
 		return nil
@@ -83,3 +134,7 @@ func (rt *StarlarkRuntime) buildOne(p Provider) starlark.Value {
 	}
 	return recv
 }
+
+// endregion
+
+// endregion

--- a/pkg/op/starvalue_marshal.go
+++ b/pkg/op/starvalue_marshal.go
@@ -26,6 +26,9 @@ var constructorRegistry sync.Map
 
 // RegisterConstructor registers a function that constructs a Go value
 // from a simpler representation (e.g., string → Blob via NewBlob).
+//
+// Parameters:
+//   - fn: constructor function converting any → (T, error).
 func RegisterConstructor[T any](fn func(any) (T, error)) {
 	t := reflect.TypeOf((*T)(nil)).Elem()
 	constructorRegistry.Store(t, func(v any) (any, error) {
@@ -34,8 +37,13 @@ func RegisterConstructor[T any](fn func(any) (T, error)) {
 }
 
 // Construct uses the constructor registry to convert value to type T.
-// Returns an error if no constructor is registered for T or if the
-// constructor rejects the value.
+//
+// Parameters:
+//   - value: the value to convert via the registered constructor.
+//
+// Returns:
+//   - T: the constructed value.
+//   - error: non-nil if no constructor is registered for T or if it rejects the value.
 func Construct[T any](value any) (T, error) {
 	t := reflect.TypeOf((*T)(nil)).Elem()
 	ctor, ok := loadConstructor(t)
@@ -53,6 +61,14 @@ func Construct[T any](value any) (T, error) {
 
 // constructResource creates a Resource using the constructor registry.
 // Returns nil, false if no constructor exists for the given type.
+//
+// Parameters:
+//   - targetType: the reflect.Type to construct.
+//   - value: the input value to pass to the constructor.
+//
+// Returns:
+//   - Resource: the constructed resource, or nil.
+//   - bool: true if construction succeeded.
 func constructResource(targetType reflect.Type, value any) (Resource, bool) {
 	ctor, ok := loadConstructor(targetType)
 	if !ok {
@@ -84,6 +100,7 @@ func constructResource(targetType reflect.Type, value any) (Resource, bool) {
 // type, it calls WrapReceiver instead of flattening to fields.
 var receiverParamsRegistry sync.Map
 
+// receiverEntry pairs a provider name with its method parameter metadata.
 type receiverEntry struct {
 	name   string
 	params MethodParams
@@ -93,12 +110,22 @@ type receiverEntry struct {
 // Called by RegisterReflectedActions as a side effect for providers with
 // actions, and directly by immediate-only providers in their Register()
 // callback.
+//
+// Parameters:
+//   - name: the provider name.
+//   - provider: the provider instance (pointer to struct).
+//   - params: maps Go method names to Starlark parameter name lists.
 func RegisterReceiverParams(name string, provider any, params MethodParams) {
 	registerReceiverParamsReflect(name, provider, params)
 }
 
 // registerReceiverParamsReflect stores receiver params using the runtime
 // reflect.Type of the provider pointer.
+//
+// Parameters:
+//   - name: the provider name.
+//   - provider: the provider instance (pointer to struct).
+//   - params: maps Go method names to Starlark parameter name lists.
 func registerReceiverParamsReflect(name string, provider any, params MethodParams) {
 	t := reflect.TypeOf(provider)
 	if t.Kind() == reflect.Ptr {
@@ -108,6 +135,13 @@ func registerReceiverParamsReflect(name string, provider any, params MethodParam
 }
 
 // lookupReceiverParams returns the receiver entry for the given type.
+//
+// Parameters:
+//   - t: the reflect.Type to look up (pointer or struct).
+//
+// Returns:
+//   - receiverEntry: the stored entry.
+//   - bool: true if found.
 func lookupReceiverParams(t reflect.Type) (receiverEntry, bool) {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -125,12 +159,14 @@ func lookupReceiverParams(t reflect.Type) (receiverEntry, bool) {
 // Computed once per type, concurrent-safe, amortized O(1) lookups.
 var typeCache sync.Map
 
+// typeInfo caches struct introspection results for Starlark field mapping.
 type typeInfo struct {
 	fields   []fieldInfo
 	attrList []string              // sorted Starlark attribute names
 	byName   map[string]*fieldInfo // starlark name → field
 }
 
+// fieldInfo maps a single exported Go struct field to its Starlark name.
 type fieldInfo struct {
 	index    int
 	starName string
@@ -139,6 +175,12 @@ type fieldInfo struct {
 
 // getTypeInfo returns cached struct metadata for the given type.
 // If t is a pointer type, the element type is used.
+//
+// Parameters:
+//   - t: the reflect.Type to introspect (pointer or struct).
+//
+// Returns:
+//   - *typeInfo: the cached field metadata.
 func getTypeInfo(t reflect.Type) *typeInfo {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
@@ -190,6 +232,12 @@ func getTypeInfo(t reflect.Type) *typeInfo {
 
 // camelToSnake converts a CamelCase identifier to snake_case.
 // Consecutive uppercase letters are treated as an acronym (e.g., "XMLParser" → "xml_parser").
+//
+// Parameters:
+//   - s: the CamelCase identifier to convert.
+//
+// Returns:
+//   - string: the snake_case equivalent.
 func camelToSnake(s string) string {
 	runes := []rune(s)
 	var b strings.Builder
@@ -215,11 +263,18 @@ func camelToSnake(s string) string {
 
 // --- Marshal (Go → Starlark) ---
 
-// marshal converts a Go value to a starlark.Value.
-// Structs become starlarkstruct.Struct. Primitives, slices, maps, and
-// pointers are handled recursively. Values already implementing
-// starlark.Value pass through unchanged.
-func marshal(v any) (starlark.Value, error) {
+// Marshal converts a Go value to a [starlark.Value].
+//
+// Structs become starlarkstruct.Struct. Primitives, slices, maps, and pointers are handled recursively.
+// Values already implementing starlark.Value pass through unchanged.
+//
+// Parameters:
+//   - v: the Go value to convert. Nil returns [starlark.None].
+//
+// Returns:
+//   - starlark.Value: the converted Starlark value.
+//   - error: non-nil if v contains an unsupported type (e.g., channels, funcs).
+func Marshal(v any) (starlark.Value, error) {
 	if v == nil {
 		return starlark.None, nil
 	}
@@ -229,6 +284,16 @@ func marshal(v any) (starlark.Value, error) {
 	return marshalReflect(reflect.ValueOf(v))
 }
 
+// marshalReflect converts a reflect.Value to a starlark.Value.
+// Pointer-to-struct types registered in the receiver params registry are
+// wrapped as ReflectedReceivers; all others are dispatched by kind.
+//
+// Parameters:
+//   - rv: the reflect.Value to convert.
+//
+// Returns:
+//   - starlark.Value: the converted Starlark value.
+//   - error: non-nil if rv contains an unsupported type.
 func marshalReflect(rv reflect.Value) (starlark.Value, error) {
 	// Check receiver params registry for pointer-to-struct types.
 	// Registered types get wrapped as ReflectedReceivers (with methods)
@@ -306,6 +371,14 @@ func marshalReflect(rv reflect.Value) (starlark.Value, error) {
 	}
 }
 
+// marshalSlice converts a reflect.Value slice to a starlark.List.
+//
+// Parameters:
+//   - rv: the reflect.Value of kind Slice to convert.
+//
+// Returns:
+//   - starlark.Value: the converted Starlark list.
+//   - error: non-nil if any element cannot be marshaled.
 func marshalSlice(rv reflect.Value) (starlark.Value, error) {
 	if rv.IsNil() {
 		return starlark.NewList(nil), nil
@@ -321,6 +394,14 @@ func marshalSlice(rv reflect.Value) (starlark.Value, error) {
 	return starlark.NewList(elems), nil
 }
 
+// marshalMap converts a reflect.Value map to a starlark.Dict.
+//
+// Parameters:
+//   - rv: the reflect.Value of kind Map to convert.
+//
+// Returns:
+//   - starlark.Value: the converted Starlark dict.
+//   - error: non-nil if any key or value cannot be marshaled.
 func marshalMap(rv reflect.Value) (starlark.Value, error) {
 	if rv.IsNil() {
 		return starlark.NewDict(0), nil
@@ -343,6 +424,15 @@ func marshalMap(rv reflect.Value) (starlark.Value, error) {
 	return dict, nil
 }
 
+// marshalStruct converts a reflect.Value struct to a starlarkstruct.Struct.
+// Exported fields are mapped to Starlark attributes using snake_case names.
+//
+// Parameters:
+//   - rv: the reflect.Value of kind Struct to convert.
+//
+// Returns:
+//   - starlark.Value: the converted Starlark struct.
+//   - error: non-nil if any field cannot be marshaled.
 func marshalStruct(rv reflect.Value) (starlark.Value, error) {
 	info := getTypeInfo(rv.Type())
 	dict := make(starlark.StringDict, len(info.fields))
@@ -360,11 +450,60 @@ func marshalStruct(rv reflect.Value) (starlark.Value, error) {
 
 // --- Unmarshal (Starlark → Go) ---
 
+// UnmarshalToAny converts a [starlark.Value] to a native Go value without a specific target type.
+//
+// Returns string, int, bool, float64, nil, []any (or []string for homogeneous string lists),
+// or map[string]any.
+//
+// Parameters:
+//   - sv: the Starlark value to convert.
+//
+// Returns:
+//   - any: the native Go value.
+//   - error: non-nil if sv contains an unsupported Starlark type.
+func UnmarshalToAny(sv starlark.Value) (any, error) {
+
+	switch v := sv.(type) {
+	case starlark.NoneType:
+		return nil, nil
+	case starlark.String:
+		return string(v), nil
+	case starlark.Int:
+		i, ok := v.Int64()
+		if !ok {
+			return nil, fmt.Errorf("unmarshal: int value out of range")
+		}
+		return int(i), nil
+	case starlark.Bool:
+		return bool(v), nil
+	case starlark.Float:
+		return float64(v), nil
+	case starlark.Bytes:
+		return []byte(v), nil
+	case *starlark.List:
+		return unmarshalListToAny(v)
+	case *starlark.Dict:
+		return unmarshalDictToAny(v)
+	case *starlarkstruct.Struct:
+		return unmarshalStructToAny(v)
+	default:
+		return nil, fmt.Errorf("unmarshal: unsupported starlark type %s", sv.Type())
+	}
+}
+
 // unmarshal populates a Go value from a starlark.Value.
 // target must be a non-nil pointer. For *any targets, native Go types
 // (string, int, bool, float64, nil, []any, map[string]any) are returned.
 // For struct targets, starlarkstruct.Struct fields are matched by name.
+//
+// Parameters:
+//   - sv: the Starlark value to convert.
+//   - target: a non-nil pointer to the Go value to populate.
+//
+// Returns:
+//   - error: non-nil if the conversion fails or target is not a pointer.
 func unmarshal(sv starlark.Value, target any) error {
+
 	rv := reflect.ValueOf(target)
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return fmt.Errorf("unmarshal: target must be a non-nil pointer, got %T", target)
@@ -372,10 +511,19 @@ func unmarshal(sv starlark.Value, target any) error {
 	return unmarshalValue(sv, rv.Elem())
 }
 
+// unmarshalValue recursively converts a Starlark value into a reflect.Value target.
+//
+// Parameters:
+//   - sv: the Starlark value to convert.
+//   - rv: the reflect.Value to populate (must be settable).
+//
+// Returns:
+//   - error: non-nil if the conversion fails.
 func unmarshalValue(sv starlark.Value, rv reflect.Value) error {
+
 	// Handle *any target: generic conversion.
 	if rv.Kind() == reflect.Interface {
-		val, err := unmarshalToAny(sv)
+		val, err := UnmarshalToAny(sv)
 		if err != nil {
 			return err
 		}
@@ -416,7 +564,7 @@ func unmarshalValue(sv starlark.Value, rv reflect.Value) error {
 			}
 		}
 		if !alreadyTarget {
-			native, err := unmarshalToAny(sv)
+			native, err := UnmarshalToAny(sv)
 			if err != nil {
 				return err
 			}
@@ -515,38 +663,15 @@ func unmarshalValue(sv starlark.Value, rv reflect.Value) error {
 	}
 }
 
-// unmarshalToAny converts a Starlark value to a native Go value without
-// a specific target type. Returns string, int, bool, float64, nil,
-// []any (or []string for homogeneous string lists), or map[string]any.
-func unmarshalToAny(sv starlark.Value) (any, error) {
-	switch v := sv.(type) {
-	case starlark.NoneType:
-		return nil, nil
-	case starlark.String:
-		return string(v), nil
-	case starlark.Int:
-		i, ok := v.Int64()
-		if !ok {
-			return nil, fmt.Errorf("unmarshal: int value out of range")
-		}
-		return int(i), nil
-	case starlark.Bool:
-		return bool(v), nil
-	case starlark.Float:
-		return float64(v), nil
-	case starlark.Bytes:
-		return []byte(v), nil
-	case *starlark.List:
-		return unmarshalListToAny(v)
-	case *starlark.Dict:
-		return unmarshalDictToAny(v)
-	case *starlarkstruct.Struct:
-		return unmarshalStructToAny(v)
-	default:
-		return nil, fmt.Errorf("unmarshal: unsupported starlark type %s", sv.Type())
-	}
-}
-
+// unmarshalListToAny converts a starlark.List to a native Go slice.
+// Returns []string for homogeneous string lists, []any otherwise.
+//
+// Parameters:
+//   - list: the Starlark list to convert.
+//
+// Returns:
+//   - any: the native Go slice ([]string or []any).
+//   - error: non-nil if any element cannot be converted.
 func unmarshalListToAny(list *starlark.List) (any, error) {
 	n := list.Len()
 	if n == 0 {
@@ -572,7 +697,7 @@ func unmarshalListToAny(list *starlark.List) (any, error) {
 
 	result := make([]any, n)
 	for i := range n {
-		val, err := unmarshalToAny(list.Index(i))
+		val, err := UnmarshalToAny(list.Index(i))
 		if err != nil {
 			return nil, fmt.Errorf("list index %d: %w", i, err)
 		}
@@ -581,6 +706,14 @@ func unmarshalListToAny(list *starlark.List) (any, error) {
 	return result, nil
 }
 
+// unmarshalDictToAny converts a starlark.Dict to a map[string]any.
+//
+// Parameters:
+//   - dict: the Starlark dict to convert.
+//
+// Returns:
+//   - map[string]any: the native Go map.
+//   - error: non-nil if any key is not a string or any value cannot be converted.
 func unmarshalDictToAny(dict *starlark.Dict) (map[string]any, error) {
 	result := make(map[string]any, dict.Len())
 	for _, item := range dict.Items() {
@@ -588,7 +721,7 @@ func unmarshalDictToAny(dict *starlark.Dict) (map[string]any, error) {
 		if !ok {
 			return nil, fmt.Errorf("dict key must be string, got %s", item[0].Type())
 		}
-		val, err := unmarshalToAny(item[1])
+		val, err := UnmarshalToAny(item[1])
 		if err != nil {
 			return nil, fmt.Errorf("dict key %q: %w", key, err)
 		}
@@ -597,6 +730,14 @@ func unmarshalDictToAny(dict *starlark.Dict) (map[string]any, error) {
 	return result, nil
 }
 
+// unmarshalStructToAny converts a starlarkstruct.Struct to a map[string]any.
+//
+// Parameters:
+//   - s: the Starlark struct to convert.
+//
+// Returns:
+//   - map[string]any: the native Go map keyed by attribute names.
+//   - error: non-nil if any attribute cannot be converted.
 func unmarshalStructToAny(s *starlarkstruct.Struct) (map[string]any, error) {
 	names := s.AttrNames()
 	result := make(map[string]any, len(names))
@@ -605,7 +746,7 @@ func unmarshalStructToAny(s *starlarkstruct.Struct) (map[string]any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("struct attr %q: %w", name, err)
 		}
-		val, err := unmarshalToAny(v)
+		val, err := UnmarshalToAny(v)
 		if err != nil {
 			return nil, fmt.Errorf("struct attr %q: %w", name, err)
 		}
@@ -614,6 +755,14 @@ func unmarshalStructToAny(s *starlarkstruct.Struct) (map[string]any, error) {
 	return result, nil
 }
 
+// unmarshalSlice converts a starlark.List into a typed Go slice via reflection.
+//
+// Parameters:
+//   - list: the Starlark list to convert.
+//   - rv: the reflect.Value of kind Slice to populate.
+//
+// Returns:
+//   - error: non-nil if any element cannot be unmarshaled.
 func unmarshalSlice(list *starlark.List, rv reflect.Value) error {
 	n := list.Len()
 	slice := reflect.MakeSlice(rv.Type(), n, n)
@@ -626,6 +775,14 @@ func unmarshalSlice(list *starlark.List, rv reflect.Value) error {
 	return nil
 }
 
+// unmarshalMap converts a starlark.Dict into a typed Go map via reflection.
+//
+// Parameters:
+//   - dict: the Starlark dict to convert.
+//   - rv: the reflect.Value of kind Map to populate.
+//
+// Returns:
+//   - error: non-nil if any key or value cannot be unmarshaled.
 func unmarshalMap(dict *starlark.Dict, rv reflect.Value) error {
 	m := reflect.MakeMapWithSize(rv.Type(), dict.Len())
 	keyType := rv.Type().Key()
@@ -646,6 +803,15 @@ func unmarshalMap(dict *starlark.Dict, rv reflect.Value) error {
 	return nil
 }
 
+// unmarshalStruct converts a starlarkstruct.Struct or starlark.Dict into a
+// typed Go struct via reflection. Fields are matched by Starlark name.
+//
+// Parameters:
+//   - sv: the Starlark value (must be *starlarkstruct.Struct or *starlark.Dict).
+//   - rv: the reflect.Value of kind Struct to populate.
+//
+// Returns:
+//   - error: non-nil if sv is neither a struct nor dict, or if any field fails.
 func unmarshalStruct(sv starlark.Value, rv reflect.Value) error {
 	info := getTypeInfo(rv.Type())
 
@@ -707,8 +873,17 @@ type CallableInput struct {
 // registry for callable extraction.
 var callableResourceType = reflect.TypeOf((*CallableResource)(nil)).Elem()
 
-// extractCallable looks up the callable constructor from the registry and extracts the given Starlark function. The mem
-// package registers a constructor via AnnounceResource that handles extraction and compilation.
+// extractCallable looks up the callable constructor from the registry and
+// extracts the given Starlark function. The mem package registers a constructor
+// via AnnounceResource that handles extraction and compilation.
+//
+// Parameters:
+//   - fn: the Starlark function to extract.
+//   - funcType: the Go func type name for signature validation.
+//
+// Returns:
+//   - CallableResource: the extracted callable resource.
+//   - error: non-nil if no extractor is registered or extraction fails.
 func extractCallable(fn *starlark.Function, funcType string) (CallableResource, error) {
 
 	ctor, ok := loadConstructor(callableResourceType)
@@ -723,12 +898,24 @@ func extractCallable(fn *starlark.Function, funcType string) (CallableResource, 
 }
 
 // isCallableResource returns true if the value implements CallableResource.
+//
+// Parameters:
+//   - v: the value to check.
+//
+// Returns:
+//   - bool: true if v implements CallableResource.
 func isCallableResource(v any) bool {
 	_, ok := v.(CallableResource)
 	return ok
 }
 
 // isFuncType returns true if the reflect.Type is a function type.
+//
+// Parameters:
+//   - t: the reflect.Type to check.
+//
+// Returns:
+//   - bool: true if t.Kind() is reflect.Func.
 func isFuncType(t reflect.Type) bool {
 	return t.Kind() == reflect.Func
 }
@@ -737,6 +924,15 @@ func isFuncType(t reflect.Type) bool {
 // func-typed method parameters, initializes them, and replaces the slot
 // value with an adapted Go function. This runs in Do() before coerceArgs
 // so the standard coercion path sees a directly-assignable func value.
+//
+// Parameters:
+//   - ctx: the execution context (provides the Starlark thread).
+//   - slots: the slot map to scan and mutate in place.
+//   - methodType: the Go method's reflect.Type for parameter introspection.
+//   - paramNames: the Starlark parameter names matching the method signature.
+//
+// Returns:
+//   - error: non-nil if callable initialization or adaptation fails.
 func initCallableSlots(ctx *Context, slots map[string]any, methodType reflect.Type, paramNames []string) error {
 	for i, name := range paramNames {
 		callable, ok := slots[name].(CallableResource)
@@ -770,7 +966,14 @@ func initCallableSlots(ctx *Context, slots map[string]any, methodType reflect.Ty
 // Go→Starlark and passed to the callable. The callable must match the
 // full signature of the Go func type. Returns are unmarshaled Starlark→Go.
 //
-// Target func signature: func(p0 T0, p1 T1, ...) (R0, R1, ...)
+// Parameters:
+//   - fn: the Starlark callable to wrap.
+//   - thread: the Starlark thread for function calls.
+//   - targetType: the Go func reflect.Type to produce.
+//
+// Returns:
+//   - any: the adapted Go function value matching targetType.
+//   - error: non-nil if adaptation fails.
 func buildCallableFunc(fn starlark.Callable, thread *starlark.Thread, targetType reflect.Type) (any, error) {
 	numIn := targetType.NumIn()
 	numOut := targetType.NumOut()
@@ -780,7 +983,7 @@ func buildCallableFunc(fn starlark.Callable, thread *starlark.Thread, targetType
 		// Marshal all Go args → Starlark.
 		starArgs := make(starlark.Tuple, numIn)
 		for i := range numIn {
-			sv, err := marshal(args[i].Interface())
+			sv, err := Marshal(args[i].Interface())
 			if err != nil {
 				return makeErrorReturn(targetType, numOut,
 					fmt.Errorf("callable arg %d: marshal: %w", i, err))
@@ -804,6 +1007,14 @@ func buildCallableFunc(fn starlark.Callable, thread *starlark.Thread, targetType
 
 // makeErrorReturn builds a reflect.Value slice for an error return.
 // Convention: the last return is error; preceding returns are zero values.
+//
+// Parameters:
+//   - funcType: the Go func reflect.Type for return type introspection.
+//   - numOut: the number of return values.
+//   - err: the error to place in the last return slot.
+//
+// Returns:
+//   - []reflect.Value: zero values for all returns except the last, which holds err.
 func makeErrorReturn(funcType reflect.Type, numOut int, err error) []reflect.Value {
 	out := make([]reflect.Value, numOut)
 	for i := range numOut - 1 {
@@ -816,8 +1027,16 @@ func makeErrorReturn(funcType reflect.Type, numOut int, err error) []reflect.Val
 }
 
 // unmarshalReturn converts a Starlark result into the target func's return
-// values. Convention: first return is the result (via unmarshalToAny), last
+// values. Convention: first return is the result (via UnmarshalToAny), last
 // return is error (nil on success). Middle returns are zero values.
+//
+// Parameters:
+//   - funcType: the Go func reflect.Type for return type introspection.
+//   - numOut: the number of return values.
+//   - result: the Starlark value to unmarshal into the first return slot.
+//
+// Returns:
+//   - []reflect.Value: the populated return values.
 func unmarshalReturn(funcType reflect.Type, numOut int, result starlark.Value) []reflect.Value {
 	out := make([]reflect.Value, numOut)
 
@@ -832,7 +1051,7 @@ func unmarshalReturn(funcType reflect.Type, numOut int, result starlark.Value) [
 
 	// First return is the result value.
 	if numOut >= 1 {
-		goVal, err := unmarshalToAny(result)
+		goVal, err := UnmarshalToAny(result)
 		if err != nil {
 			return makeErrorReturn(funcType, numOut, err)
 		}

--- a/pkg/op/starvalue_marshal_test.go
+++ b/pkg/op/starvalue_marshal_test.go
@@ -52,23 +52,23 @@ func Test_camelToSnake(t *testing.T) {
 // --- Marshal tests ---
 
 func TestMarshal_Nil(t *testing.T) {
-	got, err := marshal(nil)
+	got, err := Marshal(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got != starlark.None {
-		t.Errorf("marshal(nil) = %v, want None", got)
+		t.Errorf("Marshal(nil) = %v, want None", got)
 	}
 }
 
 func TestMarshal_StarlarkValue(t *testing.T) {
 	sv := starlark.String("pass-through")
-	got, err := marshal(sv)
+	got, err := Marshal(sv)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got != sv {
-		t.Errorf("marshal(starlark.Value) did not pass through")
+		t.Errorf("Marshal(starlark.Value) did not pass through")
 	}
 }
 
@@ -89,9 +89,9 @@ func TestMarshal_Primitives(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := marshal(tt.input)
+			got, err := Marshal(tt.input)
 			if err != nil {
-				t.Fatalf("marshal(%v) error: %v", tt.input, err)
+				t.Fatalf("Marshal(%v) error: %v", tt.input, err)
 			}
 			if got.Type() != tt.wantType {
 				t.Errorf("type = %q, want %q", got.Type(), tt.wantType)
@@ -105,9 +105,9 @@ func TestMarshal_Primitives(t *testing.T) {
 
 func TestMarshal_FileMode(t *testing.T) {
 	mode := os.FileMode(0o755)
-	got, err := marshal(mode)
+	got, err := Marshal(mode)
 	if err != nil {
-		t.Fatalf("marshal(FileMode) error: %v", err)
+		t.Fatalf("Marshal(FileMode) error: %v", err)
 	}
 	si, ok := got.(starlark.Int)
 	if !ok {
@@ -120,7 +120,7 @@ func TestMarshal_FileMode(t *testing.T) {
 }
 
 func TestMarshal_Bytes(t *testing.T) {
-	got, err := marshal([]byte("raw data"))
+	got, err := Marshal([]byte("raw data"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestMarshal_Bytes(t *testing.T) {
 }
 
 func TestMarshal_StringSlice(t *testing.T) {
-	got, err := marshal([]string{"a", "b", "c"})
+	got, err := Marshal([]string{"a", "b", "c"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestMarshal_StringSlice(t *testing.T) {
 }
 
 func TestMarshal_IntSlice(t *testing.T) {
-	got, err := marshal([]int{1, 2, 3})
+	got, err := Marshal([]int{1, 2, 3})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestMarshal_IntSlice(t *testing.T) {
 
 func TestMarshal_NilSlice(t *testing.T) {
 	var s []string
-	got, err := marshal(s)
+	got, err := Marshal(s)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestMarshal_NilSlice(t *testing.T) {
 }
 
 func TestMarshal_Map(t *testing.T) {
-	got, err := marshal(map[string]any{"name": "test", "count": 5})
+	got, err := Marshal(map[string]any{"name": "test", "count": 5})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestMarshal_Map(t *testing.T) {
 
 func TestMarshal_NilMap(t *testing.T) {
 	var m map[string]any
-	got, err := marshal(m)
+	got, err := Marshal(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestMarshal_NilMap(t *testing.T) {
 
 func TestMarshal_Pointer(t *testing.T) {
 	s := "hello"
-	got, err := marshal(&s)
+	got, err := Marshal(&s)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestMarshal_Pointer(t *testing.T) {
 
 func TestMarshal_NilPointer(t *testing.T) {
 	var s *string
-	got, err := marshal(s)
+	got, err := Marshal(s)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -259,7 +259,7 @@ type testWithTag struct {
 
 func TestMarshal_SimpleStruct(t *testing.T) {
 	p := testPoint{X: 10, Y: 20}
-	got, err := marshal(p)
+	got, err := Marshal(p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestMarshal_NestedStruct(t *testing.T) {
 		Location: &testPoint{X: 1, Y: 2},
 		Tags:     []string{"dev", "go"},
 	}
-	got, err := marshal(p)
+	got, err := Marshal(p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestMarshal_NilNestedStruct(t *testing.T) {
 		Age:      25,
 		Location: nil,
 	}
-	got, err := marshal(p)
+	got, err := Marshal(p)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestMarshal_StructTags(t *testing.T) {
 		Hidden:   "secret",
 		Normal:   42,
 	}
-	got, err := marshal(v)
+	got, err := Marshal(v)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestMarshal_StructTags(t *testing.T) {
 
 func TestMarshal_UnsupportedType(t *testing.T) {
 	ch := make(chan int)
-	_, err := marshal(ch)
+	_, err := Marshal(ch)
 	if err == nil {
 		t.Fatal("expected error for unsupported type")
 	}
@@ -708,7 +708,7 @@ func TestUnmarshal_NonPointerTarget(t *testing.T) {
 
 func TestRoundTrip_SimpleStruct(t *testing.T) {
 	original := testPoint{X: 42, Y: 99}
-	sv, err := marshal(original)
+	sv, err := Marshal(original)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
@@ -728,7 +728,7 @@ func TestRoundTrip_NestedStruct(t *testing.T) {
 		Location: &testPoint{X: 3, Y: 4},
 		Tags:     []string{"go", "dev"},
 	}
-	sv, err := marshal(original)
+	sv, err := Marshal(original)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestRoundTrip_Map(t *testing.T) {
 		"count": 5,
 		"flag":  true,
 	}
-	sv, err := marshal(original)
+	sv, err := Marshal(original)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Export `marshal` → `Marshal` and `unmarshalToAny` → `UnmarshalToAny` in `pkg/op/starvalue_marshal.go` so noblefactor-ops can replace its parallel `starlarkToGo`/`goToStarlark` implementations
- Update all internal call sites (`pkg/op/output.go`, `pkg/op/receiver_reflect.go`, test files)
- Add §4-compliant doc comments (Parameters/Returns) to all exported methods and unexported helpers across all 14 production files touched in Phases 1-4
- Add doc comments to unexported struct types (`receiverEntry`, `typeInfo`, `fieldInfo`)

Part of the [shared-provider-receivers plan](https://github.com/NobleFactor/noblefactor-ops/blob/develop/docs/plans/shared-provider-receivers.md). Phases 1-3 merged in #210, #211. Phase 5 follows.

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all packages)
- [ ] CI passes