### PR TITLE
build(dist): keep non-release tags out of the default version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ SHELL := bash
 #   make dist DEVLORE_VERSION=v0.1.0-draft   # Draft release for testing
 #   make dist DEVLORE_VERSION=v0.1.0-alpha   # Pre-release
 #   make dist                                 # Uses git describe
-DEVLORE_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# --match "v*" keeps non-release tags (e.g. develop/lkg-N) out of the version:
+# a slash-bearing describe result breaks the dist archive paths.
+DEVLORE_VERSION ?= $(shell git describe --tags --match "v*" --always --dirty 2>/dev/null || echo "dev")
 
 VERSION ?= $(DEVLORE_VERSION)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")

--- a/docs/plans/dist-version-sanitize.md
+++ b/docs/plans/dist-version-sanitize.md
@@ -1,0 +1,32 @@
+---
+title: "Keep non-release tags out of the dist version"
+issue: TBD
+status: complete
+created: 2026-07-25
+updated: 2026-07-25
+---
+
+# Plan: Keep non-release tags out of the dist version
+
+Chartered follow-up 3 of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md).
+
+## Summary
+
+`DEVLORE_VERSION` defaulted to `git describe --tags`, which can resolve to non-release
+tags such as `develop/lkg-11`. The slash-bearing version breaks the dist archive path
+(`tar: Failed to open 'dist/devlore-cli_develop/lkg-11-…_darwin_amd64.tar.gz'`), so a
+local `make dist-all` required a manual `DEVLORE_VERSION` override. CI is unaffected
+either way: the Release workflow determines and passes its version explicitly.
+
+## Changes
+
+1. `Makefile` — the `DEVLORE_VERSION` default gains `--match "v*"`, so describe only
+   resolves release-style tags (`v0.1.0-dev.…` and future `vX.Y.Z`); `--always` still
+   falls back to a bare (slash-free) commit hash when no such tag is reachable.
+
+## Verification
+
+- `make -n dist-all` derives `v0.1.0-dev.20260314201016-45-gcd7d73a0-dirty` — slash-free.
+- `make dist-all` with no override completes all six platforms and writes correctly
+  named archives.


### PR DESCRIPTION
Chartered follow-up 3 of `docs/plans/fix-windows-build-and-guide-category.md`. Plain `git describe --tags` can resolve to non-release tags like `develop/lkg-11`, and the slash-bearing version breaks the dist archive path, forcing a manual `DEVLORE_VERSION` override for local `make dist-all`. `--match "v*"` restricts describe to release-style tags, with `--always` still falling back to a bare commit hash. CI is unaffected — Release passes its version explicitly. Verified: no-override `make dist-all` completes all six platforms with correctly named archives.