### PR TITLE
lint(errcheck): assert the must-succeed classes (56 of 117 sites)

### DIFF
--- a/cmd/devlore-test/devloretest/root.go
+++ b/cmd/devlore-test/devloretest/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
 	"github.com/NobleFactor/devlore-cli/pkg/status"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -51,7 +52,7 @@ Use --output to route streams to files or /dev/null:
 			// into RuntimeEnvironmentSpec.Status so --silent applies uniformly across all
 			// emission points. The choice between Console and Discard is at the construction
 			// site — Console always emits; Discard always drops.
-			silent, _ := cmd.Flags().GetBool("silent")
+			silent := assert.Must(cmd.Flags().GetBool("silent"))
 			var s sink.Sink
 			if silent {
 				s = sink.Discard()

--- a/cmd/star/provider/commands/command_ref.go
+++ b/cmd/star/provider/commands/command_ref.go
@@ -9,6 +9,8 @@ import (
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
 
 // CommandRef wraps a command for use in Starlark. It implements starlark.Value
@@ -77,7 +79,7 @@ func (r *CommandRef) run(_ *starlark.Thread, _ *starlark.Builtin, args starlark.
 	var positional []string
 
 	for _, kv := range kwargs {
-		key := string(kv[0].(starlark.String))
+		key := string(assert.Type[starlark.String]("kwarg key", kv[0]))
 		// List kwargs are treated as positional args (e.g., path=["./internal"]).
 		if list, ok := kv[1].(*starlark.List); ok {
 			for i := 0; i < list.Len(); i++ {

--- a/cmd/star/provider/commands/provider.go
+++ b/cmd/star/provider/commands/provider.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -28,10 +29,10 @@ type Provider struct {
 // [op.RuntimeEnvironment.Application.Overrides] directly — it mutates as cobra dispatches each subcommand,
 // which doesn't fit the construction-time resolution model.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
-	_ = ctx.RegisterParameter(op.Parameter{
+	assert.NoError("register command_tree parameter", ctx.RegisterParameter(op.Parameter{
 		Name: "command_tree",
 		Type: reflect.TypeOf((*CommandTree)(nil)).Elem(),
-	})
+	}))
 	return &Provider{ProviderBase: op.NewProviderBase(ctx)}
 }
 

--- a/cmd/star/provider/config/provider.go
+++ b/cmd/star/provider/config/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	cfg "github.com/NobleFactor/devlore-cli/cmd/star/config"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -25,10 +26,10 @@ type Provider struct {
 // variable so the resolver populates it from the [application.Application]'s source maps at construction
 // time.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
-	_ = ctx.RegisterParameter(op.Parameter{
+	assert.NoError("register config parameter", ctx.RegisterParameter(op.Parameter{
 		Name: "config",
 		Type: reflect.TypeOf((*cfg.Config)(nil)),
-	})
+	}))
 	return &Provider{ProviderBase: op.NewProviderBase(ctx)}
 }
 

--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"text/template"
 	"unicode"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
 
 // =============================================================================
@@ -30,7 +32,7 @@ type parsedFile struct {
 // parseFile parses a Go file with caching.
 func (p *Provider) parseFile(path string) (*token.FileSet, *ast.File, error) {
 	if cached, ok := p.fileCache.Load(path); ok {
-		pf := cached.(*parsedFile)
+		pf := assert.Type[*parsedFile]("file cache entry", cached)
 		return pf.fset, pf.node, nil
 	}
 

--- a/cmd/star/provider/goast/provider.go
+++ b/cmd/star/provider/goast/provider.go
@@ -24,6 +24,7 @@ import (
 
 	cfg "github.com/NobleFactor/devlore-cli/cmd/star/config"
 	"github.com/NobleFactor/devlore-cli/cmd/star/provider/goast/doctaxonomy"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -40,10 +41,10 @@ type Provider struct {
 // variable so the resolver populates it from the [application.Application]'s source maps at construction
 // time.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
-	_ = ctx.RegisterParameter(op.Parameter{
+	assert.NoError("register config parameter", ctx.RegisterParameter(op.Parameter{
 		Name: "config",
 		Type: reflect.TypeOf((*cfg.Config)(nil)),
-	})
+	}))
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
 	return p
 }

--- a/cmd/star/provider/setup/provider.go
+++ b/cmd/star/provider/setup/provider.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	cfg "github.com/NobleFactor/devlore-cli/cmd/star/config"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -31,10 +32,10 @@ type Provider struct {
 // variable so the resolver populates it from the [application.Application]'s source maps at construction
 // time. Dry-run is read via [op.RuntimeEnvironment.Application.DryRun] — no parameter declaration needed.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
-	_ = ctx.RegisterParameter(op.Parameter{
+	assert.NoError("register config parameter", ctx.RegisterParameter(op.Parameter{
 		Name: "config",
 		Type: reflect.TypeOf((*cfg.Config)(nil)),
-	})
+	}))
 	return &Provider{ProviderBase: op.NewProviderBase(ctx)}
 }
 

--- a/docs/plans/lint-errcheck-asserts.md
+++ b/docs/plans/lint-errcheck-asserts.md
@@ -1,0 +1,99 @@
+---
+title: "errcheck: assert the must-succeed classes"
+issue: TBD
+status: complete
+created: 2026-07-26
+updated: 2026-07-26
+---
+
+# Plan: errcheck — assert the must-succeed classes
+
+Chartered follow-up 4, part b-1 (errcheck assert classes), of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md).
+
+## Summary
+
+Of 117 uncapped errcheck findings, this change fixes the 56 whose failure indicates a bug
+— converting silent discards into labeled panics via `pkg/assert`. Two functions are added
+to `pkg/assert` (approved 2026-07-25):
+
+- `Must[T any](value T, err error) T` — unwraps a (value, error) call; panics through
+  `raise` on error. Go forbids mixing a context argument with a multi-value call, so Must
+  carries no label; the AssertionError's captured call site supplies the location.
+- `Type[T any](name string, value any) T` — comma-ok type assertion with a labeled panic,
+  replacing unlabeled runtime panics of bare single-value assertions.
+
+## Changes
+
+1. `pkg/assert/assert.go` — `Must` and `Type` (alphabetical placement) + tests in
+   `pkg/assert/assert_test.go`.
+2. Flag getters (27 sites): the 25-case `flagValue` switch in `pkg/application/application.go`
+   collapses to `return assert.Must(cmd.Flags().GetX(f.Name))`; the two
+   `GetBool("silent")` sites in `internal/cli/root.go` and
+   `cmd/devlore-test/devloretest/root.go` use `assert.Must`.
+3. Single-value type assertions (19 sites): `assert.Type` with a named invariant, in
+   `pkg/op/binding.go` (4), `pkg/op/node.go` (4), `pkg/op/receiver_type.go` (2),
+   `pkg/op/method.go`, `pkg/op/runtime_environment.go`, `pkg/op/subgraph.go`,
+   `pkg/op/starlarkbridge/converter.go`, `pkg/op/starlarkbridge/go_receiver.go`,
+   `pkg/op/provider/regexp/provider.go`, `pkg/signing/signing.go`,
+   `cmd/star/provider/commands/command_ref.go`, `cmd/star/provider/goast/helpers.go`.
+4. Registration/transition discards (8 sites): `assert.NoError` in the four
+   `NewProvider` RegisterParameter calls (`cmd/star/provider/{commands,config,goast,setup}`),
+   `pkg/op/graph_executor.go` (frameworkFailure), `pkg/op/subgraph.go` (boundary
+   transition), `pkg/op/provider/flow/provider.go` (degraded/failed transitions).
+5. Must-succeed misc (2 sites): `uuid.Parse` of the archive-time recovery ID
+   (`pkg/op/provider/file/receipt.go`) and `json.Marshal` of the event payload
+   (`pkg/op/server/router.go`).
+
+Deliberately NOT converted: `handlerStack.Unwind` in `pkg/op/graph_executor.go`'s deferred
+error path (best-effort recovery cleanup — a panic there would mask the original failure;
+class-5 review), and the fallback sites `NewReceiverType(reflectType, nil)` and
+`platform.New(detected)` (intentional absent-tolerant flows).
+
+## Remaining errcheck debt: 61 findings
+
+### Class 2 — discarded-ok type assertions (24 sites, awaiting sign-off)
+
+Provisional classification; "policy" marks the receipt-deserialization question (own
+serialized documents, but read from disk — panic vs error on corruption):
+
+| Site | Source | Provisional |
+|---|---|---|
+| `cmd/lore/lore/origin.go:56` | `token, _ := value.(string)` | review |
+| `cmd/star/provider/commands/provider.go:44` | `t, _ := v.Value.(CommandTree)` | assert |
+| `cmd/star/provider/commands/provider.go:52` | `Overrides["current_command"].(string)` | tolerant |
+| `cmd/star/provider/setup/provider.go:51` | `c, _ := v.Value.(*cfg.Config)` | assert |
+| `cmd/writ/writ/decommission/decommission.go:220` | `runRoot, _ := value.(string)` | policy |
+| `cmd/writ/writ/deploy/deploy.go:337` | `target, _ := fields["target"].(string)` | tolerant |
+| `cmd/writ/writ/deploy/plan.go:443` | `root, _ := value.(string)` | policy |
+| `cmd/writ/writ/migrate/helpers.go:69` | `binding.Resolve(nil, nil).(string)` | review |
+| `cmd/writ/writ/readback/readback.go:309` | `targetRoot, _ = value.(string)` | policy |
+| `cmd/writ/writ/readback/readback.go:473` | `fields[key].(string)` | policy |
+| `cmd/writ/writ/upgrade/upgrade.go:443` | `runRoot, _ := value.(string)` | policy |
+| `pkg/application/application.go:73` | DryRun `Flags["dry_run"].(bool)` | tolerant (documented) |
+| `pkg/op/action_types.go:300` | `v.Interface().(Compensator)` | tolerant (capability probe) |
+| `pkg/op/graph.go:138` | `spec.Origin.(OriginBase)` | review |
+| `pkg/op/provider/file/receipt.go:445` | `fields[key].(string)` | policy |
+| `pkg/op/provider/pkg/receipt.go:223` | `fields[key].(string)` | policy |
+| `pkg/op/provider/pkg/receipt.go:237` | `fields[key].(bool)` | policy |
+| `pkg/op/provider/plan/helpers.go:71` | `kv[0].(starlark.String)` | assert |
+| `pkg/op/provider/plan/helpers.go:343` | `kv[0].(starlark.String)` | assert |
+| `pkg/op/provider/service/receipt.go:120` | `fields["was_running"].(bool)` | policy |
+| `pkg/op/provider/service/receipt.go:121` | `fields["was_enabled"].(bool)` | policy |
+| `pkg/op/recovery_stack.go:706` | `e.compensator.(Receipt)` | tolerant (variant probe) |
+| `pkg/op/recovery_stack.go:716` | `e.compensator.(*RecoveryStack)` | tolerant (variant probe) |
+| `pkg/platform/darwin_managers_darwin.go:49` | `kwargs["cask"].(bool)` | tolerant |
+
+### Classes 5–7 — cleanup discards, Fprint family, fallbacks (37 sites)
+
+Best-effort cleanup (needs the nolint-vs-logging ruling), stderr/SSE writes, and
+parse-with-fallback sites, including the compensation-path discards
+(`receipt.Commit`, `RestoreFile`, `catalog.VerifyExistence`) flagged for real scrutiny.
+
+## Verification
+
+- `make vet` — pass; `make test` — pass (full suite, twice: after the bulk edits and
+  after the final missed-site fix).
+- errcheck uncapped count: 117 → 61; zero remaining findings in converted files except
+  the deliberately deferred `application.go` DryRun site.
+- `gofmt -l` clean over `cmd`, `pkg`, `internal`.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
 	"github.com/NobleFactor/devlore-cli/pkg/status"
 	"github.com/NobleFactor/devlore-cli/schema"
@@ -52,7 +53,7 @@ func NewRootCmd(cfg RootConfig) *cobra.Command {
 			// env.Status.Note (provider emissions), and starlark print() output. The choice
 			// between Console and Discard is at the construction site — Console always emits;
 			// Discard always drops.
-			silent, _ := cmd.Flags().GetBool("silent")
+			silent := assert.Must(cmd.Flags().GetBool("silent"))
 			var s sink.Sink
 			if silent {
 				s = sink.Discard()

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
 
 // Application is the tool-side handle the workflow framework reads through its runtime environment.
@@ -137,80 +139,55 @@ func flagValue(cmd *cobra.Command, f *pflag.Flag) any {
 
 	switch f.Value.Type() {
 	case "bool":
-		v, _ := cmd.Flags().GetBool(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetBool(f.Name))
 	case "string":
-		v, _ := cmd.Flags().GetString(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetString(f.Name))
 	case "int":
-		v, _ := cmd.Flags().GetInt(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt(f.Name))
 	case "int8":
-		v, _ := cmd.Flags().GetInt8(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt8(f.Name))
 	case "int16":
-		v, _ := cmd.Flags().GetInt16(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt16(f.Name))
 	case "int32":
-		v, _ := cmd.Flags().GetInt32(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt32(f.Name))
 	case "int64":
-		v, _ := cmd.Flags().GetInt64(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt64(f.Name))
 	case "uint":
-		v, _ := cmd.Flags().GetUint(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetUint(f.Name))
 	case "uint8":
-		v, _ := cmd.Flags().GetUint8(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetUint8(f.Name))
 	case "uint16":
-		v, _ := cmd.Flags().GetUint16(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetUint16(f.Name))
 	case "uint32":
-		v, _ := cmd.Flags().GetUint32(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetUint32(f.Name))
 	case "uint64":
-		v, _ := cmd.Flags().GetUint64(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetUint64(f.Name))
 	case "float32":
-		v, _ := cmd.Flags().GetFloat32(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetFloat32(f.Name))
 	case "float64":
-		v, _ := cmd.Flags().GetFloat64(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetFloat64(f.Name))
 	case "duration":
-		v, _ := cmd.Flags().GetDuration(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetDuration(f.Name))
 	case "stringSlice":
-		v, _ := cmd.Flags().GetStringSlice(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetStringSlice(f.Name))
 	case "stringArray":
-		v, _ := cmd.Flags().GetStringArray(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetStringArray(f.Name))
 	case "intSlice":
-		v, _ := cmd.Flags().GetIntSlice(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetIntSlice(f.Name))
 	case "int32Slice":
-		v, _ := cmd.Flags().GetInt32Slice(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt32Slice(f.Name))
 	case "int64Slice":
-		v, _ := cmd.Flags().GetInt64Slice(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetInt64Slice(f.Name))
 	case "stringToString":
-		v, _ := cmd.Flags().GetStringToString(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetStringToString(f.Name))
 	case "stringToInt":
-		v, _ := cmd.Flags().GetStringToInt(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetStringToInt(f.Name))
 	case "stringToInt64":
-		v, _ := cmd.Flags().GetStringToInt64(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetStringToInt64(f.Name))
 	case "boolSlice":
-		v, _ := cmd.Flags().GetBoolSlice(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetBoolSlice(f.Name))
 	case "count":
-		v, _ := cmd.Flags().GetCount(f.Name)
-		return v
+		return assert.Must(cmd.Flags().GetCount(f.Name))
 	default:
 		return f.Value.String()
 	}

--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -49,6 +49,28 @@ func Failf(format string, args ...any) {
 	raise(2, fmt.Sprintf(format, args...))
 }
 
+// Must returns `value` unless `err` is non-nil, in which case it panics with an [*AssertionError].
+//
+// Use to unwrap a (value, error) call whose failure indicates a bug — not a recoverable runtime
+// condition: `silent := assert.Must(cmd.Flags().GetBool("silent"))`. Go forbids mixing a context
+// argument with a multi-value call, so Must carries no label; the [*AssertionError]'s captured call
+// site supplies the location.
+//
+// Parameters:
+//   - `value`: the value to return when `err` is nil.
+//   - `err`: the error to inspect.
+//
+// Returns:
+//   - `T`: `value`, unchanged.
+func Must[T any](value T, err error) T {
+
+	if err != nil {
+		raise(2, fmt.Sprintf("must: %v", err))
+	}
+
+	return value
+}
+
 // Nil panics with an [*AssertionError] when `value` is non-nil.
 //
 // Constrained to pointer types, so the nil check is type-safe; the compiler rejects non-nillable inputs (strings, ints,
@@ -150,6 +172,28 @@ func Truef(condition bool, format string, args ...any) {
 		return
 	}
 	raise(2, fmt.Sprintf(format, args...))
+}
+
+// Type returns `value` as type `T`, panicking with an [*AssertionError] when the dynamic type differs.
+//
+// Use where a value's type is guaranteed by construction (a just-parsed document field, a registry
+// invariant) and a mismatch is a bug: `id := assert.Type[string]("unit id", b.value)`. The labeled
+// panic replaces the unlabeled runtime panic of a bare single-value type assertion.
+//
+// Parameters:
+//   - `name`: a short identifier of the value being checked (e.g. "unit id").
+//   - `value`: the value whose dynamic type must be `T`.
+//
+// Returns:
+//   - `T`: `value` as `T`.
+func Type[T any](name string, value any) T {
+
+	typed, ok := value.(T)
+	if !ok {
+		raise(2, fmt.Sprintf("%s: expected %T, got %T", name, typed, value))
+	}
+
+	return typed
 }
 
 // Unimplemented panics unconditionally with an [*AssertionError].

--- a/pkg/assert/assert_test.go
+++ b/pkg/assert/assert_test.go
@@ -297,6 +297,60 @@ func TestNoErrorFails(t *testing.T) {
 
 // endregion
 
+// region Must
+
+func TestMust_ReturnsValueOnNilError(t *testing.T) {
+
+	var got int
+
+	expectNoPanic(t, "Must(7, nil)", func() { got = assert.Must(7, nil) })
+
+	if got != 7 {
+		t.Errorf("Must(7, nil) = %d, want 7", got)
+	}
+}
+
+func TestMust_FailsOnError(t *testing.T) {
+
+	got := recoverError(t, func() { assert.Must(0, errors.New("boom")) })
+
+	if got == nil {
+		t.Fatal("expected panic on non-nil error")
+	}
+	if !strings.Contains(got.Message, "boom") {
+		t.Errorf("Message = %q, want contains \"boom\"", got.Message)
+	}
+}
+
+// endregion
+
+// region Type
+
+func TestType_ReturnsTypedValueOnMatch(t *testing.T) {
+
+	var got string
+
+	expectNoPanic(t, `Type[string]("s", any("ok"))`, func() { got = assert.Type[string]("s", any("ok")) })
+
+	if got != "ok" {
+		t.Errorf(`Type[string]("s", "ok") = %q, want "ok"`, got)
+	}
+}
+
+func TestType_FailsOnMismatch(t *testing.T) {
+
+	got := recoverError(t, func() { assert.Type[string]("s", any(42)) })
+
+	if got == nil {
+		t.Fatal("expected panic on dynamic-type mismatch")
+	}
+	if !strings.Contains(got.Message, "s: expected string, got int") {
+		t.Errorf("Message = %q, want contains \"s: expected string, got int\"", got.Message)
+	}
+}
+
+// endregion
+
 // region AssertionError
 
 func TestErrorErrorFormat(t *testing.T) {

--- a/pkg/op/binding.go
+++ b/pkg/op/binding.go
@@ -3,6 +3,8 @@
 
 package op
 
+import "github.com/NobleFactor/devlore-cli/pkg/assert"
+
 // Binding is the value bound to a slot.
 //
 // It is sealed at three variants and the set is closed: [ImmediateBinding], [PromiseBinding], and [VariableBinding].
@@ -114,7 +116,7 @@ func NewPromiseBinding(unitID string) PromiseBinding {
 //   - `*Edge`: the producer→consumer dependency edge; the producer is this promise's referenced [ExecutableUnit].
 func (b PromiseBinding) Edge(consumer string) *Edge {
 
-	return &Edge{From: b.value.(string), To: consumer}
+	return &Edge{From: assert.Type[string]("promise unit ID", b.value), To: consumer}
 }
 
 // Resolve returns the referenced producer's result by querying the recovery stack.
@@ -131,7 +133,7 @@ func (b PromiseBinding) Resolve(_ map[string]Variable, stack *RecoveryStack) any
 		return nil
 	}
 
-	if result, ok := stack.ResultByUnitID(b.value.(string)); ok {
+	if result, ok := stack.ResultByUnitID(assert.Type[string]("promise unit ID", b.value)); ok {
 		return result
 	}
 
@@ -209,7 +211,7 @@ func (b VariableBinding) Field() string {
 //   - `string`: the variable name.
 func (b VariableBinding) Name() string {
 
-	return b.value.(string)
+	return assert.Type[string]("variable name", b.value)
 }
 
 // Resolve returns the value of the named variable from the supplied variable map, projected to the binding's field
@@ -231,7 +233,7 @@ func (b VariableBinding) Resolve(variables map[string]Variable, _ *RecoveryStack
 		return nil
 	}
 
-	value := variables[b.value.(string)].Value
+	value := variables[assert.Type[string]("variable name", b.value)].Value
 	if b.field == "" {
 		return value
 	}

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -879,7 +879,8 @@ func (e *GraphExecutor) retryPolicyFor(unit ExecutableUnit) *RetryPolicy {
 //   - `error`: a [dispatchFailure] carrying [ReasonFrameworkFailed].
 func (e *GraphExecutor) frameworkFailure(unitID string, cause error) error {
 
-	_ = e.Transition(unitID, ConditionExecutionFailed, ReasonFrameworkFailed, cause.Error())
+	assert.NoError("transition to framework-failed",
+		e.Transition(unitID, ConditionExecutionFailed, ReasonFrameworkFailed, cause.Error()))
 	return &dispatchFailure{reason: ReasonFrameworkFailed, cause: cause, bypassHandler: true}
 }
 

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -792,7 +792,7 @@ func errorFromValue(v reflect.Value) error {
 	if v.IsNil() {
 		return nil
 	}
-	return v.Interface().(error)
+	return assert.Type[error]("method error result", v.Interface())
 }
 
 // errorInvalidResultParameters returns a standard error for an unsupported return signature.

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -229,11 +229,11 @@ func (n *Node) Parameters() ([]Parameter, error) {
 			// A projected binding's declared slot type/default describe the FIELD, not the record-valued
 			// variable, so the variable bubbles untyped — sibling projections of different fields must not
 			// falsely collide (phase-8 step 45).
-			out = append(out, Parameter{Name: vv.value.(string)})
+			out = append(out, Parameter{Name: assert.Type[string]("variable name", vv.value)})
 			continue
 		}
 		out = append(out, Parameter{
-			Name:    vv.value.(string),
+			Name:    assert.Type[string]("variable name", vv.value),
 			Type:    param.Type,
 			Default: param.Default,
 		})
@@ -368,9 +368,9 @@ func marshalBindings(bindings map[string]Binding) map[string]bindingData {
 		case ImmediateBinding:
 			data[name] = bindingData{Immediate: &immediateData{Value: b.value}}
 		case PromiseBinding:
-			data[name] = bindingData{Promise: &promiseData{UnitID: b.value.(string)}}
+			data[name] = bindingData{Promise: &promiseData{UnitID: assert.Type[string]("promise unit ID", b.value)}}
 		case VariableBinding:
-			data[name] = bindingData{Variable: &variableData{Name: b.value.(string), Field: b.field}}
+			data[name] = bindingData{Variable: &variableData{Name: assert.Type[string]("variable name", b.value), Field: b.field}}
 		default:
 			panic(fmt.Sprintf("op: unknown Binding variant %T", binding))
 		}

--- a/pkg/op/provider/file/receipt.go
+++ b/pkg/op/provider/file/receipt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/google/uuid"
 )
@@ -378,7 +379,7 @@ func (s *ReceiptSpec) WithBoundary(boundary Entry) *ReceiptSpec {
 // Returns:
 //   - `*ReceiptSpec`: the receiver, for chaining.
 func (s *ReceiptSpec) WithRecovery(recoveryID string, digest op.Digest) *ReceiptSpec {
-	s.recoveryID, _ = uuid.Parse(recoveryID)
+	s.recoveryID = assert.Must(uuid.Parse(recoveryID))
 	s.recoveryDigest = digest
 	return s
 }

--- a/pkg/op/provider/flow/provider.go
+++ b/pkg/op/provider/flow/provider.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -649,7 +650,8 @@ func (p *Provider) Degraded(activationRecord *op.ActivationRecord, format string
 
 	rendered := op.RenderError(format, args, kwargs)
 
-	_ = activationRecord.Transition(op.ConditionDegraded, op.ReasonDegraded, "flow.degraded executed: "+rendered.Error())
+	assert.NoError("transition to degraded",
+		activationRecord.Transition(op.ConditionDegraded, op.ReasonDegraded, "flow.degraded executed: "+rendered.Error()))
 
 	_, _ = fmt.Fprintln(os.Stderr, "degraded:", rendered)
 	return rendered.Error()
@@ -676,7 +678,8 @@ func (p *Provider) Failed(activationRecord *op.ActivationRecord, format string, 
 
 	rendered := op.RenderError(format, args, kwargs)
 
-	_ = activationRecord.Transition(op.ConditionExecutionFailed, op.ReasonFailed, "flow.failed executed: "+rendered.Error())
+	assert.NoError("transition to execution-failed",
+		activationRecord.Transition(op.ConditionExecutionFailed, op.ReasonFailed, "flow.failed executed: "+rendered.Error()))
 
 	_, _ = fmt.Fprintln(os.Stderr, "failed:", rendered)
 	return rendered.Error()

--- a/pkg/op/provider/regexp/provider.go
+++ b/pkg/op/provider/regexp/provider.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sync"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -211,7 +212,7 @@ func (p *Provider) Split(pattern, text string, count int) ([]string, error) {
 func (p *Provider) compile(pattern string) (*regexp.Regexp, error) {
 
 	if v, ok := p.cache.Load(pattern); ok {
-		return v.(*regexp.Regexp), nil
+		return assert.Type[*regexp.Regexp]("pattern cache entry", v), nil
 	}
 	re, err := regexp.Compile(pattern)
 	if err != nil {

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -210,7 +210,7 @@ func (t *receiverType) Do(method string, receiver any, args []any) (reflect.Valu
 		fn, _ = t.dispatchTable.LoadOrStore(method, compileDispatcher(m))
 	}
 
-	return fn.(dispatcher)(receiver, args)
+	return assert.Type[dispatcher]("dispatch table entry", fn)(receiver, args)
 }
 
 // providerReceiverType is the concrete descriptor for providers.
@@ -518,7 +518,7 @@ func compileDispatcher(m *Method) dispatcher {
 		if rv.IsNil() {
 			return nil
 		}
-		return rv.Interface().(error)
+		return assert.Type[error]("method error result", rv.Interface())
 	}
 
 	switch m.kind {

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -477,7 +477,7 @@ func (re *RuntimeEnvironment) VariableByName(name string) (Variable, bool) {
 	}
 
 	if resolve, ok := re.resolvers.Load(name); ok {
-		return resolve.(func() (Variable, bool))()
+		return assert.Type[func() (Variable, bool)]("variable resolver", resolve)()
 	}
 
 	return Variable{}, false

--- a/pkg/op/server/router.go
+++ b/pkg/op/server/router.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -259,7 +260,7 @@ func writeSSE(w http.ResponseWriter, event op.ControlEvent) {
 		payload.Error = event.Err.Error()
 	}
 
-	data, _ := json.Marshal(payload)
+	data := assert.Must(json.Marshal(payload))
 	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventKindName(event.Kind), data)
 }
 

--- a/pkg/op/starlarkbridge/converter.go
+++ b/pkg/op/starlarkbridge/converter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"go.starlark.net/starlark"
 )
@@ -336,7 +337,7 @@ func (c converter) toNaturalGo(sv starlark.Value) (any, error) {
 		n := max(starlark.Len(v), 0)
 
 		res := make([]any, 0, n) // Optimized: Allocates capacity but stays empty for append.
-		iter := v.(starlark.Iterable).Iterate()
+		iter := assert.Type[starlark.Iterable]("sequence value", v).Iterate()
 		defer iter.Done()
 
 		var x starlark.Value

--- a/pkg/op/starlarkbridge/go_receiver.go
+++ b/pkg/op/starlarkbridge/go_receiver.go
@@ -801,7 +801,7 @@ func (g *goReceiver) dispatch(
 //   - `error`: non-nil when an ordering operator is applied to a non-scalar (struct) receiver.
 func (g *goReceiver) CompareSameType(cmp syntax.Token, x starlark.Value, depth int) (bool, error) {
 
-	other := x.(*goReceiver)
+	other := assert.Type[*goReceiver]("comparison operand", x)
 	var equal bool
 
 	if c, ok := g.instance.(op.Comparer); ok {

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -260,8 +260,9 @@ func (s *Subgraph) Execute(
 	// adjudication instead (recording it here would pre-empt an absorb); the boundary derives its condition from the
 	// reason.
 	if (err == nil || errors.Is(err, ErrPaused)) && childExecutor.status.Condition > ConditionHealthy {
-		_ = executor.Transition(s.ID(), childExecutor.status.Condition, childExecutor.status.Reason,
-			childExecutor.status.Message)
+		assert.NoError("boundary transition",
+			executor.Transition(s.ID(), childExecutor.status.Condition, childExecutor.status.Reason,
+				childExecutor.status.Message))
 	}
 
 	// Exit 3: Do returned an error.
@@ -483,7 +484,8 @@ func (s *Subgraph) bubbleOwnSlots(seen map[string]Parameter) []error {
 			typ, def = nil, nil
 		}
 
-		mergeErr := s.mergeBubbled(seen, Parameter{Name: vv.value.(string), Type: typ, Default: def})
+		mergeErr := s.mergeBubbled(seen,
+			Parameter{Name: assert.Type[string]("variable name", vv.value), Type: typ, Default: def})
 		if mergeErr != nil {
 			violations = append(violations, mergeErr)
 		}

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -31,6 +31,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -241,7 +242,7 @@ func configHome() (string, error) {
 //   - `error`: non-nil when the public half cannot be wrapped.
 func newKeyfileSigner(private ed25519.PrivateKey) (Signer, error) {
 
-	sshPublic, err := ssh.NewPublicKey(private.Public().(ed25519.PublicKey))
+	sshPublic, err := ssh.NewPublicKey(assert.Type[ed25519.PublicKey]("ed25519 public key", private.Public()))
 	if err != nil {
 		return nil, fmt.Errorf("wrap public key: %w", err)
 	}


### PR DESCRIPTION
Follow-up 4b-1 of `docs/plans/fix-windows-build-and-guide-category.md`. Adds `assert.Must` and `assert.Type` (approved 2026-07-25) and converts the errcheck classes whose silent discards hide bugs: 27 cobra flag getters, 19 single-value type assertions (now labeled invariants), 8 registration/state-transition discards, 2 must-succeed calls. Deliberately untouched: best-effort cleanup in error paths, intentional fallbacks, and the 24 discarded-ok type assertions tabulated in `docs/plans/lint-errcheck-asserts.md` for guaranteed-vs-tolerant sign-off. errcheck uncapped 117 → 61; `make vet` + `make test` green; gofmt clean.