### PR TITLE
feat(iox): Create pkg/iox with Close helper, adopt across codebase

### DIFF
--- a/docs/plans/surface-area-refactor.md
+++ b/docs/plans/surface-area-refactor.md
@@ -1,9 +1,9 @@
 ---
 title: "Reduce pkg/op Public Surface Area"
 issue: TBD
-status: draft
+status: in-progress
 created: 2026-03-15
-updated: 2026-03-15
+updated: 2026-03-16
 ---
 
 # Plan: Reduce pkg/op Public Surface Area
@@ -128,11 +128,11 @@ pkg/
 
 ## Implementation Phases
 
-### Phase 1: Create `pkg/iox`
+### Phase 1: Create `pkg/iox` — `complete`
 
-- [ ] Create `pkg/iox/close.go` with `Close` function
-- [ ] Add tests in `pkg/iox/close_test.go`
-- [ ] Adopt `iox.Close` at all 37 Close call sites identified in the inspection cleanup
+- [x] Create `pkg/iox/close.go` with `Close` function
+- [x] Add tests in `pkg/iox/close_test.go`
+- [x] Adopt `iox.Close` at all 37 Close call sites identified in the inspection cleanup
 
 ### Phase 2: Delete Dead Exports
 

--- a/internal/devloretest/commands.go
+++ b/internal/devloretest/commands.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/internal/e2e/testrunner"
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	filegen "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"
 )
@@ -92,7 +93,7 @@ All streams default to /dev/stdout. Route to files or /dev/null:
 	return cmd
 }
 
