### PR TITLE
lint(whitespace): suppress false leading-newline check; fix the 22 real findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,9 +59,10 @@ linters:
     gocognit:
       min-complexity: 20
 
-    # NobleFactor Go style requires a blank line after every function signature
-    # before the body. multi-func: true makes the whitespace linter enforce that
-    # rule rather than flag the blank line as unnecessary.
+    # multi-func: true requires a newline after every MULTI-LINE function
+    # signature. It does NOT exempt the NobleFactor-mandated blank line after
+    # a function signature from the linter's "unnecessary leading newline"
+    # check — that check is suppressed under exclusions below.
     whitespace:
       multi-func: true
 
@@ -113,6 +114,14 @@ linters:
   exclusions:
     generated: lax
     rules:
+      # NobleFactor style requires a blank line after every function signature;
+      # the whitespace linter's leading-newline check flags exactly that blank
+      # line. Suppress it; the trailing-newline and multi-line-statement checks
+      # stay active.
+      - linters:
+          - whitespace
+        text: "unnecessary leading newline"
+
       # Test files can have higher complexity
       - path: _test\.go
         linters:
@@ -141,6 +150,5 @@ output:
   formats:
     text:
       path: stdout
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
+      print-linter-name: true
+      print-issued-lines: true

--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -352,6 +352,7 @@ func (tc *TestContext) starExpectEqual(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var got, want starlark.Value
 	if err := starlark.UnpackPositionalArgs("t.expect_equal", args, kwargs, 2, &got, &want); err != nil {
 		return nil, err
@@ -372,6 +373,7 @@ func (tc *TestContext) starExpectError(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var pattern string
 	if err := starlark.UnpackPositionalArgs("t.expect_error", args, kwargs, 1, &pattern); err != nil {
 		return nil, err
@@ -396,6 +398,7 @@ func (tc *TestContext) starExpectFile(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var path string
 	var content starlark.Value
 
@@ -430,6 +433,7 @@ func (tc *TestContext) starExpectNoFile(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var path string
 	if err := starlark.UnpackPositionalArgs("t.expect_no_file", args, kwargs, 1, &path); err != nil {
 		return nil, err
@@ -452,6 +456,7 @@ func (tc *TestContext) starExpectUnitCount(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var count int
 	if err := starlark.UnpackPositionalArgs("t.expect_unit_count", args, kwargs, 1, &count); err != nil {
 		return nil, err
@@ -471,6 +476,7 @@ func (tc *TestContext) starMkdir(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var path string
 	if err := starlark.UnpackPositionalArgs("t.mkdir", args, kwargs, 1, &path); err != nil {
 		return nil, err
@@ -490,6 +496,7 @@ func (tc *TestContext) starWrite(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var path, content string
 	if err := starlark.UnpackPositionalArgs("t.write", args, kwargs, 2, &path, &content); err != nil {
 		return nil, err
@@ -514,6 +521,7 @@ func (tc *TestContext) starTmp(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var relative string
 	if err := starlark.UnpackPositionalArgs("t.tmp", args, kwargs, 1, &relative); err != nil {
 		return nil, err
@@ -553,6 +561,7 @@ func (tc *TestContext) starSetOverrides(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var d *starlark.Dict
 	if err := starlark.UnpackPositionalArgs("t.set_overrides", args, kwargs, 1, &d); err != nil {
 		return nil, err
@@ -572,6 +581,7 @@ func (tc *TestContext) starSetFlags(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var d *starlark.Dict
 	if err := starlark.UnpackPositionalArgs("t.set_flags", args, kwargs, 1, &d); err != nil {
 		return nil, err
@@ -591,6 +601,7 @@ func (tc *TestContext) starSetEnvPrefix(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var prefix string
 	if err := starlark.UnpackPositionalArgs("t.set_env_prefix", args, kwargs, 1, &prefix); err != nil {
 		return nil, err
@@ -649,6 +660,7 @@ func (tc *TestContext) starSetConfig(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var d *starlark.Dict
 	if err := starlark.UnpackPositionalArgs("t.set_config", args, kwargs, 1, &d); err != nil {
 		return nil, err
@@ -814,6 +826,7 @@ func (tc *TestContext) starExpectVariable(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var name string
 	value := starlark.Value(starlark.None)
 	origin := starlark.Value(starlark.None)
@@ -852,6 +865,7 @@ func (tc *TestContext) starExpectVariableNamespace(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	var name, namespace string
 	err := starlark.UnpackPositionalArgs("t.expect_variable_namespace", args, kwargs, 2, &name, &namespace)
 	if err != nil {

--- a/cmd/star/star/extension.go
+++ b/cmd/star/star/extension.go
@@ -229,6 +229,7 @@ func (e *Extension) starlarkConfig(
 	args starlark.Tuple,
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
+
 	if err := starlark.UnpackArgs("extension.config", args, kwargs); err != nil {
 		return nil, err
 	}

--- a/docs/plans/lint-whitespace-config-and-fixes.md
+++ b/docs/plans/lint-whitespace-config-and-fixes.md
@@ -1,0 +1,50 @@
+---
+title: "Whitespace lint: fix the config bug, then the 22 real findings"
+issue: TBD
+status: complete
+created: 2026-07-25
+updated: 2026-07-25
+---
+
+# Plan: Whitespace lint — fix the config bug, then the 22 real findings
+
+Chartered follow-up 4, part a (whitespace), of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md).
+
+## Summary
+
+The uncapped lint enumeration reported 2,027 `whitespace` findings. Classification showed
+2,005 are **false positives caused by a config bug**: the linter's "unnecessary leading
+newline" check flags the blank line after a function signature that NobleFactor style
+*requires*. The config's `multi-func: true` comment claimed it protected that blank line;
+it does not — it only requires a newline after multi-line signatures. The 22 real
+findings: 16 "multi-line statement should be followed by a newline" (missing the mandated
+blank after multi-line signatures) and 6 "unnecessary trailing newline".
+
+An initial repo-wide autofix ran under the buggy config and stripped the 2,005 mandated
+blank lines; that damage is reverted by the commit script (`git restore -- '*.go'`)
+before the corrected fixer runs.
+
+## Changes
+
+1. `.golangci.yaml` — exclusion rule suppressing the whitespace linter's
+   "unnecessary leading newline" check; corrected the `multi-func` comment to state what
+   the option actually does.
+2. `.golangci.yaml` — pre-existing v1-style `output` keys (`print-issued-lines`,
+   `print-linter-name`, `sort-results`) migrated to the v2 schema
+   (`golangci-lint config verify` failed on them; it now passes).
+3. The 22 real whitespace findings fixed by `golangci-lint run --fix
+   --enable-only=whitespace` under the corrected config (runs inside the commit script,
+   after the revert).
+
+## Verification
+
+- `golangci-lint config verify` — pass.
+- In-script, before commit: whitespace findings = 0 (uncapped), `gofmt -l` clean over
+  the repo, `make test` passes.
+
+## Chartered follow-ups (not in this change)
+
+1. **Upstream template**: `.golangci.yaml` is copied from the shared NobleFactor
+   template ("Copy this file to any Go repo root"); the template source (noblefactor-ops)
+   needs the same exclusion, comment, and v2 output-key corrections.

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -193,7 +193,6 @@ func NewMethod(
 		if !methodType.Out(2).Implements(errorType) {
 
 			err = errorInvalidResultParameters(do)
-
 		} else if !isLegalCompensator(methodType.Out(1)) {
 
 			// The compensator must be a concrete *Receipt or a *RecoveryStack if it's to join a saga — no slices, no bare

--- a/pkg/op/planner.go
+++ b/pkg/op/planner.go
@@ -346,7 +346,6 @@ func (ActionPlanner) Plan(
 						r,
 						r.Addressing())
 				}
-
 			} else {
 
 				// A plain value: convert toward the parameter type now.

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -246,7 +246,6 @@ func (p *Provider) Link(
 		}
 
 		receipt = NewReceipt(NewReceiptSpec(product, MutationUpdateFile).WithRecovery(recoveryID, preDigest))
-
 	} else {
 
 		// Does not exist — standard parent directory creation.
@@ -1958,6 +1957,7 @@ func (p *Provider) walkDir(
 	absoluteRoot string,
 	walkFn func(string, fs.DirEntry, error) error,
 ) error {
+
 	if osRoot != nil {
 		relRoot := osRoot.NewPath(absoluteRoot).Rel()
 		return fs.WalkDir(osRoot.FS(), relRoot, func(relPath string, d fs.DirEntry, walkDirErr error) error {

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -498,7 +498,6 @@ func TestBackup_MovesFileToTimestampedBackup(t *testing.T) {
 	if state.RecoveryID() != "" {
 		t.Errorf("state.RecoveryID() = %q, want empty", state.RecoveryID())
 	}
-
 }
 
 func TestBackup_DefaultSuffix(t *testing.T) {

--- a/pkg/op/provider/function/synthesize.go
+++ b/pkg/op/provider/function/synthesize.go
@@ -68,7 +68,6 @@ func synthesize(fn *starlark.Function, params []string) ([]byte, error) {
 
 		_, _ = fmt.Fprintf(&builder, "def %s(%s):\n", anonymousFuncName, strings.Join(params, ", "))
 		_, _ = fmt.Fprintf(&builder, "    return %s\n", body)
-
 	} else {
 
 		defText, err := extractDefStmt(fn)

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -392,7 +392,6 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 				methods = append(methods, method)
 			}
 		}
-
 	} else {
 
 		for reflectedMethod := range methodType.Methods() {


### PR DESCRIPTION
Follow-up 4a of `docs/plans/fix-windows-build-and-guide-category.md`. Of 2,027 uncapped whitespace findings, 2,005 were false positives: the linter's "unnecessary leading newline" check flags the blank line after a function signature that NobleFactor style requires (`multi-func: true` does not exempt it, contrary to the config's old comment). Adds the exclusion, corrects the comment, migrates v1-style `output` keys (`config verify` now passes), and fixes the 22 real findings (16 missing newlines after multi-line signatures, 6 trailing newlines) via the linter's own `--fix`. Script-verified before commit: whitespace findings 0, gofmt clean, `make test` green. Chartered: same corrections needed in the upstream shared config template.