### PR TITLE
test(provider): Add external-dependency provider integration tests and version test (Phases 5+8)

### DIFF
--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn and returns what it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = orig
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	r.Close()
+
+	return string(buf[:n])
+}
+
+func TestNewVersionCmd_FullOutput(t *testing.T) {
+	info := VersionInfo{
+		Version:   "1.2.3",
+		Commit:    "abc1234",
+		BuildDate: "2026-03-17T00:00:00Z",
+	}
+
+	cmd := NewVersionCmd(info)
+	cmd.SetArgs(nil)
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	for _, want := range []string{"1.2.3", "abc1234", "2026-03-17T00:00:00Z", "Go version:", "OS/Arch:"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestNewVersionCmd_ShortFlag(t *testing.T) {
+	info := VersionInfo{
+		Version:   "1.2.3",
+		Commit:    "abc1234",
+		BuildDate: "2026-03-17T00:00:00Z",
+	}
+
+	cmd := NewVersionCmd(info)
+	cmd.SetArgs([]string{"--short"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	trimmed := strings.TrimSpace(output)
+	if trimmed != "1.2.3" {
+		t.Errorf("short output = %q, want '1.2.3'", trimmed)
+	}
+}
+
+func TestNewVersionCmd_DefaultsAreVisible(t *testing.T) {
+	info := VersionInfo{
+		Version:   "dev",
+		Commit:    "none",
+		BuildDate: "unknown",
+	}
+
+	cmd := NewVersionCmd(info)
+	cmd.SetArgs(nil)
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	for _, want := range []string{"dev", "none", "unknown"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing default %q, got:\n%s", want, output)
+		}
+	}
+}

--- a/pkg/op/provider/appnet/integration_test.go
+++ b/pkg/op/provider/appnet/integration_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package appnet_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet"
+	appnetgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+func testCtx() op.Context {
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("test content"))
+	}))
+	defer srv.Close()
+
+	ctx := testCtx()
+	p := appnet.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(appnetgen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"appnet":   receiver,
+		"test_url": starlark.String(srv.URL),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "appnet-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertStringEQ(t, result, "result_download_type", "bytes")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Download(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("action content"))
+	}))
+	defer srv.Close()
+
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, appnetgen.Receiver, appnetgen.Params)
+
+	a, ok := reg.Get("appnet.download")
+	if !ok {
+		t.Fatal("action appnet.download not registered")
+	}
+
+	res, resErr := appnet.ResourceFromValue(srv.URL)
+	if resErr != nil {
+		t.Fatalf("ResourceFromValue: %v", resErr)
+	}
+	result, _, err := a.Do(&ctx, map[string]any{"url": res})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	b, ok := result.([]byte)
+	if !ok {
+		t.Fatalf("result type = %T, want []byte", result)
+	}
+	if string(b) != "action content" {
+		t.Errorf("result = %q, want 'action content'", string(b))
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertStringEQ(t *testing.T, globals starlark.StringDict, key, want string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	s, ok := v.(starlark.String)
+	if !ok {
+		t.Errorf("%s: expected String, got %s", key, v.Type())
+		return
+	}
+	if string(s) != want {
+		t.Errorf("%s = %q, want %q", key, string(s), want)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/appnet/testdata/integration.star
+++ b/pkg/op/provider/appnet/testdata/integration.star
@@ -1,0 +1,9 @@
+# Integration test for appnet provider.
+# appnet and test_url are injected by the Go test.
+# Exercises: download.
+
+result_download = appnet.download(test_url)
+result_download_type = type(result_download)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/encryption/integration_test.go
+++ b/pkg/op/provider/encryption/integration_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package encryption_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/aes"
+	sopsage "github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/stores/yaml"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
+	encryptiongen "github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption/gen"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	sopsclient "github.com/NobleFactor/devlore-cli/pkg/op/sops"
+
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen" // register file.Resource constructor
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+// sopsEncrypt generates age keys and encrypts plainYAML with SOPS.
+func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
+	t.Helper()
+
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := &yaml.Store{}
+	branches, err := store.LoadPlainFile(plainYAML)
+	if err != nil {
+		t.Fatalf("loading plain YAML: %v", err)
+	}
+
+	masterKey := &sopsage.MasterKey{Recipient: identity.Recipient().String()}
+
+	tree := sops.Tree{
+		Branches: branches,
+		Metadata: sops.Metadata{
+			KeyGroups: []sops.KeyGroup{{masterKey}},
+			Version:   "3.7.0",
+		},
+	}
+
+	dataKey, errs := tree.GenerateDataKey()
+	if len(errs) > 0 {
+		t.Fatalf("GenerateDataKey: %v", errs)
+	}
+
+	cipher := aes.NewCipher()
+	mac, err := tree.Encrypt(dataKey, cipher)
+	if err != nil {
+		t.Fatalf("encrypting tree: %v", err)
+	}
+
+	encryptedMac, err := cipher.Encrypt(mac, dataKey, tree.Metadata.LastModified.Format("2006-01-02T15:04:05Z"))
+	if err != nil {
+		t.Fatalf("encrypting MAC: %v", err)
+	}
+	tree.Metadata.MessageAuthenticationCode = encryptedMac
+
+	encrypted, err := store.EmitEncryptedFile(tree)
+	if err != nil {
+		t.Fatalf("emitting encrypted file: %v", err)
+	}
+
+	return encrypted, identity.String()
+}
+
+func testCtx(t *testing.T, dir string) op.Context {
+	t.Helper()
+
+	sopsConfig := filepath.Join(dir, ".sops.yaml")
+	if err := os.WriteFile(sopsConfig, []byte("creation_rules:\n  - path_regex: .*\n    age: age1abc\n"), 0o644); err != nil {
+		t.Fatalf("write .sops.yaml: %v", err)
+	}
+
+	client, err := sopsclient.NewClient(dir)
+	if err != nil {
+		t.Fatalf("sops.NewClient: %v", err)
+	}
+
+	root := op.NewRootReaderWriter(dir)
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context:    context.Background(),
+			Writer:     &bytes.Buffer{},
+			Root:       root,
+			SopsClient: client,
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	plainYAML := []byte("greeting: hello\nname: world\n")
+	encrypted, ageKey := sopsEncrypt(t, plainYAML)
+
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "secret.enc.yaml")
+	if err := os.WriteFile(srcPath, encrypted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SOPS_AGE_KEY", ageKey)
+
+	ctx := testCtx(t, dir)
+
+	// Resolve source so it has size metadata.
+	source := file.NewResource(srcPath)
+	if err := source.Resolve(ctx.Root); err != nil {
+		t.Fatalf("resolve source: %v", err)
+	}
+
+	dstPath := filepath.Join(dir, "secret.dec.yaml")
+
+	p := encryption.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(encryptiongen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"encryption":  receiver,
+		"test_source": starlark.String(srcPath),
+		"test_dest":   starlark.String(dstPath),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "encryption-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+
+	// Verify decryption.
+	decrypted, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("reading decrypted: %v", err)
+	}
+	if !bytes.Contains(decrypted, []byte("hello")) {
+		t.Errorf("decrypted missing 'hello': %s", decrypted)
+	}
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_DecryptSopsFile(t *testing.T) {
+	plainYAML := []byte("secret: value\n")
+	encrypted, ageKey := sopsEncrypt(t, plainYAML)
+
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "secret.enc.yaml")
+	if err := os.WriteFile(srcPath, encrypted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SOPS_AGE_KEY", ageKey)
+
+	ctx := testCtx(t, dir)
+
+	source := file.NewResource(srcPath)
+	if err := source.Resolve(ctx.Root); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	dstPath := filepath.Join(dir, "secret.dec.yaml")
+	dest := file.NewResource(dstPath)
+
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, encryptiongen.Receiver, encryptiongen.Params)
+
+	a, ok := reg.Get("encryption.decrypt_sops_file")
+	if !ok {
+		t.Fatal("action encryption.decrypt_sops_file not registered")
+	}
+
+	result, complement, err := a.Do(&ctx, map[string]any{
+		"source":      source,
+		"destination": dest,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	res, ok := result.(file.Resource)
+	if !ok {
+		t.Fatalf("result type = %T, want file.Resource", result)
+	}
+	if res.SourcePath.Abs() != dstPath {
+		t.Errorf("result path = %q, want %q", res.SourcePath.Abs(), dstPath)
+	}
+	if complement == nil {
+		t.Error("complement = nil, want non-nil tombstone")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/encryption/testdata/integration.star
+++ b/pkg/op/provider/encryption/testdata/integration.star
@@ -1,0 +1,8 @@
+# Integration test for encryption provider.
+# encryption, test_source, and test_dest are injected by the Go test.
+# Exercises: decrypt_sops_file.
+
+result_decrypt = encryption.decrypt_sops_file(test_source, test_dest)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/git/integration_test.go
+++ b/pkg/op/provider/git/integration_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package git_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	appnetprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	gitprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/git"
+	gitgen "github.com/NobleFactor/devlore-cli/pkg/op/provider/git/gen"
+
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/appnet/gen" // register appnet.Resource constructor
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"   // register file.Resource constructor
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+// createBareRepo creates a bare git repo with one commit on "main".
+func createBareRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	work := filepath.Join(dir, "work")
+	bare := filepath.Join(dir, "bare.git")
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = work
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", "README.md")
+	run("git", "commit", "--no-verify", "-m", "initial")
+
+	// Clone to bare.
+	cmd := exec.Command("git", "clone", "--bare", work, bare)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git clone --bare: %v", err)
+	}
+
+	return bare
+}
+
+func testCtx(t *testing.T) op.Context {
+	t.Helper()
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	bareRepo := createBareRepo(t)
+	cloneDest := filepath.Join(t.TempDir(), "cloned")
+
+	ctx := testCtx(t)
+	p := gitprov.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(gitgen.Receiver, p)
+
+	globals := starlark.StringDict{
+		"git_prov":        receiver,
+		"test_repo_url":   starlark.String(bareRepo),
+		"test_clone_dest": starlark.String(cloneDest),
+	}
+
+	thread := &starlark.Thread{
+		Name:  "git-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+
+	// Verify clone actually happened.
+	if _, err := os.Stat(filepath.Join(cloneDest, "README.md")); err != nil {
+		t.Errorf("README.md not found in clone: %v", err)
+	}
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Clone(t *testing.T) {
+	bareRepo := createBareRepo(t)
+	cloneDest := filepath.Join(t.TempDir(), "action_cloned")
+
+	ctx := testCtx(t)
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, gitgen.Receiver, gitgen.Params)
+
+	a, ok := reg.Get("git.clone")
+	if !ok {
+		t.Fatal("action git.clone not registered")
+	}
+
+	urlRes, err := appnetprov.ResourceFromValue(bareRepo)
+	if err != nil {
+		t.Fatalf("ResourceFromValue: %v", err)
+	}
+
+	result, complement, doErr := a.Do(&ctx, map[string]any{
+		"url":         urlRes,
+		"destination": file.NewResource(cloneDest),
+	})
+	if doErr != nil {
+		t.Fatalf("Do() error = %v", doErr)
+	}
+
+	res, ok := result.(gitprov.Resource)
+	if !ok {
+		t.Fatalf("result type = %T, want git.Resource", result)
+	}
+	if res.ClonePath != cloneDest {
+		t.Errorf("ClonePath = %q, want %q", res.ClonePath, cloneDest)
+	}
+	if complement == nil {
+		t.Error("complement = nil, want non-nil tombstone")
+	}
+
+	// Verify clone.
+	if _, err := os.Stat(filepath.Join(cloneDest, "README.md")); err != nil {
+		t.Errorf("README.md not found: %v", err)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/git/testdata/integration.star
+++ b/pkg/op/provider/git/testdata/integration.star
@@ -1,0 +1,15 @@
+# Integration test for git provider.
+# git_prov, test_repo_url, and test_clone_dest are injected by the Go test.
+# Exercises: clone, checkout, pull.
+
+# --- clone ---
+result_clone = git_prov.clone(test_repo_url, test_clone_dest)
+
+# --- checkout ---
+result_checkout = git_prov.checkout(result_clone, "main")
+
+# --- pull ---
+result_pull = git_prov.pull(result_clone)
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/pkg/integration_test.go
+++ b/pkg/op/provider/pkg/integration_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package pkg_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	pkgprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/pkg"
+	pkggen "github.com/NobleFactor/devlore-cli/pkg/op/provider/pkg/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+// mockPM implements op.PackageManager for testing.
+type mockPM struct {
+	installed map[string]string // name → version
+}
+
+func (m *mockPM) Name() string                             { return "mock" }
+func (m *mockPM) Installed(name string) bool               { _, ok := m.installed[name]; return ok }
+func (m *mockPM) Version(name string) string               { return m.installed[name] }
+func (m *mockPM) Available(_ string) bool                  { return true }
+func (m *mockPM) Search(_ string, _ int) []op.SearchResult { return nil }
+func (m *mockPM) Install(_ ...string) op.PlatformResult    { return op.PlatformResult{OK: true} }
+func (m *mockPM) Remove(_ string) op.PlatformResult        { return op.PlatformResult{OK: true} }
+func (m *mockPM) Update() op.PlatformResult                { return op.PlatformResult{OK: true, Stdout: "updated"} }
+func (m *mockPM) AddRepo(_, _, _ string) op.PlatformResult { return op.PlatformResult{OK: true} }
+func (m *mockPM) NeedsSudo() bool                          { return false }
+
+func testCtx() op.Context {
+	pm := &mockPM{installed: map[string]string{"curl": "7.88.0"}}
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+			Platform: &op.Platform{
+				OS:             "linux",
+				Arch:           "amd64",
+				PackageManager: pm,
+				PackageManagers: map[string]op.PackageManager{
+					"mock": pm,
+				},
+			},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := pkgprov.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(pkggen.Receiver, p)
+
+	globals := starlark.StringDict{"pkg": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "pkg-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertBool(t, result, "result_installed")
+	assertBool(t, result, "result_not_installed")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Installed(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, pkggen.Receiver, pkggen.Params)
+
+	a, ok := reg.Get("pkg.installed")
+	if !ok {
+		t.Fatal("action pkg.installed not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"name": pkgprov.NewResource("curl")})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("installed(curl) = %v, want true", result)
+	}
+}
+
+func TestActions_NotInstalled(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, pkggen.Receiver, pkggen.Params)
+
+	a, ok := reg.Get("pkg.not_installed")
+	if !ok {
+		t.Fatal("action pkg.not_installed not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"name": pkgprov.NewResource("missing-pkg")})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("not_installed(missing-pkg) = %v, want true", result)
+	}
+}
+
+func TestActions_Update(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, pkggen.Receiver, pkggen.Params)
+
+	a, ok := reg.Get("pkg.update")
+	if !ok {
+		t.Fatal("action pkg.update not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"manager": ""})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result == nil {
+		t.Error("update result = nil, want non-nil")
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/pkg/testdata/integration.star
+++ b/pkg/op/provider/pkg/testdata/integration.star
@@ -1,0 +1,15 @@
+# Integration test for pkg provider.
+# pkg and test_packages are injected by the Go test.
+# Exercises: installed, not_installed, update.
+
+# --- installed (should return True for pre-installed package) ---
+result_installed = pkg.installed("curl")
+
+# --- not_installed (should return True for missing package) ---
+result_not_installed = pkg.not_installed("nonexistent-pkg-12345")
+
+# --- update ---
+result_update = pkg.update("")
+
+# Signal completion.
+result_done = True

--- a/pkg/op/provider/service/integration_test.go
+++ b/pkg/op/provider/service/integration_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package service_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	serviceprov "github.com/NobleFactor/devlore-cli/pkg/op/provider/service"
+	servicegen "github.com/NobleFactor/devlore-cli/pkg/op/provider/service/gen"
+)
+
+func TestMain(m *testing.M) {
+	op.InitAll(op.NewActionRegistry(), op.Context{})
+	os.Exit(m.Run())
+}
+
+// mockSM implements op.ServiceManager for testing.
+type mockSM struct {
+	services map[string]struct{ running, enabled bool }
+}
+
+func (m *mockSM) Exists(name string) bool {
+	_, ok := m.services[name]
+	return ok
+}
+
+func (m *mockSM) IsRunning(name string) bool {
+	if s, ok := m.services[name]; ok {
+		return s.running
+	}
+	return false
+}
+
+func (m *mockSM) IsEnabled(name string) bool {
+	if s, ok := m.services[name]; ok {
+		return s.enabled
+	}
+	return false
+}
+
+func (m *mockSM) Status(_ string) string             { return "active" }
+func (m *mockSM) Start(_ string) op.PlatformResult   { return op.PlatformResult{OK: true} }
+func (m *mockSM) Stop(_ string) op.PlatformResult    { return op.PlatformResult{OK: true} }
+func (m *mockSM) Enable(_ string) op.PlatformResult  { return op.PlatformResult{OK: true} }
+func (m *mockSM) Disable(_ string) op.PlatformResult { return op.PlatformResult{OK: true} }
+func (m *mockSM) NeedsSudo() bool                    { return false }
+
+func sshRes(t *testing.T) serviceprov.Resource {
+	t.Helper()
+	r, err := serviceprov.ResourceFromValue("sshd")
+	if err != nil {
+		t.Fatalf("ResourceFromValue: %v", err)
+	}
+	return r
+}
+
+func testCtx() op.Context {
+	sm := &mockSM{services: map[string]struct{ running, enabled bool }{
+		"sshd": {running: true, enabled: true},
+	}}
+	return op.Context{
+		ContextBase: op.ContextBase{
+			Context: context.Background(),
+			Writer:  &bytes.Buffer{},
+			Platform: &op.Platform{
+				OS:             "linux",
+				Arch:           "amd64",
+				ServiceManager: sm,
+			},
+		},
+	}
+}
+
+// region Starlark integration
+
+func TestStarlark(t *testing.T) {
+	ctx := testCtx()
+	p := serviceprov.NewProvider(ctx)
+	receiver := op.WrapProviderInExecutingReceiver(servicegen.Receiver, p)
+
+	globals := starlark.StringDict{"service": receiver}
+
+	thread := &starlark.Thread{
+		Name:  "service-integration",
+		Print: func(_ *starlark.Thread, msg string) { t.Logf("[star] %s", msg) },
+	}
+
+	data, err := os.ReadFile("testdata/integration.star")
+	if err != nil {
+		t.Fatalf("reading script: %v", err)
+	}
+
+	opts := &syntax.FileOptions{Set: true, GlobalReassign: true, TopLevelControl: true}
+	result, err := starlark.ExecFileOptions(opts, thread, "testdata/integration.star", data, globals)
+	if err != nil {
+		t.Fatalf("exec script: %v", err)
+	}
+
+	assertBool(t, result, "result_done")
+	assertBool(t, result, "result_exists")
+	assertBool(t, result, "result_running")
+	assertBool(t, result, "result_enabled")
+	assertBool(t, result, "result_not_exists")
+}
+
+// endregion
+
+// region Action dispatch
+
+func TestActions_Exists(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, servicegen.Receiver, servicegen.Params)
+
+	a, ok := reg.Get("service.exists")
+	if !ok {
+		t.Fatal("action service.exists not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"name": sshRes(t)})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("exists(sshd) = %v, want true", result)
+	}
+}
+
+func TestActions_Running(t *testing.T) {
+	ctx := testCtx()
+	reg := op.NewActionRegistry()
+	op.RegisterActions(reg, servicegen.Receiver, servicegen.Params)
+
+	a, ok := reg.Get("service.running")
+	if !ok {
+		t.Fatal("action service.running not registered")
+	}
+
+	result, _, err := a.Do(&ctx, map[string]any{"name": sshRes(t)})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != true {
+		t.Errorf("running(sshd) = %v, want true", result)
+	}
+}
+
+// endregion
+
+// region Assertions
+
+func assertBool(t *testing.T, globals starlark.StringDict, key string) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	if v != starlark.True {
+		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+// endregion

--- a/pkg/op/provider/service/testdata/integration.star
+++ b/pkg/op/provider/service/testdata/integration.star
@@ -1,0 +1,12 @@
+# Integration test for service provider.
+# service is injected by the Go test with a mock ServiceManager.
+# Exercises: exists, running, enabled.
+
+result_exists = service.exists("sshd")
+result_running = service.running("sshd")
+result_enabled = service.enabled("sshd")
+
+result_not_exists = service.exists("nonexistent-svc") == False
+
+# Signal completion.
+result_done = True


### PR DESCRIPTION
## Summary

- **appnet** — httptest server, download via Starlark + action dispatch
- **git** — local bare repo, clone/checkout/pull via Starlark + action dispatch
- **encryption** — SOPS+age key generation, encrypt/decrypt round-trip via Starlark + action dispatch
- **pkg** — mock PackageManager, installed/not_installed/update via Starlark + action dispatch
- **service** — mock ServiceManager, exists/running/enabled via Starlark + action dispatch
- **version** — `NewVersionCmd` test for full output, --short flag, and default values (Phase 8, closes #82)
- mem provider skipped — no provider/receiver, just a resource type

## Test plan

- [x] `make test` passes — all packages green
- [x] appnet uses `httptest.NewServer` for isolation
- [x] git uses `git init --bare` with `--no-verify` commit in temp dir
- [x] encryption uses `filippo.io/age` key generation + SOPS tree encryption
- [x] pkg/service use mock implementations of `op.PackageManager`/`op.ServiceManager`
- [x] Version test captures stdout via `os.Pipe` (command uses `fmt.Printf`)