### PR TITLE
feat(op): Add **kwargs support to receiver bridges (#264)

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_flow_degraded_template.star
+++ b/cmd/devlore-test/devloretest/data/test_flow_degraded_template.star
@@ -1,9 +1,8 @@
-# test_flow_degraded_template.star — Verify degraded with promise arg.
-# The write_text result flows into the degraded message via a promise.
+# test_flow_degraded_template.star — Verify degraded with template kwargs.
+# The write_text result flows into the degraded template via a promise.
 # Graph should still complete successfully.
-# TODO: restore kwargs (path=written) after Phase 1.50 adds **kwargs bridge support.
 
 written = plan.file.write_text(destination=t.tmp("d.txt"), content="ok", mode=0o644)
-plan.degraded("wrote %s", written)
+plan.degraded("wrote {{ .path }}", path=written)
 
 t.expect_node_count(2)

--- a/cmd/devlore-test/devloretest/data/test_flow_fatal_template.star
+++ b/cmd/devlore-test/devloretest/data/test_flow_fatal_template.star
@@ -1,7 +1,6 @@
-# test_flow_fatal_template.star — Verify fatal with promise arg.
-# The write_text result flows into the fatal message via a promise.
-# TODO: restore kwargs (service=svc) after Phase 1.50 adds **kwargs bridge support.
+# test_flow_fatal_template.star — Verify fatal with template kwargs.
+# The write_text result flows into the fatal template via a promise.
 
 t.expect_error("fatal:.*startup failed")
 svc = plan.file.write_text(destination=t.tmp("svc.txt"), content="myapp", mode=0o644)
-plan.fatal("%s startup failed", svc)
+plan.fatal("{{ .service }} startup failed", service=svc)

--- a/pkg/op/flow/integration_test.go
+++ b/pkg/op/flow/integration_test.go
@@ -153,7 +153,7 @@ func TestActions_Degraded_RoundTrip(t *testing.T) {
 	graph := op.NewGraph("roundtrip")
 	p := plan.NewProvider(graph, "proj", reg)
 
-	promise, err := p.Degraded("timeout on %s", "db")
+	promise, err := p.Degraded("timeout on %s", []any{"db"}, nil)
 	if err != nil {
 		t.Fatalf("Degraded() error: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestActions_Fatal_RoundTrip(t *testing.T) {
 	graph := op.NewGraph("roundtrip")
 	p := plan.NewProvider(graph, "proj", reg)
 
-	promise, err := p.Fatal("out of memory")
+	promise, err := p.Fatal("out of memory", nil, nil)
 	if err != nil {
 		t.Fatalf("Fatal() error: %v", err)
 	}

--- a/pkg/op/planned_reflect.go
+++ b/pkg/op/planned_reflect.go
@@ -129,17 +129,49 @@ func buildPlannedBridge(
 	project string,
 	reg *ActionRegistry,
 ) builtinFunc {
+	// Detect **kwargs param and build known-kwarg set for filtering.
+	var kwargsName string
+	knownKwargs := make(map[string]bool, len(paramNames))
+	regularParams := make([]string, 0, len(paramNames))
+	for _, name := range paramNames {
+		if strings.HasPrefix(name, "**") {
+			kwargsName = strings.TrimPrefix(name, "**")
+		} else {
+			regularParams = append(regularParams, name)
+			clean := strings.TrimPrefix(name, "*")
+			clean = strings.TrimSuffix(clean, "?")
+			knownKwargs[clean] = true
+		}
+	}
+
 	return func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		// 1. Unpack args as raw starlark.Value (slots store Starlark
 		//    values for deferred execution — NOT Go types).
 		//    Handle variadic params (*name) by stripping the prefix for
 		//    UnpackArgs and collecting them separately.
-		vals := make([]starlark.Value, len(paramNames))
-		pairs := make([]any, 0, len(paramNames)*2)
-		for i, name := range paramNames {
+		vals := make([]starlark.Value, len(regularParams))
+		pairs := make([]any, 0, len(regularParams)*2)
+		for i, name := range regularParams {
 			pairs = append(pairs, strings.TrimPrefix(name, "*"), &vals[i])
 		}
-		if err := starlark.UnpackArgs(snakeName, args, kwargs, pairs...); err != nil {
+
+		// Split kwargs: known → UnpackArgs, unknown → **kwargs dict slots.
+		var filteredKwargs []starlark.Tuple
+		var extraKwargs []starlark.Tuple
+		if kwargsName != "" {
+			for _, kv := range kwargs {
+				key, _ := starlark.AsString(kv[0])
+				if knownKwargs[key] {
+					filteredKwargs = append(filteredKwargs, kv)
+				} else {
+					extraKwargs = append(extraKwargs, kv)
+				}
+			}
+		} else {
+			filteredKwargs = kwargs
+		}
+
+		if err := starlark.UnpackArgs(snakeName, args, filteredKwargs, pairs...); err != nil {
 			return nil, err
 		}
 
@@ -152,8 +184,9 @@ func buildPlannedBridge(
 
 		// 3. Fill slots from Starlark values and resolve Resource params.
 		mt := method.Type
-		for i, name := range paramNames {
+		for i, name := range regularParams {
 			cleanName := strings.TrimSuffix(name, "?")
+			cleanName = strings.TrimPrefix(cleanName, "*")
 			sv := vals[i]
 			if sv == nil {
 				continue // Optional param not provided.
@@ -196,16 +229,27 @@ func buildPlannedBridge(
 			}
 		}
 
-		// 4. Shadow output Resource for compensable methods.
+		// 4. Fill **kwargs as dict sub-slots.
+		if kwargsName != "" {
+			for _, kv := range extraKwargs {
+				key, _ := starlark.AsString(kv[0])
+				subSlot := fmt.Sprintf("%s.%s", kwargsName, key)
+				if err := FillSlot(node, graph, subSlot, kv[1]); err != nil {
+					return nil, fmt.Errorf("%s: kwarg %s: %w", snakeName, key, err)
+				}
+			}
+		}
+
+		// 5. Shadow output Resource for compensable methods.
 		// For methods that return a Resource, shadow the last
 		// Resource-typed param (the write target). This supersedes the
 		// earlier Resolve, removing the destination from DiscoveryURIs
 		// so pre-flight won't reject missing targets.
-		if err := shadowOutputParam(graph, mt, vals, paramNames, node.ID); err != nil {
+		if err := shadowOutputParam(graph, mt, vals, regularParams, node.ID); err != nil {
 			return nil, err
 		}
 
-		// 5. Append to graph and return promise.
+		// 6. Append to graph and return promise.
 		graph.Nodes = append(graph.Nodes, node)
 		return NewPromise(node, graph, ""), nil
 	}

--- a/pkg/op/provider/plan/factory.go
+++ b/pkg/op/provider/plan/factory.go
@@ -12,8 +12,8 @@ import (
 // Params maps Go method names to Starlark parameter name lists.
 var Params = op.MethodParams{
 	"Complete":  {"output?"},
-	"Degraded":  {"format", "*args"},
-	"Fatal":     {"format", "*args"},
+	"Degraded":  {"format", "*args", "**kwargs"},
+	"Fatal":     {"format", "*args", "**kwargs"},
 	"WaitUntil": {"target", "predicate", "timeout", "interval?"},
 	"Gather":    {"*promises"},
 	"Choose":    {"when", "then"},

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -65,11 +65,12 @@ func (p *Provider) Complete(output any) (*op.Promise, error) {
 // Parameters:
 //   - format: format string (immediate or Promise).
 //   - args: positional format arguments (each may be immediate or Promise).
+//   - kwargs: keyword arguments for template rendering (each may be immediate or Promise).
 //
 // Returns:
 //   - *op.Promise: promise for the terminal node.
 //   - error: any error from slot filling.
-func (p *Provider) Degraded(format any, args ...any) (*op.Promise, error) {
+func (p *Provider) Degraded(format any, args []any, kwargs map[string]any) (*op.Promise, error) {
 	node := &op.Node{
 		ID:      op.GenerateNodeID("degraded"),
 		Action:  p.reg.MustGet("flow.degraded"),
@@ -78,6 +79,7 @@ func (p *Provider) Degraded(format any, args ...any) (*op.Promise, error) {
 
 	p.fillSlot(node, "format", format)
 	p.fillListSlot(node, "args", args)
+	p.fillDictSlot(node, "kwargs", kwargs)
 
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return op.NewPromise(node, p.graph, ""), nil
@@ -88,11 +90,12 @@ func (p *Provider) Degraded(format any, args ...any) (*op.Promise, error) {
 // Parameters:
 //   - format: format string (immediate or Promise).
 //   - args: positional format arguments (each may be immediate or Promise).
+//   - kwargs: keyword arguments for template rendering (each may be immediate or Promise).
 //
 // Returns:
 //   - *op.Promise: promise for the terminal node.
 //   - error: any error from slot filling.
-func (p *Provider) Fatal(format any, args ...any) (*op.Promise, error) {
+func (p *Provider) Fatal(format any, args []any, kwargs map[string]any) (*op.Promise, error) {
 	node := &op.Node{
 		ID:      op.GenerateNodeID("fatal"),
 		Action:  p.reg.MustGet("flow.fatal"),
@@ -101,6 +104,7 @@ func (p *Provider) Fatal(format any, args ...any) (*op.Promise, error) {
 
 	p.fillSlot(node, "format", format)
 	p.fillListSlot(node, "args", args)
+	p.fillDictSlot(node, "kwargs", kwargs)
 
 	p.graph.Nodes = append(p.graph.Nodes, node)
 	return op.NewPromise(node, p.graph, ""), nil
@@ -229,6 +233,14 @@ func (p *Provider) fillListSlot(node *op.Node, slotName string, values []any) {
 		p.fillSlot(node, subSlot, v)
 	}
 	node.SetSlotImmediate(slotName+".len", len(values))
+}
+
+// fillDictSlot packs key-value pairs into keyed sub-slots on a node.
+func (p *Provider) fillDictSlot(node *op.Node, slotName string, kwargs map[string]any) {
+	for key, v := range kwargs {
+		subSlot := fmt.Sprintf("%s.%s", slotName, key)
+		p.fillSlot(node, subSlot, v)
+	}
 }
 
 // endregion

--- a/pkg/op/receiver_reflect.go
+++ b/pkg/op/receiver_reflect.go
@@ -252,46 +252,71 @@ func buildMethodBridge(
 
 	methodType := method.Type
 
-	// Separate named params from the variadic param (at most one, always last).
+	// Separate named params from variadic (*) and kwargs (**) params.
 	var variadicName string // snake_case name without "*"
 	var variadicIdx int     // index in paramNames
+	var kwargsName string   // snake_case name without "**"
+	var kwargsIdx int       // index in paramNames
 	namedParams := make([]string, 0, len(paramNames))
 	for i, p := range paramNames {
-		if strings.HasPrefix(p, "*") {
+		switch {
+		case strings.HasPrefix(p, "**"):
+			kwargsName = strings.TrimPrefix(p, "**")
+			kwargsIdx = i
+		case strings.HasPrefix(p, "*"):
 			variadicName = strings.TrimPrefix(p, "*")
 			variadicIdx = i
-		} else {
+		default:
 			namedParams = append(namedParams, p)
 		}
 	}
 	numNamed := len(namedParams)
 	numParams := len(paramNames)
 
+	// Build set of known kwarg names for filtering.
+	knownKwargs := make(map[string]bool, numNamed+1)
+	for _, name := range namedParams {
+		knownKwargs[strings.TrimSuffix(name, "?")] = true
+	}
+	if variadicName != "" {
+		knownKwargs[variadicName] = true
+	}
+
 	return func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		if variadicName == "" {
-			// --- Non-variadic path ---
+		if variadicName == "" && kwargsName == "" {
+			// --- Simple path: no variadic, no kwargs ---
 			return callNonVariadic(receiverName, providerVal, method, methodType, snakeName, paramNames, numParams, receiver, thread, args, kwargs)
 		}
 
-		// --- Variadic path ---
-		// 1. Unpack named (non-variadic) params.
+		// --- Extended path: variadic and/or kwargs ---
+		// 1. Unpack named params.
 		namedVals := make([]starlark.Value, numNamed)
 		pairs := make([]any, 0, numNamed*2)
 		for i, name := range namedParams {
 			pairs = append(pairs, name, &namedVals[i])
 		}
 
-		// Extract the variadic keyword if present, so UnpackArgs doesn't
-		// reject it as unexpected.
+		// Split kwargs: known → UnpackArgs, variadic → extracted, rest → **kwargs.
 		var kwVariadic starlark.Value
 		var filteredKwargs []starlark.Tuple
+		var extraKwargs []starlark.Tuple
 		for _, kv := range kwargs {
 			key, _ := starlark.AsString(kv[0])
-			if key == variadicName {
+			switch {
+			case key == variadicName:
 				kwVariadic = kv[1]
-			} else {
+			case knownKwargs[key]:
 				filteredKwargs = append(filteredKwargs, kv)
+			default:
+				extraKwargs = append(extraKwargs, kv)
 			}
+		}
+
+		// Reject unknown kwargs if no **kwargs param to collect them.
+		if kwargsName == "" && len(extraKwargs) > 0 {
+			key, _ := starlark.AsString(extraKwargs[0][0])
+			return nil, fmt.Errorf("%s: %s() got unexpected keyword argument %q",
+				receiverName, snakeName, key)
 		}
 
 		// Positional args beyond the named params are variadic candidates.
@@ -306,27 +331,7 @@ func buildMethodBridge(
 			return nil, err
 		}
 
-		// 2. Resolve the variadic value.
-		if len(positionalVariadic) > 0 && kwVariadic != nil {
-			return nil, fmt.Errorf("%s: %s() got both positional and keyword args for variadic param %q",
-				receiverName, snakeName, variadicName)
-		}
-
-		var variadicList *starlark.List
-		if len(positionalVariadic) > 0 {
-			elems := make([]starlark.Value, len(positionalVariadic))
-			copy(elems, positionalVariadic)
-			variadicList = starlark.NewList(elems)
-		} else if kwVariadic != nil {
-			list, ok := kwVariadic.(*starlark.List)
-			if !ok {
-				return nil, fmt.Errorf("%s.%s: keyword %s must be a list, got %s",
-					receiverName, snakeName, variadicName, kwVariadic.Type())
-			}
-			variadicList = list
-		}
-
-		// 3. Build Go args: named params + variadic slice.
+		// 2. Build Go args.
 		goArgs := make([]reflect.Value, numParams+1)
 		goArgs[0] = providerVal
 
@@ -336,6 +341,17 @@ func buildMethodBridge(
 				goArgs[i+1] = reflect.Zero(paramType)
 				continue
 			}
+
+			if starFn, ok := sv.(starlark.Callable); ok && paramType.Kind() == reflect.Func {
+				adapted, err := buildCallableFunc(starFn, thread, paramType)
+				if err != nil {
+					name := strings.TrimSuffix(namedParams[i], "?")
+					return nil, fmt.Errorf("%s.%s: param %s: adapt callable: %w", receiverName, snakeName, name, err)
+				}
+				goArgs[i+1] = reflect.ValueOf(adapted)
+				continue
+			}
+
 			goVal := reflect.New(paramType).Elem()
 			if err := unmarshalValue(sv, goVal); err != nil {
 				name := strings.TrimSuffix(namedParams[i], "?")
@@ -344,23 +360,64 @@ func buildMethodBridge(
 			goArgs[i+1] = goVal
 		}
 
-		// Variadic param: unmarshal list → Go slice type.
-		// For CallSlice, the variadic arg must be the slice itself.
-		variadicGoType := methodType.In(variadicIdx + 1) // e.g. []string
-		if variadicList == nil || variadicList.Len() == 0 {
-			goArgs[variadicIdx+1] = reflect.Zero(variadicGoType)
-		} else {
-			goVal := reflect.New(variadicGoType).Elem()
-			if err := unmarshalValue(variadicList, goVal); err != nil {
-				return nil, fmt.Errorf("%s.%s: param %s: %w", receiverName, snakeName, variadicName, err)
+		// 3. Resolve the variadic value (if present).
+		if variadicName != "" {
+			if len(positionalVariadic) > 0 && kwVariadic != nil {
+				return nil, fmt.Errorf("%s: %s() got both positional and keyword args for variadic param %q",
+					receiverName, snakeName, variadicName)
 			}
-			goArgs[variadicIdx+1] = goVal
+
+			var variadicList *starlark.List
+			if len(positionalVariadic) > 0 {
+				elems := make([]starlark.Value, len(positionalVariadic))
+				copy(elems, positionalVariadic)
+				variadicList = starlark.NewList(elems)
+			} else if kwVariadic != nil {
+				list, ok := kwVariadic.(*starlark.List)
+				if !ok {
+					return nil, fmt.Errorf("%s.%s: keyword %s must be a list, got %s",
+						receiverName, snakeName, variadicName, kwVariadic.Type())
+				}
+				variadicList = list
+			}
+
+			variadicGoType := methodType.In(variadicIdx + 1)
+			if variadicList == nil || variadicList.Len() == 0 {
+				goArgs[variadicIdx+1] = reflect.Zero(variadicGoType)
+			} else {
+				goVal := reflect.New(variadicGoType).Elem()
+				if err := unmarshalValue(variadicList, goVal); err != nil {
+					return nil, fmt.Errorf("%s.%s: param %s: %w", receiverName, snakeName, variadicName, err)
+				}
+				goArgs[variadicIdx+1] = goVal
+			}
 		}
 
-		// 4. Call via CallSlice (variadic methods).
-		results := method.Func.CallSlice(goArgs)
+		// 4. Build **kwargs map from extra keyword args.
+		if kwargsName != "" {
+			kwargsMap := make(map[string]any, len(extraKwargs))
+			for _, kv := range extraKwargs {
+				key, _ := starlark.AsString(kv[0])
+				val, err := unmarshalToAny(kv[1])
+				if err != nil {
+					return nil, fmt.Errorf("%s.%s: kwarg %s: %w", receiverName, snakeName, key, err)
+				}
+				kwargsMap[key] = val
+			}
+			goArgs[kwargsIdx+1] = reflect.ValueOf(kwargsMap)
+		}
 
-		// 5. Shadow Resource results in catalog.
+		// 5. Call the Go method.
+		// CallSlice only when Go-variadic (has *args but no **kwargs).
+		// When **kwargs is present, *args maps to an explicit []T param.
+		var results []reflect.Value
+		if variadicName != "" && kwargsName == "" {
+			results = method.Func.CallSlice(goArgs)
+		} else {
+			results = method.Func.Call(goArgs)
+		}
+
+		// 6. Shadow Resource results in catalog.
 		if receiver.catalog != nil && len(results) > 0 {
 			lastIdx := len(results) - 1
 			isErr := results[lastIdx].Type().Implements(errorType) && !results[lastIdx].IsNil()


### PR DESCRIPTION
## Summary

Phase 1.50 of #264 — add `**kwargs` support to both receiver bridges.

- **ExecutingReceiver bridge** — `"**kwargs"` in Params collects remaining keyword arguments into a `map[string]any` Go parameter. When `**kwargs` coexists with `*args`, the Go method is non-variadic (`[]any` + `map[string]any`), so `Call` is used instead of `CallSlice`.
- **PlanningReceiver bridge** — same detection and splitting; extra kwargs are filled as dict sub-slots (e.g., `kwargs.path`, `kwargs.service`) via `FillSlot`.
- **Plan Provider** — `Degraded` and `Fatal` restored to `(format any, args []any, kwargs map[string]any)` signature.
- **Test scripts** — template kwargs restored: `plan.degraded("wrote {{ .path }}", path=written)`, `plan.fatal("{{ .service }} startup failed", service=svc)`.

## Test plan

- [x] `make test` — all 80 packages pass
- [x] `make lint` — 198 issues (matches develop baseline)
- [x] devlore-test template kwargs scripts pass
- [x] flow integration tests pass