### PR TITLE
fix(build,docgen): bootstrap star for codegen rules; fix docs template fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ BUILD_TAGS ?=
 STAR_LKG ?= build/star.lkg
 STAR ?= $(if $(wildcard $(STAR_LKG)),$(STAR_LKG),build/star)
 
+# Bootstrap: codegen recipes invoke $(STAR), but a fresh checkout has no star
+# binary. This rule builds it from the committed gen files before any codegen
+# recipe runs (the codegen rules order-depend on it).
+build/star:
+	$(MAKE) star
+
 ## VARIABLES (static)
 
 # Provider source roots.
@@ -178,7 +184,7 @@ dist-clean: ## Remove distribution archives
 
 ##@ Code Generation
 
-# Each grouped target (&:) fires one star invocation that produces all gen files.
+# Each grouped target (&:) fires one star invocation that produces all gen files. | $(STAR)
 # Generation runs only when provider.go is newer than the gen outputs.
 #
 # access=both     → receiver_type.gen_test + action.gen_test + node_builder.gen_test + module.gen_test + provider
@@ -192,7 +198,7 @@ $(P)/json/gen/receiver_type.gen_test.go \
 $(P)/json/gen/action.gen_test.go \
 $(P)/json/gen/node_builder.gen_test.go \
 $(P)/json/gen/module.gen_test.go \
-$(P)/json/gen/provider.gen.go &: $(P)/json/provider.go
+$(P)/json/gen/provider.gen.go &: $(P)/json/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/json --gen=true --write=true --output=$(P)/json
 
 $(P)/platform/action_names.gen.go \
@@ -200,7 +206,7 @@ $(P)/platform/gen/receiver_type.gen_test.go \
 $(P)/platform/gen/action.gen_test.go \
 $(P)/platform/gen/node_builder.gen_test.go \
 $(P)/platform/gen/module.gen_test.go \
-$(P)/platform/gen/provider.gen.go &: $(P)/platform/provider.go
+$(P)/platform/gen/provider.gen.go &: $(P)/platform/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/platform --gen=true --write=true --output=$(P)/platform
 
 $(P)/regexp/action_names.gen.go \
@@ -208,7 +214,7 @@ $(P)/regexp/gen/receiver_type.gen_test.go \
 $(P)/regexp/gen/action.gen_test.go \
 $(P)/regexp/gen/node_builder.gen_test.go \
 $(P)/regexp/gen/module.gen_test.go \
-$(P)/regexp/gen/provider.gen.go &: $(P)/regexp/provider.go
+$(P)/regexp/gen/provider.gen.go &: $(P)/regexp/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/regexp --gen=true --write=true --output=$(P)/regexp
 
 $(P)/template/action_names.gen.go \
@@ -216,7 +222,7 @@ $(P)/template/gen/receiver_type.gen_test.go \
 $(P)/template/gen/action.gen_test.go \
 $(P)/template/gen/node_builder.gen_test.go \
 $(P)/template/gen/module.gen_test.go \
-$(P)/template/gen/provider.gen.go &: $(P)/template/provider.go
+$(P)/template/gen/provider.gen.go &: $(P)/template/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/template --gen=true --write=true --output=$(P)/template
 
 $(P)/yaml/action_names.gen.go \
@@ -224,7 +230,7 @@ $(P)/yaml/gen/receiver_type.gen_test.go \
 $(P)/yaml/gen/action.gen_test.go \
 $(P)/yaml/gen/node_builder.gen_test.go \
 $(P)/yaml/gen/module.gen_test.go \
-$(P)/yaml/gen/provider.gen.go &: $(P)/yaml/provider.go $(P)/yaml/resource.go
+$(P)/yaml/gen/provider.gen.go &: $(P)/yaml/provider.go $(P)/yaml/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/yaml --gen=true --write=true --output=$(P)/yaml
 
 # --- access=planned providers ---
@@ -234,21 +240,21 @@ $(P)/appnet/gen/receiver_type.gen_test.go \
 $(P)/appnet/gen/action.gen_test.go \
 $(P)/appnet/gen/node_builder.gen_test.go \
 $(P)/appnet/gen/provider.gen.go \
