### PR TITLE
feature(op): BindingConfig builder pattern, WithGraphBuilder (Phase 4a)

### DIFF
--- a/internal/e2e/testrunner/runner.go
+++ b/internal/e2e/testrunner/runner.go
@@ -74,6 +74,7 @@ func WithWriter(w io.Writer) Option {
 }
 
 // WithReceivers sets the Starlark namespaces to expose as globals.
+// If "plan" is included, it is extracted and handled via WithGraphBuilder.
 //
 // Parameters:
 //   - names: the receiver names to expose.
@@ -81,18 +82,35 @@ func WithWriter(w io.Writer) Option {
 // Returns:
 //   - Option: a runner option that sets the receiver list.
 func WithReceivers(names ...string) Option {
-	return func(r *Runner) { r.receivers = names }
+	return func(r *Runner) {
+		for _, name := range names {
+			if name == "plan" {
+				r.withGraphBuilder = true
+			} else {
+				r.receivers = append(r.receivers, name)
+			}
+		}
+	}
+}
+
+// WithGraphBuilder enables the plan.* graph namespace.
+//
+// Returns:
+//   - Option: a runner option that enables the graph builder.
+func WithGraphBuilder() Option {
+	return func(r *Runner) { r.withGraphBuilder = true }
 }
 
 // Runner orchestrates a single test script execution.
 type Runner struct {
-	script    string
-	dryRun    bool
-	trace     bool
-	provider  string
-	writer    io.Writer
-	receivers []string
-	graph     *op.Graph
+	script           string
+	dryRun           bool
+	trace            bool
+	provider         string
+	writer           io.Writer
+	receivers        []string
+	withGraphBuilder bool
+	graph            *op.Graph
 }
 
 // Graph returns the execution graph after Start completes. Returns nil before Start is called.
@@ -139,11 +157,13 @@ func (r *Runner) Start(ctx context.Context) (*Result, error) {
 	defer os.RemoveAll(tmpDir)
 
 	// 2. Create Runtime with requested receivers
-	bs := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      r.writer,
-		ProgramName: "devlore-test",
-		Receivers:   r.receivers,
-	})
+	cfg := op.NewBindingConfig("devlore-test").
+		WithReceivers(r.receivers...).
+		WithWriter(r.writer)
+	if r.withGraphBuilder {
+		cfg.WithGraphBuilder()
+	}
+	bs := loreStar.NewRuntime(cfg)
 
 	// 3. Create ActionRegistry with all provider actions
 	reg := op.NewActionRegistry()

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -441,12 +441,13 @@ func prepareScriptEnv(
 	*loreStar.PackageContext,
 	error, //nolint:unparam // error return reserved for future use
 ) {
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      os.Stdout,
-		ProgramName: "lore",
-		Color:       true,
-		Receivers:   []string{"ui", "plan"},
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("lore").
+			WithGraphBuilder().
+			WithReceivers("ui").
+			WithWriter(os.Stdout).
+			WithColor(),
+	)
 
 	globals := rt.BuildGlobals(graph, pkg.Name, reg)
 