-func runTest(cmd *cobra.Command, script string, outputs *outputFlags) error {
+func runTest(cmd *cobra.Command, script string, outputs *outputFlags) (err error) {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")              //nolint:errcheck // flag registered above
 	trace, _ := cmd.Flags().GetBool("trace")                 //nolint:errcheck // flag registered above
 	provider, _ := cmd.Flags().GetString("provider")         //nolint:errcheck // flag registered above
@@ -107,7 +108,7 @@ func runTest(cmd *cobra.Command, script string, outputs *outputFlags) error {
 	if err != nil {
 		return fmt.Errorf("opening graph output: %w", err)
 	}
-	defer graphOut.Close()
+	defer iox.Close(&err, graphOut)
 
 	// Build and run.
 	var opts []testrunner.Option
@@ -152,12 +153,12 @@ func openDest(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // G304: path from CLI flag
 }
 
-func writeSummary(dest string, result *testrunner.Result) error {
+func writeSummary(dest string, result *testrunner.Result) (err error) {
 	f, err := openDest(dest)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -167,7 +168,7 @@ func writeSummary(dest string, result *testrunner.Result) error {
 	return err
 }
 
-func writeReceipt(dest string, format string, graph *op.Graph) error {
+func writeReceipt(dest string, format string, graph *op.Graph) (err error) {
 	if graph == nil {
 		return nil
 	}
@@ -176,7 +177,7 @@ func writeReceipt(dest string, format string, graph *op.Graph) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	switch format {
 	case "json":
@@ -186,7 +187,7 @@ func writeReceipt(dest string, format string, graph *op.Graph) error {
 	default:
 		enc := yaml.NewEncoder(f)
 		enc.SetIndent(2)
-		defer enc.Close()
+		defer iox.Close(&err, enc)
 		return graph.Serialize(enc)
 	}
 }

--- a/internal/e2e/testrunner/runner.go
+++ b/internal/e2e/testrunner/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/internal/execution"
 	loreStar "github.com/NobleFactor/devlore-cli/internal/starlark"
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 
 	// Blank imports register provider actions and callable extractor via init().
@@ -140,7 +141,7 @@ func New(script string, opts ...Option) *Runner {
 // Returns:
 //   - *Result: the test outcome with pass/fail status and failures.
 //   - error: non-nil if script loading or graph execution fails unexpectedly.
-func (r *Runner) Start(ctx context.Context) (*Result, error) {
+func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 	// 1. Create temp directory
 	tmpDir, err := os.MkdirTemp("", "devlore-test-*")
 	if err != nil {
@@ -160,7 +161,7 @@ func (r *Runner) Start(ctx context.Context) (*Result, error) {
 	// 3. Create ActionRegistry with all provider actions
 	reg := op.NewActionRegistry()
 	root := op.NewRootReaderWriter(tmpDir)
-	defer root.Close()
+	defer iox.Close(&err, root)
 	opCtx := op.Context{ContextBase: op.NewContextBase(root)}
 	opCtx.RecoverySite = op.NewRecoverySite(opCtx)
 	bs.RegisterActions(reg, opCtx)

--- a/internal/execution/provider_test.go
+++ b/internal/execution/provider_test.go
@@ -421,12 +421,12 @@ func createTarGz(t *testing.T, dir string, files map[string]string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gw := gzip.NewWriter(f)
-	defer gw.Close()
+	defer func() { _ = gw.Close() }()
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
+	defer func() { _ = tw.Close() }()
 
 	for name, content := range files {
 		hdr := &tar.Header{
@@ -453,10 +453,10 @@ func createZip(t *testing.T, dir string, files map[string]string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	zw := zip.NewWriter(f)
-	defer zw.Close()
+	defer func() { _ = zw.Close() }()
 
 	for name, content := range files {
 		w, err := zw.Create(name)

--- a/internal/lore/builder_test.go
+++ b/internal/lore/builder_test.go
@@ -200,7 +200,7 @@ func TestEngineRunsPackageInstallActions(t *testing.T) {
 	// Register all actions (file + package)
 	tmpDir := t.TempDir()
 	root := op.NewRootReaderWriter(tmpDir)
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	opCtx := op.Context{ContextBase: op.ContextBase{Root: root}}
 	op.InitAll(reg, opCtx)
 
@@ -237,7 +237,7 @@ func TestEngineRunsNamespacedPackageActions(t *testing.T) {
 	reg := op.NewActionRegistry()
 	tmpDir := t.TempDir()
 	root := op.NewRootReaderWriter(tmpDir)
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	opCtx := op.Context{ContextBase: op.ContextBase{Root: root}}
 	op.InitAll(reg, opCtx)
 
@@ -630,7 +630,7 @@ func TestPlanner_PlanPackages(t *testing.T) {
 
 	reg := op.NewActionRegistry()
 	root := op.NewRootReaderWriter(tmpDir)
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	opCtx := op.Context{ContextBase: op.ContextBase{Root: root}}
 	op.InitAll(reg, opCtx)
 
@@ -667,7 +667,7 @@ func TestPlanner_PlanByName(t *testing.T) {
 	tmpDir := t.TempDir()
 	reg := op.NewActionRegistry()
 	root := op.NewRootReaderWriter(tmpDir)
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	opCtx := op.Context{ContextBase: op.ContextBase{Root: root}}
 	op.InitAll(reg, opCtx)
 

--- a/internal/lore/onboard/onboard.go
+++ b/internal/lore/onboard/onboard.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/internal/lorepackage"
 	"github.com/NobleFactor/devlore-cli/internal/model"
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 )
 
 // Options controls onboarding behavior.
@@ -182,7 +183,7 @@ func fetchContent(ctx context.Context, source string) (content, sourceURL string
 		if err != nil {
 			return "", "", err
 		}
-		defer resp.Body.Close()
+		defer iox.Close(&err, resp.Body)
 
 		if resp.StatusCode != http.StatusOK {
 			return "", "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)

--- a/pkg/iox/close.go
+++ b/pkg/iox/close.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+// Package iox provides standalone I/O utilities independent of the op framework.
+package iox
+
+import (
+	"errors"
+	"io"
+)
+
+// Close closes all provided closers, joining any errors into *err.
+// Nil closers are safely skipped. Use with named returns:
+//
+//	defer iox.Close(&err, f, enc)
+//
+// Parameters:
+//   - err: pointer to the named error return; close errors are joined into *err
+//   - closers: values to close; nil entries are skipped
+func Close(err *error, closers ...io.Closer) {
+
+	for _, c := range closers {
+		if c != nil {
+			*err = errors.Join(*err, c.Close())
+		}
+	}
+}

--- a/pkg/iox/close_test.go
+++ b/pkg/iox/close_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package iox
+
+import (
+	"errors"
+	"testing"
+)
+
+type errCloser struct{ err error }
+
+func (c errCloser) Close() error { return c.err }
+
+func TestClose_NilErr(t *testing.T) {
+
+	var err error
+	Close(&err, errCloser{nil})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestClose_SingleError(t *testing.T) {
+
+	want := errors.New("close failed")
+	var err error
+	Close(&err, errCloser{want})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestClose_JoinsMultipleErrors(t *testing.T) {
+
+	e1 := errors.New("first")
+	e2 := errors.New("second")
+	var err error
+	Close(&err, errCloser{e1}, errCloser{e2})
+	if !errors.Is(err, e1) || !errors.Is(err, e2) {
+		t.Fatalf("expected both errors, got %v", err)
+	}
+}
+
+func TestClose_PreservesExistingError(t *testing.T) {
+
+	existing := errors.New("existing")
+	closeErr := errors.New("close")
+	err := existing
+	Close(&err, errCloser{closeErr})
+	if !errors.Is(err, existing) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected both errors, got %v", err)
+	}
+}
+
+func TestClose_SkipsNilCloser(t *testing.T) {
+
+	var err error
+	Close(&err, nil, errCloser{nil})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestClose_NoClosers(t *testing.T) {
+
+	var err error
+	Close(&err)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestClose_MixedNilAndErrors(t *testing.T) {
+
+	want := errors.New("only")
+	var err error
+	Close(&err, errCloser{nil}, nil, errCloser{want}, errCloser{nil})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}

--- a/pkg/op/platform_linux.go
+++ b/pkg/op/platform_linux.go
@@ -40,7 +40,7 @@ func detectLinuxDistro() (distro, version string) {
 	if err != nil {
 		return "linux", ""
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/pkg/op/provider/appnet/provider.go
+++ b/pkg/op/provider/appnet/provider.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -28,7 +29,7 @@ func NewProvider(ctx op.Context) *Provider {
 //
 // Parameters:
 //   - url: network resource identifying the URL to fetch
-func (p *Provider) Download(url Resource) ([]byte, error) {
+func (p *Provider) Download(url Resource) (_ []byte, err error) {
 	rawURL := url.SourceURL.String()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
@@ -38,7 +39,7 @@ func (p *Provider) Download(url Resource) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", rawURL, err)
 	}
-	defer resp.Body.Close()
+	defer iox.Close(&err, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download %s: HTTP %d", rawURL, resp.StatusCode)

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -99,7 +100,7 @@ func extractTarGz(source, prefix string) (created []string, err error) { //nolin
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -24,13 +24,13 @@ func createTarGz(t *testing.T, archivePath string, entries map[string]string) {
 	if err != nil {
 		t.Fatalf("create archive file: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gw := gzip.NewWriter(f)
-	defer gw.Close()
+	defer func() { _ = gw.Close() }()
 
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
+	defer func() { _ = tw.Close() }()
 
 	for name, content := range entries {
 		hdr := &tar.Header{
@@ -55,10 +55,10 @@ func createZip(t *testing.T, archivePath string, entries map[string]string) {
 	if err != nil {
 		t.Fatalf("create archive file: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	zw := zip.NewWriter(f)
-	defer zw.Close()
+	defer func() { _ = zw.Close() }()
 
 	for name, content := range entries {
 		w, err := zw.Create(name)

--- a/pkg/op/provider/file/gitignore/tracker.go
+++ b/pkg/op/provider/file/gitignore/tracker.go
@@ -8,12 +8,15 @@ package gitignore
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 )
 
 // Tracker manages a stack of gitignore pattern sources and provides path matching.
@@ -55,11 +58,12 @@ func NewTracker(root string) (*Tracker, error) {
 	// Layer 0: Global ignore (core.excludesfile or XDG fallback)
 
 	if globalPath := resolveGlobalIgnore(); globalPath != "" {
-		if patterns := loadPatterns(globalPath, nil); len(patterns) > 0 {
-			t.stack = append(t.stack, PatternSource{
-				Path:     globalPath,
-				Patterns: patterns,
-			})
+		patterns, err := loadPatterns(globalPath, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(patterns) > 0 {
+			t.stack = append(t.stack, PatternSource{Path: globalPath, Patterns: patterns})
 			t.dirs = append(t.dirs, "")
 		}
 	}
@@ -68,11 +72,12 @@ func NewTracker(root string) (*Tracker, error) {
 
 	excludePath := filepath.Join(absRoot, ".git", "info", "exclude")
 
-	if patterns := loadPatterns(excludePath, nil); len(patterns) > 0 {
-		t.stack = append(t.stack, PatternSource{
-			Path:     excludePath,
-			Patterns: patterns,
-		})
+	patterns, err := loadPatterns(excludePath, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(patterns) > 0 {
+		t.stack = append(t.stack, PatternSource{Path: excludePath, Patterns: patterns})
 		t.dirs = append(t.dirs, "")
 	}
 
@@ -80,11 +85,12 @@ func NewTracker(root string) (*Tracker, error) {
 
 	rootGI := filepath.Join(absRoot, ".gitignore")
 
-	if patterns := loadPatterns(rootGI, nil); len(patterns) > 0 {
-		t.stack = append(t.stack, PatternSource{
-			Path:     rootGI,
-			Patterns: patterns,
-		})
+	patterns, err = loadPatterns(rootGI, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(patterns) > 0 {
+		t.stack = append(t.stack, PatternSource{Path: rootGI, Patterns: patterns})
 		t.dirs = append(t.dirs, "")
 	}
 
@@ -132,7 +138,10 @@ func (t *Tracker) IsIgnored(path string, isDir bool) (ignored bool, source strin
 //
 // Parameters:
 //   - dir: Relative path to the directory containing the .gitignore file (e.g. "src/main.cpp")
-func (t *Tracker) Push(dir string) {
+//
+// Returns:
+//   - error: any I/O error other than a missing .gitignore file
+func (t *Tracker) Push(dir string) error {
 
 	dirSlash := filepath.ToSlash(dir)
 
@@ -154,34 +163,44 @@ func (t *Tracker) Push(dir string) {
 	// Don't push if this directory is already on top
 
 	if len(t.dirs) > 0 && t.dirs[len(t.dirs)-1] == dir {
-		return
+		return nil
 	}
 
 	giPath := filepath.Join(t.root, dir, ".gitignore")
 	domain := strings.Split(dirSlash, "/")
 
-	if patterns := loadPatterns(giPath, domain); len(patterns) > 0 {
-		t.stack = append(t.stack, PatternSource{
-			Path:     giPath,
-			Patterns: patterns,
-		})
+	patterns, err := loadPatterns(giPath, domain)
+	if err != nil {
+		return err
+	}
+	if len(patterns) > 0 {
+		t.stack = append(t.stack, PatternSource{Path: giPath, Patterns: patterns})
 		t.dirs = append(t.dirs, dir)
 	}
+	return nil
 }
 
 // loadPatterns reads a gitignore file and returns parsed patterns.
 //
+// A missing file is not an error — the function returns (nil, nil). Other I/O failures are returned.
+//
 // Parameters:
+//   - path: absolute path to the gitignore file.
 //   - domain: the path segments of the directory containing the file (nil for root-level files).
 //
 // Returns:
-//   - The parsed patterns from the gitignore file
-func loadPatterns(path string, domain []string) []gitignore.Pattern {
+//   - []gitignore.Pattern: parsed patterns, or nil if the file does not exist
+//   - error: any I/O error other than a missing file
+func loadPatterns(path string, domain []string) (_ []gitignore.Pattern, err error) {
+
 	f, err := os.Open(path)
 	if err != nil {
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	var patterns []gitignore.Pattern
 	scanner := bufio.NewScanner(f)
@@ -193,7 +212,7 @@ func loadPatterns(path string, domain []string) []gitignore.Pattern {
 		}
 		patterns = append(patterns, gitignore.ParsePattern(line, domain))
 	}
-	return patterns
+	return patterns, scanner.Err()
 }
 
 // resolveGlobalIgnore finds the global gitignore file path.

--- a/pkg/op/provider/file/gitignore/tracker_test.go
+++ b/pkg/op/provider/file/gitignore/tracker_test.go
@@ -122,7 +122,9 @@ func TestNestedGitignore(t *testing.T) {
 	}
 
 	// Push src directory to load its .gitignore
-	tracker.Push("src")
+	if err := tracker.Push("src"); err != nil {
+		t.Fatalf("Push(src): %v", err)
+	}
 
 	// Inside src: debug.log should NOT be ignored (negation in src/.gitignore)
 	ignored, _ = tracker.IsIgnored("src/debug.log", false)
@@ -161,14 +163,18 @@ func TestPushAutoPop(t *testing.T) {
 	}
 
 	// Push a: *.tmp should now also be ignored
-	tracker.Push("a")
+	if err := tracker.Push("a"); err != nil {
+		t.Fatalf("Push(a): %v", err)
+	}
 	ignored, _ = tracker.IsIgnored("a/test.tmp", false)
 	if !ignored {
 		t.Error("expected a/test.tmp to be ignored after Push(a)")
 	}
 
 	// Push b: auto-pops a, *.tmp should no longer be ignored in b
-	tracker.Push("b")
+	if err := tracker.Push("b"); err != nil {
+		t.Fatalf("Push(b): %v", err)
+	}
 	ignored, _ = tracker.IsIgnored("b/test.bak", false)
 	if !ignored {
 		t.Error("expected b/test.bak to be ignored after Push(b)")

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gitignore"
 )
@@ -164,13 +165,13 @@ func (p *Provider) Copy(sourceFile Resource, destinationFilename Resource, desti
 	if err != nil {
 		return result, undo, err
 	}
-	defer src.Close()
+	defer iox.Close(&err, src)
 
 	dst, err := p.openFile(result.SourcePath.Abs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, destinationFileMode)
 	if err != nil {
 		return result, undo, err
 	}
-	defer dst.Close()
+	defer iox.Close(&err, dst)
 
 	if _, err := io.Copy(dst, src); err != nil {
 		return result, undo, err
@@ -549,7 +550,9 @@ func (p *Provider) WalkTree(root Resource, fn Reducer, honorGitignore bool) (res
 
 		if tracker != nil {
 			if isDir {
-				tracker.Push(relativePath)
+				if pushErr := tracker.Push(relativePath); pushErr != nil {
+					return pushErr
+				}
 			}
 			ignored, _ := tracker.IsIgnored(relativePath, isDir)
 			if ignored && isDir {
@@ -847,13 +850,13 @@ func (p *Provider) Parent(path string) string {
 // isDirAndNotEmpty checks if the path is a directory that contains at least one entry. Returns true if it is a
 // directory with contents, false if it's a file, a symlink, or an empty directory. Check for existence on error return
 // using errors.Is(err, os.ErrNotExist).
-func (p *Provider) isDirAndNotEmpty(abs string) (bool, error) {
+func (p *Provider) isDirAndNotEmpty(abs string) (_ bool, err error) {
 
 	f, err := p.open(abs)
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	fileInfo, err := f.Stat()
 	if err != nil {
@@ -1155,7 +1158,7 @@ func (p *Provider) write(resource Resource, data []byte, mode os.FileMode) (resu
 	if err != nil {
 		return result, undo, err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	hasher := sha256.New()
 	mw := io.MultiWriter(f, hasher)

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -158,13 +159,13 @@ func (r *Resource) String() string { return r.Format(r) }
 // Returns:
 //   - int64: number of bytes written
 //   - error: any error that occurred during writing
-func (r *Resource) WriteTo(root op.Root, writer io.Writer) (int64, error) {
+func (r *Resource) WriteTo(root op.Root, writer io.Writer) (_ int64, err error) {
 
 	f, err := root.Open(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer iox.Close(&err, f)
 
 	return io.Copy(writer, f)
 }

--- a/pkg/op/root_test.go
+++ b/pkg/op/root_test.go
@@ -290,7 +290,7 @@ func TestRoot_Open(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Open: %v", err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			buf := make([]byte, 7)
 			n, err := f.Read(buf)
@@ -540,7 +540,7 @@ func TestConfinedRoot_RejectsTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewConfinedRoot: %v", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	// Construct a path that escapes the root.
 	p := op.NewPath(dir, "../../etc/passwd")


### PR DESCRIPTION
## Summary

- **New package `pkg/iox`** with `Close(err *error, closers ...io.Closer)` — joins close errors into a named return via `errors.Join`. 7 unit tests.
- **Adopted `iox.Close`** at all production close sites where a named error return exists (11 call sites across 7 files). Functions without error returns use `defer func() { _ = x.Close() }()`.
- **Fixed silent error swallowing** in `gitignore.loadPatterns` — now returns error, distinguishes missing files (expected) from real I/O failures. Also captures `scanner.Err()`.
- **Changed `gitignore.Tracker.Push`** to return error, updated its single production caller and 3 test callers.
- **Test code**: 15 close sites converted to `_ = x.Close()` pattern across 4 test files.
- Phase 1 of the surface-area-refactor plan marked complete.

## Test plan

- [x] `go test ./pkg/iox/...` — 7/7 pass
- [x] `go test ./pkg/op/provider/file/...` — pass (file + gitignore)
- [x] `go test ./pkg/op/provider/archive/...` — pass
- [x] `go test ./pkg/op/provider/appnet/...` — pass
- [x] `go test ./pkg/op/...` — pass (includes root_test.go)
- [x] `go test ./internal/execution/...` — pass
- [x] `go vet` on all changed packages — clean
- [ ] CI