### PR TITLE
feat(op): StructValue marshaling, star extension migration, and hermeticity docs

### DIFF
--- a/docs/architecture/2.4-hermeticity-guarantees.md
+++ b/docs/architecture/2.4-hermeticity-guarantees.md
@@ -176,6 +176,7 @@ The orchestration logic in `internal/writ/commands.go` needs four changes:
 - **Execution engine compatibility**: no changes needed below the command layer. `Context`, `Root`, `RecoverySite`, providers, and graph structure all support multi-scope by construction.
 
 ## Risk Areas
+<<<<<<< Updated upstream
 
 ### Failure Coordination and Compensation
 
@@ -189,6 +190,37 @@ The test surface is the 2×3 matrix (System/Home × base/team/personal) with 1�
 - Only Home sources → 1 graph
 - Cross-scope collision (same relative path in System and Home) → Home shadows System
 - Layers with no System content → 0 system graphs
+=======
+
+### Coupled Design Decisions
+
+Confinement reachability, receipt identity, and failure coordination must be designed together — they are coupled:
+
+- A failure policy that compensates across graphs depends on receipts knowing which graph they belong to.
+- Receipt identity depends on cell tagging.
+- Cell tagging depends on how many graphs were produced, which is driven by confinement reachability.
+
+These three cannot be designed in isolation.
+
+### Combinatorial Test Surface
+
+The 2×3 matrix with variable graph counts (2–4) creates a combinatorial test surface. Fixtures are needed for all reachability scenarios:
+
+- All layer repos within `$HOME` (1 home graph)
+- One layer repo outside `$HOME` (2 home graphs)
+- All layer repos outside `$HOME` (3 home graphs)
+- Layers with no System content (0 system graphs)
+
+### Failure Coordination and Compensation
+
+If the system graph fails, what happens to home graphs that haven't started? The `RecoverySite` compensates within a single graph, but cross-graph compensation is not currently modeled. The failure policy needs to answer: does a failed system graph block home execution, and if home graphs have already completed, should they be rolled back?
+
+## Open Questions
+
+### Execution Coordination
+- What is the failure policy across graphs? Fail-fast (stop all on first failure), continue (execute remaining graphs), or selective (skip dependent graphs)?
+- Does `GraphContext` need to record the cell identity (target scope + layer), or is `TargetRoot` + `Layer` sufficient?
+>>>>>>> Stashed changes
 
 ### Dirty Working Tree Policy
 - Should the planner refuse to plan if a layer has uncommitted changes? This enforces discipline (commit before deploy) but may be inconvenient during development.

--- a/docs/plans/lazy-resource-registration.md
+++ b/docs/plans/lazy-resource-registration.md
@@ -222,6 +222,7 @@ happens. The safe order: (a) update `star`, (b) add exported constructors alongs
 `init()`, (c) run `make generate` to produce gen files, (d) verify tests pass with both paths
 active, (e) delete hand-written `init()` functions.
 
+<<<<<<< Updated upstream
 - [x] Extend `star` codegen to read `resource.go` and emit `gen/resource.gen.go`
 - [x] Add exported constructors (`ResourceFromValue`) alongside existing `init()` in each
       `resource.go` — both paths active temporarily
@@ -253,18 +254,45 @@ active, (e) delete hand-written `init()` functions.
   constructor registration
 - `pkg/op/provider/git/provider_test.go` — Modified: added test `init()` for cross-package
   constructor registration
+=======
+- [ ] Extend `star` codegen to read `resource.go` and emit `gen/resource.gen.go`
+- [ ] Add exported constructors (`ResourceFromValue`) alongside existing `init()` in each
+      `resource.go` — both paths active temporarily
+- [ ] Run `make generate` and verify `gen/resource.gen.go` files are produced
+- [ ] Verify resource `init()` fires via existing `register.go` blank imports (DC4 — no changes
+      to `register.go` needed)
+- [ ] Verify all existing tests pass with both registration paths active
+- [ ] Delete hand-written `init()` functions from each `resource.go`
+- [ ] Verify tests pass with only generated registration
+
+**Files**:
+
+- `noblefactor-ops/cmd/star` — Modify: extend codegen to read resource.go (do this first)
+- `pkg/op/provider/file/resource.go` — Modify: export constructor, delete `init()`
+- `pkg/op/provider/git/resource.go` — Modify: same
+- `pkg/op/provider/pkg/resource.go` — Modify: same
+- `pkg/op/provider/service/resource.go` — Modify: same
+- `pkg/op/provider/appnet/resource.go` — Modify: same
+- `pkg/op/provider/mem/resource.go` — Modify: same (constructor only; callable extractor in Phase 3)
+- `pkg/op/provider/*/gen/resource.gen.go` — Create: generated resource descriptors
+>>>>>>> Stashed changes
 
 ### Phase 3: Generalize callable extraction ✅
 
 Fold the callable extractor into the marshaler so `mem` no longer needs a special registration.
 Split into three sub-phases, each independently testable.
 