--- a/internal/starlark/integration_test.go
+++ b/internal/starlark/integration_test.go
@@ -29,12 +29,11 @@ import (
 func TestLoadIntegration(t *testing.T) {
 	t.Skip("https://github.com/NobleFactor/devlore-cli/issues/172")
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-		Receivers:   []string{"ui"},
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithReceivers("ui").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -74,11 +73,10 @@ func TestLoadIntegration(t *testing.T) {
 
 // TestLoadIntegrationUnknownModule verifies that loading an unknown module produces a clear error.
 func TestLoadIntegrationUnknownModule(t *testing.T) {
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -106,11 +104,10 @@ func TestLoadIntegrationUnknownModule(t *testing.T) {
 
 // TestLoadIntegrationBadPrefix verifies that a non-@devlore// load fails.
 func TestLoadIntegrationBadPrefix(t *testing.T) {
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()

--- a/internal/starlark/runtime.go
+++ b/internal/starlark/runtime.go
@@ -33,7 +33,7 @@ type loaderEntry struct {
 //
 // Returns:
 //   - *Runtime: the initialized runtime.
-func NewRuntime(cfg op.BindingConfig) *Runtime {
+func NewRuntime(cfg *op.BindingConfig) *Runtime {
 
 	return &Runtime{
 		StarlarkRuntime: op.NewStarlarkRuntime(cfg),
@@ -74,7 +74,7 @@ func (rt *Runtime) BuildGlobals(graph *op.Graph, project string, reg *op.ActionR
 	globals := rt.BuildReceivers()
 
 	// Build "plan" if requested.
-	if rt.Included("plan") {
+	if rt.HasGraphBuilder() {
 		planned := collectPlannedProviders()
 		if len(planned) > 0 {
 			globals["plan"] = NewPlanRootFromProviders(graph, project, reg, planned)

--- a/internal/starlark/runtime_test.go
+++ b/internal/starlark/runtime_test.go
@@ -74,11 +74,10 @@ func (p *rtTestCountingImmProvider) NewImmediate(_ op.BindingConfig) starlark.Va
 func TestRuntimeRegisterActions(t *testing.T) {
 	op.Announce(&rtTestActionProvider{actionName: "_test_actions.do"})
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	reg := op.NewActionRegistry()
 	rt.RegisterActions(reg, op.Context{})
@@ -92,11 +91,10 @@ func TestRuntimeRegisterActionsAlwaysRegistersAll(t *testing.T) {
 	op.Announce(&rtTestAllActsProvider{})
 
 	// No Receivers — but actions should still be registered.
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	reg := op.NewActionRegistry()
 	rt.RegisterActions(reg, op.Context{})
@@ -110,23 +108,23 @@ func TestRuntimeBuildGlobalsWithPlanAndImmediate(t *testing.T) {
 	op.Announce(&rtTestPlannedProvider{name: "_test_plan2"})
 	op.Announce(&rtTestImmediateProvider{name: "_test_imm2"})
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-		Receivers:   []string{"plan", "_test_imm2"},
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithGraphBuilder().
+			WithReceivers("_test_imm2").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
 	globals := rt.BuildGlobals(graph, "test-project", reg)
 
-	// "plan" should be present (requested via Receivers).
+	// "plan" should be present (requested via WithGraphBuilder).
 	if _, ok := globals["plan"]; !ok {
 		t.Error("expected 'plan' in globals")
 	}
 
-	// "_test_imm2" should be present (requested via Receivers).
+	// "_test_imm2" should be present (requested via WithReceivers).
 	if _, ok := globals["_test_imm2"]; !ok {
 		t.Error("expected '_test_imm2' in globals")
 	}
@@ -149,12 +147,11 @@ func TestRuntimeBuildGlobalsOnlyIncludesReceivers(t *testing.T) {
 	op.Announce(&rtTestImmediateProvider{name: "_test_not_included"})
 
 	// Don't include "_test_not_included" in Receivers.
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-		Receivers:   []string{"ui"},
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithReceivers("ui").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -164,20 +161,19 @@ func TestRuntimeBuildGlobalsOnlyIncludesReceivers(t *testing.T) {
 		t.Error("expected '_test_not_included' to NOT be in globals (not in Receivers)")
 	}
 
-	// plan should also not be present (not in Receivers).
+	// plan should also not be present (WithGraphBuilder not called).
 	if _, ok := globals["plan"]; ok {
-		t.Error("expected 'plan' to NOT be in globals (not in Receivers)")
+		t.Error("expected 'plan' to NOT be in globals (WithGraphBuilder not called)")
 	}
 }
 
 func TestRuntimeConfigureThreadEnablesLoad(t *testing.T) {
 	op.Announce(&rtTestImmediateProvider{name: "_test_loadable"})
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -203,11 +199,10 @@ func TestRuntimeConfigureThreadEnablesLoad(t *testing.T) {
 }
 
 func TestRuntimeLoaderRejectsUnknownPrefix(t *testing.T) {
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -221,11 +216,10 @@ func TestRuntimeLoaderRejectsUnknownPrefix(t *testing.T) {
 }
 
 func TestRuntimeLoaderRejectsUnknownProvider(t *testing.T) {
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -242,11 +236,10 @@ func TestRuntimeLoaderCachesResults(t *testing.T) {
 	callCount := 0
 	op.Announce(&rtTestCountingImmProvider{name: "_test_cached", callCount: &callCount})
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()
@@ -265,11 +258,10 @@ func TestRuntimeLoaderCachesResults(t *testing.T) {
 func TestRuntimeLoaderLoadsPlan(t *testing.T) {
 	op.Announce(&rtTestPlannedProvider{name: "_test_plan_load"})
 
-	rt := loreStar.NewRuntime(op.BindingConfig{
-		Writer:      &bytes.Buffer{},
-		ProgramName: "test",
-		Color:       false,
-	})
+	rt := loreStar.NewRuntime(
+		op.NewBindingConfig("test").
+			WithWriter(&bytes.Buffer{}),
+	)
 
 	graph := &op.Graph{}
 	reg := op.NewActionRegistry()

--- a/pkg/op/binding_config.go
+++ b/pkg/op/binding_config.go
@@ -3,27 +3,103 @@
 
 package op
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
 // BindingConfig holds configuration for constructing Starlark bindings.
-// Passed to ImmediateProvider.NewImmediate so immediate receivers can write
-// output and identify the running program.
+// Use [NewBindingConfig] to create, then chain With* methods:
+//
+//	cfg := op.NewBindingConfig("lore").
+//	    WithGraphBuilder().
+//	    WithReceivers("ui", "file").
+//	    WithColor()
 type BindingConfig struct {
-	// Writer is the output destination for immediate receivers (e.g., ui.note).
-	Writer io.Writer
-
 	// ProgramName identifies the running tool (e.g., "lore", "writ").
 	ProgramName string
 
+	// Receivers lists the Starlark namespaces to expose as globals.
+	// Provider names (e.g., "file", "ui") include their immediate receivers.
+	Receivers []string
+
+	// GraphBuilder enables the plan.* graph namespace (PlanRoot).
+	GraphBuilder bool
+
+	// Writer is the output destination for immediate receivers (e.g., ui.note).
+	// Defaults to os.Stderr.
+	Writer io.Writer
+
 	// Color enables ANSI color codes in output.
 	Color bool
-
-	// Platform provides platform abstractions (package manager, service manager)
-	// for providers that need them in immediate mode.
-	Platform *Platform
-
-	// Receivers lists the Starlark namespaces to expose as globals.
-	// "plan" includes the PlanRoot aggregate; provider names (e.g., "file", "ui")
-	// include their immediate receivers.
-	Receivers []string
 }
+
+// NewBindingConfig creates a BindingConfig with the given program name.
+// Writer defaults to os.Stderr.
+//
+// Parameters:
+//   - programName: the name of the running tool (e.g., "lore", "writ").
+//
+// Returns:
+//   - *BindingConfig: the initialized config.
+func NewBindingConfig(programName string) *BindingConfig {
+
+	return &BindingConfig{
+		ProgramName: programName,
+		Writer:      os.Stderr,
+	}
+}
+
+// region EXPORTED METHODS
+
+// region State management
+
+// WithGraphBuilder enables the plan.* graph namespace in the runtime.
+//
+// Returns:
+//   - *BindingConfig: the config for method chaining.
+func (c *BindingConfig) WithGraphBuilder() *BindingConfig {
+
+	c.GraphBuilder = true
+	return c
+}
+
+// WithReceivers sets the Starlark namespaces to expose as globals.
+//
+// Parameters:
+//   - names: the receiver names to expose.
+//
+// Returns:
+//   - *BindingConfig: the config for method chaining.
+func (c *BindingConfig) WithReceivers(names ...string) *BindingConfig {
+
+	c.Receivers = names
+	return c
+}
+
+// WithWriter sets the output destination for immediate receivers.
+//
+// Parameters:
+//   - w: the output writer.
+//
+// Returns:
+//   - *BindingConfig: the config for method chaining.
+func (c *BindingConfig) WithWriter(w io.Writer) *BindingConfig {
+
+	c.Writer = w
+	return c
+}
+
+// WithColor enables ANSI color codes in output.
+//
+// Returns:
+//   - *BindingConfig: the config for method chaining.
+func (c *BindingConfig) WithColor() *BindingConfig {
+
+	c.Color = true
+	return c
+}
+
+// endregion
+
+// endregion

--- a/pkg/op/starlark_runtime.go
+++ b/pkg/op/starlark_runtime.go
@@ -10,7 +10,7 @@ import "go.starlark.net/starlark"
 // External consumers (e.g., noblefactor-ops) use this to obtain framework-managed receivers
 // without hand-coding receiver construction.
 type StarlarkRuntime struct {
-	cfg      BindingConfig
+	cfg      *BindingConfig
 	included map[string]bool
 	ctx      Context // stored by Initialize for receiver context injection
 }
@@ -23,7 +23,7 @@ type StarlarkRuntime struct {
 //
 // Returns:
 //   - *StarlarkRuntime: the initialized runtime.
-func NewStarlarkRuntime(cfg BindingConfig) *StarlarkRuntime {
+func NewStarlarkRuntime(cfg *BindingConfig) *StarlarkRuntime {
 
 	included := make(map[string]bool, len(cfg.Receivers))
 	for _, name := range cfg.Receivers {
@@ -49,6 +49,15 @@ func NewStarlarkRuntime(cfg BindingConfig) *StarlarkRuntime {
 func (rt *StarlarkRuntime) Included(name string) bool {
 
 	return rt.included[name]
+}
+
+// HasGraphBuilder reports whether the plan.* graph namespace is enabled.
+//
+// Returns:
+//   - bool: true if the graph builder is included.
+func (rt *StarlarkRuntime) HasGraphBuilder() bool {
+
+	return rt.cfg.GraphBuilder
 }
 
 // endregion
@@ -128,7 +137,7 @@ func (rt *StarlarkRuntime) buildOne(p Provider) starlark.Value {
 	if !ok {
 		return nil
 	}
-	recv := ip.NewImmediate(rt.cfg)
+	recv := ip.NewImmediate(*rt.cfg)
 	if rr, ok := recv.(*ReflectedReceiver); ok && rt.ctx.Root != nil {
 		rr.SetContext(rt.ctx)
 	}


### PR DESCRIPTION
## Summary
- Rewrite BindingConfig as builder pattern: `NewBindingConfig("name").WithGraphBuilder().WithReceivers(...).WithColor()`
- Replace `"plan"` magic string in Receivers with `WithGraphBuilder()` boolean capability flag
- Remove Platform from BindingConfig (executor option, not a binding concern)
- Writer defaults to `os.Stderr` in constructor
- Add `HasGraphBuilder()` to StarlarkRuntime
- Update all call sites and tests

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] All call sites updated to builder pattern
- [x] Style compliance audit against Go style guidelines