### PR TITLE
fix(ci): Set git identity for annotated LKG tags

### DIFF
--- a/.github/workflows/lkg-tag.yaml
+++ b/.github/workflows/lkg-tag.yaml
@@ -53,6 +53,9 @@ jobs:
 
       - name: Create and push LKG tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           TAG_NAME="${{ steps.pr.outputs.base_branch }}/lkg"
           MERGE_SHA="${{ steps.pr.outputs.merge_sha }}"
           PR_TITLE="${{ steps.pr.outputs.pr_title }}"


### PR DESCRIPTION
## Summary

- **Fix** — annotated `git tag -a` requires a committer identity, which isn't configured on GitHub Actions runners by default. Adds `git config user.name/email` before tag creation.

## Test plan

- [ ] Merge, then run `gh workflow run lkg-tag.yaml -f pr=<this PR>` to verify