### PR TITLE
fix(inspect): Runtime safety, exhaustive switch cases (Phase 1+3)

### DIFF
--- a/docs/plans/goland-inspection-cleanup.md
+++ b/docs/plans/goland-inspection-cleanup.md
@@ -54,22 +54,22 @@ or removed separately.
 
 ## Implementation Phases
 
-### Phase 1: Potential Runtime Bugs (16 issues)
+### Phase 1: Potential Runtime Bugs (16 issues) — `complete`
 
 Fix issues that could cause panics or silently wrong behavior.
 
 **GoMaybeNil (14)** — add nil guards or `require.NotNil` assertions:
 
-- [ ] `internal/cli/selfinstall_test.go` lines 65, 89 — `err` dereference after nil check
-- [ ] `internal/console/console_test.go` lines 155, 160, 173 — `session.Next()` may return nil
-- [ ] `internal/execution/phase_test.go` lines 318, 321, 324, 327, 469 — `graph.PhaseByID()` may return nil
-- [ ] `pkg/op/provider/starcomplexity/provider.go` line 99 — `opts.Parse()` may return nil
-- [ ] `pkg/op/provider/starindex/provider.go` line 132 — `opts.Parse()` may return nil
+- [x] `internal/cli/selfinstall_test.go` lines 65, 89 — `t.Error` → `t.Fatal` to prevent nil dereference
+- [x] `internal/console/console_test.go` lines 155, 160, 173 — nil guard after `session.Next()`
+- [x] `internal/execution/phase_test.go` lines 318, 321, 324, 327, 469 — nil guard after `graph.PhaseByID()`
+- [x] `pkg/op/provider/starcomplexity/provider.go` line 99 — nil guard after `opts.Parse()`
+- [x] `pkg/op/provider/starindex/provider.go` line 132 — nil guard after `opts.Parse()`
 
 **GoBoolExpressions (2)** — conditions that are always false:
 
-- [ ] `internal/cli/output_test.go` line 84 — `DefaultFormat != "json"` always false
-- [ ] `internal/writ/segment/segment_test.go` line 398 — `EnvVarPrefix != "WRIT_SEGMENT_"` always false
+- [x] `internal/cli/output_test.go` line 84 — deleted tautological test (const can never differ)
+- [x] `internal/writ/segment/segment_test.go` line 398 — deleted tautological test (const can never differ)
 
 **Files**:
 
@@ -102,17 +102,17 @@ Fix error comparisons that fail on wrapped errors.
 - `pkg/op/triad_test.go` — Modify
 - `cmd/devlore-test/cli_test.go` — Modify
 
-### Phase 3: Missing Switch Cases (11 issues)
+### Phase 3: Missing Switch Cases (11 issues) — `complete`
 
 Add exhaustive `case` branches (or explicit `default` with panic) for iota-const switches.
 
-- [ ] `internal/cli/output.go` lines 319, 356 — two switches
-- [ ] `internal/console/model.go` lines 126, 168, 223, 293 — four switches
-- [ ] `internal/execution/executor.go` line 804 — one switch
-- [ ] `internal/writ/commands.go` line 614 — one switch
-- [ ] `internal/writ/migrate/session.go` line 113 — one switch
-- [ ] `internal/writ/migrate/session_test.go` line 304 — one switch
-- [ ] `pkg/op/provider/file/gitignore/tracker.go` line 118 — one switch
+- [x] `internal/cli/output.go` lines 319, 356 — added `default:` to both reflect.Kind switches
+- [x] `internal/console/model.go` lines 126, 168, 223, 293 — added StepProgress case, default for key types, exhaustive StepType cases
+- [x] `internal/execution/executor.go` line 804 — added ResultPending, ResultRunning cases
+- [x] `internal/writ/commands.go` line 614 — added upgradeResultError case with error reporting
+- [x] `internal/writ/migrate/session.go` line 113 — added missing SessionState cases
+- [x] `internal/writ/migrate/session_test.go` line 304 — added default case
+- [x] `pkg/op/provider/file/gitignore/tracker.go` line 118 — added NoMatch case
 
 **Files**:
 
@@ -240,7 +240,7 @@ global variables. Per the governing principle: this is greenfield — no legacy 
 
 **Files**: ~30 files across internal/ and pkg/.
 