-$(P)/appnet/gen/resource.gen.go &: $(P)/appnet/provider.go $(P)/appnet/resource.go
+$(P)/appnet/gen/resource.gen.go &: $(P)/appnet/provider.go $(P)/appnet/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/appnet --gen=true --write=true --output=$(P)/appnet
 
 $(P)/archive/action_names.gen.go \
 $(P)/archive/gen/receiver_type.gen_test.go \
 $(P)/archive/gen/action.gen_test.go \
 $(P)/archive/gen/node_builder.gen_test.go \
-$(P)/archive/gen/provider.gen.go &: $(P)/archive/provider.go
+$(P)/archive/gen/provider.gen.go &: $(P)/archive/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/archive --gen=true --write=true --output=$(P)/archive
 
 $(P)/encryption/action_names.gen.go \
 $(P)/encryption/gen/receiver_type.gen_test.go \
 $(P)/encryption/gen/action.gen_test.go \
 $(P)/encryption/gen/node_builder.gen_test.go \
-$(P)/encryption/gen/provider.gen.go &: $(P)/encryption/provider.go
+$(P)/encryption/gen/provider.gen.go &: $(P)/encryption/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/encryption --gen=true --write=true --output=$(P)/encryption
 
 $(P)/file/action_names.gen.go \
@@ -256,7 +262,7 @@ $(P)/file/gen/receiver_type.gen_test.go \
 $(P)/file/gen/action.gen_test.go \
 $(P)/file/gen/node_builder.gen_test.go \
 $(P)/file/gen/module.gen_test.go \
-$(P)/file/gen/provider.gen.go &: $(P)/file/provider.go $(P)/file/resource.go
+$(P)/file/gen/provider.gen.go &: $(P)/file/provider.go $(P)/file/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/file --gen=true --write=true --output=$(P)/file
 
 $(P)/git/action_names.gen.go \
@@ -264,7 +270,7 @@ $(P)/git/gen/receiver_type.gen_test.go \
 $(P)/git/gen/action.gen_test.go \
 $(P)/git/gen/node_builder.gen_test.go \
 $(P)/git/gen/provider.gen.go \
-$(P)/git/gen/resource.gen.go &: $(P)/git/provider.go $(P)/git/resource.go
+$(P)/git/gen/resource.gen.go &: $(P)/git/provider.go $(P)/git/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/git --gen=true --write=true --output=$(P)/git
 
 $(P)/pkg/action_names.gen.go \
@@ -272,7 +278,7 @@ $(P)/pkg/gen/receiver_type.gen_test.go \
 $(P)/pkg/gen/action.gen_test.go \
 $(P)/pkg/gen/node_builder.gen_test.go \
 $(P)/pkg/gen/provider.gen.go \
-$(P)/pkg/gen/resource.gen.go &: $(P)/pkg/provider.go $(P)/pkg/resource.go
+$(P)/pkg/gen/resource.gen.go &: $(P)/pkg/provider.go $(P)/pkg/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/pkg --gen=true --write=true --output=$(P)/pkg
 
 $(P)/service/action_names.gen.go \
@@ -280,21 +286,21 @@ $(P)/service/gen/receiver_type.gen_test.go \
 $(P)/service/gen/action.gen_test.go \
 $(P)/service/gen/node_builder.gen_test.go \
 $(P)/service/gen/provider.gen.go \
-$(P)/service/gen/resource.gen.go &: $(P)/service/provider.go $(P)/service/resource.go
+$(P)/service/gen/resource.gen.go &: $(P)/service/provider.go $(P)/service/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/service --gen=true --write=true --output=$(P)/service
 
 $(P)/shell/action_names.gen.go \
 $(P)/shell/gen/receiver_type.gen_test.go \
 $(P)/shell/gen/action.gen_test.go \
 $(P)/shell/gen/node_builder.gen_test.go \
-$(P)/shell/gen/provider.gen.go &: $(P)/shell/provider.go
+$(P)/shell/gen/provider.gen.go &: $(P)/shell/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/shell --gen=true --write=true --output=$(P)/shell
 
 $(P)/powershell/action_names.gen.go \
 $(P)/powershell/gen/receiver_type.gen_test.go \
 $(P)/powershell/gen/action.gen_test.go \
 $(P)/powershell/gen/node_builder.gen_test.go \
-$(P)/powershell/gen/provider.gen.go &: $(P)/powershell/provider.go
+$(P)/powershell/gen/provider.gen.go &: $(P)/powershell/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/powershell --gen=true --write=true --output=$(P)/powershell
 
 $(P)/function/action_names.gen.go \
