### PR TITLE
fix(build,docs): windows platform splits; provider guide matches astro schema

### DIFF
--- a/docs/guides/provider-development.md
+++ b/docs/guides/provider-development.md
@@ -1,12 +1,12 @@
 ---
-title: "Provider Development"
+title: "How to create and modify providers"
 description: "How to create and modify providers in devlore-cli"
 tool: "devlore"
-category: "development"
+category: "tutorial"
 order: 10
 ---
 
-# Provider Development
+# How to create and modify providers
 
 Providers live in `pkg/op/provider/<name>/`. Each provider has a `Provider` struct
 annotated with `+devlore:access` to declare its binding level.

--- a/docs/plans/fix-windows-build-and-guide-category.md
+++ b/docs/plans/fix-windows-build-and-guide-category.md
@@ -1,0 +1,69 @@
+---
+title: "Fix Windows build and guide category"
+issue: TBD
+status: complete
+created: 2026-07-25
+updated: 2026-07-25
+---
+
+# Plan: Fix Windows build and guide category
+
+## Summary
+
+PR #290's merge surfaced two pipeline failures:
+
+1. **Release failed** on the windows/amd64 cross-build: `pkg/op/default_funcs.go` called
+   `syscall.Umask`, which does not exist in the Windows `syscall` package. A second, masked
+   break sat behind it: `pkg/op/provider/file` type-asserts `*syscall.Stat_t` (also absent
+   on Windows) at two sites; CI never reached it because packages depending on `pkg/op`
+   were not compiled after `pkg/op` failed. The failed Release also skipped the
+   `sync-install-script` job, so no install-script sync PR was created.
+2. **The website deploy failed** after the docs sync merged: `provider-development.md`
+   carried `category: "development"`, which the site's Astro guides schema rejects
+   (allowed: `overview | tutorial | concept | reference`).
+
+## Changes
+
+1. `pkg/op/default_funcs_unix.go` (new, `//go:build unix`) — `processUmask()` reads the
+   process umask via the `syscall.Umask` round-trip (set zero, restore).
+2. `pkg/op/default_funcs_windows.go` (new, `//go:build windows`) — `processUmask()`
+   returns zero: Windows has no umask, so `{{ umask base }}` resolves to the base mode.
+3. `pkg/op/default_funcs.go` — `defaultUmask` calls `processUmask()`; `syscall` import
+   removed; banned `env:` parameter-bullet keys renamed to `runtimeEnvironment:`.
+4. `pkg/op/provider/file/helpers_unix.go` (new, `//go:build unix`) — `statIdentity()`
+   returns the inode and device numbers from `*syscall.Stat_t`.
+5. `pkg/op/provider/file/helpers_windows.go` (new, `//go:build windows`) —
+   `statIdentity()` returns zeros: change detection falls back to size and mtime.
+6. `pkg/op/provider/file/helpers.go` (`statTupleEtag`) and
+   `pkg/op/provider/file/provider.go` (`Observe`) — call `statIdentity()`; the
+   `syscall` import leaves `provider.go` (`helpers.go` keeps it for `ENOTEMPTY`,
+   which exists on Windows).
+7. `docs/guides/provider-development.md` — `title` and body H1 become
+   "How to create and modify providers" (per review); `category` becomes `"tutorial"`.
+   All 12 other guides were enumerated and already carry valid categories.
+
+## Verification
+
+- `gofmt -l` clean over the change set.
+- `make vet` — pass.
+- `make test` — pass (after `make star`; see follow-up 2).
+- `make dist-all DEVLORE_VERSION=v0.0.0-local` — all six platforms compile, including
+  windows/amd64 and windows/arm64 (see follow-up 3 for why the version override).
+
+## Chartered follow-ups (not in this change)
+
+1. **Guides metadata**: writ guides have an `order: 4` collision (Packages Manifest,
+   Deployment Receipts); the site's `categoryLabel` has no case for `reference`, so that
+   badge renders as raw lowercase text.
+2. **Stale generator bootstrap**: the `build/star:` rule has no prerequisites, so an
+   existing stale binary is silently used; a June-27 `build/star` rejected the `chmod`
+   keyword that `generate.star` now passes. `make star` fixed it locally; the rule
+   deserves real prerequisites or a staleness check.
+3. **Local `dist-all` version**: `git describe` can yield slash-bearing versions
+   (`develop/lkg-11-…`), which break the tar path. CI passes an explicit version;
+   locally an override is required.
+4. **Lint debt**: `make lint` reports 283 pre-existing findings repo-wide (this change
+   adds none); CI's quality-gate does not gate them.
+5. **Doc-comment sweep**: pre-existing multi-line doc summaries remain in
+   `default_funcs.go`, `helpers.go`, and `provider.go` (≈9 sites enumerated by the
+   mechanical sweep), out of scope for this fix.

