### PR TITLE
refactor(star): Migrate star extensions to framework provider API

### DIFF
--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -77,7 +77,7 @@ def load_template(name, ext_dir):
     if name not in LOCAL_TEMPLATES:
         fail("unknown template: " + name)
     path = file.join(ext_dir, "templates", LOCAL_TEMPLATES[name])
-    return file.read(path)
+    return file.read_text(path)
 
 def to_snake(name):
     """Convert CamelCase to snake_case."""
@@ -1156,7 +1156,7 @@ def gen_file(ctx, template_name, descriptor, filename, label, method_count, outp
         out_dir = file.parent(out_path)
         if not file.exists(out_dir):
             file.mkdir(out_dir)
-        file.write(out_path, code)
+        file.write_text(out_path, code)
         ui.success("Wrote " + out_path)
     else:
         ui.note("--- " + filename + " ---")

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
@@ -56,7 +56,7 @@ def run(ctx):
             fail("--source required (no ../devlore-cli found)")
 
     # Validate paths exist
-    if not file.is_directory(source):
+    if not file.is_dir(source):
         fail("Source path not found: " + source)
 
     # Build knowledge for selected domain(s)
@@ -79,7 +79,7 @@ def _resolve_target(ctx):
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -87,7 +87,7 @@ def _resolve_target(ctx):
 def _find_sibling(name):
     """Find a sibling directory by name."""
     sibling = file.join("..", name)
-    if file.is_directory(sibling):
+    if file.is_dir(sibling):
         return sibling
     return ""
 
@@ -157,14 +157,13 @@ def _build_ns_descriptions(starlark_path):
     """
     descriptions = {"(root)": "Top-level graph construction primitives"}
     provider_base = file.join(starlark_path, "..", "execution", "provider")
-    if not file.is_directory(provider_base):
+    if not file.is_dir(provider_base):
         return descriptions
 
-    for entry in file.list(provider_base):
-        if not entry.is_dir:
+    for provider_path in file.glob(file.join(provider_base, "*")):
+        if not file.is_dir(provider_path):
             continue
-        ns = str(entry.name)
-        provider_path = file.join(provider_base, ns)
+        ns = file.name(provider_path)
         doc = str(goast.type_doc(provider_path, "Provider"))
         if doc:
             # Join paragraph lines into one string, stopping at blank lines or directives.
@@ -654,7 +653,7 @@ def build_onboarding_knowledge(source, target, fmt = "all"):
     ui.note("Building onboarding knowledge (Starlark API)...")
 
     starlark_path = file.join(source, "internal", "starlark")
-    if not file.is_directory(starlark_path):
+    if not file.is_dir(starlark_path):
         fail("Starlark package not found: " + starlark_path)
 
     # Parse the API using Go AST primitives
@@ -683,7 +682,7 @@ def build_onboarding_knowledge(source, target, fmt = "all"):
         changes_detected = False
         new_content = yaml.encode(api)
         if file.exists(reference_path):
-            current_content = file.read(reference_path)
+            current_content = file.read_text(reference_path)
             if current_content != new_content:
                 changes_detected = True
                 ui.note("  Changes detected in reference.yaml")
@@ -692,7 +691,7 @@ def build_onboarding_knowledge(source, target, fmt = "all"):
             ui.note("  Creating new reference.yaml")
 
         if changes_detected:
-            file.write(reference_path, new_content)
+            file.write_text(reference_path, new_content)
             ui.success("  Wrote " + reference_path)
         else:
             ui.success("  No changes to reference.yaml")
@@ -704,7 +703,7 @@ def build_onboarding_knowledge(source, target, fmt = "all"):
 
         md_changed = False
         if file.exists(md_path):
-            current_md = file.read(md_path)
+            current_md = file.read_text(md_path)
             if current_md != md_content:
                 md_changed = True
                 ui.note("  Changes detected in reference.md")
@@ -713,7 +712,7 @@ def build_onboarding_knowledge(source, target, fmt = "all"):
             ui.note("  Creating new reference.md")
 
         if md_changed:
-            file.write(md_path, md_content)
+            file.write_text(md_path, md_content)
             ui.success("  Wrote " + md_path)
         else:
             ui.success("  No changes to reference.md")
@@ -924,15 +923,15 @@ def build_migration_knowledge(source, target):
     ui.note("Building migration knowledge...")
 
     migrate_path = file.join(source, "internal", "writ", "migrate")
-    if not file.is_directory(migrate_path):
+    if not file.is_dir(migrate_path):
         fail("Migrate source not found: " + migrate_path)
 
     execution_path = file.join(source, "internal", "execution")
-    if not file.is_directory(execution_path):
+    if not file.is_dir(execution_path):
         fail("Execution source not found: " + execution_path)
 
     knowledge_path = file.join(target, "knowledge", "migration")
-    if not file.is_directory(knowledge_path):
+    if not file.is_dir(knowledge_path):
         fail("Migration knowledge path not found: " + knowledge_path)
 
     # Step 1: Parse Go source files
@@ -957,14 +956,12 @@ def build_migration_knowledge(source, target):
     # Step 2: Load registry signature files
     signatures_path = file.join(knowledge_path, "signatures")
     registry_systems = []
-    if file.is_directory(signatures_path):
-        for entry in file.list(signatures_path):
-            if entry.name.endswith(".yaml"):
-                sig_path = file.join(signatures_path, entry.name)
-                content = file.read(sig_path)
+    if file.is_dir(signatures_path):
+        for sig_path in file.glob(file.join(signatures_path, "*.yaml")):
+                content = file.read_text(sig_path)
                 sig = yaml.decode(content)
                 if sig.get("name"):
-                    system_name = entry.name.replace(".yaml", "")
+                    system_name = file.name(sig_path).replace(".yaml", "")
                     registry_systems.append(system_name)
 
     # Step 3: Load writ-structure.yaml for platform validation
@@ -972,7 +969,7 @@ def build_migration_knowledge(source, target):
     registry_platforms = []
     registry_platform_aliases = []
     if file.exists(writ_structure_path):
-        content = file.read(writ_structure_path)
+        content = file.read_text(writ_structure_path)
         structure = yaml.decode(content)
         segments = structure.get("naming", {}).get("segments", {})
         platform_list = segments.get("platforms", [])
@@ -1007,7 +1004,7 @@ def build_migration_knowledge(source, target):
 
     changes_detected = False
     if file.exists(systems_ref_path):
-        current_content = file.read(systems_ref_path)
+        current_content = file.read_text(systems_ref_path)
         new_content = yaml.encode(systems_ref)
         if current_content != new_content:
             changes_detected = True
@@ -1017,7 +1014,7 @@ def build_migration_knowledge(source, target):
         ui.note("  Creating new systems-reference.yaml")
 
     if changes_detected:
-        file.write(systems_ref_path, yaml.encode(systems_ref))
+        file.write_text(systems_ref_path, yaml.encode(systems_ref))
         ui.success("  Wrote " + systems_ref_path)
     else:
         ui.success("  No changes to systems-reference.yaml")
@@ -1040,7 +1037,7 @@ _SCHEMA_OVERRIDES = {
 def generate_execution_schema(source, knowledge_path, execution):
     """Generate engine-graph.json schema from Go struct definitions."""
     schemas_path = file.join(knowledge_path, "schemas")
-    if not file.is_directory(schemas_path):
+    if not file.is_dir(schemas_path):
         ui.warn("  Schemas path not found: " + schemas_path)
         return
 
@@ -1139,7 +1136,7 @@ def generate_execution_schema(source, knowledge_path, execution):
 
     changes_detected = False
     if file.exists(engine_schema_path):
-        current_content = file.read(engine_schema_path)
+        current_content = file.read_text(engine_schema_path)
         if current_content != new_content:
             changes_detected = True
             ui.note("  Changes detected in engine-graph.json")
@@ -1148,7 +1145,7 @@ def generate_execution_schema(source, knowledge_path, execution):
         ui.note("  Creating new engine-graph.json")
 
     if changes_detected:
-        file.write(engine_schema_path, new_content)
+        file.write_text(engine_schema_path, new_content)
         ui.success("  Wrote " + engine_schema_path)
     else:
         ui.success("  No changes to engine-graph.json")
@@ -1280,7 +1277,7 @@ def validate_signature_coverage(source_systems, signatures_path):
         if not file.exists(sig_file):
             ui.warn("  Missing signature file: " + sig_file)
         else:
-            content = file.read(sig_file)
+            content = file.read_text(sig_file)
             sig = yaml.decode(content)
             if not sig.get("name"):
                 ui.warn("  Signature missing 'name': " + sig_file)
@@ -1305,7 +1302,7 @@ def build_ops_knowledge(source, target):
     ui.note("Building ops knowledge (operation surface)...")
 
     execution_path = file.join(source, "internal", "execution")
-    if not file.is_directory(execution_path):
+    if not file.is_dir(execution_path):
         fail("Execution source not found: " + execution_path)
 
     # Discover *Service structs
@@ -1384,7 +1381,7 @@ def build_ops_knowledge(source, target):
 
         changes_detected = False
         if file.exists(mapping_path):
-            current_content = file.read(mapping_path)
+            current_content = file.read_text(mapping_path)
             if current_content != mapping_yaml:
                 changes_detected = True
                 ui.note("  Changes detected in " + mapping_file)
@@ -1393,7 +1390,7 @@ def build_ops_knowledge(source, target):
             ui.note("  Creating new " + mapping_file)
 
         if changes_detected:
-            file.write(mapping_path, mapping_yaml)
+            file.write_text(mapping_path, mapping_yaml)
             ui.success("  Wrote " + mapping_path)
         else:
             ui.success("  No changes to " + mapping_file)

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
@@ -26,13 +26,10 @@ def list_files(dir_path):
         return []
 
     files = []
-    def collect(entry):
-        if entry.is_dir:
-            return "skip"
-        if entry.name.startswith("."):
-            return
-        files.append(entry.name)
-    file.walk_tree(root=dir_path, callback=collect)
+    for path in file.glob(file.join(dir_path, "*")):
+        name = file.name(path)
+        if not file.is_dir(path) and not name.startswith("."):
+            files.append(name)
     return sorted(files)
 
 def build_asset_entries(dir_path):
@@ -60,12 +57,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -84,12 +81,11 @@ def run(ctx):
     domains_processed = 0
     total_assets = 0
 
-    for entry in file.list(knowledge_dir):
-        if not entry.is_dir:
+    for domain_path in file.glob(file.join(knowledge_dir, "*")):
+        if not file.is_dir(domain_path):
             continue
 
-        domain_name = entry.name
-        domain_path = entry.path
+        domain_name = file.name(domain_path)
 
         index = build_index(domain_name, domain_path)
 
@@ -111,7 +107,7 @@ def run(ctx):
             print(index_content)
             print("---")
         else:
-            file.write(index_path, index_content)
+            file.write_text(index_path, index_content)
             ui.success("Wrote: " + index_path + " (" + str(asset_count) + " assets)")
 
         domains_processed = domains_processed + 1

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/sign.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/sign.star
@@ -21,12 +21,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
@@ -41,7 +41,7 @@ def validate_file(file_path, schema_json):
     """Validate a single file against a schema."""
     content = file.read_text(file_path)
     doc = yaml.parse(content)
-    if doc.value == None:
+    if doc.parsed == None:
         return False, ["Failed to parse YAML"]
 
     result = doc.validate(schema_json)

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/validate.star
@@ -32,24 +32,21 @@ def find_files(target, pattern):
             break
         search_root = file.join(search_root, part)
 
-    if not file.exists(search_root) or not file.is_directory(search_root):
+    if not file.exists(search_root) or not file.is_dir(search_root):
         return []
 
-    files = []
-    def collect(entry):
-        if not entry.is_dir and entry.name == filename:
-            files.append(file.join(search_root, entry.path))
-    file.walk_tree(root=search_root, callback=collect)
-    return files
+    return file.find(file.join(search_root, "**", filename))
 
 def validate_file(file_path, schema_json):
     """Validate a single file against a schema."""
-    content = file.read(file_path)
-    data = yaml.decode(content)
-    if data == None:
+    content = file.read_text(file_path)
+    doc = yaml.parse(content)
+    if doc.value == None:
         return False, ["Failed to parse YAML"]
 
-    valid, errors = schema.validate(data, schema_json)
+    result = doc.validate(schema_json)
+    valid = result.valid
+    errors = result.errors
     return valid, errors
 
 
@@ -58,12 +55,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -81,7 +78,7 @@ def run(ctx):
         if not file.exists(schema_path):
             continue
 
-        schema_json = file.read(schema_path)
+        schema_json = file.read_text(schema_path)
         files = find_files(target, config["pattern"])
 
         if len(files) == 0:

--- a/star/extensions/com.noblefactor.devlore.Model/commands/build.star
+++ b/star/extensions/com.noblefactor.devlore.Model/commands/build.star
@@ -44,7 +44,7 @@ def build_modelfile(knowledge_path, domain, model):
     # Include each asset type in order
     for asset_type, section_name, extension in SYSTEM_ASSET_ORDER:
         asset_dir = file.join(knowledge_path, asset_type)
-        if not file.is_directory(asset_dir):
+        if not file.is_dir(asset_dir):
             continue
 
         section_content = _build_section(asset_dir, section_name, extension)
@@ -75,7 +75,7 @@ def _build_section(asset_dir, section_name, extension):
 
     for filename in files:
         filepath = file.join(asset_dir, filename)
-        content = file.read(filepath)
+        content = file.read_text(filepath)
 
         # Skip baseline/generated files in examples
         if filename.startswith("baseline-"):
@@ -107,15 +107,11 @@ def _list_asset_files(dir_path, extension=""):
         return []
 
     files = []
-    def collect(entry):
-        if entry.is_dir:
-            return "skip"
-        if entry.name.startswith("."):
-            return
-        if extension and not entry.name.endswith(extension):
-            return
-        files.append(entry.name)
-    file.walk_tree(root=dir_path, callback=collect)
+    pattern = "*" + extension if extension else "*"
+    for path in file.glob(file.join(dir_path, pattern)):
+        name = file.name(path)
+        if not file.is_dir(path) and not name.startswith("."):
+            files.append(name)
     return sorted(files)
 
 
@@ -129,12 +125,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -142,26 +138,27 @@ def _resolve_target(ctx):
 def _list_knowledge_domains(target):
     """List all knowledge domains in the target."""
     knowledge_path = file.join(target, "knowledge")
-    if not file.is_directory(knowledge_path):
+    if not file.is_dir(knowledge_path):
         return []
 
     domains = []
-    for entry in file.list(knowledge_path):
-        if entry.is_dir and not entry.name.startswith("."):
-            domains.append(entry.name)
+    for path in file.glob(file.join(knowledge_path, "*")):
+        name = file.name(path)
+        if file.is_dir(path) and not name.startswith("."):
+            domains.append(name)
     return sorted(domains)
 
 
 def _build_domain(target, domain, model):
     """Build Modelfile for a single domain."""
     knowledge_path = file.join(target, "knowledge", domain)
-    if not file.is_directory(knowledge_path):
+    if not file.is_dir(knowledge_path):
         fail("Knowledge domain not found: " + domain)
 
     content = build_modelfile(knowledge_path, domain, model)
     output_path = file.join(target, "Modelfile." + domain)
 
-    file.write(output_path, content)
+    file.write_text(output_path, content)
     ui.success("Generated: " + output_path)
 
     # Show stats

--- a/star/extensions/com.noblefactor.devlore.Package/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Package/commands/index.star
@@ -39,22 +39,18 @@ def scan_packages(packages_dir):
     pkg_dirs = []     # [(name, abs_path)]
     variant_map = {}  # pkg_name -> [variant_name]
 
-    def collect(entry):
-        if not entry.is_dir:
-            return
-        depth = entry.path.count("/") + 1
-        if depth == 1:
-            pkg_dirs.append((entry.name, file.join(packages_dir, entry.path)))
-        elif depth == 2 and not entry.name.startswith("."):
-            parent = entry.path.split("/")[0]
-            if parent not in variant_map:
-                variant_map[parent] = []
-            variant_map[parent].append(entry.name)
-            return "skip"
-        elif depth > 2:
-            return "skip"
-
-    file.walk_tree(root=packages_dir, callback=collect)
+    # Depth 1: top-level package directories
+    for pkg_path in file.glob(file.join(packages_dir, "*")):
+        if file.is_dir(pkg_path):
+            pkg_name = file.name(pkg_path)
+            pkg_dirs.append((pkg_name, pkg_path))
+            # Depth 2: variant subdirectories
+            for variant_path in file.glob(file.join(pkg_path, "*")):
+                variant_name = file.name(variant_path)
+                if file.is_dir(variant_path) and not variant_name.startswith("."):
+                    if pkg_name not in variant_map:
+                        variant_map[pkg_name] = []
+                    variant_map[pkg_name].append(variant_name)
 
     packages = []
     for pkg_name, pkg_path in pkg_dirs:
@@ -63,7 +59,7 @@ def scan_packages(packages_dir):
             ui.warn("Skipping " + pkg_name + " (no lifecycle.yaml)")
             continue
 
-        content = file.read(lifecycle_path)
+        content = file.read_text(lifecycle_path)
         pkg = parse_lifecycle(content)
         if pkg == None:
             ui.warn("Skipping " + pkg_name + " (invalid lifecycle.yaml)")
@@ -134,12 +130,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -164,7 +160,7 @@ def run(ctx):
     # Build and write package index
     index = build_index(packages)
     index_path = file.join(packages_dir, "index.yaml")
-    file.write(index_path, yaml.encode(index))
+    file.write_text(index_path, yaml.encode(index))
     ui.success("Wrote: " + index_path)
 
     # Build and write cross-reference
@@ -177,7 +173,7 @@ def run(ctx):
         total_mappings = total_mappings + len(names)
 
     if total_mappings > 0:
-        file.write(xref_path, yaml.encode(xref))
+        file.write_text(xref_path, yaml.encode(xref))
         ui.success("Wrote: " + xref_path)
         ui.note(str(len(xref)) + " managers, " + str(total_mappings) + " mappings")
     else:

--- a/star/extensions/com.noblefactor.devlore.Package/commands/sign.star
+++ b/star/extensions/com.noblefactor.devlore.Package/commands/sign.star
@@ -18,12 +18,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 

--- a/star/extensions/com.noblefactor.devlore.Package/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Package/commands/validate.star
@@ -49,7 +49,7 @@ def validate_file(file_path, schema_json):
     """Validate a single file against a schema."""
     content = file.read_text(file_path)
     doc = yaml.parse(content)
-    if doc.value == None:
+    if doc.parsed == None:
         return False, ["Failed to parse YAML"]
 
     result = doc.validate(schema_json)

--- a/star/extensions/com.noblefactor.devlore.Package/commands/validate.star
+++ b/star/extensions/com.noblefactor.devlore.Package/commands/validate.star
@@ -40,24 +40,21 @@ def find_files(target, pattern):
             break
         search_root = file.join(search_root, part)
 
-    if not file.exists(search_root) or not file.is_directory(search_root):
+    if not file.exists(search_root) or not file.is_dir(search_root):
         return []
 
-    files = []
-    def collect(entry):
-        if not entry.is_dir and entry.name == filename:
-            files.append(file.join(search_root, entry.path))
-    file.walk_tree(root=search_root, callback=collect)
-    return files
+    return file.find(file.join(search_root, "**", filename))
 
 def validate_file(file_path, schema_json):
     """Validate a single file against a schema."""
-    content = file.read(file_path)
-    data = yaml.decode(content)
-    if data == None:
+    content = file.read_text(file_path)
+    doc = yaml.parse(content)
+    if doc.value == None:
         return False, ["Failed to parse YAML"]
 
-    valid, errors = schema.validate(data, schema_json)
+    result = doc.validate(schema_json)
+    valid = result.valid
+    errors = result.errors
     return valid, errors
 
 
@@ -66,12 +63,12 @@ def _resolve_target(ctx):
     target = ctx.args.get("target", "")
     if not target:
         sibling = file.join("..", "devlore-registry")
-        if file.is_directory(sibling):
+        if file.is_dir(sibling):
             target = sibling
             ui.note("Using sibling registry: " + target)
         else:
             fail("--target required (no ../devlore-registry found)")
-    if not file.is_directory(target):
+    if not file.is_dir(target):
         fail("Target path not found: " + target)
     return target
 
@@ -89,7 +86,7 @@ def run(ctx):
         if not file.exists(schema_path):
             continue
 
-        schema_json = file.read(schema_path)
+        schema_json = file.read_text(schema_path)
         files = find_files(target, config["pattern"])
 
         if len(files) == 0:


### PR DESCRIPTION
## Summary

- **9 star extension scripts** migrated to framework file provider API
- **file.read/write/is_directory** → `read_text`/`write_text`/`is_dir` (48 sites)
- **file.list** → `file.glob` + `file.name`/`file.is_dir` for single-level directory listing (4 sites)
- **file.walk_tree** → `file.find` for recursive search, `file.glob` for non-recursive (4 sites)
- **schema.validate** → `yaml.parse(content).validate(schema_json)` using yaml.Resource (2 sites)

## Test plan

- [x] All old API patterns removed (grep confirms zero matches)
- [x] Net -20 lines — simpler code without callback-based walk_tree
- [ ] End-to-end validation requires noblefactor-ops runtime with framework providers wired