### PR TITLE
ci(sync): merge sync PRs directly instead of enabling auto-merge

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -81,4 +81,4 @@ jobs:
             --body "$BODY" \
             --base develop)
           echo "Created PR: $PR_URL"
-          gh pr merge "$PR_URL" --squash --auto --delete-branch
+          gh pr merge "$PR_URL" --squash --delete-branch

--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -110,4 +110,4 @@ jobs:
             --body "Automated knowledge sync from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA})." \
             --base "${{ github.ref_name }}")
           echo "Created PR: $PR_URL"
-          gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --squash --auto --delete-branch
+          gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --squash --delete-branch


### PR DESCRIPTION
Auto-merge never applies bypass and waits on review requirements the automation app's PRs cannot satisfy, so knowledge syncs to devlore-registry failed at the merge step and CLI-docs PRs on devlore.noblefactor.com piled up open (45 currently). The org ruleset already grants noblefactor-automation `bypass_mode: always`; dropping `--auto` from both `gh pr merge` invocations lets the app merge directly under that bypass. No settings changes. The stale sync PRs on devlore.noblefactor.com still need closing separately, and the registry's red "Validate YAML schemas" check (star built from noblefactor-ops vs devlore-cli extensions) is chartered as its own follow-up.