--- a/pkg/op/default_funcs.go
+++ b/pkg/op/default_funcs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"syscall"
 )
 
 // fileModeType is the [reflect.Type] of [os.FileMode], cached so per-arg type-equality checks compare
@@ -29,11 +28,11 @@ func init() {
 // defaultUmask implements `{{ umask base }}` — masks the literal base mode by the process umask.
 //
 // Mirrors the semantic Linux's cp and mkdir use when no explicit mode is supplied: the file mode is
-// `base &^ umask`. The umask is read via a [syscall.Umask] round-trip (Get-and-restore), so the
-// process's actual umask is unchanged after the call.
+// `base &^ umask`. The umask comes from [processUmask], which reads it without changing it; on
+// Windows, where no umask exists, the mask is zero and the base mode passes through unmasked.
 //
 // Parameters:
-//   - env:  unused.
+//   - runtimeEnvironment: unused.
 //   - _:    sibling-slot map; unused (umask has no sibling references).
 //   - args: exactly one argument — the base mode as int, uint, or os.FileMode.
 //
@@ -51,10 +50,7 @@ func defaultUmask(_ *RuntimeEnvironment, _ map[string]any, args []reflect.Value)
 		return reflect.Value{}, err
 	}
 
-	mask := syscall.Umask(0)
-	syscall.Umask(mask)
-
-	return reflect.ValueOf(base &^ os.FileMode(mask)), nil
+	return reflect.ValueOf(base &^ processUmask()), nil
 }
 
 // defaultMode implements `{{ mode symbolic }}` — parses a 9-character POSIX permission string into
@@ -67,7 +63,7 @@ func defaultUmask(_ *RuntimeEnvironment, _ map[string]any, args []reflect.Value)
 // message if the input doesn't match the 9-char template.
 //
 // Parameters:
-//   - env:  unused.
+//   - runtimeEnvironment: unused.
 //   - _:    sibling-slot map; unused.
 //   - args: exactly one argument — the symbolic mode string.
 //
@@ -100,7 +96,7 @@ func defaultMode(_ *RuntimeEnvironment, _ map[string]any, args []reflect.Value) 
 // once such a stage is registered. v1 ships only the bare lookup.
 //
 // Parameters:
-//   - env:  unused (the function reads from os.Environ, not from the runtime environment).
+//   - runtimeEnvironment: unused (the function reads from os.Environ, not from the runtime environment).
 //   - _:    sibling-slot map; unused.
 //   - args: exactly one argument — the environment-variable name as a string.
 //

--- a/pkg/op/default_funcs_unix.go
+++ b/pkg/op/default_funcs_unix.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package op
+
+import (
+	"os"
+	"syscall"
+)
+
+// processUmask returns the process umask without changing it.
+//
+// POSIX offers no read-only umask query, so the mask is read via a [syscall.Umask] round-trip: set
+// zero, capture the previous value, restore it. The process umask is unchanged after the call.
+//
+// Returns:
+//   - `os.FileMode`: the process umask.
+func processUmask() os.FileMode {
+
+	mask := syscall.Umask(0)
+	syscall.Umask(mask)
+
+	//nolint:gosec // G115: a umask fits in 12 permission bits; the conversion cannot overflow.
+	return os.FileMode(mask)
+}

