### PR TITLE
fix(inspect): Handle all unhandled error results (Phase 4)

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -26,17 +26,17 @@ func TestMain(m *testing.M) {
 	// Build the binary to a temp directory.
 	tmp, err := os.MkdirTemp("", "devlore-test-cli-*")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(tmp)
+	defer func() { _ = os.RemoveAll(tmp) }()
 
 	binary = filepath.Join(tmp, "devlore-test")
 
 	// Find repo root (walk up from this file's directory until we find go.mod).
 	root, err := findRepoRoot()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "finding repo root: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "finding repo root: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 	build.Dir = root
 	build.Stderr = os.Stderr
 	if err := build.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "building devlore-test: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "building devlore-test: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -23,7 +23,7 @@ func main() {
 	flag.Parse()
 
 	if err := run(*outputDir, *version); err != nil {
-		fmt.Fprintf(os.Stderr, "docgen: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "docgen: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/indexgen/main.go
+++ b/cmd/indexgen/main.go
@@ -112,20 +112,20 @@ func main() { //nolint:gocognit
 			}
 		}
 		if *registryPath == "" {
-			fmt.Fprintln(os.Stderr, "error: --registry path required (or set DEVLORE_REGISTRY)")
+			_, _ = fmt.Fprintln(os.Stderr, "error: --registry path required (or set DEVLORE_REGISTRY)")
 			os.Exit(1)
 		}
 	}
 
 	knowledgeDir := filepath.Join(*registryPath, "knowledge")
 	if _, err := os.Stat(knowledgeDir); err != nil {
-		fmt.Fprintf(os.Stderr, "error: knowledge directory not found: %s\n", knowledgeDir)
+		_, _ = fmt.Fprintf(os.Stderr, "error: knowledge directory not found: %s\n", knowledgeDir)
 		os.Exit(1)
 	}
 
 	entries, err := os.ReadDir(knowledgeDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading knowledge directory: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error reading knowledge directory: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -138,7 +138,7 @@ func main() { //nolint:gocognit
 
 		index, err := buildIndex(domain, domainPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: error building index for %s: %v\n", domain, err)
+			_, _ = fmt.Fprintf(os.Stderr, "warning: error building index for %s: %v\n", domain, err)
 			continue
 		}
 
@@ -151,7 +151,7 @@ func main() { //nolint:gocognit
 			fmt.Println(string(data))
 		} else {
 			if err := writeIndex(domainPath, index); err != nil {
-				fmt.Fprintf(os.Stderr, "error writing index for %s: %v\n", domain, err)
+				_, _ = fmt.Fprintf(os.Stderr, "error writing index for %s: %v\n", domain, err)
 				continue
 			}
 			fmt.Printf("wrote %s/index.yaml\n", domain)

--- a/docs/plans/goland-inspection-cleanup.md
+++ b/docs/plans/goland-inspection-cleanup.md
@@ -124,51 +124,50 @@ Add exhaustive `case` branches (or explicit `default` with panic) for iota-const
 - `internal/writ/migrate/session_test.go` — Modify
 - `pkg/op/provider/file/gitignore/tracker.go` — Modify
 
-### Phase 4: Unhandled Error Results (117 issues)
+### Phase 4: Unhandled Error Results (117 issues) — `complete`
 
 The largest category. Many are `defer f.Close()` or `fmt.Fprintf` where the error is
 discarded. Strategy:
 
-- **`Close` errors (defer)**: Use a helper or assign to named return: `defer func() { _ = f.Close() }()` or check with
-  `closeErr`.
-- **`fmt.Fprintf/Fprintln/Fprint`**: Assign to `_` explicitly where the write target is stdout/stderr. For other
-  writers, check the error.
-- **`os.Remove/RemoveAll`**: Check the error or assign to `_` with comment if best-effort.
-- **`t.Setenv` / `os.Setenv` in tests**: These are legitimate `os.Setenv` calls — check the error.
+- **`Close` errors (defer)**: Use `iox.Close` helper (adopted in PR #232) or `defer func() { _ = f.Close() }()`.
+  Check error on write-file Close in success paths.
+- **`fmt.Fprintf/Fprintln/Fprint`**: Assign to `_` explicitly: `_, _ = fmt.Fprintf(...)`.
+- **`os.Remove/RemoveAll`**: Check the error or assign to `_` for best-effort.
+- **`os.Setenv` in tests**: Replace with `t.Setenv()` (idiomatic, auto-restores).
 
 **Production code (77 errors across 18 files)**:
 
-- [ ] `internal/lore/onboard/onboard.go` — 11 (Close, Fprintf)
-- [ ] `internal/writ/migrate/session.go` — 10 (Fprintf, Fprintln)
-- [ ] `internal/writ/tree/output.go` — 10 (Fprintf)
-- [ ] `pkg/op/provider/archive/provider.go` — 10 (Close, Remove)
-- [ ] `cmd/indexgen/main.go` — 5 (Fprintf, Fprintln)
-- [ ] `internal/model/config.go` — 5 (Fprint)
-- [ ] `internal/devloretest/commands.go` — 4 (Close)
-- [ ] `pkg/op/provider/file/provider.go` — 4 (Close)
-- [ ] `pkg/op/provider/mem/extract.go` — 4 (Fprintf)
-- [ ] `internal/execution/executor.go` — 3 (Close)
-- [ ] `pkg/op/provider/file/gitignore/tracker.go` — 3 (Close)
-- [ ] `internal/e2e/testrunner/runner.go` — 2 (Close, RemoveAll)
-- [ ] `cmd/docgen/main.go` — 1 (Fprintf)
-- [ ] `internal/cli/man.go` — 1 (Remove)
-- [ ] `internal/cli/receipts.go` — 1 (Remove)
-- [ ] `internal/execution/flow/degraded.go` — 1 (Fprintln)
-- [ ] `pkg/op/provider/appnet/provider.go` — 1 (Close)
-- [ ] `pkg/op/provider/file/resource.go` — 1 (Close)
+- [x] `internal/lore/onboard/onboard.go` — 11 (Close via iox.Close in prior PR, Fprintf: `_, _ =`)
+- [x] `internal/writ/migrate/session.go` — 10 (Fprintf: `_, _ =`, Fprintln: `_, _ =`)
+- [x] `internal/writ/tree/output.go` — 10 (Fprintf: `_, _ =`)
+- [x] `pkg/op/provider/archive/provider.go` — 10 (Close: checked on success, `_ =` on error; Remove: `//nolint:errcheck`)
+- [x] `cmd/indexgen/main.go` — 5 (Fprintf/Fprintln: `_, _ =`)
+- [x] `internal/model/config.go` — 5 (Fprint: `_, _ =`)
+- [x] `internal/devloretest/commands.go` — 4 (Close: already `iox.Close` in prior PR)
+- [x] `pkg/op/provider/file/provider.go` — 4 (Close: already `iox.Close` in prior PR)
+- [x] `pkg/op/provider/mem/extract.go` — 4 (Fprintf: `_, _ =`)
+- [x] `internal/execution/executor.go` — 3 (Close: `defer func() { _ = execCtx.Root.Close() }()`)
+- [x] `pkg/op/provider/file/gitignore/tracker.go` — 3 (Close: already `iox.Close` in prior PR)
+- [x] `internal/e2e/testrunner/runner.go` — 2 (Close: already `iox.Close`; RemoveAll: `defer func() { _ = ... }()`)
+- [x] `cmd/docgen/main.go` — 1 (Fprintf: `_, _ =`)
+- [x] `internal/cli/man.go` — 1 (Remove: already `//nolint:errcheck` + `_ = tmpFile.Close()`)
+- [x] `internal/cli/receipts.go` — 1 (Remove: already `//nolint:errcheck`)
+- [x] `internal/execution/flow/degraded.go` — 1 (Fprintln: `_, _ =`)
+- [x] `pkg/op/provider/appnet/provider.go` — 1 (Close: already `iox.Close` in prior PR)
+- [x] `pkg/op/provider/file/resource.go` — 1 (Close: already `iox.Close` in prior PR)
 
 **Test code (40 errors across 10 files)**:
 
-- [ ] `internal/credentials/credentials_test.go` — 12 (Setenv)
-- [ ] `pkg/op/provider/archive/provider_test.go` — 5 (Close)
-- [ ] `pkg/op/root_test.go` — 5 (Close)
-- [ ] `cmd/devlore-test/cli_test.go` — 4 (Fprintf, RemoveAll)
-- [ ] `internal/lore/builder_test.go` — 4 (Close)
-- [ ] `internal/execution/preflight_test.go` — 3 (Close, Shadow)
-- [ ] `internal/cli/config_test.go` — 2 (Close, ReadFrom)
-- [ ] `pkg/op/provider/file/provider_test.go` — 2 (Close)
-- [ ] `pkg/op/triad_test.go` — 2 (Close, RemoveAll)
-- [ ] `pkg/op/recovery_site_test.go` — 1 (RemoveAll)
+- [x] `internal/credentials/credentials_test.go` — 12 (Setenv → `t.Setenv`)
+- [x] `pkg/op/provider/archive/provider_test.go` — 5 (Close: already `defer func() { _ = f.Close() }()`)
+- [x] `pkg/op/root_test.go` — 5 (Close: `_ = f.Close()`, `_ = cr.Close()` in Cleanup)
+- [x] `cmd/devlore-test/cli_test.go` — 4 (Fprintf: `_, _ =`; RemoveAll: `defer func() { _ = ... }()`)
+- [x] `internal/lore/builder_test.go` — 4 (Close: already `defer func() { _ = root.Close() }()`)
+- [x] `internal/execution/preflight_test.go` — 3 (Close: `_ = f.Close()`; Shadow: `_, _ =`)
+- [x] `internal/cli/config_test.go` — 2 (Close: `_ = w.Close()`; ReadFrom: `_, _ =`)
+- [x] `pkg/op/provider/file/provider_test.go` — 2 (Close: `_ = f.Close()`)
+- [x] `pkg/op/triad_test.go` — 2 (Close: `_ = root.Close()` in Cleanup; RemoveAll: `_ =`)
+- [x] `pkg/op/recovery_site_test.go` — 1 (RemoveAll: `_ =`)
 
 **Files**: All 28 files listed above.
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -201,9 +201,9 @@ func TestPrintFlattened_ShowsAllSettings(t *testing.T) {
 
 	printFlattened("", config)
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 
 	output := buf.String()
 

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -12,9 +12,7 @@ import (
 func TestCredentialsRoundTrip(t *testing.T) {
 	// Use a temporary credentials directory for testing
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	key := "test/api-key"
 	secret := "test-secret-value-12345"
@@ -51,9 +49,7 @@ func TestCredentialsRoundTrip(t *testing.T) {
 func TestGetNonexistent(t *testing.T) {
 	// Use a temporary credentials directory for testing
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	_, err := Get("nonexistent/key")
 	// Should either return error or empty string
@@ -64,9 +60,7 @@ func TestGetNonexistent(t *testing.T) {
 func TestDeleteNonexistent(t *testing.T) {
 	// Use a temporary credentials directory for testing
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Deleting a nonexistent key should not error
 	err := Delete("nonexistent/key")
@@ -78,9 +72,7 @@ func TestDeleteNonexistent(t *testing.T) {
 func TestSetOverwrite(t *testing.T) {
 	// Use a temporary credentials directory for testing
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	key := "test/overwrite"
 
@@ -112,9 +104,7 @@ func TestSetOverwrite(t *testing.T) {
 func TestCredentialsFilePath(t *testing.T) {
 	// Verify credentials are stored in expected location
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	key := "test/filepath"
 	err := Set(key, "value")
@@ -137,9 +127,7 @@ func TestCredentialsFilePath(t *testing.T) {
 func TestMultipleKeys(t *testing.T) {
 	// Use a temporary credentials directory for testing
 	tmpDir := t.TempDir()
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	keys := map[string]string{
 		"ai/anthropic": "sk-ant-xxx",

--- a/internal/e2e/testrunner/runner.go
+++ b/internal/e2e/testrunner/runner.go
@@ -147,7 +147,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// 2. Create Runtime with requested providers
 	cfg := op.NewBindingConfig("devlore-test").

--- a/internal/execution/executor.go
+++ b/internal/execution/executor.go
@@ -15,6 +15,7 @@ import (
 
 	"go.starlark.net/starlark"
 
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/sops"
 )
@@ -218,14 +219,15 @@ func (e *GraphExecutor) Run(ctx context.Context, g *op.Graph) error {
 //
 // Returns:
 //   - error: non-nil if any node fails (when ConflictResolution is Stop).
-func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
+func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) (err error) {
+
 	ordered := OrderNodes(g.Nodes, g.Edges)
 
 	execCtx, err := e.newContext(ctx)
 	if err != nil {
 		return err
 	}
-	defer execCtx.Root.Close()
+	defer iox.Close(&err, execCtx.Root)
 	execCtx.Catalog = g.Catalog
 	execCtx.Graph = g
 
@@ -278,12 +280,13 @@ func (e *GraphExecutor) runFlat(ctx context.Context, g *op.Graph) error {
 //
 // Returns:
 //   - error: non-nil if any phase fails (includes rollback errors).
-func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) error { //nolint:gocognit,gocyclo // complexity is inherent to the algorithm
+func (e *GraphExecutor) RunPhased(ctx context.Context, g *op.Graph) (err error) { //nolint:gocognit,gocyclo // complexity is inherent to the algorithm
+
 	execCtx, err := e.newContext(ctx)
 	if err != nil {
 		return err
 	}
-	defer execCtx.Root.Close()
+	defer iox.Close(&err, execCtx.Root)
 	execCtx.Catalog = g.Catalog
 	execCtx.Graph = g
 
@@ -527,14 +530,15 @@ func (e *GraphExecutor) ExecutePhaseInner(ctx *op.Context, g *op.Graph, phase *o
 // Returns:
 //   - []*NodeResult: the per-node execution results.
 //   - error: non-nil if context creation or a node fails (when ConflictResolution is Stop).
-func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*op.Node, edges []op.Edge) ([]*NodeResult, error) {
+func (e *GraphExecutor) RunNodes(ctx context.Context, nodes []*op.Node, edges []op.Edge) (_ []*NodeResult, err error) {
+
 	ordered := OrderNodes(nodes, edges)
 
 	execCtx, err := e.newContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer execCtx.Root.Close()
+	defer iox.Close(&err, execCtx.Root)
 
 	// Hydrate stub actions and inject context into provider-backed actions.
 	freshReg := op.NewActionRegistry()

--- a/internal/execution/flow/degraded.go
+++ b/internal/execution/flow/degraded.go
@@ -32,7 +32,7 @@ func (a *Degraded) Do(_ *op.Context, slots map[string]any) (op.Result, op.Comple
 	kwargs := reassembleKwargs(slots)
 
 	rendered := op.RenderError(format, args, kwargs)
-	fmt.Fprintln(os.Stderr, "degraded:", rendered)
+	_, _ = fmt.Fprintln(os.Stderr, "degraded:", rendered)
 	return rendered, nil, nil
 }
 

--- a/internal/execution/preflight_test.go
+++ b/internal/execution/preflight_test.go
@@ -19,11 +19,12 @@ func TestResolveResources_NilCatalog(t *testing.T) {
 }
 
 func TestResolveResources_AllExist(t *testing.T) {
+
 	f, err := os.CreateTemp(t.TempDir(), "preflight-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	catalog := op.NewResourceCatalog()
 	catalog.Resolve("file://" + f.Name())
@@ -75,11 +76,12 @@ func TestResolveResources_NonFileScheme_Skipped(t *testing.T) {
 }
 
 func TestResolveResources_ShadowedEntry_Skipped(t *testing.T) {
+
 	catalog := op.NewResourceCatalog()
 	// Resolve then shadow — the shadow supersedes the discovery entry.
 	catalog.Resolve("file:///nonexistent/file")
 
-	catalog.Shadow(new(op.NewResourceBase("file:///nonexistent/file")), "writer-node")
+	_, _ = catalog.Shadow(new(op.NewResourceBase("file:///nonexistent/file")), "writer-node")
 
 	// The discovery entry is superseded; no file check needed.
 	if err := ResolveResources(catalog); err != nil {
@@ -88,11 +90,12 @@ func TestResolveResources_ShadowedEntry_Skipped(t *testing.T) {
 }
 
 func TestResolveResources_MixedSchemes(t *testing.T) {
+
 	f, err := os.CreateTemp(t.TempDir(), "preflight-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	catalog := op.NewResourceCatalog()
 	catalog.Resolve("file://" + f.Name())        // exists

--- a/internal/lore/onboard/onboard.go
+++ b/internal/lore/onboard/onboard.go
@@ -274,7 +274,7 @@ func parseDocuments(ctx context.Context, opts Options, docs []documentContent) (
 	// Build combined document content
 	var sb strings.Builder
 	for i, doc := range docs {
-		fmt.Fprintf(&sb, "## Document %d: %s\n\n", i+1, doc.URL)
+		_, _ = fmt.Fprintf(&sb, "## Document %d: %s\n\n", i+1, doc.URL)
 		sb.WriteString(truncateContent(doc.Content, 30000))
 		sb.WriteString("\n\n---\n\n")
 	}
@@ -312,12 +312,12 @@ func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, _ strin
 	var sb strings.Builder
 
 	if discovery.Product != nil {
-		fmt.Fprintf(&sb, "# Package: %s\n", discovery.Product.Name)
+		_, _ = fmt.Fprintf(&sb, "# Package: %s\n", discovery.Product.Name)
 		if discovery.Product.Vendor != "" {
-			fmt.Fprintf(&sb, "# Vendor: %s\n", discovery.Product.Vendor)
+			_, _ = fmt.Fprintf(&sb, "# Vendor: %s\n", discovery.Product.Vendor)
 		}
 		if discovery.Product.Version != "" {
-			fmt.Fprintf(&sb, "# Version: %s\n", discovery.Product.Version)
+			_, _ = fmt.Fprintf(&sb, "# Version: %s\n", discovery.Product.Version)
 		}
 		sb.WriteString("#\n")
 	}
@@ -326,7 +326,7 @@ func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, _ strin
 	if discovery.Complexity != nil && discovery.Complexity.Rating == "complex" {
 		sb.WriteString("# WARNING: Complex installation\n")
 		for _, concern := range discovery.Complexity.Concerns {
-			fmt.Fprintf(&sb, "#   - %s\n", concern)
+			_, _ = fmt.Fprintf(&sb, "#   - %s\n", concern)
 		}
 		sb.WriteString("#\n")
 	}
@@ -337,12 +337,12 @@ func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, _ strin
 	for _, slot := range slots {
 		if slot.Name == "install_command" || slot.Name == "package_manager" {
 			if slot.Platform != "" && slot.Platform != "all" {
-				fmt.Fprintf(&sb, "# Platform: %s\n", slot.Platform)
+				_, _ = fmt.Fprintf(&sb, "# Platform: %s\n", slot.Platform)
 			}
-			fmt.Fprintf(&sb, "%s\n", slot.Value)
+			_, _ = fmt.Fprintf(&sb, "%s\n", slot.Value)
 			if len(slot.Annotations) > 0 {
 				for _, ann := range slot.Annotations {
-					fmt.Fprintf(&sb, "  # %s\n", ann)
+					_, _ = fmt.Fprintf(&sb, "  # %s\n", ann)
 				}
 			}
 			sb.WriteString("\n")
@@ -351,8 +351,8 @@ func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, _ strin
 
 	// If no install commands found, use canonical name as placeholder
 	if discovery.Product != nil && !strings.Contains(sb.String(), discovery.Product.CanonicalName) {
-		fmt.Fprintf(&sb, "# TODO: Add installation method for %s\n", discovery.Product.CanonicalName)
-		fmt.Fprintf(&sb, "# %s\n", discovery.Product.CanonicalName)
+		_, _ = fmt.Fprintf(&sb, "# TODO: Add installation method for %s\n", discovery.Product.CanonicalName)
+		_, _ = fmt.Fprintf(&sb, "# %s\n", discovery.Product.CanonicalName)
 	}
 
 	return sb.String()

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -255,7 +255,7 @@ func promptForProvider(ctx context.Context) (Provider, error) { //nolint:gocyclo
 	cli.Note("  [4] OpenAI (cloud, GPT models)")
 	cli.Note("      Get API key: https://platform.openai.com")
 	cli.Note("")
-	fmt.Fprint(os.Stderr, "Choice [1/2/3/4]: ")
+	_, _ = fmt.Fprint(os.Stderr, "Choice [1/2/3/4]: ")
 
 	input, err := reader.ReadString('\n')
 	if err != nil {
@@ -267,7 +267,7 @@ func promptForProvider(ctx context.Context) (Provider, error) { //nolint:gocyclo
 
 	switch choice {
 	case "1", "":
-		fmt.Fprint(os.Stderr, "Groq API key: ")
+		_, _ = fmt.Fprint(os.Stderr, "Groq API key: ")
 		apiKey, err := reader.ReadString('\n')
 		if err != nil {
 			return nil, err
@@ -279,7 +279,7 @@ func promptForProvider(ctx context.Context) (Provider, error) { //nolint:gocyclo
 		}
 
 	case "2":
-		fmt.Fprint(os.Stderr, "Gemini API key: ")
+		_, _ = fmt.Fprint(os.Stderr, "Gemini API key: ")
 		apiKey, err := reader.ReadString('\n')
 		if err != nil {
 			return nil, err
@@ -291,7 +291,7 @@ func promptForProvider(ctx context.Context) (Provider, error) { //nolint:gocyclo
 		}
 
 	case "3":
-		fmt.Fprint(os.Stderr, "Anthropic API key: ")
+		_, _ = fmt.Fprint(os.Stderr, "Anthropic API key: ")
 		apiKey, err := reader.ReadString('\n')
 		if err != nil {
 			return nil, err
@@ -303,7 +303,7 @@ func promptForProvider(ctx context.Context) (Provider, error) { //nolint:gocyclo
 		}
 
 	case "4":
-		fmt.Fprint(os.Stderr, "OpenAI API key: ")
+		_, _ = fmt.Fprint(os.Stderr, "OpenAI API key: ")
 		apiKey, err := reader.ReadString('\n')
 		if err != nil {
 			return nil, err

--- a/internal/writ/migrate/session.go
+++ b/internal/writ/migrate/session.go
@@ -210,21 +210,21 @@ Do not output JSON. Write in a friendly, conversational tone.`
 func (s *Session) generateStaticInitialResponse() string {
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "## Analysis of %s\n\n", s.opts.SourceRoot)
-	fmt.Fprintf(&sb, "**Detected system:** %s", s.analysis.System)
+	_, _ = fmt.Fprintf(&sb, "## Analysis of %s\n\n", s.opts.SourceRoot)
+	_, _ = fmt.Fprintf(&sb, "**Detected system:** %s", s.analysis.System)
 	if s.analysis.SystemConfidence > 0 {
-		fmt.Fprintf(&sb, " (%.0f%% confidence)", s.analysis.SystemConfidence*100)
+		_, _ = fmt.Fprintf(&sb, " (%.0f%% confidence)", s.analysis.SystemConfidence*100)
 	}
 	sb.WriteString("\n\n")
 
 	st := s.analysis.Stats
-	fmt.Fprintf(&sb, "**Files:** %d | **Projects:** %d | **Platforms:** %d\n\n",
+	_, _ = fmt.Fprintf(&sb, "**Files:** %d | **Projects:** %d | **Platforms:** %d\n\n",
 		st.TotalFiles, st.Projects, st.Platforms)
 
 	if len(s.analysis.Observations) > 0 {
 		sb.WriteString("### Observations\n")
 		for _, obs := range s.analysis.Observations {
-			fmt.Fprintf(&sb, "- %s\n", obs)
+			_, _ = fmt.Fprintf(&sb, "- %s\n", obs)
 		}
 		sb.WriteString("\n")
 	}
@@ -232,7 +232,7 @@ func (s *Session) generateStaticInitialResponse() string {
 	if len(s.analysis.Warnings) > 0 {
 		sb.WriteString("### Warnings\n")
 		for _, warn := range s.analysis.Warnings {
-			fmt.Fprintf(&sb, "- %s\n", warn)
+			_, _ = fmt.Fprintf(&sb, "- %s\n", warn)
 		}
 		sb.WriteString("\n")
 	}
@@ -240,7 +240,7 @@ func (s *Session) generateStaticInitialResponse() string {
 	if len(s.analysis.Recommendations) > 0 {
 		sb.WriteString("### Recommendations\n")
 		for _, rec := range s.analysis.Recommendations {
-			fmt.Fprintf(&sb, "- %s\n", rec)
+			_, _ = fmt.Fprintf(&sb, "- %s\n", rec)
 		}
 		sb.WriteString("\n")
 	}
@@ -366,7 +366,7 @@ func (s *Session) formatGraphForPrompt() string {
 		tgt, _ := node.GetSlot("path").(string)   //nolint:errcheck // zero value (empty) is acceptable
 		source := strings.TrimPrefix(src, s.opts.SourceRoot+"/")
 		target := strings.TrimPrefix(tgt, s.opts.SourceRoot+"/")
-		fmt.Fprintf(&sb, "  %s -> %s\n", source, target)
+		_, _ = fmt.Fprintf(&sb, "  %s -> %s\n", source, target)
 	}
 	return sb.String()
 }
@@ -560,7 +560,7 @@ func (s *Session) outputJSON() {
 		cli.Warn("Failed to format JSON output: %v", err)
 		return
 	}
-	fmt.Fprintln(os.Stdout, buf.String()) //nolint:errcheck // stdout output
+	_, _ = fmt.Fprintln(os.Stdout, buf.String())
 }
 
 // completeStep shows the completion message.
@@ -573,7 +573,7 @@ func (s *Session) completeStep() *console.Step {
 	if len(s.analysis.Recommendations) > 0 {
 		content.WriteString("### Next Steps\n")
 		for i, rec := range s.analysis.Recommendations {
-			fmt.Fprintf(&content, "%d. %s\n", i+1, rec)
+			_, _ = fmt.Fprintf(&content, "%d. %s\n", i+1, rec)
 		}
 	}
 

--- a/internal/writ/tree/output.go
+++ b/internal/writ/tree/output.go
@@ -21,27 +21,27 @@ func (r *BuildResult) String() string {
 
 	// Multi-source mode: show all sources
 	if len(r.Sources) > 0 {
-		fmt.Fprintf(&sb, "Deployment: %d layers → %s\n", len(r.Sources), r.TargetRoot)
+		_, _ = fmt.Fprintf(&sb, "Deployment: %d layers → %s\n", len(r.Sources), r.TargetRoot)
 		for _, src := range r.Sources {
-			fmt.Fprintf(&sb, "  %s: %s\n", src.Layer, src.SourceRoot)
+			_, _ = fmt.Fprintf(&sb, "  %s: %s\n", src.Layer, src.SourceRoot)
 		}
 		sb.WriteString("\n")
 	} else {
 		// Single-source mode
-		fmt.Fprintf(&sb, "Deployment: %s → %s\n\n", r.SourceRoot, r.TargetRoot)
+		_, _ = fmt.Fprintf(&sb, "Deployment: %s → %s\n\n", r.SourceRoot, r.TargetRoot)
 	}
-	fmt.Fprintf(&sb, "Projects: %s\n\n", strings.Join(r.Projects, ", "))
+	_, _ = fmt.Fprintf(&sb, "Projects: %s\n\n", strings.Join(r.Projects, ", "))
 
 	sb.WriteString("Matched directories:\n")
 	for _, m := range r.MatchedDirs {
-		fmt.Fprintf(&sb, "  %s/\n", filepath.Base(m.Path))
+		_, _ = fmt.Fprintf(&sb, "  %s/\n", filepath.Base(m.Path))
 	}
 	sb.WriteString("\n")
 
 	if r.HasCollisions() {
-		fmt.Fprintf(&sb, "Collisions (%d):\n", len(r.Collisions))
+		_, _ = fmt.Fprintf(&sb, "Collisions (%d):\n", len(r.Collisions))
 		for _, c := range r.Collisions {
-			fmt.Fprintf(&sb, "  %s: %s (specificity %d) overrides %s (specificity %d)\n",
+			_, _ = fmt.Fprintf(&sb, "  %s: %s (specificity %d) overrides %s (specificity %d)\n",
 				c.Target,
 				filepath.Base(filepath.Dir(c.Winner)),
 				c.WinnerSpecificity,
@@ -51,13 +51,13 @@ func (r *BuildResult) String() string {
 		sb.WriteString("\n")
 	}
 
-	fmt.Fprintf(&sb, "Files (%d):\n", r.FileCount())
-	fmt.Fprintf(&sb, "  Links: %d, Templates: %d, Secrets: %d\n\n",
+	_, _ = fmt.Fprintf(&sb, "Files (%d):\n", r.FileCount())
+	_, _ = fmt.Fprintf(&sb, "  Links: %d, Templates: %d, Secrets: %d\n\n",
 		r.LinkCount(), r.TemplateCount(), r.SecretCount())
 
 	for _, f := range r.Files {
 		actions := "[" + strings.Join(f.Operations, ", ") + "]"
-		fmt.Fprintf(&sb, "  %-40s %s\n", f.ID, actions)
+		_, _ = fmt.Fprintf(&sb, "  %-40s %s\n", f.ID, actions)
 	}
 
 	return sb.String()

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -8,6 +8,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -96,6 +97,7 @@ func removeEmptyDirs(root string) error {
 }
 
 func extractTarGz(source, prefix string) (created []string, err error) { //nolint:gocognit
+
 	f, err := os.Open(source)
 	if err != nil {
 		return nil, err
@@ -141,10 +143,11 @@ func extractTarGz(source, prefix string) (created []string, err error) { //nolin
 				return created, err
 			}
 			if _, err := io.Copy(out, io.LimitReader(tr, 1<<30)); err != nil { //nolint:gosec // G110: bounded to 1 GiB
-				out.Close()
+				return created, errors.Join(err, out.Close())
+			}
+			if err := out.Close(); err != nil {
 				return created, err
 			}
-			out.Close()
 			created = append(created, target)
 		}
 	}
@@ -152,6 +155,7 @@ func extractTarGz(source, prefix string) (created []string, err error) { //nolin
 }
 
 func extractZip(source, prefix string) (created []string, err error) {
+
 	r, err := zip.OpenReader(source)
 	if err != nil {
 		return nil, err
@@ -186,17 +190,16 @@ func extractZip(source, prefix string) (created []string, err error) {
 
 		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		if err != nil {
-			rc.Close()
-			return created, err
+			return created, errors.Join(err, rc.Close())
 		}
 
 		if _, err := io.Copy(out, io.LimitReader(rc, 1<<30)); err != nil { //nolint:gosec // G110: bounded to 1 GiB
-			out.Close()
-			rc.Close()
-			return created, err
+			return created, errors.Join(err, out.Close(), rc.Close())
 		}
-		out.Close()
-		rc.Close()
+		if err := out.Close(); err != nil {
+			return created, errors.Join(err, rc.Close())
+		}
+		_ = rc.Close()
 		created = append(created, target)
 	}
 	return created, nil

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -1680,10 +1680,10 @@ func testFileResource(t *testing.T, content []byte) Resource {
 		t.Fatalf("creating temp file: %v", err)
 	}
 	if _, err := f.Write(content); err != nil {
-		f.Close()
+		_ = f.Close()
 		t.Fatalf("writing temp file: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 	root := testRoot(t, dir)
 	fileResource := NewResource(f.Name())
 	if err := fileResource.Resolve(root); err != nil {

--- a/pkg/op/provider/mem/extract.go
+++ b/pkg/op/provider/mem/extract.go
@@ -95,7 +95,7 @@ func synthesize(fn *starlark.Function, params []string) ([]byte, error) {
 	// Header comment.
 	pos := fn.Position()
 	if pos.IsValid() {
-		fmt.Fprintf(&b, "# Extracted callable — from %s\n", pos)
+		_, _ = fmt.Fprintf(&b, "# Extracted callable — from %s\n", pos)
 	}
 
 	// Closure bindings as module-level constants.
@@ -107,7 +107,7 @@ func synthesize(fn *starlark.Function, params []string) ([]byte, error) {
 			if err != nil {
 				return nil, fmt.Errorf("closure binding %q: %w", binding.Name, err)
 			}
-			fmt.Fprintf(&b, "%s = %s\n", binding.Name, lit)
+			_, _ = fmt.Fprintf(&b, "%s = %s\n", binding.Name, lit)
 		}
 		b.WriteString("\n")
 	}
@@ -121,8 +121,8 @@ func synthesize(fn *starlark.Function, params []string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("lambda extraction: %w", err)
 		}
-		fmt.Fprintf(&b, "def _callable(%s):\n", strings.Join(params, ", "))
-		fmt.Fprintf(&b, "    return %s\n", body)
+		_, _ = fmt.Fprintf(&b, "def _callable(%s):\n", strings.Join(params, ", "))
+		_, _ = fmt.Fprintf(&b, "    return %s\n", body)
 	} else {
 		// For named functions, extract the full def from source.
 		defText, err := extractDefSource(fn)

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -127,7 +127,9 @@ func TestRestoreFile_RecreatesParentDir(t *testing.T) {
 	}
 
 	// Simulate pruneEmptyParents removing the parent directory.
-	os.RemoveAll(filepath.Join(tmp, "a"))
+	if err := os.RemoveAll(filepath.Join(tmp, "a")); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := site.RestoreFile(p, recoveryID); err != nil {
 		t.Fatalf("RestoreFile() error = %v", err)

--- a/pkg/op/root_test.go
+++ b/pkg/op/root_test.go
@@ -388,7 +388,7 @@ func TestRoot_OpenFile(t *testing.T) {
 			if _, err := f.Write([]byte("written")); err != nil {
 				t.Fatalf("Write: %v", err)
 			}
-			f.Close()
+			_ = f.Close()
 
 			data, err := os.ReadFile(p.Abs())
 			if err != nil {
@@ -573,7 +573,7 @@ func allRoots(t *testing.T, dir string) []rootCase {
 	if err != nil {
 		t.Fatalf("NewConfinedRoot: %v", err)
 	}
-	t.Cleanup(func() { cr.Close() })
+	t.Cleanup(func() { _ = cr.Close() })
 
 	return []rootCase{
 		{"RootReader", op.NewRootReader(dir)},
@@ -590,7 +590,7 @@ func writableRoots(t *testing.T, dir string) []rootCase {
 	if err != nil {
 		t.Fatalf("NewConfinedRoot: %v", err)
 	}
-	t.Cleanup(func() { cr.Close() })
+	t.Cleanup(func() { _ = cr.Close() })
 
 	return []rootCase{
 		{"RootReaderWriter", op.NewRootReaderWriter(dir)},

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -46,7 +46,7 @@ func newTriadConfined(t *testing.T) triadEnv {
 	if err != nil {
 		t.Fatalf("NewConfinedRoot: %v", err)
 	}
-	t.Cleanup(func() { root.Close() })
+	t.Cleanup(func() { _ = root.Close() })
 	return newTriad(t, root, dir)
 }
 
@@ -223,7 +223,9 @@ func TestTriad_NestedPathRecreation(t *testing.T) {
 			}
 
 			// Remove parent dirs to simulate pruneEmptyParents.
-			os.RemoveAll(filepath.Join(env.Dir, "a"))
+			if err := os.RemoveAll(filepath.Join(env.Dir, "a")); err != nil {
+				t.Fatal(err)
+			}
 
 			// Restore recreates parents.
 			if err := env.Site.RestoreFile(p, recoveryID); err != nil {


### PR DESCRIPTION
## Summary

- Resolve all 117 `GoUnhandledErrorResult` inspection warnings (Phase 4 of the GoLand inspection cleanup plan)
- Production Close errors: `defer iox.Close(&err, ...)` with named returns in executor.go; `errors.Join` on error paths in archive extraction loops
- `fmt.Fprintf`/`Fprint` to `strings.Builder` and `os.Stderr`: explicit `_, _ =` discard
- Test cleanup: `os.Setenv` → `t.Setenv`, bare `.Close()` → checked or explicitly discarded, `os.RemoveAll` in test setup → checked with `t.Fatal`
- Blank-line-after-signature style fixes in all touched functions

## Test plan

- [x] `make vet` passes
- [x] `make test` passes (all 73 packages)
- [x] Grep for `legacy|backward|compat|deprecated` — no actionable matches
- [ ] Re-export GoLand inspections and confirm GoUnhandledErrorResult count drops to zero