### PR TITLE
test(provider): Add Starlark and action dispatch integration tests (Phases 1-4)

### DIFF
--- a/docs/plans/platform-provider-tests.md
+++ b/docs/plans/platform-provider-tests.md
@@ -1,0 +1,216 @@
+---
+title: "Provider and Flow Integration Tests"
+issue: TBD
+status: in-progress
+created: 2026-03-17
+updated: 2026-03-17
+---
+
+# Plan: Provider and Flow Integration Tests
+
+## Summary
+
+Add black-box integration tests for every provider and flow element. Only starcode has Starlark integration tests today — all other providers (19) and flow have zero. Every provider must be tested through the Starlark executing receiver and through graph action dispatch. Generated tests are out of scope — they are the code generator's responsibility.
+
+## Goals
+
+1. **Starlark integration tests** for every provider: execute a `.star` script that exercises the provider's full API surface via the executing receiver
+2. **Graph action tests** for every provider: exercise `action.Do()` with a real context, verifying result values
+3. **Flow integration tests**: exercise flow actions (choose, gather, elevate, wait_until, complete, degraded, fatal) through both the Plan receiver and action dispatch
+
+## Current State
+
+| Provider | Hand-written tests | Starlark `.star` | Integration test | Gap |
+| --- | --- | --- | --- | --- |
+| platform | 0 | 0 | 0 | All three paths missing |
+| json | 1 | 0 | 0 | Starlark + action tests missing |
+| yaml | 1 | 0 | 0 | Starlark + action tests missing |
+| regexp | 1 | 0 | 0 | Starlark + action tests missing |
+| ui | 1 | 0 | 0 | Starlark + action tests missing |
+| shell | 1 | 0 | 0 | Starlark + action tests missing |
+| template | 1 | 0 | 0 | Starlark + action tests missing |
+| file | 1 | 0 | 0 | Starlark + action tests missing |
+| archive | 1 | 0 | 0 | Starlark + action tests missing |
+| encryption | 1 | 0 | 0 | Starlark + action tests missing |
+| git | 2 | 0 | 0 | Starlark + action tests missing |
+| appnet | 2 | 0 | 0 | Starlark + action tests missing |
+| pkg | 2 | 0 | 0 | Starlark + action tests missing |
+| service | 1 | 0 | 0 | Starlark + action tests missing |
+| mem | 4 | 0 | 0 | Starlark + action tests missing |
+| starcode | 3 | 6 | 1 | Reference implementation — complete |
+| staranalysis | 1 | 0 | 0 | Starlark + action tests missing |
+| starcomplexity | 2 | 0 | 0 | Starlark + action tests missing |
+| starindex | 1 | 0 | 0 | Starlark + action tests missing |
+| starstats | 1 | 0 | 0 | Starlark + action tests missing |
+| **flow** | 1 (unit) | 0 | 0 | Starlark plan + action tests missing |
+
+## Implementation Phases
+
+### Phase 1: Pure-data providers (no I/O, no mocks needed)
+
+These providers are self-contained — no filesystem, network, or platform dependencies. Ideal starting point.
+
+- [x] **platform** — `integration_test.go` + `testdata/integration.star`; inject known `op.Platform` on context
+- [x] **json** — encode/decode round-trips through Starlark
+- [x] **yaml** — encode/decode round-trips through Starlark
+- [x] **regexp** — all 8 methods: match, find, findAll, findSubmatch, findAllSubmatch, replace, replaceLiteral, split
+- [x] **template** — DEFERRED to Phase 7 (refactor first)
+
+Each provider gets:
+- `testdata/integration.star` — exercises full API, sets `result_*` globals
+- `integration_test.go` — builds context, wraps in `ExecutingReceiver`, executes script, asserts globals
+
+**Files** (10 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/platform/testdata/integration.star` | Create |
+| `pkg/op/provider/platform/integration_test.go` | Create |
+| `pkg/op/provider/json/testdata/integration.star` | Create |
+| `pkg/op/provider/json/integration_test.go` | Create |
+| `pkg/op/provider/yaml/testdata/integration.star` | Create |
+| `pkg/op/provider/yaml/integration_test.go` | Create |
+| `pkg/op/provider/regexp/testdata/integration.star` | Create |
+| `pkg/op/provider/regexp/integration_test.go` | Create |
+### Phase 2: UI and shell providers
+
+These have side effects but are testable with buffer writers and controlled environments.
+
+- [x] **ui** — error, note, success, warn, fail; capture writer output in Starlark test
+- [x] **shell** — exec with a trivial command (e.g., `echo hello`)
+
+**Files** (4 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/ui/testdata/integration.star` | Create |
+| `pkg/op/provider/ui/integration_test.go` | Create |
+| `pkg/op/provider/shell/testdata/integration.star` | Create |
+| `pkg/op/provider/shell/integration_test.go` | Create |
+
+### Phase 3: Filesystem providers
+
+Require temp directories and `op.Root` setup.
+
+- [x] **file** — writeText, readText, copy, link, remove, exists, isFile, isDir, mkdir, join, name, parent, root
+- [x] **archive** — extract tar.gz into temp dir, verify extraction + compensation tombstone
+
+**Files** (4 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/file/testdata/integration.star` | Create |
+| `pkg/op/provider/file/integration_test.go` | Create |
+| `pkg/op/provider/archive/testdata/integration.star` | Create |
+| `pkg/op/provider/archive/integration_test.go` | Create |
+
+### Phase 4: Starlark analysis providers
+
+These are already tested at the Go level but not through the Starlark runtime.
+
+- [x] **staranalysis** — analyze with config dict
+- [x] **starcomplexity** — computeComplexity on test .star files
+- [x] **starindex** — indexFiles with docstrings/globals flags
+- [x] **starstats** — computeStats with bytes/loc flags
+
+**Files** (8 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/staranalysis/testdata/integration.star` | Create |
+| `pkg/op/provider/staranalysis/integration_test.go` | Create |
+| `pkg/op/provider/starcomplexity/testdata/integration.star` | Create |
+| `pkg/op/provider/starcomplexity/integration_test.go` | Create |
+| `pkg/op/provider/starindex/testdata/integration.star` | Create |
+| `pkg/op/provider/starindex/integration_test.go` | Create |
+| `pkg/op/provider/starstats/testdata/integration.star` | Create |
+| `pkg/op/provider/starstats/integration_test.go` | Create |
+
+### Phase 5: External-dependency providers (mocked or skippable)
+
+These need network/platform services. Use interface mocks or skip when unavailable.
+
+- [ ] **appnet** — download with a test HTTP server
+- [ ] **git** — clone/checkout/pull with a local bare repo
+- [ ] **encryption** — decrypt with a test SOPS fixture
+- [ ] **pkg** — install/remove/upgrade with mock PackageManager
+- [ ] **service** — enable/disable/start/stop with mock ServiceManager
+- [ ] **mem** — memory provider operations
+
+**Files** (12 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/appnet/testdata/integration.star` | Create |
+| `pkg/op/provider/appnet/integration_test.go` | Create |
+| `pkg/op/provider/git/testdata/integration.star` | Create |
+| `pkg/op/provider/git/integration_test.go` | Create |
+| `pkg/op/provider/encryption/testdata/integration.star` | Create |
+| `pkg/op/provider/encryption/integration_test.go` | Create |
+| `pkg/op/provider/pkg/testdata/integration.star` | Create |
+| `pkg/op/provider/pkg/integration_test.go` | Create |
+| `pkg/op/provider/service/testdata/integration.star` | Create |
+| `pkg/op/provider/service/integration_test.go` | Create |
+| `pkg/op/provider/mem/testdata/integration.star` | Create |
+| `pkg/op/provider/mem/integration_test.go` | Create |
+
+### Phase 6: Flow actions
+
+Flow is handwritten (not generated). Test through the `Plan` receiver and action `Do()`.
+
+- [ ] **complete** — create terminal node via Plan, execute action
+- [ ] **degraded** — format string with args/kwargs, verify error message
+- [ ] **fatal** — verify FatalError return
+- [ ] **choose** — branch selection with condition evaluation
+- [ ] **gather** — parallel fan-out collection
+- [ ] **elevate** — privilege escalation marker
+- [ ] **wait_until** — condition polling
+
+**Files** (2 new):
+
+| File | Action |
+| --- | --- |
+| `pkg/op/flow/testdata/integration.star` | Create |
+| `pkg/op/flow/integration_test.go` | Create |
+
+## Test Structure
+
+Each `integration_test.go` contains two subtests:
+
+1. `TestStarlark` — wraps provider in `ExecutingReceiver`, runs `testdata/integration.star`, asserts result globals
+2. `TestActions` — registers actions via `RegisterActions`, calls `action.Do()` with a real context and params map, asserts result values
+
+Same context setup, same provider instance, different entry points. One file per provider covers both the Starlark reflection bridge and the action dispatch bridge.
+
+### Phase 7: Template provider refactor
+
+The current `Render` method conflates template execution with metadata injection. `source`, `path`, and `project` are pipeline metadata — they describe where content came from and where it's going. They belong on the context or in the caller's data map, not as provider method parameters.
+
+**Refactor:**
+
+1. Replace `Render` with two entry points:
+   - `RenderText(content string, data map[string]any) (string, error)`
+   - `RenderBytes(content []byte, data map[string]any) ([]byte, error)`
+2. Remove `source`, `path`, `project` parameters — callers inject these into `data` if needed
+3. Update all callers in `internal/execution/` to populate `data["Source"]`, `data["Target"]`, `data["Project"]` before calling render
+4. Update codegen params, regenerate
+5. Add integration tests (Starlark + action dispatch)
+
+**Files**:
+
+| File | Action |
+| --- | --- |
+| `pkg/op/provider/template/provider.go` | Modify |
+| `pkg/op/provider/template/provider_test.go` | Modify |
+| `pkg/op/provider/template/gen/params.gen.go` | Regenerate |
+| `internal/execution/plan.go` | Modify |
+| `internal/execution/execution_test.go` | Modify |
+| `internal/execution/lifecycle_test.go` | Modify |
+| `pkg/op/provider/template/testdata/integration.star` | Create |
+| `pkg/op/provider/template/integration_test.go` | Modify |
+
+## Out of Scope
+
+- Modifying or adding tests in `gen/` directories — those are the code generator's responsibility
+- Unit tests on provider internals — focus is black-box through Starlark and graph actions
+- starcode — already has complete integration test coverage

--- a/pkg/op/provider/archive/integration_test.go
+++ b/pkg/op/provider/archive/integration_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package archive_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/archive"
+	archivegen "github.com/NobleFactor/devlore-cli/pkg/op/provider/archive/gen"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen" // register file.Resource constructor
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx(t *testing.T) (op.Context, string) {
+	t.Helper()
+	dir := t.TempDir()
+	root := op.NewRootReaderWriter(dir)
+	ctx := op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+			Root:    root,
+		},
+	}
+	ctx.RecoverySite = op.NewRecoverySite(ctx)
+	return ctx, dir
+}
+
+// createTestTarGz creates a tar.gz with a single file inside.
+func createTestTarGz(t *testing.T, dir string) string {
+	t.Helper()
+	archivePath := filepath.Join(dir, "test.tar.gz")
+
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	content := []byte("extracted content")
+	hdr := &tar.Header{
+		Name: "sample.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write content: %v", err)
+	}
+
+	return archivePath
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx, dir := testCtx(t)
+	archivePath := createTestTarGz(t, dir)
+	destDir := filepath.Join(dir, "extracted")
+
+	p := archive.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(archivegen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"archive":      receiver,
+		"test_archive": starlark.String(archivePath),
+		"test_dest":    starlark.String(destDir),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "archive-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+
+	// Verify the file was actually extracted.
+	extracted := filepath.Join(destDir, "sample.txt")
+	content, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("reading extracted file: %v", err)
+	}
+	if string(content) != "extracted content" {
+		t.Errorf("extracted content = %q, want 'extracted content'", string(content))
+	}
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Extract(t *testing.T) {
+	ctx, dir := testCtx(t)
+	archivePath := createTestTarGz(t, dir)
+	destDir := filepath.Join(dir, "action_extracted")
+
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, archivegen.Receiver, archivegen.Params)
+
+	a, ok := reg.Get("archive.extract")
+	if !ok {
+		t.Fatal("action archive.extract not registered")
+	}
+
+	result, complement, err := a.Do(&ctx, map[string]any{
+		"source": file.NewResource(archivePath),
+		"prefix": file.NewResource(destDir),
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	// Result should be a file.Resource for the dest dir.
+	res, ok := result.(file.Resource)
+	if !ok {
+		t.Fatalf("result type = %T, want file.Resource", result)
+	}
+	if res.SourcePath.Abs() != destDir {
+		t.Errorf("result path = %q, want %q", res.SourcePath.Abs(), destDir)
+	}
+
+	// Complement should be non-nil (compensable action).
+	if complement == nil {
+		t.Error("complement = nil, want non-nil tombstone")
+	}
+
+	// Verify extraction.
+	extracted := filepath.Join(destDir, "sample.txt")
+	content, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("reading extracted file: %v", err)
+	}
+	if string(content) != "extracted content" {
+		t.Errorf("extracted content = %q, want 'extracted content'", string(content))
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/archive/testdata/integration.star
+++ b/pkg/op/provider/archive/testdata/integration.star
@@ -1,0 +1,8 @@
+# Integration test for archive provider.
+# test_archive and test_dest are injected by the Go test.
+# Exercises: extract (tar.gz).
+
+result_extract = archive.extract(test_archive, test_dest)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/file/integration_test.go
+++ b/pkg/op/provider/file/integration_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package file_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	filegen "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx(t *testing.T) (op.Context, string) {
+	t.Helper()
+	dir := t.TempDir()
+	root := op.NewRootReaderWriter(dir)
+	ctx := op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+			Root:    root,
+		},
+	}
+	ctx.RecoverySite = op.NewRecoverySite(ctx)
+	return ctx, dir
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx, dir := testCtx(t)
+	p := file.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(filegen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"file":     receiver,
+		"test_dir": starlark.String(dir),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "file-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+
+	// path utilities
+	assertStringContains(t, result, "result_join", "sub")
+	assertStringEQ(t, result, "result_name", "c.txt")
+	assertStringEQ(t, result, "result_parent", "/a/b")
+	assertStringEQ(t, result, "result_root", dir)
+
+	// mkdir + is_dir
+	assertBool(t, result, "result_is_dir")
+
+	// write_text + read_text + exists + is_file
+	assertBool(t, result, "result_exists")
+	assertBool(t, result, "result_is_file")
+	assertStringEQ(t, result, "result_read", "hello world")
+
+	// copy
+	assertBool(t, result, "result_copy_exists")
+	assertStringEQ(t, result, "result_copy_read", "hello world")
+
+	// link
+	assertBool(t, result, "result_link_exists")
+
+	// remove
+	assertBool(t, result, "result_removed")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_WriteText_ReadText(t *testing.T) {
+	ctx, dir := testCtx(t)
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, filegen.Receiver, filegen.Params)
+
+	// write_text
+	writeAction, ok := reg.Get("file.write_text")
+	if !ok {
+		t.Fatal("action file.write_text not registered")
+	}
+
+	dest := file.NewResource(dir + "/action_test.txt")
+	_, _, err := writeAction.Do(&ctx, map[string]any{
+		"destination": dest,
+		"content":     "action content",
+		"mode":        os.FileMode(0o644),
+	})
+	if err != nil {
+		t.Fatalf("write_text Do() error = %v", err)
+	}
+
+	// read_text
+	readAction, ok := reg.Get("file.read_text")
+	if !ok {
+		t.Fatal("action file.read_text not registered")
+	}
+
+	result, _, err := readAction.Do(&ctx, map[string]any{
+		"resource": dest,
+	})
+	if err != nil {
+		t.Fatalf("read_text Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if s != "action content" {
+		t.Errorf("result = %q, want 'action content'", s)
+	}
+}
+
+func TestActions_Exists(t *testing.T) {
+	ctx, dir := testCtx(t)
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, filegen.Receiver, filegen.Params)
+
+	a, ok := reg.Get("file.exists")
+	if !ok {
+		t.Fatal("action file.exists not registered")
+	}
+
+	// Existing directory.
+	result, _, err := a.Do(&ctx, map[string]any{"resource": file.NewResource(dir)})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("exists(%s) = %v, want true", dir, result)
+	}
+
+	// Non-existing path.
+	result, _, err = a.Do(&ctx, map[string]any{"resource": file.NewResource(dir + "/nope")})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != false {
+		t.Errorf("exists(nope) = %v, want false", result)
+	}
+}
+
+func TestActions_Join(t *testing.T) {
+	ctx, _ := testCtx(t)
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, filegen.Receiver, filegen.Params)
+
+	a, ok := reg.Get("file.join")
+	if !ok {
+		t.Fatal("action file.join not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"parts": []string{"a", "b", "c.txt"}})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if s != "a/b/c.txt" {
+		t.Errorf("result = %q, want 'a/b/c.txt'", s)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+func assertStringContains(t *testing.T, globals starlark.StringDict, key, substr string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if !bytes.Contains([]byte(string(s)), []byte(substr)) {
+		t.Errorf("%s = %q, want to contain %q", key, string(s), substr)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/file/testdata/integration.star
+++ b/pkg/op/provider/file/testdata/integration.star
@@ -1,0 +1,40 @@
+# Integration test for file provider.
+# test_dir is injected by the Go test as the temp directory path.
+# Exercises: write_text, read_text, exists, is_file, is_dir, mkdir,
+#            join, name, parent, root, copy, link, remove.
+
+# --- path utilities (pure, no I/O) ---
+result_join = file.join(test_dir, "sub", "file.txt")
+result_name = file.name("/a/b/c.txt")
+result_parent = file.parent("/a/b/c.txt")
+result_root = file.root
+
+# --- mkdir ---
+sub = file.join(test_dir, "subdir")
+file.mkdir(sub, 0o755)
+result_is_dir = file.is_dir(sub)
+
+# --- write_text + read_text ---
+txt_path = file.join(test_dir, "hello.txt")
+file.write_text(txt_path, "hello world", 0o644)
+result_exists = file.exists(txt_path)
+result_is_file = file.is_file(txt_path)
+result_read = file.read_text(txt_path)
+
+# --- copy ---
+copy_dest = file.join(test_dir, "hello_copy.txt")
+file.copy(txt_path, copy_dest, 0o644)
+result_copy_exists = file.exists(copy_dest)
+result_copy_read = file.read_text(copy_dest)
+
+# --- link ---
+link_target = file.join(test_dir, "hello_link.txt")
+file.link(txt_path, link_target)
+result_link_exists = file.exists(link_target)
+
+# --- remove ---
+file.remove(copy_dest, False, test_dir)
+result_removed = file.exists(copy_dest) == False
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/json/integration_test.go
+++ b/pkg/op/provider/json/integration_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package json_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	jsonprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/json"
+	jsongen "github.com/NobleFactor/devlore-cli/pkg/op/provider/json/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	receiver := op.WrapProviderInExecutingReceiver(jsongen.Receiver, jsonprov.NewProvider(ctx))
+
+	globals := starlark.StringDict{"json": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "json-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertStringEQ(t, result, "result_encode_type", "string")
+	assertBool(t, result, "result_encode_has_name")
+	assertStringEQ(t, result, "result_decode_color", "blue")
+	assertFloatEQ(t, result, "result_decode_count", 42)
+	assertStringEQ(t, result, "result_indent_type", "string")
+	assertBool(t, result, "result_indent_has_newline")
+	assertStringEQ(t, result, "result_roundtrip_key", "value")
+	assertIntEQ(t, result, "result_roundtrip_list_len", 3)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Encode(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, jsongen.Receiver, jsongen.Params)
+
+	a, ok := reg.Get("json.encode")
+	if !ok {
+		t.Fatal("action json.encode not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"value": map[string]any{"key": "val"}})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if s == "" {
+		t.Error("result is empty")
+	}
+}
+
+func TestActions_Decode(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, jsongen.Receiver, jsongen.Params)
+
+	a, ok := reg.Get("json.decode")
+	if !ok {
+		t.Fatal("action json.decode not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"data": `{"color":"red"}`})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", result)
+	}
+	if m["color"] != "red" {
+		t.Errorf("color = %v, want red", m["color"])
+	}
+}
+
+func TestActions_EncodeIndent(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, jsongen.Receiver, jsongen.Params)
+
+	a, ok := reg.Get("json.encode_indent")
+	if !ok {
+		t.Fatal("action json.encode_indent not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"value": map[string]any{"a": 1}, "indent": "  "})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if len(s) == 0 {
+		t.Error("result is empty")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+func assertFloatEQ(t *testing.T, globals starlark.StringDict, key string, want float64) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	f, ok := v.(starlark.Float)
+	if !ok {
+		t.Errorf("%s: expected Float, got %s", key, v.Type())
+		return
+	}
+	if float64(f) != want {
+		t.Errorf("%s = %f, want %f", key, float64(f), want)
+	}
+}
+
+func assertIntEQ(t *testing.T, globals starlark.StringDict, key string, want int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) != want {
+		t.Errorf("%s = %d, want %d", key, n, want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/json/testdata/integration.star
+++ b/pkg/op/provider/json/testdata/integration.star
@@ -1,0 +1,27 @@
+# Integration test for json provider.
+# Exercises encode, encode_indent, and decode via the executing receiver.
+# Sets result_* globals for the Go test to inspect.
+
+# --- encode ---
+encoded = json.encode({"name": "alice", "age": 30})
+result_encode_type = type(encoded)
+result_encode_has_name = "alice" in encoded
+
+# --- decode ---
+decoded = json.decode('{"color":"blue","count":42}')
+result_decode_color = decoded["color"]
+result_decode_count = decoded["count"]
+
+# --- encode_indent ---
+indented = json.encode_indent({"x": 1}, "  ")
+result_indent_type = type(indented)
+result_indent_has_newline = "\n" in indented
+
+# --- round-trip ---
+original = {"key": "value", "list": [1, 2, 3]}
+rt = json.decode(json.encode(original))
+result_roundtrip_key = rt["key"]
+result_roundtrip_list_len = len(rt["list"])
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/platform/integration_test.go
+++ b/pkg/op/provider/platform/integration_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package platform_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/platform"
+	platformgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/platform/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+var testPlatform = &op.Platform{
+	OS:       "linux",
+	Arch:     "arm64",
+	Distro:   "Ubuntu",
+	Hostname: "build-host",
+	Version:  "24.04",
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context:  context.Background(),
+			Writer:   &bytes.Buffer{},
+			Platform: testPlatform,
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	receiver := op.WrapProviderInExecutingReceiver(platformgen.Receiver, platform.NewProvider(ctx))
+
+	globals := starlark.StringDict{"platform": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "platform-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertStringEQ(t, result, "result_arch", "arm64")
+	assertStringEQ(t, result, "result_os", "linux")
+	assertStringEQ(t, result, "result_distro", "Ubuntu")
+	assertStringEQ(t, result, "result_hostname", "build-host")
+	assertStringEQ(t, result, "result_version", "24.04")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, platformgen.Receiver, platformgen.Params)
+
+	tests := []struct {
+		action string
+		want   string
+	}{
+		{"platform.arch", "arm64"},
+		{"platform.os", "linux"},
+		{"platform.distro", "Ubuntu"},
+		{"platform.hostname", "build-host"},
+		{"platform.version", "24.04"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			a, ok := reg.Get(tt.action)
+			if !ok {
+				t.Fatalf("action %q not registered", tt.action)
+			}
+			result, _, err := a.Do(&ctx, map[string]any{})
+			if err != nil {
+				t.Fatalf("Do() error = %v", err)
+			}
+			got, ok := result.(string)
+			if !ok {
+				t.Fatalf("result type = %T, want string", result)
+			}
+			if got != tt.want {
+				t.Errorf("result = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/platform/testdata/integration.star
+++ b/pkg/op/provider/platform/testdata/integration.star
@@ -1,0 +1,13 @@
+# Integration test for platform provider.
+# Exercises all five properties via the executing receiver.
+# Sets result_* globals for the Go test to inspect.
+
+# --- properties (zero-param, string-return → eager evaluation) ---
+result_arch = platform.arch
+result_os = platform.os
+result_distro = platform.distro
+result_hostname = platform.hostname
+result_version = platform.version
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/regexp/integration_test.go
+++ b/pkg/op/provider/regexp/integration_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package regexp_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	regexpprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/regexp"
+	regexpgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/regexp/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	receiver := op.WrapProviderInExecutingReceiver(regexpgen.Receiver, regexpprov.NewProvider(ctx))
+
+	globals := starlark.StringDict{"regexp": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "regexp-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+
+	// match
+	assertBool(t, result, "result_match_true")
+	assertBoolFalse(t, result, "result_match_false")
+
+	// find
+	assertStringEQ(t, result, "result_find_first", "42")
+	assertStringEQ(t, result, "result_find_none", "")
+
+	// find_all
+	assertIntEQ(t, result, "result_find_all_count", 2) // "42" and "3"
+
+	// find_submatch
+	assertStringEQ(t, result, "result_submatch_full", "42 lazy")
+	assertStringEQ(t, result, "result_submatch_group1", "42")
+	assertStringEQ(t, result, "result_submatch_group2", "lazy")
+
+	// find_all_submatch
+	assertIntEQ(t, result, "result_all_submatch_count", 2)
+
+	// replace
+	assertStringContains(t, result, "result_replace", "NUM")
+
+	// replace_literal
+	assertStringEQ(t, result, "result_replace_literal", "aXbXcX")
+
+	// split
+	assertIntEQ(t, result, "result_split_count", 3)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Match(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, regexpgen.Receiver, regexpgen.Params)
+
+	a, ok := reg.Get("regexp.match")
+	if !ok {
+		t.Fatal("action regexp.match not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"pattern": `\d+`, "text": "abc123"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("result = %v, want true", result)
+	}
+}
+
+func TestActions_Find(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, regexpgen.Receiver, regexpgen.Params)
+
+	a, ok := reg.Get("regexp.find")
+	if !ok {
+		t.Fatal("action regexp.find not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"pattern": `\d+`, "text": "abc123def"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != "123" {
+		t.Errorf("result = %v, want 123", result)
+	}
+}
+
+func TestActions_Replace(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, regexpgen.Receiver, regexpgen.Params)
+
+	a, ok := reg.Get("regexp.replace")
+	if !ok {
+		t.Fatal("action regexp.replace not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"pattern": `\d+`, "text": "a1b2", "replacement": "X"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != "aXbX" {
+		t.Errorf("result = %v, want aXbX", result)
+	}
+}
+
+func TestActions_Split(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, regexpgen.Receiver, regexpgen.Params)
+
+	a, ok := reg.Get("regexp.split")
+	if !ok {
+		t.Fatal("action regexp.split not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"pattern": `,`, "text": "a,b,c", "count": -1})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	parts, ok := result.([]string)
+	if !ok {
+		t.Fatalf("result type = %T, want []string", result)
+	}
+	if len(parts) != 3 {
+		t.Errorf("len(result) = %d, want 3", len(parts))
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertBoolFalse(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.False {
+		t.Errorf("%s = %v, want false", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+func assertStringContains(t *testing.T, globals starlark.StringDict, key, substr string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if !bytes.Contains([]byte(string(s)), []byte(substr)) {
+		t.Errorf("%s = %q, want to contain %q", key, string(s), substr)
+	}
+}
+
+func assertIntEQ(t *testing.T, globals starlark.StringDict, key string, want int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) != want {
+		t.Errorf("%s = %d, want %d", key, n, want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/regexp/testdata/integration.star
+++ b/pkg/op/provider/regexp/testdata/integration.star
@@ -1,0 +1,40 @@
+# Integration test for regexp provider.
+# Exercises all eight methods via the executing receiver.
+# Sets result_* globals for the Go test to inspect.
+
+text = "The quick brown fox jumps over 42 lazy dogs at 3pm"
+
+# --- match ---
+result_match_true = regexp.match(r"\d+", text)
+result_match_false = regexp.match(r"^zzz", text)
+
+# --- find ---
+result_find_first = regexp.find(r"\d+", text)
+result_find_none = regexp.find(r"zzz", text)
+
+# --- find_all ---
+result_find_all = regexp.find_all(r"\d+", text, -1)
+result_find_all_count = len(result_find_all)
+
+# --- find_submatch ---
+result_find_submatch = regexp.find_submatch(r"(\d+)\s+(\w+)", text)
+result_submatch_full = result_find_submatch[0]
+result_submatch_group1 = result_find_submatch[1]
+result_submatch_group2 = result_find_submatch[2]
+
+# --- find_all_submatch ---
+result_find_all_submatch = regexp.find_all_submatch(r"(\d+)", text, -1)
+result_all_submatch_count = len(result_find_all_submatch)
+
+# --- replace ---
+result_replace = regexp.replace(r"\d+", text, "NUM")
+
+# --- replace_literal ---
+result_replace_literal = regexp.replace_literal(r"\d+", "a1b2c3", "X")
+
+# --- split ---
+result_split = regexp.split(r"\s+", "one two three", -1)
+result_split_count = len(result_split)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/shell/integration_test.go
+++ b/pkg/op/provider/shell/integration_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package shell_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/shell"
+	shellgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/shell/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() (op.Context, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	ctx := op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  buf,
+		},
+	}
+	return ctx, buf
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell.exec uses sh -c, skipping on windows")
+	}
+
+	ctx, buf := testCtx()
+	receiver := op.WrapProviderInExecutingReceiver(shellgen.Receiver, shell.NewProvider(ctx))
+
+	globals := starlark.StringDict{"shell": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "shell-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertStringEQ(t, result, "result_exec", "echo hello")
+	assertStringEQ(t, result, "result_exec_type", "string")
+
+	// Verify echo output was written to the buffer.
+	if !strings.Contains(buf.String(), "hello") {
+		t.Errorf("output = %q, want to contain 'hello'", buf.String())
+	}
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Exec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell.exec uses sh -c, skipping on windows")
+	}
+
+	ctx, buf := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, shellgen.Receiver, shellgen.Params)
+
+	a, ok := reg.Get("shell.exec")
+	if !ok {
+		t.Fatal("action shell.exec not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"command": "echo action_test"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if s != "echo action_test" {
+		t.Errorf("result = %q, want 'echo action_test'", s)
+	}
+	if !strings.Contains(buf.String(), "action_test") {
+		t.Errorf("output = %q, want to contain 'action_test'", buf.String())
+	}
+}
+
+func TestActions_Exec_EmptyCommand(t *testing.T) {
+	ctx, _ := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, shellgen.Receiver, shellgen.Params)
+
+	a, ok := reg.Get("shell.exec")
+	if !ok {
+		t.Fatal("action shell.exec not registered")
+	}
+
+	_, _, err := a.Do(&ctx, map[string]any{"command": ""})
+	if err == nil {
+		t.Fatal("expected error for empty command, got nil")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/shell/testdata/integration.star
+++ b/pkg/op/provider/shell/testdata/integration.star
@@ -1,0 +1,10 @@
+# Integration test for shell provider.
+# Exercises the exec method via the executing receiver.
+# Sets result_* globals for the Go test to inspect.
+
+# --- exec returns the command string ---
+result_exec = shell.exec("echo hello")
+result_exec_type = type(result_exec)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/staranalysis/integration_test.go
+++ b/pkg/op/provider/staranalysis/integration_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package staranalysis_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/staranalysis"
+	staranalysisgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/staranalysis/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func sampleFiles(t *testing.T) []string {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/sample.star")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return []string{abs}
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+func starlarkFileList(files []string) *starlark.List {
+	elems := make([]starlark.Value, len(files))
+	for i, f := range files {
+		elems[i] = starlark.String(f)
+	}
+	return starlark.NewList(elems)
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := staranalysis.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(staranalysisgen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"staranalysis": receiver,
+		"test_files":   starlarkFileList(sampleFiles(t)),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "staranalysis-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertBool(t, result, "result_has_stats")
+	assertBool(t, result, "result_has_complexity")
+	assertBool(t, result, "result_has_index")
+	assertIntGE(t, result, "result_hotspot_count", 0)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Analyze(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, staranalysisgen.Receiver, staranalysisgen.Params)
+
+	a, ok := reg.Get("staranalysis.analyze")
+	if !ok {
+		t.Fatal("action staranalysis.analyze not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{
+		"files": sampleFiles(t),
+		"cfg": staranalysis.AnalysisConfig{
+			Hotspots:            true,
+			CyclomaticThreshold: 2,
+			CognitiveThreshold:  2,
+			WithIndex:           true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	report, ok := result.(*staranalysis.AnalysisReport)
+	if !ok {
+		t.Fatalf("result type = %T, want *staranalysis.AnalysisReport", result)
+	}
+	if report.Stats == nil {
+		t.Error("expected non-nil Stats")
+	}
+	if report.Index == nil {
+		t.Error("expected non-nil Index (WithIndex=true)")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertIntGE(t *testing.T, globals starlark.StringDict, key string, minimum int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) < minimum {
+		t.Errorf("%s = %d, want >= %d", key, n, minimum)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/staranalysis/testdata/integration.star
+++ b/pkg/op/provider/staranalysis/testdata/integration.star
@@ -1,0 +1,17 @@
+# Integration test for staranalysis provider.
+# test_files is injected by the Go test as a list of absolute paths.
+
+report = staranalysis.analyze(test_files, cfg={
+    "hotspots": True,
+    "cyclomatic_threshold": 2,
+    "cognitive_threshold": 2,
+    "with_index": True,
+})
+
+result_has_stats = report.stats != None
+result_has_complexity = report.complexity != None
+result_has_index = report.index != None
+result_hotspot_count = len(report.hotspots)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/staranalysis/testdata/sample.star
+++ b/pkg/op/provider/staranalysis/testdata/sample.star
@@ -1,0 +1,18 @@
+# Sample Starlark file for integration tests.
+
+def classify(x):
+    if x > 100:
+        return "large"
+    elif x > 50:
+        return "medium"
+    else:
+        return "small"
+
+THRESHOLD = 42
+
+def process(items):
+    results = []
+    for item in items:
+        if item > THRESHOLD:
+            results.append(classify(item))
+    return results

--- a/pkg/op/provider/starcomplexity/integration_test.go
+++ b/pkg/op/provider/starcomplexity/integration_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starcomplexity_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/starcomplexity"
+	starcomplexitygen "github.com/NobleFactor/devlore-cli/pkg/op/provider/starcomplexity/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func sampleFiles(t *testing.T) []string {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/sample.star")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return []string{abs}
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+func starlarkFileList(files []string) *starlark.List {
+	elems := make([]starlark.Value, len(files))
+	for i, f := range files {
+		elems[i] = starlark.String(f)
+	}
+	return starlark.NewList(elems)
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := starcomplexity.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(starcomplexitygen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"starcomplexity": receiver,
+		"test_files":     starlarkFileList(sampleFiles(t)),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "starcomplexity-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertIntGE(t, result, "result_file_count", 1)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_ComputeComplexity(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, starcomplexitygen.Receiver, starcomplexitygen.Params)
+
+	a, ok := reg.Get("starcomplexity.compute_complexity")
+	if !ok {
+		t.Fatal("action starcomplexity.compute_complexity not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"files": sampleFiles(t)})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	report, ok := result.(*starcomplexity.ComplexityReport)
+	if !ok {
+		t.Fatalf("result type = %T, want *starcomplexity.ComplexityReport", result)
+	}
+	if len(report.Files) < 1 {
+		t.Error("expected at least 1 file in report")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertIntGE(t *testing.T, globals starlark.StringDict, key string, minimum int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) < minimum {
+		t.Errorf("%s = %d, want >= %d", key, n, minimum)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/starcomplexity/testdata/integration.star
+++ b/pkg/op/provider/starcomplexity/testdata/integration.star
@@ -1,0 +1,9 @@
+# Integration test for starcomplexity provider.
+# test_files is injected by the Go test as a list of absolute paths.
+
+report = starcomplexity.compute_complexity(test_files)
+
+result_file_count = len(report.files)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/starcomplexity/testdata/sample.star
+++ b/pkg/op/provider/starcomplexity/testdata/sample.star
@@ -1,0 +1,18 @@
+# Sample Starlark file for integration tests.
+
+def classify(x):
+    if x > 100:
+        return "large"
+    elif x > 50:
+        return "medium"
+    elif x > 10:
+        return "small"
+    else:
+        return "tiny"
+
+def process(items):
+    results = []
+    for item in items:
+        if item > 0:
+            results.append(classify(item))
+    return results

--- a/pkg/op/provider/starindex/integration_test.go
+++ b/pkg/op/provider/starindex/integration_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starindex_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/starindex"
+	starindexgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/starindex/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func sampleFiles(t *testing.T) []string {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/sample.star")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return []string{abs}
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+func starlarkFileList(files []string) *starlark.List {
+	elems := make([]starlark.Value, len(files))
+	for i, f := range files {
+		elems[i] = starlark.String(f)
+	}
+	return starlark.NewList(elems)
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := starindex.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(starindexgen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"starindex":  receiver,
+		"test_files": starlarkFileList(sampleFiles(t)),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "starindex-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertIntGE(t, result, "result_file_count", 1)
+	assertIntGE(t, result, "result_functions", 1)
+	assertIntGE(t, result, "result_globals", 1)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_IndexFiles(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, starindexgen.Receiver, starindexgen.Params)
+
+	a, ok := reg.Get("starindex.index_files")
+	if !ok {
+		t.Fatal("action starindex.index_files not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{
+		"files":           sampleFiles(t),
+		"with_docstrings": true,
+		"with_globals":    true,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	idx, ok := result.(*starindex.Index)
+	if !ok {
+		t.Fatalf("result type = %T, want *starindex.Index", result)
+	}
+	if idx.Totals.FileCount < 1 {
+		t.Errorf("file_count = %d, want >= 1", idx.Totals.FileCount)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertIntGE(t *testing.T, globals starlark.StringDict, key string, minimum int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) < minimum {
+		t.Errorf("%s = %d, want >= %d", key, n, minimum)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/starindex/testdata/integration.star
+++ b/pkg/op/provider/starindex/testdata/integration.star
@@ -1,0 +1,11 @@
+# Integration test for starindex provider.
+# test_files is injected by the Go test as a list of absolute paths.
+
+idx = starindex.index_files(test_files, with_docstrings=True, with_globals=True)
+
+result_file_count = idx.totals.file_count
+result_functions = idx.totals.functions
+result_globals = idx.totals.globals
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/starindex/testdata/sample.star
+++ b/pkg/op/provider/starindex/testdata/sample.star
@@ -1,0 +1,9 @@
+# Sample Starlark file for integration tests.
+
+def greet(name):
+    """Greet someone by name."""
+    return "hello " + name
+
+MESSAGE = "world"
+
+result = greet(MESSAGE)

--- a/pkg/op/provider/starstats/integration_test.go
+++ b/pkg/op/provider/starstats/integration_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package starstats_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/starstats"
+	starstatsgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/starstats/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func sampleFiles(t *testing.T) []string {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/sample.star")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return []string{abs}
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+func starlarkFileList(files []string) *starlark.List {
+	elems := make([]starlark.Value, len(files))
+	for i, f := range files {
+		elems[i] = starlark.String(f)
+	}
+	return starlark.NewList(elems)
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := starstats.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(starstatsgen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"starstats":  receiver,
+		"test_files": starlarkFileList(sampleFiles(t)),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "starstats-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertIntGE(t, result, "result_file_count", 1)
+	assertIntGE(t, result, "result_total_bytes", 1)
+	assertIntGE(t, result, "result_total_loc", 1)
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_ComputeStats(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, starstatsgen.Receiver, starstatsgen.Params)
+
+	a, ok := reg.Get("starstats.compute_stats")
+	if !ok {
+		t.Fatal("action starstats.compute_stats not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{
+		"files":      sampleFiles(t),
+		"with_bytes": true,
+		"with_loc":   true,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	st, ok := result.(*starstats.Stats)
+	if !ok {
+		t.Fatalf("result type = %T, want *starstats.Stats", result)
+	}
+	if st.Totals.FileCount < 1 {
+		t.Errorf("file_count = %d, want >= 1", st.Totals.FileCount)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertIntGE(t *testing.T, globals starlark.StringDict, key string, minimum int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) < minimum {
+		t.Errorf("%s = %d, want >= %d", key, n, minimum)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/starstats/testdata/integration.star
+++ b/pkg/op/provider/starstats/testdata/integration.star
@@ -1,0 +1,11 @@
+# Integration test for starstats provider.
+# test_files is injected by the Go test as a list of absolute paths.
+
+st = starstats.compute_stats(test_files, with_bytes=True, with_loc=True)
+
+result_file_count = st.totals.file_count
+result_total_bytes = st.totals.total_bytes
+result_total_loc = st.totals.total_loc
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/starstats/testdata/sample.star
+++ b/pkg/op/provider/starstats/testdata/sample.star
@@ -1,0 +1,9 @@
+# Sample Starlark file for integration tests.
+
+def greet(name):
+    return "hello " + name
+
+def add(a, b):
+    return a + b
+
+result = greet("world")

--- a/pkg/op/provider/ui/integration_test.go
+++ b/pkg/op/provider/ui/integration_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package ui_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/ui"
+	uigen "github.com/NobleFactor/devlore-cli/pkg/op/provider/ui/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() (op.Context, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	ctx := op.Context{
+		ContextBase: op.ContextBase{
+			Context:     context.Background(),
+			Writer:      buf,
+			ProgramName: "test",
+		},
+	}
+	return ctx, buf
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx, buf := testCtx()
+	p := ui.NewProvider(ctx)
+	p.Color = false // disable ANSI for easier assertion
+	receiver := op.WrapProviderInExecutingReceiver(uigen.Receiver, p)
+
+	globals := starlark.StringDict{"ui": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "ui-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertBool(t, result, "result_note_is_none")
+	assertBool(t, result, "result_success_is_none")
+	assertBool(t, result, "result_warn_is_none")
+	assertBool(t, result, "result_error_is_none")
+
+	// Verify output was written to the buffer.
+	output := buf.String()
+	if !strings.Contains(output, "hello from note") {
+		t.Errorf("output missing note message, got: %q", output)
+	}
+	if !strings.Contains(output, "operation completed") {
+		t.Errorf("output missing success message, got: %q", output)
+	}
+	if !strings.Contains(output, "something looks off") {
+		t.Errorf("output missing warn message, got: %q", output)
+	}
+	if !strings.Contains(output, "something went wrong") {
+		t.Errorf("output missing error message, got: %q", output)
+	}
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Note(t *testing.T) {
+	ctx, buf := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, uigen.Receiver, uigen.Params)
+
+	a, ok := reg.Get("ui.note")
+	if !ok {
+		t.Fatal("action ui.note not registered")
+	}
+
+	_, _, err := a.Do(&ctx, map[string]any{"msg": "action note"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "action note") {
+		t.Errorf("output = %q, want to contain 'action note'", buf.String())
+	}
+}
+
+func TestActions_Fail(t *testing.T) {
+	ctx, _ := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, uigen.Receiver, uigen.Params)
+
+	a, ok := reg.Get("ui.fail")
+	if !ok {
+		t.Fatal("action ui.fail not registered")
+	}
+
+	_, _, err := a.Do(&ctx, map[string]any{"msg": "fatal error"})
+	if err == nil {
+		t.Fatal("expected error from ui.fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "fatal error") {
+		t.Errorf("error = %q, want to contain 'fatal error'", err)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/ui/testdata/integration.star
+++ b/pkg/op/provider/ui/testdata/integration.star
@@ -1,0 +1,19 @@
+# Integration test for ui provider.
+# Exercises all five messaging methods via the executing receiver.
+# UI methods write to the context writer; void methods return None.
+# Sets result_* globals for the Go test to inspect.
+
+# --- void methods (write to writer, return None) ---
+result_note = ui.note("hello from note")
+result_success = ui.success("operation completed")
+result_warn = ui.warn("something looks off")
+result_error = ui.error("something went wrong")
+
+# note/success/warn/error return None
+result_note_is_none = (result_note == None)
+result_success_is_none = (result_success == None)
+result_warn_is_none = (result_warn == None)
+result_error_is_none = (result_error == None)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/yaml/integration_test.go
+++ b/pkg/op/provider/yaml/integration_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package yaml_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	yamlprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/yaml"
+	yamlgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/yaml/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	receiver := op.WrapProviderInExecutingReceiver(yamlgen.Receiver, yamlprov.NewProvider(ctx))
+
+	globals := starlark.StringDict{"yaml": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "yaml-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertStringEQ(t, result, "result_encode_type", "string")
+	assertBool(t, result, "result_encode_has_name")
+	assertStringEQ(t, result, "result_decode_color", "blue")
+	assertIntEQ(t, result, "result_decode_count", 42)
+	assertStringEQ(t, result, "result_roundtrip_key", "value")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Encode(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, yamlgen.Receiver, yamlgen.Params)
+
+	a, ok := reg.Get("yaml.encode")
+	if !ok {
+		t.Fatal("action yaml.encode not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"value": map[string]any{"key": "val"}})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("result type = %T, want string", result)
+	}
+	if s == "" {
+		t.Error("result is empty")
+	}
+}
+
+func TestActions_Decode(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, yamlgen.Receiver, yamlgen.Params)
+
+	a, ok := reg.Get("yaml.decode")
+	if !ok {
+		t.Fatal("action yaml.decode not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"data": "color: green\n"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", result)
+	}
+	if m["color"] != "green" {
+		t.Errorf("color = %v, want green", m["color"])
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+func assertIntEQ(t *testing.T, globals starlark.StringDict, key string, want int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	i, ok := v.(starlark.Int)
+	if !ok {
+		t.Errorf("%s: expected Int, got %s", key, v.Type())
+		return
+	}
+	n, _ := i.Int64()
+	if int(n) != want {
+		t.Errorf("%s = %d, want %d", key, n, want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/yaml/testdata/integration.star
+++ b/pkg/op/provider/yaml/testdata/integration.star
@@ -1,0 +1,21 @@
+# Integration test for yaml provider.
+# Exercises encode and decode via the executing receiver.
+# Sets result_* globals for the Go test to inspect.
+
+# --- encode ---
+encoded = yaml.encode({"name": "alice", "age": 30})
+result_encode_type = type(encoded)
+result_encode_has_name = "alice" in encoded
+
+# --- decode ---
+decoded = yaml.decode("color: blue\ncount: 42\n")
+result_decode_color = decoded["color"]
+result_decode_count = decoded["count"]
+
+# --- round-trip ---
+original = {"key": "value"}
+rt = yaml.decode(yaml.encode(original))
+result_roundtrip_key = rt["key"]
+
+# Signal completion.
+result_done = True


### PR DESCRIPTION
## Summary

- **12 providers** gain integration tests through both the Starlark executing receiver and graph action `Do()` dispatch
- **34 new files** — 12 `integration_test.go` + 12 `testdata/integration.star` + 6 `testdata/sample.star` + plan document
- **Phase 1** (pure-data): platform, json, yaml, regexp — properties, encode/decode round-trips, all 8 regexp methods
- **Phase 2** (side-effects): ui, shell — buffer writer capture, trivial exec
- **Phase 3** (filesystem): file, archive — temp dir with `op.Root`, compensable extract with tombstone
- **Phase 4** (star* analysis): starstats, starindex, starcomplexity, staranalysis — file-based analysis through Starlark
- Template provider **deferred** to Phase 7 pending `Render` → `RenderText`/`RenderBytes` refactor

## Test plan

- [x] `make test` passes — all 87 packages green
- [x] Each provider tested through Starlark executing receiver (full script execution)
- [x] Each provider tested through action `Do()` with real context and params
- [x] File/archive tests use `t.TempDir()` with `op.NewRootReaderWriter` for isolation
- [x] Star* tests use injected `test_files` globals pointing to `testdata/sample.star`
- [x] Shell tests skip on Windows (`runtime.GOOS` guard)