+<<<<<<< Updated upstream
 #### Phase 3a: Revert `*os.Root` from extraction chain ✅
+=======
+#### Phase 3a: Revert `*os.Root` from extraction chain
+>>>>>>> Stashed changes
 
 Remove the dead `*os.Root` parameter from the extraction pipeline. This is a standalone correction
 (DC5) with no behavioral change — `readSource` falls back to `os.ReadFile` unconditionally after
 this change.
 
+<<<<<<< Updated upstream
 - [x] Remove `root` parameter from `Extract`, `ExtractWithName`, `synthesize`, `extractLambdaBody`,
       `extractDefSource`
 - [x] Replace `readSource(filename, root)` with direct `os.ReadFile(filename)`; delete `readSource`
@@ -282,6 +310,60 @@ this change.
 - `pkg/op/callable_test.go` — Modified: updated `ExtractCallable` and `RegisterCallableExtractor`
   calls
 - `pkg/op/planned_reflect.go` — Modified: dropped `nil` root argument from `ExtractCallable` call
+=======
+- [ ] Remove `root` parameter from `Extract`, `ExtractWithName`, `synthesize`, `extractLambdaBody`,
+      `extractDefSource`
+- [ ] Replace `readSource(filename, root)` with direct `os.ReadFile(filename)`; delete `readSource`
+- [ ] Remove `*os.Root` from `callableExtractorFn` and `RegisterCallableExtractor` signatures
+- [ ] Update `ExtractCallable` signature and its call site in `planned_reflect.go`
+- [ ] Update all extraction tests
+- [ ] `make test` — verify no behavioral change
+
+**Files**:
+
+- `pkg/op/provider/mem/extract.go` — Modify: remove `root` parameter from all extraction functions
+- `pkg/op/provider/mem/extract_test.go` — Modify: update tests
+- `pkg/op/callable.go` — Modify: remove `*os.Root` from extractor signatures
+- `pkg/op/planned_reflect.go` — Modify: drop `nil` root argument from `ExtractCallable` call
+
+#### Phase 3b: Merge callable logic into the marshaler
+
+Move the callable adapter infrastructure from `callable.go` into `starvalue_marshal.go`. The
+extraction pipeline stays in `mem` as domain code — only the registration plumbing and adapter
+logic move.
+
+- [ ] Move `CallableResource` interface, `buildCallableFunc`, `initCallableSlots`,
+      `makeErrorReturn`, `unmarshalReturn`, `isCallableResource`, `isFuncType` into
+      `starvalue_marshal.go`
+- [ ] Delete `callable.go`
+- [ ] `make test` — verify no behavioral change
+
+**Files**:
+
+- `pkg/op/callable.go` — Delete: merge into `starvalue_marshal.go`
+- `pkg/op/starvalue_marshal.go` — Modify: absorb callable adapter logic
+
+#### Phase 3c: Remove special-case registration, unify through marshaler
+
+Replace `RegisterCallableExtractor` / `ExtractCallable` with the standard `AnnounceResource` /
+lazy `Init()` pattern. Rewire `planned_reflect.go` and `action_reflect.go` to go through the
+marshaler for callable coercion.
+
+- [ ] Register `mem.Extract` + `mem.Compile` as a resource constructor via `AnnounceResource`
+- [ ] Remove `RegisterCallableExtractor`, `callableExtractorFn`, and `ExtractCallable` —
+      replaced by `sync.Once`-protected descriptor (DC1)
+- [ ] Update `planned_reflect.go` to use marshaler for `*starlark.Function → func(...)` coercion
+- [ ] Update `action_reflect.go` to remove callable special-case
+- [ ] Remove `RegisterCallableExtractor` call from `mem/resource.go` init
+- [ ] `make test` — verify callable tests pass
+
+**Files**:
+
+- `pkg/op/starvalue_marshal.go` — Modify: handle `*starlark.Function → func(...)` natively
+- `pkg/op/planned_reflect.go` — Modify: remove direct `ExtractCallable` call
+- `pkg/op/action_reflect.go` — Modify: remove callable special-case
+- `pkg/op/provider/mem/resource.go` — Modify: remove `RegisterCallableExtractor` from init
+>>>>>>> Stashed changes
 
 #### Phase 3b: Merge callable logic into the marshaler ✅
 

