### PR TITLE
fix(inspect): Go 1.26 modernization (Phase 6)

### DIFF
--- a/docs/plans/goland-inspection-cleanup.md
+++ b/docs/plans/goland-inspection-cleanup.md
@@ -240,7 +240,7 @@ global variables. Per the governing principle: this is greenfield — no legacy 
 
 **Files**: ~30 files across internal/ and pkg/.
 
-### Phase 6: Style & Modernization (42 issues, 6 skipped) — `in-progress`
+### Phase 6: Style & Modernization (42 issues, 6 skipped) — `complete`
 
 **GoRedundantConversion (15)** — `complete`:
 
@@ -250,16 +250,16 @@ global variables. Per the governing principle: this is greenfield — no legacy 
 - [x] `pkg/op/provider/starcode/integration_test.go` line 129 — redundant `bool`
 - [x] `pkg/op/receiver_reflect_test.go` lines 198, 239 — 2 redundant `starlark.Tuple`
 
-**GoSimplifyWithNew (11)** — Go 1.26 `new()` syntax:
+**GoSimplifyWithNew (11)** — Go 1.26 `new()` syntax — `complete`:
 
-- [ ] `internal/cli/help.go` line 60, `internal/cli/man.go` line 63, `internal/cli/selfinstall.go` line 325 — `&now`
-- [ ] `internal/execution/preflight_test.go` line 83 — `&base`
-- [ ] `internal/signing/azure_kv.go` line 204 — `&algorithm`
-- [ ] `pkg/op/output_test.go` line 694 — `&base`
-- [ ] `pkg/op/resource_catalog.go` line 42 — `&base`
-- [ ] `pkg/op/resource_catalog_test.go` lines 196, 267 — `&base`
-- [ ] `pkg/op/resource_test.go` line 69 — `&base`
-- [ ] `pkg/op/starvalue_marshal_test.go` line 221 — `&s`
+- [x] `internal/cli/help.go` line 60, `internal/cli/man.go` line 63, `internal/cli/selfinstall.go` line 325 — `&now` → `new(time.Now())`
+- [x] `internal/execution/preflight_test.go` line 83 — `&base` → `new(op.NewResourceBase(...))`
+- [x] `internal/signing/azure_kv.go` line 204 — N/A (file removed in prior cleanup)
+- [x] `pkg/op/output_test.go` line 694 — `&base` → `new(NewResourceBase(...))`
+- [x] `pkg/op/resource_catalog.go` line 42 — `&base` → `new(NewResourceBase(uri))`
+- [x] `pkg/op/resource_catalog_test.go` lines 196, 267 — `&base` → `new(NewResourceBase(...))`
+- [x] `pkg/op/resource_test.go` line 69 — `&base` → `new(NewResourceBase(...))`
+- [x] `pkg/op/starvalue_marshal_test.go` line 221 — `&s` → `new("hello")`
 
 **GoMixedReceiverTypes (6)** — `Path` struct in `pkg/op/root.go` — `skipped` (false positive):
 
@@ -267,13 +267,13 @@ global variables. Per the governing principle: this is greenfield — no legacy 
   receiver on `UnmarshalJSON` is correct Go idiom. Changing to all-pointer would alter copy
   semantics. No action needed.
 
-**GoErrorsAsToAsType (5)** — Go 1.26 `errors.AsType`:
+**GoErrorsAsToAsType (5)** — Go 1.26 `errors.AsType` — `complete`:
 
