### PR TITLE
refactor(star): Rename go.* to goast.* in Starlark scripts

### DIFF
--- a/docs/plans/binding-unification/phase-2.md
+++ b/docs/plans/binding-unification/phase-2.md
@@ -9,33 +9,33 @@ net, and content from top-level PlanRoot builtins to sub-namespaces.
 
 ## API Changes
 
-| Old API | New API |
-|---------|---------|
-| `plan.service("nginx", "start")` | `plan.service.start("nginx")` |
-| `plan.shell("command")` | `plan.shell.exec("command")` |
-| `plan.download(url)` | `plan.net.download(url)` |
-| `plan.literal(content)` | `plan.content.literal(content)` |
+| Old API                          | New API                         |
+|----------------------------------|---------------------------------|
+| `plan.service("nginx", "start")` | `plan.service.start("nginx")`   |
+| `plan.shell("command")`          | `plan.shell.exec("command")`    |
+| `plan.download(url)`             | `plan.net.download(url)`        |
+| `plan.literal(content)`          | `plan.content.literal(content)` |
 
 PlanRoot keeps only `plan.source(path)` and `plan.gather(...)` as top-level
 builtins (graph construction primitives, not resource operations).
 
 ## Files
 
-| File | Action |
-|------|--------|
-| `plan_file_gen.go` | Generate (replaces plan_file.go) |
-| `plan_package_gen.go` | Generate (replaces plan_package.go) |
-| `plan_encryption_gen.go` | Generate (replaces plan_encryption.go) |
-| `plan_template_gen.go` | Generate (replaces plan_template.go) |
-| `plan_service_gen.go` | Generate (new) |
-| `plan_shell_gen.go` | Generate (new) |
-| `plan_net_gen.go` | Generate (new) |
-| `plan_content_gen.go` | Generate (new) |
-| `plan_file.go` | Delete |
-| `plan_package.go` | Delete |
-| `plan_encryption.go` | Delete |
-| `plan_template.go` | Delete |
-| `plan_root.go` | Modify: add sub-namespaces, remove builtins |
+| File                     | Action                                      |
+|--------------------------|---------------------------------------------|
+| `plan_file_gen.go`       | Generate (replaces plan_file.go)            |
+| `plan_package_gen.go`    | Generate (replaces plan_package.go)         |
+| `plan_encryption_gen.go` | Generate (replaces plan_encryption.go)      |
+| `plan_template_gen.go`   | Generate (replaces plan_template.go)        |
+| `plan_service_gen.go`    | Generate (new)                              |
+| `plan_shell_gen.go`      | Generate (new)                              |
+| `plan_net_gen.go`        | Generate (new)                              |
+| `plan_content_gen.go`    | Generate (new)                              |
+| `plan_file.go`           | Delete                                      |
+| `plan_package.go`        | Delete                                      |
+| `plan_encryption.go`     | Delete                                      |
+| `plan_template.go`       | Delete                                      |
+| `plan_root.go`           | Modify: add sub-namespaces, remove builtins |
 
 ## Design Decisions
 

