### PR TITLE
refactor(star): Use native starlark types for bool/int flags

### DIFF
--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -1223,7 +1223,7 @@ def run(ctx):
     if not path:
         fail("--source is required")
 
-    gen_mode = ctx.args.get("gen", "false") == "true"
+    gen_mode = ctx.args.get("gen", False)
 
     # All providers use the same struct name
     struct_name = "Provider"
@@ -1246,9 +1246,9 @@ def run(ctx):
 
         # Resource-only package: generate resource descriptor and return.
         if not gen_mode:
-            fail("--gen=true is required")
+            fail("--gen is required")
         output_dir = ctx.args.get("output", "")
-        write_files = ctx.args.get("write", "false") == "true"
+        write_files = ctx.args.get("write", False)
         provider = path.split("/")[-1]
         provider_import = compute_provider_import(path)
         resource_params = detect_resource_params(path)
@@ -1310,13 +1310,13 @@ def run(ctx):
     # Parse common flags
     # -------------------------------------------------------------------------
     output_dir = ctx.args.get("output", "")
-    write_files = ctx.args.get("write", "false") == "true"
+    write_files = ctx.args.get("write", False)
 
     # -------------------------------------------------------------------------
     # Dispatch to gen/ mode
     # -------------------------------------------------------------------------
     if not gen_mode:
-        fail("--gen=true is required")
+        fail("--gen is required")
 
     generate_gen_mode(ctx, path, provider, struct_short, struct_name, access, lifetime,
                       all_method_names, all_descriptors,

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
@@ -70,7 +70,7 @@ def _resolve_target(ctx):
 def run(ctx):
     """Main entry point."""
     target = _resolve_target(ctx)
-    dry_run = ctx.args.get("dry_run", "") == "true"
+    dry_run = ctx.args.get("dry_run", False)
 
     knowledge_dir = file.join(target, "knowledge")
 

--- a/star/extensions/com.noblefactor.devlore.Test/commands/run.star
+++ b/star/extensions/com.noblefactor.devlore.Test/commands/run.star
@@ -36,9 +36,9 @@ def build_args(ctx, tool_path):
     """Build the devlore-test command arguments."""
     args = [tool_path, ctx.args["script"]]
 
-    if ctx.args.get("dry-run", "false") == "true":
+    if ctx.args.get("dry-run", False):
         args.append("--dry-run")
-    if ctx.args.get("trace", "false") == "true":
+    if ctx.args.get("trace", False):
         args.append("--trace")
 
     return args


### PR DESCRIPTION
## Summary

- **Native bool types** — `.star` files use `ctx.args.get("flag", False)` instead of `ctx.args.get("flag", "false") == "true"`
- **Companion to noblefactor-ops#121** — that PR changes `Command.Run` to pass `starlark.Bool` / `starlark.Int` via `ctx.args`

## Test plan

- [x] `make build` succeeds in noblefactor-ops (code generation uses these .star files)
- [x] `make test` passes in noblefactor-ops