-- [ ] `internal/cli/output.go` line 82
-- [ ] `internal/cli/viper.go` line 87
-- [ ] `internal/pwsh/pwsh.go` line 273
-- [ ] `internal/signing/gcp_kms_test.go` line 217
-- [ ] `pkg/op/platform_helpers.go` line 36
+- [x] `internal/cli/output.go` line 82 — `errors.As` → `errors.AsType[*exitError]`
+- [x] `internal/cli/viper.go` line 87 — `errors.As` → `errors.AsType[viper.ConfigFileNotFoundError]`
+- [x] `internal/pwsh/pwsh.go` line 273 — `errors.As` → `errors.AsType[*exec.ExitError]`
+- [x] `internal/signing/gcp_kms_test.go` line 217 — N/A (file removed in prior cleanup)
+- [x] `pkg/op/platform_helpers.go` line 36 — `errors.As` → `errors.AsType[*exec.ExitError]`
 
 **GoDeprecation (2)** — deprecated `Parse` calls — `complete`:
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -53,11 +53,10 @@ Examples:
 			// Check if man page exists
 			if _, err := os.Stat(manPath); err == nil {
 				// Man page exists - try to display it via pager
-				now := time.Now()
 				h := &doc.GenManHeader{
 					Title:   header.Title,
 					Section: header.Section,
-					Date:    &now,
+					Date:    new(time.Now()),
 					Source:  header.Source,
 					Manual:  header.Manual,
 				}

--- a/internal/cli/man.go
+++ b/internal/cli/man.go
@@ -55,12 +55,10 @@ Examples:
 			h := &doc.GenManHeader{
 				Title:   header.Title,
 				Section: header.Section,
-				Date:    &time.Time{},
+				Date:    new(time.Now()),
 				Source:  header.Source,
 				Manual:  header.Manual,
 			}
-			now := time.Now()
-			h.Date = &now
 
 			if install {
 				return installManPages(rootCmd, h, installPath)

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -78,8 +78,7 @@ func ExitCode(err error) int {
 	if err == nil {
 		return ExitOK
 	}
-	var coded *exitError
-	if errors.As(err, &coded) {
+	if coded, ok := errors.AsType[*exitError](err); ok {
 		return coded.code
 	}
 	return ExitError

--- a/internal/cli/selfinstall.go
+++ b/internal/cli/selfinstall.go
@@ -318,11 +318,10 @@ func installManPagesTo(rootCmd *cobra.Command, path string, header ManHeader) ([
 	}
 
 	// Build header
-	now := time.Now()
 	h := &doc.GenManHeader{
 		Title:   header.Title,
 		Section: header.Section,
-		Date:    &now,
+		Date:    new(time.Now()),
 		Source:  header.Source,
 		Manual:  header.Manual,
 	}

--- a/internal/cli/viper.go
+++ b/internal/cli/viper.go
@@ -83,8 +83,7 @@ func InitViper(cfg ViperConfig) error {
 
 	// Read config file (ignore if not found)
 	if err := viper.ReadInConfig(); err != nil {
-		var notFound viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return fmt.Errorf("error reading config: %w", err)
 		}
 		// Config file not found is OK - use defaults and env vars

--- a/internal/execution/preflight_test.go
+++ b/internal/execution/preflight_test.go
@@ -79,8 +79,7 @@ func TestResolveResources_ShadowedEntry_Skipped(t *testing.T) {
 	// Resolve then shadow — the shadow supersedes the discovery entry.
 	catalog.Resolve("file:///nonexistent/file")
 
-	base := op.NewResourceBase("file:///nonexistent/file")
-	catalog.Shadow(&base, "writer-node")
+	catalog.Shadow(new(op.NewResourceBase("file:///nonexistent/file")), "writer-node")
 
 	// The discovery entry is superseded; no file check needed.
 	if err := ResolveResources(catalog); err != nil {

--- a/internal/pwsh/pwsh.go
+++ b/internal/pwsh/pwsh.go
@@ -244,8 +244,11 @@ func (s *Session) Run(command string) *Result {
 	// Send command directly in session scope, then emit a marker with the
 	// exit code. Using $global:LASTEXITCODE preserves native command exit
 	// codes; $? reflects PowerShell command success.
-	_, _ = fmt.Fprintf(s.stdin, "%s\n", command)                                                                                                                           //nolint:errcheck // best-effort stdin write
-	_, _ = fmt.Fprintf(s.stdin, "Write-Output '%s'$(if ($?) { $global:LASTEXITCODE } else { if ($global:LASTEXITCODE) { $global:LASTEXITCODE } else { 1 } })\n", s.marker) //nolint:errcheck // best-effort stdin write
+	_, _ = fmt.Fprintf(s.stdin, "%s\n", command)
+	_, _ = fmt.Fprintf(s.stdin,
+		"Write-Output '%s'$(if ($?) { $global:LASTEXITCODE } else { if ($global:LASTEXITCODE) { $global:LASTEXITCODE } else { 1 } })\n",
+		s.marker,
+	)
 
 	// Read output until we see the marker, stripping ANSI escape sequences.
 	// If the scanner hits EOF (process exited), capture exit from process state.
@@ -269,8 +272,7 @@ func (s *Session) Run(command string) *Result {
 	if !strings.HasPrefix(stripANSI(s.scanner.Text()), s.marker) {
 		s.dead = true
 		if err := s.cmd.Wait(); err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
+			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 				result.ExitCode = exitErr.ExitCode()
 			} else {
 				result.ExitCode = 1

--- a/pkg/op/output_test.go
+++ b/pkg/op/output_test.go
@@ -690,8 +690,7 @@ func TestFillSlotImplicitEdge_PlainResource(t *testing.T) {
 	consumer := makeTestNode("reader", "file.read")
 
 	// A plain ResourceBase with origin.
-	base := NewResourceBase("file:///baz")
-	res := &base
+	res := new(NewResourceBase("file:///baz"))
 	if _, err := g.Catalog.Shadow(res, "producer"); err != nil {
 		t.Fatalf("Shadow error: %v", err)
 	}

--- a/pkg/op/platform_helpers.go
+++ b/pkg/op/platform_helpers.go
@@ -32,8 +32,7 @@ func runShellCommand(command string, sudo bool) PlatformResult {
 	err := cmd.Run()
 	code := 0
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			code = exitErr.ExitCode()
 		} else {
 			code = -1

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -38,8 +38,7 @@ func (c *ResourceCatalog) Resolve(uri string) string {
 	if id, ok := c.ns[uri]; ok {
 		return id
 	}
-	base := NewResourceBase(uri)
-	return c.catalogLocked(&base, "")
+	return c.catalogLocked(new(NewResourceBase(uri)), "")
 }
 
 // Shadow catalogs a new resource version, updates the namespace to point to

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -192,8 +192,7 @@ func TestCatalog_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			base := NewResourceBase("file:///concurrent")
-			id, _ := cat.Shadow(&base, "")
+			id, _ := cat.Shadow(new(NewResourceBase("file:///concurrent")), "")
 			ids <- id
 		}()
 	}
@@ -263,8 +262,7 @@ func TestCatalog_IDsAreMonotonic(t *testing.T) {
 		t.Errorf("first ID = %q, want res-1", id1)
 	}
 
-	base := NewResourceBase("file:///b")
-	id2, err := cat.Shadow(&base, "node-1")
+	id2, err := cat.Shadow(new(NewResourceBase("file:///b")), "node-1")
 	if err != nil {
 		t.Fatalf("Shadow error: %v", err)
 	}

--- a/pkg/op/resource_test.go
+++ b/pkg/op/resource_test.go
@@ -65,8 +65,7 @@ func TestResourceBase_ParseFragment(t *testing.T) {
 }
 
 func TestResourceBase_SatisfiesInterface(t *testing.T) {
-	base := NewResourceBase("file:///bar")
-	var r Resource = &base
+	var r Resource = new(NewResourceBase("file:///bar"))
 	if r.URI() != "file:///bar" {
 		t.Errorf("Resource.URI() = %q, want file:///bar", r.URI())
 	}

--- a/pkg/op/starvalue_marshal_test.go
+++ b/pkg/op/starvalue_marshal_test.go
@@ -217,8 +217,7 @@ func TestMarshal_NilMap(t *testing.T) {
 }
 
 func TestMarshal_Pointer(t *testing.T) {
-	s := "hello"
-	got, err := Marshal(&s)
+	got, err := Marshal(new("hello"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **`errors.AsType[T]`**: Replace `errors.As(err, &typed)` with generic `errors.AsType[T](err)` in `output.go`, `viper.go`, `pwsh.go`, `platform_helpers.go`
- **`new(expr)`**: Replace `x := expr; &x` with `new(expr)` in 10 sites across `help.go`, `man.go`, `selfinstall.go`, `preflight_test.go`, `output_test.go`, `resource_catalog.go`, `resource_catalog_test.go`, `resource_test.go`, `starvalue_marshal_test.go`
- **nolint cleanup**: Remove redundant `//nolint:errcheck` directives on `_, _ = fmt.Fprintf(...)` calls in `pwsh.go`
- 2 items N/A (files removed in prior cleanup: `signing/gcp_kms_test.go`, `signing/azure_kv.go`)

Phase 6 (Style & Modernization) of the GoLand inspection cleanup is now complete. Phases 4 (Unhandled Errors) and 5 (Dead Code Removal) remain.

## Test plan

- [x] `make vet` passes
- [x] `make build` passes
- [x] `make test` passes (all packages)
- [ ] CI checks pass