-### Phase 6: Style & Modernization (42 issues) — `in-progress`
+### Phase 6: Style & Modernization (42 issues, 6 skipped) — `in-progress`
 
 **GoRedundantConversion (15)** — `complete`:
 
@@ -261,9 +261,11 @@ global variables. Per the governing principle: this is greenfield — no legacy 
 - [ ] `pkg/op/resource_test.go` line 69 — `&base`
 - [ ] `pkg/op/starvalue_marshal_test.go` line 221 — `&s`
 
-**GoMixedReceiverTypes (6)** — `Path` struct in `pkg/op/root.go`:
+**GoMixedReceiverTypes (6)** — `Path` struct in `pkg/op/root.go` — `skipped` (false positive):
 
-- [ ] `pkg/op/root.go` lines 49, 52, 55, 58, 61, 81 — standardize receivers to pointer
+- [x] `pkg/op/root.go` lines 49, 52, 55, 58, 61, 81 — value receivers on getters, pointer
+  receiver on `UnmarshalJSON` is correct Go idiom. Changing to all-pointer would alter copy
+  semantics. No action needed.
 
 **GoErrorsAsToAsType (5)** — Go 1.26 `errors.AsType`:
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -341,9 +341,10 @@ func getFieldNames(item interface{}) []string {
 			names[i] = fmt.Sprintf("%v", k.Interface())
 		}
 		return names
-	}
 
-	return nil
+	default:
+		return nil
+	}
 }
 
 // getFieldValue retrieves a field value from a struct or map.
@@ -375,6 +376,9 @@ func getFieldValue(item interface{}, field string) interface{} {
 		if mv.IsValid() {
 			return mv.Interface()
 		}
+
+	default:
+		// No fields for non-struct/non-map kinds.
 	}
 
 	return nil

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -80,12 +80,6 @@ func TestExitCode(t *testing.T) {
 	}
 }
 
