### PR TITLE
fix(op): Auto-create RecoverySite in StarlarkRuntime.Initialize

### DIFF
--- a/pkg/op/starlark_runtime.go
+++ b/pkg/op/starlark_runtime.go
@@ -71,8 +71,10 @@ func (rt *StarlarkRuntime) HasGraphBuilder() bool {
 //   - reg: the action registry to populate.
 //   - ctx: the base execution context for provider initialization.
 func (rt *StarlarkRuntime) Initialize(reg *ActionRegistry, ctx ContextBase) {
-
 	rt.ctx = Context{ContextBase: ctx}
+	if ctx.Root != nil {
+		rt.ctx.RecoverySite = NewRecoverySite(rt.ctx)
+	}
 	InitAll(reg, rt.ctx)
 }
 


### PR DESCRIPTION
## Summary

- **One-line fix** — `Initialize` creates a `RecoverySite` when Root is non-nil, enabling compensable file operations (WriteText, Remove) in immediate-mode Starlark receivers

## Test plan

- [x] `make test` passes — all devlore-cli packages green
- [x] Verified via noblefactor-ops local replace: lint-copyright fix mode (WriteText) no longer panics