### PR TITLE
feat(file): Add Find method for recursive file discovery with ** patterns

### DIFF
--- a/pkg/op/provider/file/gen/actions_gen_test.go
+++ b/pkg/op/provider/file/gen/actions_gen_test.go
@@ -123,6 +123,7 @@ func TestActionNames(t *testing.T) {
 		"file.write_text",
 		"file.exists",
 		"file.glob",
+		"file.find",
 		"file.is_dir",
 		"file.is_file",
 		"file.mkdir",
@@ -157,6 +158,7 @@ func TestRegister(t *testing.T) {
 		"file.write_text",
 		"file.exists",
 		"file.glob",
+		"file.find",
 		"file.is_dir",
 		"file.is_file",
 		"file.mkdir",
@@ -469,6 +471,29 @@ func TestGlobAction_DryRun(t *testing.T) {
 	output := ctx.Writer.(*bytes.Buffer).String()
 	if !strings.Contains(output, "[dry-run] file.glob") {
 		t.Errorf("dry-run output = %q, want to contain %q", output, "[dry-run] file.glob")
+	}
+}
+
+func TestFindAction_DryRun(t *testing.T) {
+
+	reg := makeRegistry(t)
+	action := getAction(t, reg, "file.find")
+	ctx := dryRunCtx(t)
+
+	result, undo, err := action.Do(ctx, map[string]any{})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if result != nil {
+		t.Errorf("dry-run result = %v, want nil", result)
+	}
+	if undo != nil {
+		t.Errorf("dry-run undo = %v, want nil", undo)
+	}
+
+	output := ctx.Writer.(*bytes.Buffer).String()
+	if !strings.Contains(output, "[dry-run] file.find") {
+		t.Errorf("dry-run output = %q, want to contain %q", output, "[dry-run] file.find")
 	}
 }
 

--- a/pkg/op/provider/file/gen/params.gen.go
+++ b/pkg/op/provider/file/gen/params.gen.go
@@ -22,6 +22,7 @@ var Params = op.MethodParams{
 	"WriteText":  {"destination", "content", "mode?"},
 	"Exists":     {"resource"},
 	"Glob":       {"pattern", "honor_gitignore?"},
+	"Find":       {"pattern", "honor_gitignore?"},
 	"IsDir":      {"resource"},
 	"IsFile":     {"resource"},
 	"Mkdir":      {"resource", "mode?"},

--- a/pkg/op/provider/file/integration_test.go
+++ b/pkg/op/provider/file/integration_test.go
@@ -102,6 +102,11 @@ func TestStarlark(t *testing.T) {
 
 	// defaults: remove without prune/boundary
 	assertBool(t, result, "result_defaults_remove")
+
+	// find: recursive ** pattern
+	assertListLen(t, result, "result_find_go", 2)  // top.go + deep/deep.go
+	assertListLen(t, result, "result_find_md", 1)  // deep/notes.md
+	assertListLen(t, result, "result_find_all", 3) // all three files
 }
 
 // endregion
@@ -217,6 +222,23 @@ func assertBool(t *testing.T, globals starlark.StringDict, key string) {
 	}
 	if v != starlark.True {
 		t.Errorf("%s = %v, want true", key, v)
+	}
+}
+
+func assertListLen(t *testing.T, globals starlark.StringDict, key string, want int) {
+	t.Helper()
+	v, ok := globals[key]
+	if !ok {
+		t.Errorf("missing global %q", key)
+		return
+	}
+	list, ok := v.(*starlark.List)
+	if !ok {
+		t.Errorf("%s: expected List, got %s", key, v.Type())
+		return
+	}
+	if list.Len() != want {
+		t.Errorf("%s: len = %d, want %d", key, list.Len(), want)
 	}
 }
 

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -14,6 +14,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
@@ -766,6 +767,136 @@ func (p *Provider) Glob(pattern string, honorGitignore bool) ([]string, error) {
 	return filtered, nil
 }
 
+// Find returns file paths matching a glob pattern with recursive ** support.
+//
+// Unlike [Glob], which uses Go's [filepath.Glob] (no ** support), Find walks the directory tree
+// and matches each entry against the pattern. The ** wildcard matches zero or more directory levels.
+//
+// +devlore:defaults honorGitignore=true
+//
+// Parameters:
+//   - pattern: Glob pattern with ** support (e.g., "**/*.go", "src/**/*.yaml")
+//   - honorGitignore: If true, filter results using gitignore rules
+//
+// Returns:
+//   - []string: List of matching file paths
+//   - error: any error from walking the directory tree
+func (p *Provider) Find(pattern string, honorGitignore bool) ([]string, error) {
+	root, matchPattern := splitFindPattern(pattern)
+	if root == "" {
+		root = "."
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("find: resolve root %q: %w", root, err)
+	}
+
+	tracker, err := p.newTrackerIfEnabled(absRoot, honorGitignore)
+	if err != nil {
+		return nil, fmt.Errorf("find: gitignore tracker: %w", err)
+	}
+
+	var matches []string
+	walkErr := filepath.WalkDir(absRoot, func(entryAbs string, d fs.DirEntry, walkDirErr error) error {
+		if walkDirErr != nil {
+			return walkDirErr
+		}
+
+		relPath, relErr := filepath.Rel(absRoot, entryAbs)
+		if relErr != nil {
+			return relErr
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		if skip := p.applyGitignore(tracker, d, relPath); skip != nil {
+			if errors.Is(skip, errSkipEntry) {
+				return nil
+			}
+			return skip
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if matchDoublestar(matchPattern, relPath) {
+			matches = append(matches, entryAbs)
+		}
+
+		return nil
+	})
+
+	if walkErr != nil {
+		return nil, fmt.Errorf("find: walk %q: %w", absRoot, walkErr)
+	}
+
+	return matches, nil
+}
+
+// splitFindPattern splits a pattern like "src/**/*.go" into a root directory ("src")
+// and a match pattern ("**/*.go"). If the pattern starts with **, root is empty.
+func splitFindPattern(pattern string) (root, match string) {
+	idx := strings.Index(pattern, "**")
+	if idx < 0 {
+		// No ** — treat the directory part as root, filename as match.
+		return filepath.Dir(pattern), filepath.Base(pattern)
+	}
+	root = strings.TrimRight(pattern[:idx], string(filepath.Separator))
+	match = pattern[idx:]
+	return root, match
+}
+
+// matchDoublestar matches a path against a pattern containing ** wildcards.
+// ** matches zero or more directory levels. Other wildcards follow filepath.Match rules.
+func matchDoublestar(pattern, path string) bool {
+	parts := strings.Split(pattern, "**")
+	if len(parts) == 1 {
+		return pathMatch(pattern, path)
+	}
+
+	// Common case: prefix**suffix (e.g., "**/*.go" → prefix="", suffix="/*.go").
+	if len(parts) == 2 {
+		return matchDoublestarSingle(parts[0], parts[1], path)
+	}
+
+	// Multiple ** segments — fall back to simple tail match.
+	tail := strings.TrimLeft(parts[len(parts)-1], string(filepath.Separator))
+	return pathMatch(tail, filepath.Base(path))
+}
+
+// matchDoublestarSingle handles patterns with exactly one ** wildcard.
+func matchDoublestarSingle(rawPrefix, rawSuffix, path string) bool {
+	prefix := strings.TrimRight(rawPrefix, string(filepath.Separator))
+	suffix := strings.TrimLeft(rawSuffix, string(filepath.Separator))
+
+	if prefix != "" {
+		if !strings.HasPrefix(path, prefix+string(filepath.Separator)) && path != prefix {
+			return false
+		}
+		path = strings.TrimPrefix(path, prefix+string(filepath.Separator))
+	}
+
+	// Match suffix against every possible tail of the remaining path.
+	segments := strings.Split(path, string(filepath.Separator))
+	for i := range segments {
+		tail := strings.Join(segments[i:], string(filepath.Separator))
+		if pathMatch(suffix, tail) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathMatch wraps filepath.Match, treating errors as non-matches.
+func pathMatch(pattern, name string) bool {
+	ok, err := filepath.Match(pattern, name)
+	return err == nil && ok
+}
+
 // IsDir returns true if the resource exists and is a directory.
 //
 // Parameters:
@@ -815,6 +946,9 @@ func (p *Provider) IsFile(resource Resource) (bool, error) {
 // Returns:
 //   - string: The absolute path of the created directory
 func (p *Provider) Mkdir(resource Resource, mode os.FileMode) (Resource, error) {
+	if mode == 0 {
+		mode = 0o755
+	}
 	return resource, p.mkdirAll(resource.SourcePath.Abs(), mode)
 }
 

--- a/pkg/op/provider/file/testdata/integration.star
+++ b/pkg/op/provider/file/testdata/integration.star
@@ -53,5 +53,17 @@ result_defaults_glob = file.glob(file.join(test_dir, "*.txt"))
 file.remove(defaults_txt)
 result_defaults_remove = file.exists(defaults_txt) == False
 
+# --- find: recursive ** pattern ---
+# Create nested files for find to discover.
+nested = file.join(test_dir, "findtest", "deep")
+file.mkdir(nested)
+file.write_text(file.join(test_dir, "findtest", "top.go"), "package top")
+file.write_text(file.join(nested, "deep.go"), "package deep")
+file.write_text(file.join(nested, "notes.md"), "# notes")
+
+result_find_go = file.find(file.join(test_dir, "findtest", "**", "*.go"))
+result_find_md = file.find(file.join(test_dir, "findtest", "**", "*.md"))
+result_find_all = file.find(file.join(test_dir, "findtest", "**", "*.*"))
+
 # Signal completion.
 result_done = True


### PR DESCRIPTION
## Summary

- **file.Find** — new method for recursive file discovery with `**` glob patterns, honoring gitignore
- **Mkdir zero-mode guard** — `Mkdir(path)` without mode now defaults to 0755 (was passing 0, causing permission denied)
- **Issue #248** — logged WalkTree Reducer redesign for Starlark consumption

Unblocks noblefactor-ops Phase 2: `.star` scripts can use `file.find("**/*.go")` instead of the hand-coded recursive glob.

## Test plan

- [x] `make test` passes — all packages green
- [x] `golangci-lint run ./pkg/op/provider/file/...` — 0 issues
- [x] Starlark integration tests: `find("**/*.go")` finds 2 files, `find("**/*.md")` finds 1, `find("**/*.*")` finds 3
- [x] `make generate` produces correct params with `Find` entry