-func TestOutputFlagsDefaults(t *testing.T) {
-	if DefaultFormat != "json" {
-		t.Errorf("expected DefaultFormat 'json', got %q", DefaultFormat)
-	}
-}
-
 func TestAddOutputFlags(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	var flags OutputFlags

--- a/internal/cli/selfinstall_test.go
+++ b/internal/cli/selfinstall_test.go
@@ -60,7 +60,7 @@ func TestNewSelfInstallCmd_RequiresPrefix(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	if err == nil {
-		t.Error("expected error when --prefix is not provided")
+		t.Fatal("expected error when --prefix is not provided")
 	}
 	if !strings.Contains(err.Error(), "--prefix is required") {
 		t.Errorf("expected '--prefix is required' error, got: %v", err)
@@ -83,7 +83,7 @@ func TestNewSelfInstallCmd_RejectsPositionalArgs(t *testing.T) {
 	cmd.SetArgs([]string{"~/.local"})
 	err := cmd.Execute()
 	if err == nil {
-		t.Error("expected error when positional argument is provided")
+		t.Fatal("expected error when positional argument is provided")
 	}
 	// The error message depends on cobra's implementation
 	if !strings.Contains(err.Error(), "unknown command") && !strings.Contains(err.Error(), "accepts 0 arg") {

--- a/internal/console/console_test.go
+++ b/internal/console/console_test.go
@@ -152,11 +152,17 @@ func TestMockSession(t *testing.T) {
 
 	// Advance through steps
 	step1 := session.Next()
+	if step1 == nil {
+		t.Fatal("expected non-nil step1")
+	}
 	if step1.Title != "Step 1" {
 		t.Errorf("expected 'Step 1', got %q", step1.Title)
 	}
 
 	step2 := session.Next()
+	if step2 == nil {
+		t.Fatal("expected non-nil step2")
+	}
 	if step2.Title != "Step 2" {
 		t.Errorf("expected 'Step 2', got %q", step2.Title)
 	}
@@ -170,6 +176,9 @@ func TestMockSession(t *testing.T) {
 	}
 
 	step3 := session.Next()
+	if step3 == nil {
+		t.Fatal("expected non-nil step3")
+	}
 	if step3.Title != "Done" {
 		t.Errorf("expected 'Done', got %q", step3.Title)
 	}

--- a/internal/console/model.go
+++ b/internal/console/model.go
@@ -132,6 +132,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleSelectKey(msg)
 	case StepInput:
 		return m.handleInputKey(msg)
+	case StepProgress:
+		return m, nil
 	case StepComplete, StepError:
 		if msg.Type == tea.KeyEnter {
 			m.quitting = true
@@ -178,6 +180,8 @@ func (m *Model) handleSelectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.selectedIndex < len(m.step.Options) {
 			return m.advance(m.step.Options[m.selectedIndex].Value)
 		}
+	default:
+		// Ignore unhandled key types
 	}
 	return m, nil
 }
@@ -228,6 +232,8 @@ func (m *Model) initInputForStep() tea.Cmd {
 		return textinput.Blink
 	case StepProgress:
 		return m.spinner.Tick
+	case StepInfo, StepConfirm, StepSelect, StepComplete, StepError:
+		// No initialization needed.
 	}
 	return nil
 }
@@ -345,6 +351,9 @@ func (m *Model) renderStepInteraction() string {
 			b.WriteString(m.styles.Error.Render("✗ An error occurred"))
 		}
 		b.WriteString("\n")
+
+	case StepInfo:
+		// Info steps render only the title/description — no interaction area.
 	}
 
 	return b.String()

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -816,6 +816,8 @@ func ApplyResults(g *op.Graph, results []*NodeResult) {
 				if r.Error != nil {
 					n.Error = r.Error.Error()
 				}
+			case ResultPending, ResultRunning:
+				// Not expected in final results; leave node status unchanged.
 			}
 			n.Timestamp = time.Now().Format(time.RFC3339)
 		}

--- a/internal/execution/phase_test.go
+++ b/internal/execution/phase_test.go
@@ -315,6 +315,10 @@ func TestPhasedExecutionFailureWithRollback(t *testing.T) {
 	provision := graph.PhaseByID("phase.provision")
 	verify := graph.PhaseByID("phase.verify")
 
+	if prepare == nil || install == nil || provision == nil || verify == nil {
+		t.Fatal("expected all phases to be present in graph")
+	}
+
 	if prepare.Status != op.PhaseRolledBack {
 		t.Errorf("prepare: expected rolled_back, got %s", prepare.Status)
 	}
@@ -466,6 +470,9 @@ func TestPhasedExecutionRetryExhausted(t *testing.T) {
 	}
 
 	phase := graph.PhaseByID("phase.install")
+	if phase == nil {
+		t.Fatal("expected phase.install to be present in graph")
+	}
 	if phase.Status != op.PhaseFailed {
 		t.Errorf("expected failed, got %s", phase.Status)
 	}

--- a/internal/writ/commands.go
+++ b/internal/writ/commands.go
@@ -608,6 +608,7 @@ func executeUpgrades(cfg *UpgradeConfig, view *execution.StateView, copied map[s
 	var regenerated, skipped int
 	var skippedFiles []string
 
+	var errored int
 	for relTarget, entry := range copied {
 		result := upgradeFile(cfg, view, relTarget, entry, engineData, sopsClient, identities)
 		switch result {
@@ -616,6 +617,8 @@ func executeUpgrades(cfg *UpgradeConfig, view *execution.StateView, copied map[s
 		case upgradeResultSkipped:
 			skipped++
 			skippedFiles = append(skippedFiles, relTarget)
+		case upgradeResultError:
+			errored++
 		}
 	}
 
@@ -635,6 +638,9 @@ func executeUpgrades(cfg *UpgradeConfig, view *execution.StateView, copied map[s
 		cli.Success("%d file(s) regenerated", regenerated)
 	}
 
+	if errored > 0 {
+		return fmt.Errorf("%d file(s) failed to upgrade", errored)
+	}
 	return nil
 }
 

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -115,6 +115,8 @@ func (s *Session) Respond(response string) error {
 		return s.processConversation(response)
 	case StatePlanProposed:
 		return s.processPlanResponse(response)
+	case StateAnalyzing, StateExecuting, StateComplete, StateError:
+		// No response processing in these states.
 	}
 
 	return nil

--- a/internal/writ/migrate/session_test.go
+++ b/internal/writ/migrate/session_test.go
@@ -307,6 +307,8 @@ func TestSessionWithRealDirectory(t *testing.T) {
 	case console.StepProgress:
 		// Analysis completed, next call should return conversation step
 		t.Log("Analysis in progress")
+	default:
+		t.Logf("Unexpected step type: %v", step.Type)
 	}
 }
 

--- a/internal/writ/segment/segment_test.go
+++ b/internal/writ/segment/segment_test.go
@@ -392,10 +392,3 @@ func TestLoadFromEnvOverridesExisting(t *testing.T) {
 		t.Errorf("ROLE = %q, want %q", result.Get("ROLE"), "server")
 	}
 }
-
-func TestEnvVarPrefix(t *testing.T) {
-	// Verify the constant is what we expect
-	if EnvVarPrefix != "WRIT_SEGMENT_" {
-		t.Errorf("EnvVarPrefix = %q, want %q", EnvVarPrefix, "WRIT_SEGMENT_")
-	}
-}

--- a/pkg/op/provider/file/gitignore/tracker.go
+++ b/pkg/op/provider/file/gitignore/tracker.go
@@ -120,6 +120,8 @@ func (t *Tracker) IsIgnored(path string, isDir bool) (ignored bool, source strin
 				return true, t.stack[i].Path
 			case gitignore.Include:
 				return false, t.stack[i].Path
+			case gitignore.NoMatch:
+				continue
 			}
 		}
 	}

--- a/pkg/op/provider/starcomplexity/provider.go
+++ b/pkg/op/provider/starcomplexity/provider.go
@@ -6,6 +6,7 @@
 package starcomplexity
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -92,6 +93,9 @@ func analyzeFileComplexity(absPath, root string) (*FileComplexity, error) {
 	f, err := opts.Parse(relPath, data, 0)
 	if err != nil {
 		return nil, err
+	}
+	if f == nil {
+		return nil, fmt.Errorf("parse returned nil file for %s", relPath)
 	}
 
 	fc := &FileComplexity{Path: relPath}

--- a/pkg/op/provider/starindex/provider.go
+++ b/pkg/op/provider/starindex/provider.go
@@ -7,6 +7,7 @@ package starindex
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,6 +118,9 @@ func indexFile(absPath, root string, withDocstrings, withGlobals bool) (*Indexed
 	f, err := opts.Parse(relPath, data, 0)
 	if err != nil {
 		return nil, err
+	}
+	if f == nil {
+		return nil, fmt.Errorf("parse returned nil file for %s", relPath)
 	}
 
 	loc, sloc, comments, blanks := countLines(data)


### PR DESCRIPTION
## Summary

- Fix 27 GoLand inspection issues from the `goland-inspection-cleanup` plan
- **Phase 1 (Runtime Bugs)**: Prevent nil dereferences via `t.Fatal` upgrades, nil guards after `PhaseByID()`/`Next()`/`Parse()`, delete tautological const tests (16 issues)
- **Phase 3 (Missing Switch Cases)**: Add exhaustive case coverage for `StepType`, `ResultStatus`, `upgradeResult`, `SessionState`, `reflect.Kind`, and `gitignore.MatchResult` (11 issues)

## Files changed (15)

| File | Change |
|---|---|
| `internal/cli/selfinstall_test.go` | `t.Error` → `t.Fatal` before nil `err.Error()` |
| `internal/console/console_test.go` | Nil guards after `session.Next()` |
| `internal/execution/phase_test.go` | Nil guards after `graph.PhaseByID()` |
| `pkg/op/provider/starcomplexity/provider.go` | Nil guard after `opts.Parse()` |
| `pkg/op/provider/starindex/provider.go` | Nil guard after `opts.Parse()` |
| `internal/cli/output_test.go` | Delete tautological `DefaultFormat` test |
| `internal/writ/segment/segment_test.go` | Delete tautological `EnvVarPrefix` test |
| `internal/cli/output.go` | `default:` in both `reflect.Kind` switches |
| `internal/console/model.go` | `StepProgress` + exhaustive `StepType` cases |
| `internal/execution/executor.go` | `ResultPending`, `ResultRunning` cases |
| `internal/writ/commands.go` | `upgradeResultError` case with error return |
| `internal/writ/migrate/session.go` | Missing `SessionState` cases |
| `internal/writ/migrate/session_test.go` | `default:` for `StepType` switch |
| `pkg/op/provider/file/gitignore/tracker.go` | `gitignore.NoMatch` case |
| `docs/plans/goland-inspection-cleanup.md` | Phase 1+3 marked complete |

## Test plan

- [x] `make vet` passes
- [x] `make test` passes — all packages green
- [x] `gofmt -l` reports no formatting issues on all changed files