--- a/internal/execution/flow/planned.go
+++ b/internal/execution/flow/planned.go
@@ -11,28 +11,53 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// FlowPlan implements the plan.flow namespace for Starlark scripts.
-// Handwritten — flow actions have custom signatures that don't fit the
-// reflection-based WrapProviderInPlanningReceiver model.
-type FlowPlan struct {
+// Plan implements the plan.flow namespace for Starlark scripts. Handwritten — flow actions have custom signatures that
+// don't fit the reflection-based WrapProviderInPlanningReceiver model.
+type Plan struct {
 	graph   *op.Graph
 	project string
 	reg     *op.ActionRegistry
 }
 
-// NewFlowPlan creates a plan.flow namespace bound to the given graph.
-func NewFlowPlan(graph *op.Graph, project string, reg *op.ActionRegistry) *FlowPlan {
-	return &FlowPlan{graph: graph, project: project, reg: reg}
+// NewFlowPlan creates a [Plan] bound to the given graph.
+//
+// Parameters:
+//   - graph: the operation graph to populate
+//   - project: the project identifier
+//   - reg: the action registry for node creation
+//
+// Returns:
+//   - *Plan: the plan.flow namespace
+func NewFlowPlan(graph *op.Graph, project string, reg *op.ActionRegistry) *Plan {
+
+	return &Plan{graph: graph, project: project, reg: reg}
 }
 
-func (f *FlowPlan) String() string        { return "flow" }
-func (f *FlowPlan) Type() string          { return "flow" }
-func (f *FlowPlan) Freeze()               {}
-func (f *FlowPlan) Truth() starlark.Bool  { return true }
-func (f *FlowPlan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: flow") }
+// String implements [starlark.Value].
+func (f *Plan) String() string { return "flow" }
 
-// Attr implements starlark.HasAttrs.
-func (f *FlowPlan) Attr(name string) (starlark.Value, error) {
+// Type implements [starlark.Value].
+func (f *Plan) Type() string { return "flow" }
+
+// Freeze implements [starlark.Value].
+func (f *Plan) Freeze() {}
+
+// Truth implements [starlark.Value].
+func (f *Plan) Truth() starlark.Bool { return true }
+
+// Hash implements [starlark.Value].
+func (f *Plan) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: flow") }
+
+// Attr implements [starlark.HasAttrs].
+//
+// Parameters:
+//   - name: the attribute name to look up
+//
+// Returns:
+//   - starlark.Value: the builtin function for the attribute
+//   - error: if the attribute does not exist
+func (f *Plan) Attr(name string) (starlark.Value, error) {
+
 	switch name {
 	case "complete":
 		return starlark.NewBuiltin("flow.complete", f.complete), nil
@@ -45,14 +70,27 @@ func (f *FlowPlan) Attr(name string) (starlark.Value, error) {
 	}
 }
 
-// AttrNames implements starlark.HasAttrs.
-func (f *FlowPlan) AttrNames() []string {
+// AttrNames implements [starlark.HasAttrs].
+//
+// Returns:
+//   - []string: the available attribute names
+func (f *Plan) AttrNames() []string {
+
 	return []string{"complete", "degraded", "fatal"}
 }
 
 // complete creates a flow.complete terminal node in the graph.
+//
 // Usage: plan.flow.complete() or plan.flow.complete(output=value)
-func (f *FlowPlan) complete(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+//
+// Parameters:
+//   - args: positional arguments (unused)
+//   - kwargs: optional "output" keyword argument
+//
+// Returns:
+//   - starlark.Value: an [op.Output] promise for the terminal node
+//   - error: any error from slot filling
+func (f *Plan) complete(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var output starlark.Value = starlark.None
 
 	if err := starlark.UnpackArgs("complete", args, kwargs, "output?", &output); err != nil {
@@ -74,12 +112,20 @@ func (f *FlowPlan) complete(_ *starlark.Thread, _ *starlark.Builtin, args starla
 }
 
 // degraded creates a flow.degraded terminal node in the graph.
+//
 // Usage: plan.flow.degraded(format, *args, **kwargs)
 //
-// First positional arg is the format string. Remaining positional args
-// are packed into the "args" list slot. Keyword args are packed into
-// the "kwargs" dict slot. Promise values in any position create edges.
-func (f *FlowPlan) degraded(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// First positional arg is the format string. Remaining positional args are packed into the "args" list slot. Keyword
+// args are packed into the "kwargs" dict slot. Promise values in any position create edges.
+//
+// Parameters:
+//   - args: format string (required) followed by optional positional arguments
+//   - kwargs: optional keyword arguments for string formatting
+//
+// Returns:
+//   - starlark.Value: an [op.Output] promise for the terminal node
+//   - error: any error from slot filling
+func (f *Plan) degraded(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("degraded: missing required argument: format")
 	}
@@ -110,11 +156,19 @@ func (f *FlowPlan) degraded(_ *starlark.Thread, _ *starlark.Builtin, args starla
 }
 
 // fatal creates a flow.fatal terminal node in the graph.
+//
 // Usage: plan.flow.fatal(format, *args, **kwargs)
 //
-// Same signature as degraded. The action returns FatalError which halts
-// graph execution.
-func (f *FlowPlan) fatal(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// Same signature as degraded. The action returns FatalError which halts graph execution.
+//
+// Parameters:
+//   - args: format string (required) followed by optional positional arguments
+//   - kwargs: optional keyword arguments for string formatting
+//
+// Returns:
+//   - starlark.Value: an [op.Output] promise for the terminal node
+//   - error: any error from slot filling
+func (f *Plan) fatal(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("fatal: missing required argument: format")
 	}
@@ -141,8 +195,17 @@ func (f *FlowPlan) fatal(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 	return op.NewOutput(node, f.graph, ""), nil
 }
 
-// fillListSlot packs Starlark values into a list slot on a node.
-// Promise values create edges; immediates are stored directly.
+// fillListSlot packs Starlark values into indexed sub-slots on a node. Promise values create edges; immediates are
+// stored directly.
+//
+// Parameters:
+//   - node: the graph node to populate
+//   - graph: the operation graph for edge creation
+//   - slotName: base name for the indexed sub-slots (e.g., "args" → "args[0]", "args[1]")
+//   - values: the Starlark values to pack
+//
+// Returns:
+//   - error: any error from slot filling
 func fillListSlot(node *op.Node, graph *op.Graph, slotName string, values starlark.Tuple) error {
 	if len(values) == 0 {
 		return nil
@@ -157,8 +220,17 @@ func fillListSlot(node *op.Node, graph *op.Graph, slotName string, values starla
 	return nil
 }
 
-// fillDictSlot packs Starlark keyword tuples into a dict slot on a node.
-// Promise values create edges; immediates are stored directly.
+// fillDictSlot packs Starlark keyword tuples into keyed sub-slots on a node. Promise values create edges; immediates
+// are stored directly.
+//
+// Parameters:
+//   - node: the graph node to populate
+//   - graph: the operation graph for edge creation
+//   - slotName: base name for the keyed sub-slots (e.g., "kwargs" → "kwargs.key")
+//   - kwargs: the Starlark keyword tuples to pack
+//
+// Returns:
+//   - error: any error from slot filling
 func fillDictSlot(node *op.Node, graph *op.Graph, slotName string, kwargs []starlark.Tuple) error {
 	if len(kwargs) == 0 {
 		return nil

--- a/internal/lore/builder.go
+++ b/internal/lore/builder.go
@@ -298,6 +298,7 @@ func BuildFromPackages(packages []string, targetPlatform string) (*BuildResult, 
 // Returns:
 //   - error: non-nil if script execution or node building fails.
 func buildPackageNodes(graph *op.Graph, pkg *lorepackage.Release, targetPlatform string, cfg BuildConfig, reg *op.ActionRegistry) error { //nolint:gocognit
+
 	action := lorepackage.Deploy
 	phases := lorepackage.PhaseOrder(action)
 

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -3,8 +3,8 @@
 
 # generate.star - Generate receivers and actions from provider structs
 #
-# Reads a provider struct's methods via go.methods(), then calls
-# go.render() to produce planned receivers, graph actions, and
+# Reads a provider struct's methods via goast.methods(), then calls
+# goast.render() to produce planned receivers, graph actions, and
 # immediate receivers.
 #
 # The Provider struct carries directives:
@@ -125,7 +125,7 @@ def struct_access(path):
 
     Returns 'immediate' if no directive is found (the default).
     """
-    doc = go.type_doc(path)
+    doc = goast.type_doc(path)
     for line in doc.split("\n"):
         line = line.strip().lstrip("/").strip()
         if "+devlore:access=" in line:
@@ -141,7 +141,7 @@ def struct_lifetime(path):
 
     Returns 'stateless' if no directive is found (the default).
     """
-    doc = go.type_doc(path)
+    doc = goast.type_doc(path)
     for line in doc.split("\n"):
         line = line.strip().lstrip("/").strip()
         if "+devlore:lifetime=" in line:
@@ -199,7 +199,7 @@ def parse_bind_directives(path):
     Example: '+devlore:bind Root=WorkDir'
     → [{"name": "Root", "cfg_field": "WorkDir"}]
     """
-    doc = go.type_doc(path)
+    doc = goast.type_doc(path)
     result = []
     for line in doc.split("\n"):
         line = line.strip().lstrip("/").strip()
@@ -264,7 +264,7 @@ def resolve_struct_param(struct_type, structs_by_name, path):
 
     For local types (no "."), looks up in structs_by_name.
     For cross-package types (e.g., "staranalysis.AnalysisConfig"), resolves
-    by calling go.structs() on the sibling package.
+    by calling goast.structs() on the sibling package.
 
     Returns (struct_info, resolved_type) where resolved_type is the type name
     to use in generated code (may include package prefix for cross-package).
@@ -280,7 +280,7 @@ def resolve_struct_param(struct_type, structs_by_name, path):
     if not file.exists(sibling_path):
         fail("cross-package struct_param: sibling package path %s does not exist" % sibling_path)
 
-    sibling_structs = go.structs(sibling_path)
+    sibling_structs = goast.structs(sibling_path)
     for s in sibling_structs:
         if s.name == bare:
             return s, struct_type
@@ -291,7 +291,7 @@ def build_method_descriptors(methods, all_names, defaults_map, struct_param_map,
 
     defaults_map: method_name → {param_name: default_value}
     struct_param_map: method_name → {var_name: struct_type}
-    structs_by_name: struct_name → struct info from go.structs()
+    structs_by_name: struct_name → struct info from goast.structs()
     path: filesystem path to the package (for cross-package struct resolution)
     """
     descriptors = []
@@ -558,7 +558,7 @@ def collect_type_graph(path, provider_methods, structs_by_name):
         seen[type_name] = True
 
         # Check if this type has methods (→ dependent type with HasAttrs wrapper)
-        type_methods = go.methods(path, receiver_type=type_name)
+        type_methods = goast.methods(path, receiver_type=type_name)
         has_methods = False
         for m in type_methods:
             if m.name[0].isupper() and m.name not in SKIP_METHODS:
@@ -643,7 +643,7 @@ def detect_resource(path):
     Returns the constructor function name if found, or "" if no Resource struct
     or no matching constructor exists. Fails if multiple constructors match.
     """
-    structs = go.structs(path)
+    structs = goast.structs(path)
     has_resource = False
     for s in structs:
         if s.name == "Resource":
@@ -655,7 +655,7 @@ def detect_resource(path):
         return ""
 
     # Look for constructor function: func(any) (Resource, error)
-    funcs = go.funcs(path)
+    funcs = goast.funcs(path)
     constructor_name = ""
     for fn in funcs:
         if fn.returns != "(Resource, error)":
@@ -677,10 +677,10 @@ def detect_resource(path):
 def compute_provider_import(path):
     """Compute the Go import path for the provider package.
 
-    Uses go.deps() to get the module path, then finds go.mod to compute
+    Uses goast.deps() to get the module path, then finds go.mod to compute
     the relative package path.
     """
-    deps = go.deps(path)
+    deps = goast.deps(path)
     module_path = deps.module_path
 
     if not module_path:
@@ -733,7 +733,7 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
         # Build default and type maps from Provider struct inspection
         default_map = {}
         type_map = {}
-        structs = go.structs(path)
+        structs = goast.structs(path)
         for s in structs:
             if s.name == "Provider":
                 for f in s.fields:
@@ -750,7 +750,7 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
     # Require ProviderBase embedding
     # -------------------------------------------------------------------------
     embeds_provider_base = False
-    structs = go.structs(path)
+    structs = goast.structs(path)
     for s in structs:
         if s.name == "Provider":
             for f in s.fields:
@@ -762,7 +762,7 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
     # -------------------------------------------------------------------------
     # Parse defaults and struct_param directives from method docs
     # -------------------------------------------------------------------------
-    structs = go.structs(path)
+    structs = goast.structs(path)
     structs_by_name = {}
     for s in structs:
         structs_by_name[s.name] = s
@@ -790,7 +790,7 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
     # -------------------------------------------------------------------------
     dependent_descriptors = {}
     for type_name in dependent_types:
-        type_methods = go.methods(path, receiver_type=type_name)
+        type_methods = goast.methods(path, receiver_type=type_name)
         filtered, dep_all_names = filter_methods(type_methods, [])
 
         # Parse defaults and struct_param for dependent type methods
@@ -819,7 +819,7 @@ def generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, li
     # -------------------------------------------------------------------------
     # Re-build Provider method descriptors with defaults/struct_param applied
     # -------------------------------------------------------------------------
-    all_methods_raw = go.methods(path, receiver_type=struct_name)
+    all_methods_raw = goast.methods(path, receiver_type=struct_name)
     filtered_raw, all_names_raw = filter_methods(all_methods_raw, [])
     provider_method_descs = build_method_descriptors(
         filtered_raw, all_names_raw, defaults_map, struct_param_map, structs_by_name, path,
@@ -988,7 +988,7 @@ def annotate_result_exprs(descriptors, data_structs, provider_prefix):
             desc["result_expr"] = converter + "(%s)"
 
 # =============================================================================
-# Pre-computation Helpers for go.render()
+# Pre-computation Helpers for goast.render()
 # =============================================================================
 
 def compute_provider_type_prefix(desc):
@@ -1000,7 +1000,7 @@ def compute_provider_type_prefix(desc):
 def compute_param_names_list(method):
     """Pre-compute the quoted, comma-separated parameter name list for a method.
 
-    Replicates templateFuncParamNamesList from codegen.go.
+    Replicates templateFuncParamNamesList from codegen.goast.
     Optional params get '?' suffix. Variadic params get '*' prefix.
     """
     parts = []
@@ -1016,7 +1016,7 @@ def compute_param_names_list(method):
 def compute_provider_init(desc):
     """Pre-compute the ImmediateFactory body code.
 
-    Replicates templateFuncProviderInit from codegen.go.
+    Replicates templateFuncProviderInit from codegen.goast.
     Generates the Go code that constructs the provider from BindingConfig
     and delegates to New<StructName><WrapperSuffix>.
     """
@@ -1107,7 +1107,7 @@ def compute_descriptor_init(desc):
     return "\n".join(lines)
 
 def prepare_render_data(descriptor, template_name):
-    """Prepare a descriptor dict for go.render().
+    """Prepare a descriptor dict for goast.render().
 
     Pre-computes template function values and adds derived fields.
     Returns render_data.
@@ -1146,9 +1146,9 @@ def gen_file(ctx, template_name, descriptor, filename, label, method_count, outp
     ui.note("Generating %s for %s (%d items)..." % (template_name, label, method_count))
     template_content = load_template(template_name, ctx.extension.dir)
 
-    # Pre-compute template values and render via go.render()
+    # Pre-compute template values and render via goast.render()
     render_data = prepare_render_data(descriptor, template_name)
-    code = go.render(template=template_content, data=render_data)
+    code = goast.render(template=template_content, data=render_data)
 
     if write_files and output_dir:
         out_path = output_dir + "/" + filename
@@ -1184,7 +1184,7 @@ def run(ctx):
     # -------------------------------------------------------------------------
     # Discover Provider methods (may be absent for resource-only packages)
     # -------------------------------------------------------------------------
-    methods = go.methods(path, receiver_type=struct_name)
+    methods = goast.methods(path, receiver_type=struct_name)
     has_provider = len(methods) > 0
 
     if has_provider:

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/validate.star
@@ -64,19 +64,19 @@ def run(ctx):
 def _parse_devlore_api(path):
     """Parse devlore-cli Starlark API from Go source files.
 
-    Uses go.methods() and go.calls() to extract:
+    Uses goast.methods() and goast.calls() to extract:
     - Binding names from Attr methods (via NewBuiltin calls)
     - Handler details: doc, slots, operations, output
     - StringDict violations (non-Attr NewBuiltin registrations)
     """
-    attr_methods = go.methods(path, name="Attr")
+    attr_methods = goast.methods(path, name="Attr")
     bindings = {}
     seen = {}
 
     for attr_method in attr_methods:
         # Look for both direct NewBuiltin and MakeAttr (which wraps NewBuiltin)
         for call_name in ["NewBuiltin", "MakeAttr"]:
-            builtin_calls = go.calls(attr_method.scope, name=call_name)
+            builtin_calls = goast.calls(attr_method.scope, name=call_name)
             for call in builtin_calls:
                 args = list(call.args)
                 if len(args) < 2:
@@ -93,12 +93,12 @@ def _parse_devlore_api(path):
                     bindings[binding_name] = binding
 
     # Detect StringDict violations
-    all_methods = go.methods(path)
+    all_methods = goast.methods(path)
     violations = []
     for method in all_methods:
         if str(method.name) == "Attr":
             continue
-        nb_calls = go.calls(method.scope, name="NewBuiltin")
+        nb_calls = goast.calls(method.scope, name="NewBuiltin")
         for call in nb_calls:
             args = list(call.args)
             if len(args) < 1:
@@ -171,7 +171,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
     if not handler_name:
         return {"file": fallback_file, "line": fallback_line}
 
-    handler_methods = go.methods(path, name=handler_name)
+    handler_methods = goast.methods(path, name=handler_name)
     if len(list(handler_methods)) == 0:
         return {"file": fallback_file, "line": fallback_line}
 
@@ -183,7 +183,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
     # Extract slots from FillSlot calls
     slots = []
     slot_seen = {}
-    fill_calls = go.calls(scope, name="FillSlot")
+    fill_calls = goast.calls(scope, name="FillSlot")
     for call in fill_calls:
         args = list(call.args)
         if len(args) >= 3:
@@ -194,7 +194,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
 
     # Extract operations from execution.Node composites
     operations = []
-    node_composites = go.composites(scope, type="execution.Node")
+    node_composites = goast.composites(scope, type="execution.Node")
     for comp in node_composites:
         ops_field = getattr(comp.fields, "Operations", None)
         if ops_field:
@@ -205,7 +205,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
 
     # Detect output type
     output = "none"
-    output_calls = go.calls(scope, name="NewOutput")
+    output_calls = goast.calls(scope, name="NewOutput")
     if len(list(output_calls)) > 0:
         output = "promise"
 

--- a/star/extensions/com.noblefactor.devlore.Actions/extension.yaml
+++ b/star/extensions/com.noblefactor.devlore.Actions/extension.yaml
@@ -5,9 +5,9 @@ extension: com.noblefactor.devlore.Actions
 description: Devlore actions tooling - generate graph actions and validate API contracts
 
 receivers:
-  - name: go
+  - name: goast
     builtin: true
-    type: GoReceiver
+    type: goast.Provider
     description: Go source parsing and code generation
   - name: file
     builtin: true

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
@@ -106,16 +106,16 @@ def _build_attr_names_from_source(path):
     attr_names = {}
 
     # Index Attr methods by receiver_type for prefix derivation
-    attr_methods = go.methods(path, name="Attr")
+    attr_methods = goast.methods(path, name="Attr")
     attr_by_receiver = {}
     for m in attr_methods:
         attr_by_receiver[str(m.receiver_type)] = m
 
     # Extract static AttrNames from each receiver
-    attr_names_methods = go.methods(path, name="AttrNames")
+    attr_names_methods = goast.methods(path, name="AttrNames")
     for m in attr_names_methods:
         receiver = str(m.receiver_type)
-        names = list(go.return_strings(m.scope))
+        names = list(goast.return_strings(m.scope))
         if not names:
             continue  # Dynamic AttrNames (e.g., PlanRoot) — skip
 
@@ -137,7 +137,7 @@ def _derive_attr_prefix(attr_method):
     """
     scope = str(attr_method.scope)
     for call_type in ["MakeAttr", "NewBuiltin"]:
-        calls = go.calls(scope, name=call_type)
+        calls = goast.calls(scope, name=call_type)
         for call in calls:
             args = list(call.args)
             if len(args) >= 1:
@@ -165,7 +165,7 @@ def _build_ns_descriptions(starlark_path):
             continue
         ns = str(entry.name)
         provider_path = file.join(provider_base, ns)
-        doc = str(go.type_doc(provider_path, "Provider"))
+        doc = str(goast.type_doc(provider_path, "Provider"))
         if doc:
             # Join paragraph lines into one string, stopping at blank lines or directives.
             para_lines = []
@@ -199,7 +199,7 @@ def _build_ns_descriptions(starlark_path):
 def _parse_devlore_api(path):
     """Parse devlore-cli Starlark API from Go source files.
 
-    Uses go.methods() and go.calls() to extract:
+    Uses goast.methods() and goast.calls() to extract:
     - Binding names from Attr methods (via NewBuiltin and MakeAttr calls)
     - Handler details: doc, slots, operations, output
     - Properties from _KNOWN_PROPERTIES
@@ -207,12 +207,12 @@ def _parse_devlore_api(path):
     - AttrNames cross-reference violations
     """
     # Step 1: Find all Attr methods and extract bindings via NewBuiltin
-    attr_methods = go.methods(path, name="Attr")
+    attr_methods = goast.methods(path, name="Attr")
     bindings = {}
     seen = {}
 
     for attr_method in attr_methods:
-        builtin_calls = go.calls(attr_method.scope, name="NewBuiltin")
+        builtin_calls = goast.calls(attr_method.scope, name="NewBuiltin")
         for call in builtin_calls:
             args = list(call.args)
             if len(args) < 2:
@@ -232,7 +232,7 @@ def _parse_devlore_api(path):
 
     # Step 1b: Extract bindings via MakeAttr (same 2-arg signature as NewBuiltin)
     for attr_method in attr_methods:
-        make_attr_calls = go.calls(attr_method.scope, name="MakeAttr")
+        make_attr_calls = goast.calls(attr_method.scope, name="MakeAttr")
         for call in make_attr_calls:
             args = list(call.args)
             if len(args) < 2:
@@ -271,12 +271,12 @@ def _parse_devlore_api(path):
 
     # Step 3: Detect StringDict violations
     # Any NewBuiltin call for API bindings outside Attr methods is a violation
-    all_methods = go.methods(path)
+    all_methods = goast.methods(path)
     violations = []
     for method in all_methods:
         if str(method.name) == "Attr":
             continue
-        nb_calls = go.calls(method.scope, name="NewBuiltin")
+        nb_calls = goast.calls(method.scope, name="NewBuiltin")
         for call in nb_calls:
             args = list(call.args)
             if len(args) < 1:
@@ -408,9 +408,9 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
     # Find the handler method, filtering by receiver type to disambiguate
     # methods with the same name on different receivers (e.g., remove, exists).
     if receiver_type:
-        handler_methods = go.methods(path, name=handler_name, receiver_type=receiver_type)
+        handler_methods = goast.methods(path, name=handler_name, receiver_type=receiver_type)
     else:
-        handler_methods = go.methods(path, name=handler_name)
+        handler_methods = goast.methods(path, name=handler_name)
     if len(list(handler_methods)) == 0:
         return {"file": fallback_file, "line": fallback_line}
 
@@ -427,7 +427,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
     # Extract slots from FillSlot calls
     slots = []
     slot_seen = {}
-    fill_calls = go.calls(scope, name="FillSlot")
+    fill_calls = goast.calls(scope, name="FillSlot")
     for call in fill_calls:
         args = list(call.args)
         if len(args) >= 3:
@@ -438,7 +438,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
 
     # Extract operations from execution.Node composites
     operations = []
-    node_composites = go.composites(scope, type="execution.Node")
+    node_composites = goast.composites(scope, type="execution.Node")
     for comp in node_composites:
         ops_field = getattr(comp.fields, "Operations", None)
         if ops_field:
@@ -449,7 +449,7 @@ def _extract_binding_info(path, handler_name, binding_name, fallback_file, fallb
 
     # Detect output type (promise if NewOutput is called)
     output = "none"
-    output_calls = go.calls(scope, name="NewOutput")
+    output_calls = goast.calls(scope, name="NewOutput")
     if len(list(output_calls)) > 0:
         output = "promise"
 
@@ -536,7 +536,7 @@ def _strip_doc_prefix(doc, handler_name):
 
 
 def _parse_migrate_knowledge(path):
-    """Parse migration constants from Go source using go.const_groups and go.raw_string."""
+    """Parse migration constants from Go source using goast.const_groups and goast.raw_string."""
     analysis_path = file.join(path, _ANALYSIS_FILE)
     plan_path = file.join(path, _PLAN_FILE)
 
@@ -546,7 +546,7 @@ def _parse_migrate_knowledge(path):
 
     # Parse typed const groups from analysis.go
     if file.exists(analysis_path):
-        groups = go.const_groups(analysis_path)
+        groups = goast.const_groups(analysis_path)
         for group in groups:
             type_name = str(group.type_name)
             for c in group.constants:
@@ -568,10 +568,10 @@ def _parse_migrate_knowledge(path):
     system_prompt = ""
     platforms = []
     if file.exists(plan_path):
-        prompt_funcs = go.funcs(plan_path, name="buildSystemPrompt")
+        prompt_funcs = goast.funcs(plan_path, name="buildSystemPrompt")
         func_list = list(prompt_funcs)
         if len(func_list) > 0:
-            system_prompt = str(go.raw_string(func_list[0].scope))
+            system_prompt = str(goast.raw_string(func_list[0].scope))
             platforms = _extract_platforms(system_prompt)
 
     return {
@@ -626,17 +626,17 @@ def _extract_platforms(prompt_text):
 def _scan_execution(path):
     """Scan execution package: structs, consts, and ops in one pass."""
     graph_path = file.join(path, _GRAPH_FILE)
-    structs = go.structs(graph_path) if file.exists(graph_path) else []
-    consts = go.const_groups(graph_path) if file.exists(graph_path) else []
+    structs = goast.structs(graph_path) if file.exists(graph_path) else []
+    consts = goast.const_groups(graph_path) if file.exists(graph_path) else []
 
     # Find Name() methods returning string on *Op types
-    methods = go.methods(path, name="Name", returns="string")
+    methods = goast.methods(path, name="Name", returns="string")
     ops = []
     seen_ops = {}
     for m in methods:
         recv_type = str(m.receiver_type).lstrip("*")
         if recv_type.endswith("Op"):
-            name = str(go.return_string(m.scope))
+            name = str(goast.return_string(m.scope))
             if name and name not in seen_ops:
                 seen_ops[name] = True
                 ops.append({"name": name, "type": recv_type})
@@ -1309,7 +1309,7 @@ def build_ops_knowledge(source, target):
         fail("Execution source not found: " + execution_path)
 
     # Discover *Service structs
-    all_structs = go.structs(execution_path)
+    all_structs = goast.structs(execution_path)
     services = []
     for s in all_structs:
         name = str(s.name)
@@ -1328,7 +1328,7 @@ def build_ops_knowledge(source, target):
 
     for service_name in sorted(services):
         # Get methods for this service
-        methods = go.methods(execution_path, receiver_type=service_name)
+        methods = goast.methods(execution_path, receiver_type=service_name)
 
         # Filter to public methods, skip starlark.Value methods
         filtered = []
@@ -1366,7 +1366,7 @@ def build_ops_knowledge(source, target):
                 "params": params,
             })
 
-        # Build descriptor for go.mapping()
+        # Build descriptor for goast.mapping()
         descriptor = {
             "package": "execution",
             "provider": provider,
@@ -1376,7 +1376,7 @@ def build_ops_knowledge(source, target):
         }
 
         # Generate mapping YAML
-        mapping_yaml = str(go.mapping(descriptor))
+        mapping_yaml = str(goast.mapping(descriptor))
 
         # Write mapping artifact
         mapping_file = provider + ".yaml"


### PR DESCRIPTION
## Summary

Update all Starlark scripts and extension.yaml to use the new `goast` receiver
name. Companion to noblefactor-ops PR that migrated the Go receiver to a proper
`pkg/op` provider.

### Changes

- `generate.star`: 35 `go.*` → `goast.*` call sites
- `extract.star`: 28 call sites
- `validate.star`: 9 call sites
- `extension.yaml` (Actions): receiver `go` → `goast`, type `GoReceiver` → `goast.Provider`
- `planned.go`: rename `FlowPlan` → `Plan`, add doc comments (style compliance)
- `builder.go`: blank line after function signature (style compliance)
- `phase-2.md`: markdown table alignment

### Verification

- `make clean build test-race STAR_REPO=../noblefactor-ops` passes
  (noblefactor-ops develop now has the goast provider)
- Codegen produces identical gen/ files for all 19 providers

## Test plan

- [x] `make clean build test-race` — all packages compile, codegen succeeds, all tests pass with race detector
- [x] Codegen before/after: identical output for all 19 providers