### PR TITLE
build(star): always rebuild the in-tree generator before codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,16 @@ BUILD_TAGS ?=
 STAR_LKG ?= build/star.lkg
 STAR ?= $(if $(wildcard $(STAR_LKG)),$(STAR_LKG),build/star)
 
-# Bootstrap: codegen recipes invoke $(STAR), but a fresh checkout has no star
-# binary. This rule builds it from the committed gen files before any codegen
-# recipe runs (the codegen rules order-depend on it).
-build/star:
+# Bootstrap and staleness: codegen recipes invoke $(STAR); a fresh checkout has
+# no star binary, and an existing binary may predate the current source (a stale
+# star silently rejects or mis-generates current inputs). FORCE delegates to the
+# star target on every run — Go's build cache makes an up-to-date rebuild cost
+# seconds. The LKG escape hatch is unaffected: when build/star.lkg exists,
+# $(STAR) resolves to it and this rule is never consulted.
+build/star: FORCE
 	$(MAKE) star
+
+FORCE:
 
 ## VARIABLES (static)
 

--- a/docs/plans/build-star-staleness.md
+++ b/docs/plans/build-star-staleness.md
@@ -1,0 +1,34 @@
+---
+title: "Always rebuild the in-tree star generator"
+issue: TBD
+status: complete
+created: 2026-07-25
+updated: 2026-07-25
+---
+
+# Plan: Always rebuild the in-tree star generator
+
+Chartered follow-up 2 of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md).
+
+## Summary
+
+The `build/star:` rule had no prerequisites, so once any `build/star` binary existed,
+make considered it permanently up to date and codegen silently ran a stale generator.
+Observed failure: a June-27 binary rejected the `chmod` keyword argument that
+`generate.star` now passes, failing `make test` until a by-hand `make star`.
+
+## Changes
+
+1. `Makefile` — `build/star:` becomes `build/star: FORCE` delegating to `$(MAKE) star`
+   on every run, with the classic empty `FORCE:` target. The comment documents the
+   staleness rationale.
+
+The LKG escape hatch is unaffected: when `build/star.lkg` exists, `$(STAR)` resolves to
+it and the `build/star` rule is never consulted.
+
+## Verification
+
+- `make build/star` twice: the rule fires both times; a warm, up-to-date rebuild costs
+  ~2.1–2.3 s (Go build cache), matching the "seconds" cost claim.
+- `make test` — pass end to end (codegen with the freshly built generator, then tests).


### PR DESCRIPTION
Chartered follow-up 2 of `docs/plans/fix-windows-build-and-guide-category.md`. The `build/star:` rule had no prerequisites, so an existing stale binary was silently used for codegen (a June-27 binary rejected the `chmod` kwarg `generate.star` now passes). `build/star: FORCE` delegates to `$(MAKE) star` on every run — a warm rebuild costs ~2 s via Go's build cache — and the LKG escape hatch (`build/star.lkg`) is untouched. Verified: rule fires on consecutive runs; `make test` passes end to end.