@@ -302,88 +308,88 @@ $(P)/function/gen/receiver_type.gen_test.go \
 $(P)/function/gen/action.gen_test.go \
 $(P)/function/gen/node_builder.gen_test.go \
 $(P)/function/gen/provider.gen.go \
-$(P)/function/gen/resource.gen.go &: $(P)/function/provider.go $(P)/function/resource.go
+$(P)/function/gen/resource.gen.go &: $(P)/function/provider.go $(P)/function/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/function --gen=true --write=true --output=$(P)/function
 
 $(P)/flow/action_names.gen.go \
 $(P)/flow/gen/receiver_type.gen_test.go \
 $(P)/flow/gen/action.gen_test.go \
 $(P)/flow/gen/node_builder.gen_test.go \
-$(P)/flow/gen/provider.gen.go &: $(P)/flow/provider.go
+$(P)/flow/gen/provider.gen.go &: $(P)/flow/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/flow --gen=true --write=true --output=$(P)/flow
 
 # --- access=immediate providers ---
 
 $(P)/plan/gen/receiver_type.gen_test.go \
 $(P)/plan/gen/module.gen_test.go \
-$(P)/plan/gen/provider.gen.go &: $(P)/plan/provider.go
+$(P)/plan/gen/provider.gen.go &: $(P)/plan/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/plan --gen=true --write=true --output=$(P)/plan
 
 # --- star-specific providers (cmd/star/provider, access=immediate) ---
 
 $(SP)/staranalysis/gen/receiver_type.gen_test.go \
 $(SP)/staranalysis/gen/module.gen_test.go \
-$(SP)/staranalysis/gen/provider.gen.go &: $(SP)/staranalysis/provider.go
+$(SP)/staranalysis/gen/provider.gen.go &: $(SP)/staranalysis/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/staranalysis --gen=true --write=true --output=$(SP)/staranalysis
 
 $(SP)/starcode/gen/receiver_type.gen_test.go \
 $(SP)/starcode/gen/module.gen_test.go \
-$(SP)/starcode/gen/provider.gen.go &: $(SP)/starcode/provider.go
+$(SP)/starcode/gen/provider.gen.go &: $(SP)/starcode/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/starcode --gen=true --write=true --output=$(SP)/starcode
 
 $(SP)/starcomplexity/gen/receiver_type.gen_test.go \
 $(SP)/starcomplexity/gen/module.gen_test.go \
-$(SP)/starcomplexity/gen/provider.gen.go &: $(SP)/starcomplexity/provider.go
+$(SP)/starcomplexity/gen/provider.gen.go &: $(SP)/starcomplexity/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/starcomplexity --gen=true --write=true --output=$(SP)/starcomplexity
 
 $(SP)/starindex/gen/receiver_type.gen_test.go \
 $(SP)/starindex/gen/module.gen_test.go \
-$(SP)/starindex/gen/provider.gen.go &: $(SP)/starindex/provider.go
+$(SP)/starindex/gen/provider.gen.go &: $(SP)/starindex/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/starindex --gen=true --write=true --output=$(SP)/starindex
 
 $(SP)/starstats/gen/receiver_type.gen_test.go \
 $(SP)/starstats/gen/module.gen_test.go \
-$(SP)/starstats/gen/provider.gen.go &: $(SP)/starstats/provider.go
+$(SP)/starstats/gen/provider.gen.go &: $(SP)/starstats/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/starstats --gen=true --write=true --output=$(SP)/starstats
 
 $(SP)/commands/gen/receiver_type.gen_test.go \
 $(SP)/commands/gen/module.gen_test.go \
-$(SP)/commands/gen/provider.gen.go &: $(SP)/commands/provider.go
+$(SP)/commands/gen/provider.gen.go &: $(SP)/commands/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/commands --gen=true --write=true --output=$(SP)/commands
 
 $(SP)/config/gen/receiver_type.gen_test.go \
 $(SP)/config/gen/module.gen_test.go \
-$(SP)/config/gen/provider.gen.go &: $(SP)/config/provider.go
+$(SP)/config/gen/provider.gen.go &: $(SP)/config/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/config --gen=true --write=true --output=$(SP)/config
 
 $(SP)/goast/gen/receiver_type.gen_test.go \
 $(SP)/goast/gen/module.gen_test.go \