--- a/docs/plans/star-struct-methods.md
+++ b/docs/plans/star-struct-methods.md
@@ -1,0 +1,167 @@
+---
+title: "Marshal Go struct methods to Starlark"
+issue: TBD
+status: draft
+created: 2026-03-18
+updated: 2026-03-18
+---
+
+# Plan: Marshal Go struct methods to Starlark
+
+## Summary
+
+Extend `Marshal()` so that Go struct methods are automatically exposed as Starlark attributes alongside fields. Today the marshaler handles fields; after this change it handles methods too. Go programmers write normal Go code — structs with fields and methods — and the marshaler figures it out. Annotations are occasional hints; custom marshaling is the rarest case.
+
+Internally, marshaled structs shift from `starlarkstruct.Struct` (pre-baked dict, fields only) to a lightweight `StructValue` type with lazy `Attr()` dispatch (fields and methods computed on access). This is an implementation detail — callers of `Marshal()` don't see or construct `StructValue` directly.
+
+## Goals
+
+1. **Methods just work**: Exported zero-arg methods become Starlark attrs automatically, same as fields do today.
+2. **Consistent semantics**: Lazy attr dispatch for both fields and methods, matching `ExecutingReceiver` behavior and Python's attribute protocol.
+3. **starlark.Value passthrough**: Types already implementing `starlark.Value` are returned directly, not flattened.
+4. **Stringer integration**: `fmt.Stringer` drives the value's representation, not exposed as an attr.
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| Field marshaling | Working | `Marshal()` handles fields via reflection + `starlark` tags |
+| Method marshaling | Missing | Methods are silently discarded |
+| starlark.Value passthrough | Partial | Top-level `Marshal()` catches it; recursive `marshalReflect` does not |
+
+## Requirements
+
+### R1: Method discovery in `getTypeInfo`
+
+Extend the cached `typeInfo` to include eligible methods alongside fields. A method is eligible if:
+
+- Exported
+- Zero non-receiver parameters
+- Returns exactly 1 value (`func() T`) or 2 values where the second is `error` (`func() (T, error)`)
+- `func() error` alone is not eligible
+- Not `String` matching the `fmt.Stringer` signature (reserved for value representation)
+
+Methods are discovered from `reflect.PointerTo(structType)` so that both value-receiver and pointer-receiver methods are included.
+
+Go prevents field/method name collisions at compile time. Tag-aliased collisions (e.g., field `FullText` tagged `starlark:"text"` alongside method `Text()`) are the author's responsibility to resolve — either by renaming or re-tagging.
+
+### R2: Lazy `StructValue` replaces `starlarkstruct.Struct`
+
+Replace the pre-baked `starlarkstruct.Struct` with an internal `StructValue` type. It holds a `reflect.Value` (the Go struct) and a `*typeInfo`, and implements `starlark.Value` + `starlark.HasAttrs`:
+
+- `Attr(name)`: fields are marshaled on access; methods are called on access and their return values marshaled. Errors from `func() (T, error)` methods propagate.
+- `AttrNames()`: returns sorted field + method names from `typeInfo`.
+- `String()`: delegates to `fmt.Stringer` if the Go type implements it; otherwise formats as `type_name(field = val, ...)`.
+- `Type()`: snake_case type name.
+- `Freeze()`: no-op. `Truth()`: `True`. `Hash()`: error (unhashable).
+
+For non-addressable struct values, store a pointer via `reflect.New` to enable pointer-receiver method calls.
+
+### R3: Update unmarshal and `FormatLiteral` for `StructValue`
+
+Sites that type-assert on `*starlarkstruct.Struct` need a parallel `*StructValue` case:
+
+- `unmarshalStruct` — add case using `Attr()` (same pattern as existing `*starlarkstruct.Struct` case)
+- `unmarshalToAny` — add case delegating to shared helper
+- `FormatLiteral` / `formatStruct` in `pkg/op/provider/mem/literals.go` — add case using `AttrNames()` + `Attr()`
+
+### R4: `starlark.Value` passthrough in `marshalReflect`
+
+In the `reflect.Struct` case, for structs with no exported fields, check `starlark.Value` (value and pointer) before the existing `starvalue.Marshaler` check. Return directly if satisfied.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Which methods? | All exported with supported signatures, minus `String` | Same as fields — the marshaler figures it out; `String` reserved for representation |
+| Eager or lazy? | Lazy (computed in `Attr()`) | Consistent with `ExecutingReceiver`; Go author controls caching |
+| Internal type | `StructValue` (unexported to callers) | Implementation detail of `Marshal()`; Go programmers never see it |
+| Non-addressable values | Store pointer via `reflect.New` | Enables pointer-receiver methods; safe for read-only access |
+
+## Implementation Phases
+
+### Phase 1: Extend `typeInfo` with method discovery
+
+- [ ] Add `methodInfo` struct (Go name, Starlark name, hasError flag)
+- [ ] Add `methods []methodInfo` and `byMethod map[string]*methodInfo` to `typeInfo`
+- [ ] In `getTypeInfo`, after field loop, iterate `reflect.PointerTo(t).NumMethod()` and collect eligible methods
+- [ ] Exclude `String` if it matches `fmt.Stringer` signature
+- [ ] Include method names in `attrList` (sorted alongside field names)
+- [ ] Cache the snake_case type name in `typeInfo` (avoid recomputing `camelToSnake` per marshal)
+
+**Files**:
+
+- `pkg/op/starvalue_marshal.go` - Modify
+
+### Phase 2: `StructValue` type
+
+- [ ] Define `StructValue` struct (typeName, goValue, info)
+- [ ] Implement `starlark.Value`: `String()`, `Type()`, `Freeze()`, `Truth()`, `Hash()`
+- [ ] Implement `starlark.HasAttrs`: `Attr()`, `AttrNames()`
+- [ ] `Attr()` resolves fields first (marshal via `marshalReflect`), then methods (call + marshal)
+- [ ] `String()` delegates to `fmt.Stringer` if available, otherwise formats attrs
+
+**Files**:
+
+- `pkg/op/starvalue_struct.go` - Create
+
+### Phase 3: Wire `marshalStruct` to produce `StructValue`
+
+- [ ] Replace `marshalStruct` body: wrap Go value in `StructValue`
+- [ ] For non-addressable values, create pointer via `reflect.New`
+- [ ] Remove pre-baked `starlark.StringDict` construction
+
+**Files**:
+
+- `pkg/op/starvalue_marshal.go` - Modify
+
+### Phase 4: Update unmarshal and `FormatLiteral`
+
+- [ ] Add `*StructValue` case to `unmarshalStruct`
+- [ ] Add `*StructValue` case to `unmarshalToAny`
+- [ ] Add `*StructValue` case to `FormatLiteral` in `pkg/op/provider/mem/literals.go`
+
+**Files**:
+
+- `pkg/op/starvalue_marshal.go` - Modify
+- `pkg/op/provider/mem/literals.go` - Modify
+
+### Phase 5: `starlark.Value` passthrough
+
+- [ ] In the `reflect.Struct` case of `marshalReflect`, check `starlark.Value` for fieldless structs
+- [ ] Place check before the existing `starvalue.Marshaler` check
+
+**Files**:
+
+- `pkg/op/starvalue_marshal.go` - Modify
+
+### Phase 6: Tests
+
+- [ ] Test field access via `Attr()` returns correct marshaled value
+- [ ] Test method with `func() T` signature appears as attr (lazy, called on access)
+- [ ] Test method with `func() (T, error)` appears as attr (success path)
+- [ ] Test method with `func() (T, error)` propagates error on access
+- [ ] Test methods with unsupported signatures are ignored
+- [ ] Test `String()` excluded from attrs, used for representation
+- [ ] Test `AttrNames()` includes both fields and methods, sorted
+- [ ] Test type implementing `starlark.Value` is returned directly
+- [ ] Test unmarshal round-trip through `StructValue`
+- [ ] Test `FormatLiteral` handles `StructValue`
+- [ ] Update existing tests that assert `*starlarkstruct.Struct` to expect `*StructValue`
+- [ ] Run `make check` to verify no regressions
+
+**Files**:
+
+- `pkg/op/starvalue_struct_test.go` - Create
+- `pkg/op/starvalue_marshal_test.go` - Modify
+- `pkg/op/provider/mem/literals_test.go` - Modify (if needed)
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `pkg/op/starvalue_struct.go` | Create | Internal `StructValue` type with lazy `Attr()` dispatch |
+| `pkg/op/starvalue_struct_test.go` | Create | Tests for field + method access, String, AttrNames |
+| `pkg/op/starvalue_marshal.go` | Modify | Extend `typeInfo`, replace `marshalStruct`, add starlark.Value passthrough |
+| `pkg/op/starvalue_marshal_test.go` | Modify | Update existing assertions for new output type |
+| `pkg/op/provider/mem/literals.go` | Modify | Add `StructValue` case to `FormatLiteral` |


### PR DESCRIPTION
## Summary

- **StructValue marshaling** — Replace starlarkstruct.Struct with lazy StructValue for marshaled Go structs; exported zero-arg methods become Starlark attrs alongside fields, types implementing starlark.Value returned directly
- **Star extension migration** — Update all 9 star extension scripts to use framework file provider API and yaml.Resource.Validate instead of hand-coded receivers (file.read_text, file.write_text, file.is_dir, file.glob, file.find, yaml.parse().validate())
- **Receiver params fix** — Check receiver params registry for value-type structs so methods taking arguments aren't lost on by-value Resources
- **Documentation** — Hermeticity guarantees architecture doc, lazy resource registration plan, struct methods plan

## Test plan

- [x] `make check` passes
- [x] StructValue unit tests cover field access, method invocation, and starlark.Value passthrough
- [x] Star extension scripts updated and tested against framework provider API
- [x] Receiver reflect tests updated for value-type struct handling