--- a/pkg/op/default_funcs_windows.go
+++ b/pkg/op/default_funcs_windows.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build windows
+
+package op
+
+import "os"
+
+// processUmask returns the process umask without changing it.
+//
+// Windows has no umask, so the mask is always zero and `{{ umask base }}` resolves to the base mode
+// unmasked.
+//
+// Returns:
+//   - `os.FileMode`: zero, always.
+func processUmask() os.FileMode {
+	return 0
+}

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -553,8 +553,8 @@ func splitFindPattern(pattern string) (root, match string) {
 // statTupleEtag packs the stat tuple (size, mtime_ns, ino) little-endian and returns its sha256 as lowercase hex.
 //
 // The shared change-detection token form for every taxonomy variant and the catch-all base: an inexpensive signal
-// the catalog uses to trigger the full [op.Resource.Digest] comparison. The inode is zero when the platform's stat
-// carries no [syscall.Stat_t].
+// the catalog uses to trigger the full [op.Resource.Digest] comparison. The inode comes from [statIdentity] and is
+// zero on Windows, whose stat carries no inode.
 //
 // Parameters:
 //   - `info`: the stat (or lstat) result to pack; the caller chooses follow semantics.
@@ -563,11 +563,7 @@ func splitFindPattern(pattern string) (root, match string) {
 //   - `string`: lowercase hex sha256 of the packed stat tuple.
 func statTupleEtag(info os.FileInfo) string {
 
-	var inode uint64
-
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		inode = stat.Ino
-	}
+	inode, _ := statIdentity(info)
 
 	var buf [24]byte
 

--- a/pkg/op/provider/file/helpers_unix.go
+++ b/pkg/op/provider/file/helpers_unix.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package file
+
+import (
+	"os"
+	"syscall"
+)
+
+// statIdentity returns the inode and device numbers that identify `info`'s file on its filesystem.
+//
+// Parameters:
+//   - `info`: the stat (or lstat) result to read.
+//
+// Returns:
+//   - `uint64`: the inode number.
+//   - `uint64`: the device number.
+func statIdentity(info os.FileInfo) (uint64, uint64) {
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0
+	}
+
+	//nolint:gosec // G115: Dev is platform-specific; overflow is not a practical concern.
+	return stat.Ino, uint64(stat.Dev)
+}

--- a/pkg/op/provider/file/helpers_windows.go
+++ b/pkg/op/provider/file/helpers_windows.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build windows
+
+package file
+
+import "os"
+
+// statIdentity returns the inode and device numbers that identify `info`'s file on its filesystem.
+//
+// Windows file metadata carries neither number, so both are zero: [statTupleEtag] falls back to size
+// and mtime alone, and [Provider.Observe] reports no inode or device.
+//
+// Parameters:
+//   - `info`: unused.
+//
+// Returns:
+//   - `uint64`: zero, always.
+//   - `uint64`: zero, always.
+func statIdentity(_ os.FileInfo) (uint64, uint64) {
+	return 0, 0
+}

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
@@ -1213,11 +1212,7 @@ func (p *Provider) Observe(resource Entry) (*Observation, error) {
 		return nil, fmt.Errorf("file.Provider.Observe: stat %s: %w", resource.Path().Abs(), err)
 	}
 
-	var inode, device uint64
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		inode = stat.Ino
-		device = uint64(stat.Dev) //nolint:gosec // G115: Dev is platform-specific; overflow is not a practical concern.
-	}
+	inode, device := statIdentity(info)
 
 	return NewObservation(
 		resource,


### PR DESCRIPTION
Fixes the two failures left by #290's merge. (1) Release: `syscall.Umask` and `*syscall.Stat_t` do not exist on Windows; both uses now sit behind `//go:build unix` / `windows` splits (`processUmask()` in pkg/op, `statIdentity()` in the file provider), and `make dist-all` compiles all six platforms. The Stat_t break was masked in CI because pkg/op failed first. (2) Website deploy: `provider-development.md` carried `category: "development"`, rejected by the site's Astro guides schema; now `"tutorial"`, retitled "How to create and modify providers". After merge the pipeline self-heals: Release re-runs and creates the skipped install-script sync PR, and docs-publish syncs the corrected guide so the site deploy goes green. Chartered follow-ups in docs/plans/fix-windows-build-and-guide-category.md.