-$(SP)/goast/gen/provider.gen.go &: $(SP)/goast/provider.go
+$(SP)/goast/gen/provider.gen.go &: $(SP)/goast/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/goast --gen=true --write=true --output=$(SP)/goast
 
 $(SP)/lint/gen/receiver_type.gen_test.go \
 $(SP)/lint/gen/module.gen_test.go \
-$(SP)/lint/gen/provider.gen.go &: $(SP)/lint/provider.go
+$(SP)/lint/gen/provider.gen.go &: $(SP)/lint/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/lint --gen=true --write=true --output=$(SP)/lint
 
 $(SP)/setup/gen/receiver_type.gen_test.go \
 $(SP)/setup/gen/module.gen_test.go \
-$(SP)/setup/gen/provider.gen.go &: $(SP)/setup/provider.go
+$(SP)/setup/gen/provider.gen.go &: $(SP)/setup/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/setup --gen=true --write=true --output=$(SP)/setup
 
 $(SP)/shellcheck/gen/receiver_type.gen_test.go \
 $(SP)/shellcheck/gen/module.gen_test.go \
-$(SP)/shellcheck/gen/provider.gen.go &: $(SP)/shellcheck/provider.go
+$(SP)/shellcheck/gen/provider.gen.go &: $(SP)/shellcheck/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(SP)/shellcheck --gen=true --write=true --output=$(SP)/shellcheck
 
 $(P)/ui/gen/receiver_type.gen_test.go \
 $(P)/ui/gen/module.gen_test.go \
-$(P)/ui/gen/provider.gen.go &: $(P)/ui/provider.go
+$(P)/ui/gen/provider.gen.go &: $(P)/ui/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/ui --gen=true --write=true --output=$(P)/ui
 
 # --- resource-only packages ---
 
-$(P)/mem/gen/resource.gen.go: $(P)/mem/resource.go
+$(P)/mem/gen/resource.gen.go: $(P)/mem/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/mem --gen=true --write=true --output=$(P)/mem
 
 NEW_OP_INVENTORY := \

--- a/internal/tools/docgen/template.go
+++ b/internal/tools/docgen/template.go
@@ -82,13 +82,13 @@ version: "{{ .Version }}"
 
 | Option | Default | Description |
 |--------|---------|-------------|
-{{ range .Options }}| ` + "`{{ .ReceiverName }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
+{{ range .Options }}| ` + "`{{ .Name }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
 {{ end }}{{ end }}{{ if .GlobalFlags }}
 ## Global Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
-{{ range .GlobalFlags }}| ` + "`{{ .ReceiverName }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
+{{ range .GlobalFlags }}| ` + "`{{ .Name }}`" + ` | ` + "`{{ .Default }}`" + ` | {{ .Description }} |
 {{ end }}{{ end }}{{ if .Examples }}
 ## Examples
 
@@ -100,13 +100,13 @@ version: "{{ .Version }}"
 
 | Command | Description |
 |---------|-------------|
-| [{{ .ParentCmd.ReceiverName }}]({{ .ParentCmd.Path }}) | {{ .ParentCmd.Description }} |
+| [{{ .ParentCmd.Name }}]({{ .ParentCmd.Path }}) | {{ .ParentCmd.Description }} |
 {{ end }}{{ if .Children }}
 ## Child Commands
 
 | Command | Description |
 |---------|-------------|
-{{ range .Children }}| [{{ .ReceiverName }}]({{ .Path }}) | {{ .Description }} |
+{{ range .Children }}| [{{ .Name }}]({{ .Path }}) | {{ .Description }} |
 {{ end }}{{ end }}`))
 
 // BuildPageData extracts page data from a Cobra command.


### PR DESCRIPTION
Two stacked defects broke CI on develop and docs-publish. (1) The Makefile's 31 codegen rules invoke `$(STAR)` but nothing built it, so fresh checkouts failed with "build/star: No such file or directory" whenever checkout mtimes made a gen file look stale -- a mtime lottery, which is why PR runs passed while develop runs failed. A `build/star` bootstrap rule plus an order-only `| $(STAR)` prerequisite on each codegen rule fixes it under both serial and parallel make, with no effect for LKG users. (2) docgen's page template referenced `.ReceiverName` where the structs declare `Name`, so `make docs` failed even once star existed. Both reproduced and verified green on a pristine develop tarball (cold tree, hostile mtimes).