### PR TITLE
lint(errcheck): close out the remaining 61 findings (now 0)

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -281,6 +281,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 
 	defer func() {
 		for k := range tc.EnvSet() {
+			//nolint:errcheck // diagnose-ignored-error: env restore; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = os.Unsetenv(k)
 		}
 	}()

--- a/cmd/lore/lore/origin.go
+++ b/cmd/lore/lore/origin.go
@@ -3,7 +3,10 @@
 
 package lore
 
-import "github.com/NobleFactor/devlore-cli/pkg/op"
+import (
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
 
 // Origin is lore's typed, read-only view over a graph's [op.Origin].
 //
@@ -52,8 +55,10 @@ func (o Origin) Packages() []string {
 // Returns:
 //   - `string`: the platform token (e.g. "Linux.Debian"); "" when unset.
 func (o Origin) Platform() string {
-	value, _ := o.Annotations().Get("platform")
-	token, _ := value.(string)
+	token := ""
+	if value, ok := o.Annotations().Get("platform"); ok {
+		token = assert.Type[string]("platform annotation", value)
+	}
 	return token
 }
 

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -433,6 +433,7 @@ func registerStarlarkCommand(rootCmd *cobra.Command, cmd *starruntime.Command) {
 		case "bool":
 			cobraCmd.Flags().Bool(flag.Name, flag.Default == "true", flag.Help)
 		case "int":
+			//nolint:errcheck // diagnose-ignored-error: falls back to 0; see docs/architecture/2.8-eventing-infrastructure.md
 			n, _ := strconv.Atoi(flag.Default)
 			cobraCmd.Flags().Int(flag.Name, n, flag.Help)
 		default:

--- a/cmd/star/provider/commands/provider.go
+++ b/cmd/star/provider/commands/provider.go
@@ -41,16 +41,17 @@ func (p *Provider) tree() CommandTree {
 	if !ok {
 		return nil
 	}
-	t, _ := v.Value.(CommandTree)
-	return t
+	return assert.Type[CommandTree]("command_tree variable", v.Value)
 }
 
 func (p *Provider) currentCommand() string {
 	if p.RuntimeEnvironment().Application == nil {
 		return ""
 	}
-	s, _ := p.RuntimeEnvironment().Application.Overrides["current_command"].(string)
-	return s
+	if s, ok := p.RuntimeEnvironment().Application.Overrides["current_command"].(string); ok {
+		return s
+	}
+	return ""
 }
 
 // Current returns the name of the currently executing command.

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -529,8 +529,8 @@ func parseMarkdownLintOutput(output string) []mdIssue {
 			continue
 		}
 		lineNum := 0
-		n, _ := fmt.Sscanf(locParts[1], "%d", &lineNum)
-		if n == 0 || lineNum == 0 {
+		n, err := fmt.Sscanf(locParts[1], "%d", &lineNum)
+		if err != nil || n == 0 || lineNum == 0 {
 			continue
 		}
 		rest := parts[1]

--- a/cmd/star/provider/setup/provider.go
+++ b/cmd/star/provider/setup/provider.go
@@ -48,8 +48,7 @@ func (p *Provider) config() *cfg.Config {
 	if !ok {
 		return nil
 	}
-	c, _ := v.Value.(*cfg.Config)
-	return c
+	return assert.Type[*cfg.Config]("config variable", v.Value)
 }
 
 func (p *Provider) gitRoot() string {
@@ -68,6 +67,7 @@ func (p *Provider) gitRoot() string {
 func (p *Provider) Tools() (ToolsResult, error) {
 	result := ToolsResult{AllInstalled: true, Platform: runtime.GOOS}
 	for _, tool := range devTools {
+		//nolint:errcheck // diagnose-ignored-error: probe result; see docs/architecture/2.8-eventing-infrastructure.md
 		path, _ := exec.LookPath(tool.Binary)
 		installed := path != ""
 		if !installed {
@@ -93,6 +93,7 @@ func (p *Provider) Tools() (ToolsResult, error) {
 //   - PrecommitCheckResult: hook installation status
 //   - error: never
 func (p *Provider) PrecommitCheck() (PrecommitCheckResult, error) {
+	//nolint:errcheck // diagnose-ignored-error: probe result; see docs/architecture/2.8-eventing-infrastructure.md
 	precommitPath, _ := exec.LookPath("pre-commit")
 	root := p.gitRoot()
 

--- a/cmd/star/star/command.go
+++ b/cmd/star/star/command.go
@@ -129,6 +129,7 @@ func flagToStarlark(flagType, value string) starlark.Value {
 	case "bool":
 		return starlark.Bool(value == "true")
 	case "int":
+		//nolint:errcheck // diagnose-ignored-error: falls back to 0; see docs/architecture/2.8-eventing-infrastructure.md
 		n, _ := strconv.Atoi(value)
 		return starlark.MakeInt(n)
 	default:

--- a/cmd/star/star/loader.go
+++ b/cmd/star/star/loader.go
@@ -187,6 +187,7 @@ func (l *ExtensionLoader) discoverEmbedded() ([]*Extension, error) {
 		}
 
 		ext, readErr := document.Read[Extension](f)
+		//nolint:errcheck // diagnose-ignored-error: read-only close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = f.Close()
 		if readErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", path, readErr)

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/readback"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
@@ -216,8 +217,10 @@ func buildScopeGraph(
 //   - `error`: non-nil when the spec cannot be configured, the plan cannot persist, or the run fails.
 func runGraph(ctx context.Context, cfg *Config, graph *op.Graph) error {
 
-	value, _ := graph.Origin().Annotations().Get("run_root")
-	runRoot, _ := value.(string)
+	runRoot := ""
+	if value, ok := graph.Origin().Annotations().Get("run_root"); ok {
+		runRoot = assert.Type[string]("run_root annotation", value)
+	}
 
 	spec, err := removalSpec(runRoot, cfg.DryRun)
 	if err != nil {

--- a/cmd/writ/writ/deploy/deploy.go
+++ b/cmd/writ/writ/deploy/deploy.go
@@ -334,7 +334,7 @@ func plannedTargets(graph *op.Graph) map[string]bool {
 		if !ok {
 			continue
 		}
-		if target, _ := fields["target"].(string); target != "" {
+		if target, ok := fields["target"].(string); ok && target != "" {
 			targets[target] = true
 		}
 	}

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/tree"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
@@ -440,7 +441,10 @@ func deploySpec(root string, dryRun bool, conflict op.ConflictPolicy) (*op.Runti
 func runSpec(graph *op.Graph, dryRun bool, conflict op.ConflictPolicy) (*op.RuntimeEnvironmentSpec, error) {
 
 	value, ok := graph.Origin().Annotations().Get("run_root")
-	root, _ := value.(string)
+	root := ""
+	if ok {
+		root = assert.Type[string]("run_root annotation", value)
+	}
 	if !ok || root == "" {
 		return nil, fmt.Errorf("graph %s carries no run_root annotation", graph.Checksum())
 	}

--- a/cmd/writ/writ/migrate/helpers.go
+++ b/cmd/writ/writ/migrate/helpers.go
@@ -66,8 +66,10 @@ func immediateString(node *op.Node, slot string) string {
 		return ""
 	}
 
-	value, _ := binding.Resolve(nil, nil).(string)
-	return value
+	if value, ok := binding.Resolve(nil, nil).(string); ok {
+		return value
+	}
+	return ""
 }
 
 // migrateSpec constructs a fresh [op.RuntimeEnvironmentSpec] confined at `root` for one phase of a migrate flow

--- a/cmd/writ/writ/migrate/session.go
+++ b/cmd/writ/writ/migrate/session.go
@@ -592,6 +592,7 @@ func (s *Session) outputJSON() {
 		cli.Warn("Failed to format JSON output: %v", err)
 		return
 	}
+	//nolint:errcheck // diagnose-ignored-error: stdout write; see docs/architecture/2.8-eventing-infrastructure.md
 	_, _ = fmt.Fprintln(os.Stdout, buf.String())
 }
 

--- a/cmd/writ/writ/readback/readback.go
+++ b/cmd/writ/writ/readback/readback.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
@@ -306,7 +307,7 @@ func foldRun(env *op.RuntimeEnvironment, r run, inventory *Inventory) {
 
 	targetRoot := ""
 	if value, ok := origin.Annotations().Get("target_root"); ok {
-		targetRoot, _ = value.(string)
+		targetRoot = assert.Type[string]("target_root annotation", value)
 	}
 
 	recorded := recordedIdentity(trace.Catalog)
@@ -460,18 +461,24 @@ func ContentDigest(data []byte) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
-// stringField reads a string value from a decoded annotation map, tolerating absence and other types.
+// stringField reads a string value from a decoded annotation map, tolerating absence.
+//
+// The map decodes a graph annotation, and graphs are checksum-verified on load ([op.LoadGraph]), so a present value
+// of the wrong type can only be a serialization bug — it panics via [assert.Type] rather than degrading silently.
 //
 // Parameters:
 //   - `fields`: the decoded map.
 //   - `key`: the field to read.
 //
 // Returns:
-//   - `string`: the value, or "" when absent or not a string.
+//   - `string`: the value, or "" when absent.
 func stringField(fields map[string]any, key string) string {
 
-	value, _ := fields[key].(string)
-	return value
+	value, ok := fields[key]
+	if !ok {
+		return ""
+	}
+	return assert.Type[string]("files annotation field "+key, value)
 }
 
 // loadGraph loads a graph document from the store by checksum.

--- a/cmd/writ/writ/snapshot/snapshot.go
+++ b/cmd/writ/writ/snapshot/snapshot.go
@@ -61,8 +61,11 @@ func Pin(repoPath, layer string) (*Snapshot, error) {
 	if dirExists(worktreeDir) {
 		if err := verifyWorktree(worktreeDir, hash); err != nil {
 			// Integrity check failed — remove and recreate
+			//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = unlockWorktree(worktreeDir)
+			//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = os.RemoveAll(worktreeDir)
+			//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = gitWorktreePrune(repoPath)
 		} else {
 			return &Snapshot{
@@ -100,12 +103,15 @@ func Pin(repoPath, layer string) (*Snapshot, error) {
 //   - error: git worktree removal or directory cleanup error
 func (s *Snapshot) Close() error {
 	// Unlock worktree so git can remove it (Darwin: clears UF_IMMUTABLE)
+	//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 	_ = unlockWorktree(s.WorktreePath)
 
 	// Remove the git worktree registration
 	if err := gitWorktreeRemove(s.RepoPath, s.WorktreePath); err != nil {
 		// If git worktree remove fails, try force removal
+		//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = os.RemoveAll(s.WorktreePath)
+		//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = gitWorktreePrune(s.RepoPath)
 		return nil //nolint:nilerr // best-effort cleanup; directory removed
 	}
@@ -250,6 +256,7 @@ func CheckClean(sources []tree.LayerSource) ([]string, error) {
 // closeAll closes all snapshots, logging errors but not failing.
 func closeAll(snapshots []*Snapshot) {
 	for _, s := range snapshots {
+		//nolint:errcheck // diagnose-ignored-error: close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = s.Close()
 	}
 }

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -39,6 +39,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/tree"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
@@ -439,8 +440,10 @@ func buildScopeGraph(
 //   - `error`: non-nil when the spec cannot be configured, the plan cannot persist, or the run fails.
 func runGraph(ctx context.Context, cfg *Config, graph *op.Graph) (int, error) {
 
-	value, _ := graph.Origin().Annotations().Get("run_root")
-	runRoot, _ := value.(string)
+	runRoot := ""
+	if value, ok := graph.Origin().Annotations().Get("run_root"); ok {
+		runRoot = assert.Type[string]("run_root annotation", value)
+	}
 
 	spec, err := upgradeSpec(runRoot, cfg.DryRun)
 	if err != nil {

--- a/docs/architecture/2.8-eventing-infrastructure.md
+++ b/docs/architecture/2.8-eventing-infrastructure.md
@@ -90,6 +90,23 @@ severities and categories — not separate machinery, exactly what the default-v
 **new API to add**: today providers narrate through `status.Narrator`; the span-correlated DEBUG / TRACE diagnostics
 channel is the piece stream 3 introduces.
 
+## Ignored errors are diagnostics
+
+An intentionally ignored error — best-effort cleanup, an unwind on an already-failing path, a fallback probe — is never
+silent. Every such error is a **pending diagnostic**: once the diagnostics API (stream 3) lands, the site logs the
+ignored error to the diagnostics stream (DEBUG, span-correlated) instead of discarding it.
+
+Until then, every ignored-error site carries the canonical search string `diagnose-ignored-error` inside its lint
+suppression, linking back to this spec:
+
+```go
+//nolint:errcheck // diagnose-ignored-error: <why ignoring is correct here>; see docs/architecture/2.8-eventing-infrastructure.md
+```
+
+**Search string: `diagnose-ignored-error`** — grep for it to enumerate every site that owes the diagnostics stream a
+log call. When the diagnostics API lands, the sweep converts each site to a real diagnostics call and deletes the
+suppression; the marker count reaching zero is the done signal.
+
 ## Is eventing OpenTelemetry?
 
 OpenTelemetry's collectors support many forms of logging and export, so its collector / exporter pipeline already **is**

--- a/docs/plans/lint-errcheck-remainder.md
+++ b/docs/plans/lint-errcheck-remainder.md
@@ -1,0 +1,67 @@
+---
+title: "errcheck: close out the remaining 61 findings"
+issue: TBD
+status: complete
+created: 2026-07-26
+updated: 2026-07-26
+---
+
+# Plan: errcheck — close out the remaining 61 findings
+
+Chartered follow-up 4, part b-2, of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md). Applies the
+two rulings settled 2026-07-26: the **checksum trust boundary** (disk-document corruption
+before checksum verification is an error; any read failure after verification is a panic)
+and **ignored errors are diagnostics** (spec section added to
+`docs/architecture/2.8-eventing-infrastructure.md`, canonical search string
+`diagnose-ignored-error`, which ships in this change).
+
+## The audit that drove the split
+
+- `op.LoadGraph` recomputes and compares the graph checksum on load (`pkg/op/graph.go`),
+  so every loaded `*op.Graph` is post-verification: graph-annotation decodes panic on
+  mistype (absence stays contractual).
+- Trace documents are read by `cli.LoadTrace` = `document.ReadFile` — **no verification**
+  (signing exists but is only checked by `writ verify`), so trace/receipt field decodes
+  are pre-verification: mistype is a decode **error**, never a panic.
+- `ReceiptSpec.WithRecovery` audit (from 4b-1): **passes** — all five callers pass a
+  just-minted archive ID; the deserialization path parses `recovery_id` with error returns.
+
+## Changes (61 findings → 0)
+
+1. **assert.Type conversions (10)** — post-verification decodes: the four guaranteed-type
+   rows (command_tree/config variables, two starlark kwarg keys), five graph-annotation
+   sites (`origin.go` platform, decommission/upgrade/deploy-plan/readback run/target
+   roots — absent-guarded, mistype panics), and readback's `stringField` helper.
+2. **Explicit comma-ok (9)** — documented-tolerant sites: current-command override,
+   Compensator capability probe, recovery-entry variant probes (×2), brew cask kwarg,
+   migrate binding resolve, `Application.DryRun`, deploy targets filter, `NewGraph`'s
+   OriginBase carrier.
+3. **Trace-decoder error side (5 findings)** — `file`/`pkg` receipt `stringField`/
+   `boolField` now return an error on present-but-mistyped fields (absence still yields
+   the zero value per contract); both `RestoreEncoded` bodies propagate; `service`
+   receipt's two bool fields check inline.
+4. **`diagnose-ignored-error` markers (31)** — best-effort cleanup, error-path recovery,
+   stream writes, and probes, each with a terse reason and the spec link.
+5. **Restructures (6)** — Sscanf uses its error; viper probe via stdlib `errors.As`;
+   devconfig `Items` asserts its just-enumerated names; `fsroot.makePath` and appnet's
+   URL unescape assert construction invariants; `ParsePURL` propagates a version-unescape
+   error (external input).
+
+## Verification
+
+- errcheck uncapped: 61 → **0**. Marker census: 31 `diagnose-ignored-error` sites.
+- `make vet` pass; `make test` pass (full suite); `gofmt -l` clean.
+
+## Chartered follow-ups (not in this change)
+
+1. **Trace documents carry no integrity checksum** — the ruling's panic zone is empty for
+   them until one exists; adding a trace checksum (mirroring the graph's) is a design
+   decision to take.
+2. **The checksum-trust-boundary ruling needs an architecture-doc home** — it currently
+   lives in decoder doc comments and session memory only.
+3. **`receipt.Commit` on the resume path** (`graph_executor.go`, marker "resume stamp")
+   deserves design scrutiny: a failed commit silently loses the compensation stamping.
+4. **Remaining lint debt for 4b-3+**: 281 non-complexity findings (gocritic 133, gosec
+   55, revive 30, unparam 15, noctx 14, unused 11, nilerr 6, misspell 5, staticcheck 4,
+   errorlint 4, bodyclose 3, goimports 1); the 61 complexity findings stay chartered.

--- a/internal/cli/receipts.go
+++ b/internal/cli/receipts.go
@@ -104,6 +104,7 @@ func WriteTrace(trace *op.Trace) (string, error) {
 	}
 
 	latest := filepath.Join(directory, "latest.yaml")
+	//nolint:errcheck // diagnose-ignored-error: stale link; see docs/architecture/2.8-eventing-infrastructure.md
 	_ = os.Remove(latest) // best-effort: replace any prior link
 	if err := os.Symlink(filename, latest); err != nil {
 		return "", fmt.Errorf("link latest trace %s: %w", latest, err)

--- a/internal/cli/viper.go
+++ b/internal/cli/viper.go
@@ -83,7 +83,8 @@ func InitViper(cfg ViperConfig) error {
 
 	// Read config file (ignore if not found)
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) {
 			return fmt.Errorf("error reading config: %w", err)
 		}
 		// Config file not found is OK - use defaults and env vars

--- a/internal/pwsh/pwsh.go
+++ b/internal/pwsh/pwsh.go
@@ -242,7 +242,9 @@ func (s *Session) Run(command string) *Result {
 	// Send command directly in session scope, then emit a marker with the
 	// exit code. Using $global:LASTEXITCODE preserves native command exit
 	// codes; $? reflects PowerShell command success.
+	//nolint:errcheck // diagnose-ignored-error: surfaces on read; see docs/architecture/2.8-eventing-infrastructure.md
 	_, _ = fmt.Fprintf(s.stdin, "%s\n", command)
+	//nolint:errcheck // diagnose-ignored-error: surfaces on read; see docs/architecture/2.8-eventing-infrastructure.md
 	_, _ = fmt.Fprintf(s.stdin,
 		"Write-Output '%s'$(if ($?) { $global:LASTEXITCODE } else { if ($global:LASTEXITCODE) { $global:LASTEXITCODE } else { 1 } })\n",
 		s.marker,

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -70,8 +70,10 @@ type Application struct {
 //   - `bool`: true when `--dry-run` was supplied; false otherwise.
 func (a *Application) DryRun() bool {
 
-	v, _ := a.Flags["dry_run"].(bool)
-	return v
+	if v, ok := a.Flags["dry_run"].(bool); ok {
+		return v
+	}
+	return false
 }
 
 // NewApplication constructs an [Application] from a cobra command's parsed flag state.

--- a/pkg/devconfig/config.go
+++ b/pkg/devconfig/config.go
@@ -24,6 +24,8 @@ import (
 
 	"go.starlark.net/starlark"
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
 
 // Interface guards.
@@ -338,7 +340,9 @@ func (d *DataSection) Items() []starlark.Tuple {
 	names := d.Names()
 	items := make([]starlark.Tuple, 0, len(names))
 	for _, name := range names {
-		value, _, _ := d.Get(starlark.String(name))
+		value, found, err := d.Get(starlark.String(name))
+		assert.NoError("data section get", err)
+		assert.True("data section name present", found)
 		items = append(items, starlark.Tuple{starlark.String(name), value})
 	}
 	return items

--- a/pkg/fsroot/root.go
+++ b/pkg/fsroot/root.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
 
 // Interface guards.
@@ -677,7 +679,7 @@ func (p *Path) UnmarshalYAML(value *yaml.Node) error {
 func makePath(rootName, path string) Path {
 
 	if filepath.IsAbs(path) {
-		rel, _ := filepath.Rel(rootName, path)
+		rel := assert.Must(filepath.Rel(rootName, path))
 		return Path{root: rootName, rel: rel, abs: filepath.Clean(path)}
 	}
 	return Path{

--- a/pkg/op/action_types.go
+++ b/pkg/op/action_types.go
@@ -297,8 +297,10 @@ func compensatorOrNil(v reflect.Value) Compensator {
 	default:
 	}
 
-	compensator, _ := v.Interface().(Compensator)
-	return compensator
+	if compensator, ok := v.Interface().(Compensator); ok {
+		return compensator
+	}
+	return nil
 }
 
 // dryRunLog writes dry-run output to the context status UI.

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -135,7 +135,10 @@ func NewGraph(spec *GraphSpec) (*Graph, error) {
 
 	// spec.Origin is the op.Origin interface; the graph stores the concrete OriginBase carrier. Construction always
 	// passes an OriginBase (tools build via NewOriginBase), so a nil / non-OriginBase value yields the zero origin.
-	graphOrigin, _ := spec.Origin.(OriginBase)
+	var graphOrigin OriginBase
+	if origin, ok := spec.Origin.(OriginBase); ok {
+		graphOrigin = origin
+	}
 
 	g, err := buildGraph(root, graphMetadata{
 		schemaVersion:   GraphSchemaVersion,

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -298,6 +298,7 @@ func (e *GraphExecutor) ResumeUnwind(ctx context.Context) error {
 		if e.environment.ResourceCatalog != nil {
 			e.ledgerSnapshot = e.environment.ResourceCatalog.Snapshot()
 		}
+		//nolint:errcheck // diagnose-ignored-error: cleanup close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = e.environment.Close()
 		e.environment = nil
 	}()
@@ -482,6 +483,7 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 		if e.environment.ResourceCatalog != nil {
 			e.ledgerSnapshot = e.environment.ResourceCatalog.Snapshot()
 		}
+		//nolint:errcheck // diagnose-ignored-error: cleanup close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = e.environment.Close()
 		e.environment = nil
 		e.variables = nil
@@ -725,6 +727,7 @@ func (e *GraphExecutor) dispatchHandler(
 			err = fmt.Errorf("handler panicked: %v", recovered)
 		}
 		if err != nil {
+			//nolint:errcheck // diagnose-ignored-error: error wins; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = handlerStack.Unwind(e.environment)
 		}
 	}()
@@ -970,6 +973,7 @@ func (e *GraphExecutor) resolvePendingResources() {
 			continue
 		}
 		// Mark, don't fail: VerifyExistence records Gone on a missing resource; the error is informational here.
+		//nolint:errcheck // diagnose-ignored-error: records Gone; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = catalog.VerifyExistence(resource)
 	}
 }
@@ -1072,6 +1076,7 @@ func (e *GraphExecutor) pushAuditReceipt(
 	if action != nil {
 		// A minimal activation carries the caller identity Commit stamps (step 30): the unit's id as the caller,
 		// plus the graph so Commit can resolve the unit object for its action-name stamping.
+		//nolint:errcheck // diagnose-ignored-error: resume stamp; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = receipt.Commit(&ActivationRecord{Graph: e.graph, CallerID: unit.ID()}, result, compensator, dispatchErr)
 	}
 

--- a/pkg/op/provider/appnet/resource.go
+++ b/pkg/op/provider/appnet/resource.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -437,7 +438,7 @@ func canonicalURL(value string) (*url.URL, error) {
 
 	sourceURL.Host = host
 	sourceURL.RawPath = p
-	sourceURL.Path, _ = url.PathUnescape(p)
+	sourceURL.Path = assert.Must(url.PathUnescape(p))
 	sourceURL.RawQuery = q
 
 	return sourceURL, nil

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -464,6 +464,7 @@ func (p *Provider) Move(
 	if err = p.rename(sourceAbs, product.Path().Abs()); err != nil {
 		// Attempt to restore destination on failure if we archived it.
 		if receipt.RecoveryID() != "" {
+			//nolint:errcheck // diagnose-ignored-error: rename error wins; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = p.RuntimeEnvironment().RecoverySite.RestoreFile(product.Path(), receipt.RecoveryID())
 		}
 		return nil, nil, err

--- a/pkg/op/provider/file/receipt.go
+++ b/pkg/op/provider/file/receipt.go
@@ -274,9 +274,19 @@ func (r *Receipt) RestoreEncoded(
 		return fmt.Errorf("file.Receipt: RestoreEncoded requires a runtime environment with a catalog")
 	}
 
-	resource, err := lookupResource(runtimeEnvironment, stringField(fields, "resource_id"))
+	resourceID, err := stringField(fields, "resource_id")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+
+	resource, err := lookupResource(runtimeEnvironment, resourceID)
 	if err != nil {
 		return err
+	}
+
+	transactionID, err := stringField(fields, "transaction_id")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
 	}
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
@@ -289,36 +299,56 @@ func (r *Receipt) RestoreEncoded(
 		Status:             base.Status,
 		CompensationError:  base.CompensationError,
 		ResourceURI:        resource.URI(),
-		TransactionID:      stringField(fields, "transaction_id"),
+		TransactionID:      transactionID,
 	}); err != nil {
 		return fmt.Errorf("file.Receipt: RestoreEncoded restore base: %w", err)
 	}
 
-	if boundaryID := stringField(fields, "boundary_id"); boundaryID != "" {
+	boundaryID, err := stringField(fields, "boundary_id")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+	if boundaryID != "" {
 		if r.boundary, err = lookupResource(runtimeEnvironment, boundaryID); err != nil {
 			return err
 		}
 	}
 
-	if sourceID := stringField(fields, "source_id"); sourceID != "" {
+	sourceID, err := stringField(fields, "source_id")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+	if sourceID != "" {
 		if r.source, err = lookupResource(runtimeEnvironment, sourceID); err != nil {
 			return err
 		}
 	}
 
-	if recoveryID := stringField(fields, "recovery_id"); recoveryID != "" {
+	recoveryID, err := stringField(fields, "recovery_id")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+	if recoveryID != "" {
 		if r.recoveryID, err = uuid.Parse(recoveryID); err != nil {
 			return fmt.Errorf("file.Receipt: RestoreEncoded parse recovery_id %q: %w", recoveryID, err)
 		}
 	}
 
-	if recoveryDigest := stringField(fields, "recovery_digest"); recoveryDigest != "" {
+	recoveryDigest, err := stringField(fields, "recovery_digest")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+	if recoveryDigest != "" {
 		if r.recoveryDigest, err = op.ParseDigest(recoveryDigest); err != nil {
 			return fmt.Errorf("file.Receipt: RestoreEncoded parse recovery_digest %q: %w", recoveryDigest, err)
 		}
 	}
 
-	r.kind = MutationKind(stringField(fields, "kind"))
+	kind, err := stringField(fields, "kind")
+	if err != nil {
+		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
+	}
+	r.kind = MutationKind(kind)
 
 	return nil
 }
@@ -428,22 +458,32 @@ func lookupResource(runtimeEnvironment *op.RuntimeEnvironment, id string) (Entry
 	return resource, nil
 }
 
-// stringField returns the string value at `key` in a decoded receipt subfield, or "" when absent or not a string.
+// stringField returns the string value at `key` in a decoded receipt subfield, or "" when absent.
 //
-// The subfield arrives as a format-neutral map (decoded by whichever codec read the trace), so reads go through a
-// typed lookup rather than struct-tag decoding; an absent or wrong-typed value yields "", which the caller treats as
-// "not present".
+// The subfield arrives as a format-neutral map (decoded by whichever codec read the trace). Trace documents carry no
+// integrity checksum, so a present value of the wrong type is document corruption — an error, never a panic. Absence
+// stays "not present".
 //
 // Parameters:
 //   - `fields`: the decoded id-reference subfield.
 //   - `key`: the field name to read.
 //
 // Returns:
-//   - `string`: the value, or "" when absent or not a string.
-func stringField(fields map[string]any, key string) string {
+//   - `string`: the value, or "" when absent.
+//   - `error`: non-nil when the value is present but not a string.
+func stringField(fields map[string]any, key string) (string, error) {
 
-	value, _ := fields[key].(string)
-	return value
+	raw, ok := fields[key]
+	if !ok {
+		return "", nil
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("field %q: expected string, got %T", key, raw)
+	}
+
+	return value, nil
 }
 
 // endregion

--- a/pkg/op/provider/function/resource.go
+++ b/pkg/op/provider/function/resource.go
@@ -679,6 +679,7 @@ func (f *Resource) loadProgram() (*starlark.Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mmap %s: %w", abs, err)
 	}
+	//nolint:errcheck // diagnose-ignored-error: module close; see docs/architecture/2.8-eventing-infrastructure.md
 	defer func() { _ = m.Close() }()
 
 	h, err := readFunctionPackHeader(m)
@@ -744,6 +745,7 @@ func (f *Resource) sourceBytes() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mmap %s: %w", abs, err)
 	}
+	//nolint:errcheck // diagnose-ignored-error: module close; see docs/architecture/2.8-eventing-infrastructure.md
 	defer func() { _ = m.Close() }()
 
 	h, err := readFunctionPackHeader(m)

--- a/pkg/op/provider/mem/helpers.go
+++ b/pkg/op/provider/mem/helpers.go
@@ -129,6 +129,7 @@ func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) 
 
 	defer func() {
 		if !promoted {
+			//nolint:errcheck // diagnose-ignored-error: staging cleanup; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = root.Remove(staging)
 		}
 	}()

--- a/pkg/op/provider/pkg/receipt.go
+++ b/pkg/op/provider/pkg/receipt.go
@@ -170,7 +170,10 @@ func (r *Receipt) RestoreEncoded(
 		return fmt.Errorf("pkg.Receipt: RestoreEncoded requires a runtime environment with a catalog")
 	}
 
-	resourceURI := stringField(fields, "resource_uri")
+	resourceURI, err := stringField(fields, "resource_uri")
+	if err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
+	}
 
 	var resource op.Resource
 	if resourceURI != "" {
@@ -179,6 +182,11 @@ func (r *Receipt) RestoreEncoded(
 			return fmt.Errorf("pkg.Receipt: RestoreEncoded resource %q: %w", resourceURI, err)
 		}
 		resource = got
+	}
+
+	transactionID, err := stringField(fields, "transaction_id")
+	if err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
 	}
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
@@ -191,15 +199,26 @@ func (r *Receipt) RestoreEncoded(
 		Status:             base.Status,
 		CompensationError:  base.CompensationError,
 		ResourceURI:        resourceURI,
-		TransactionID:      stringField(fields, "transaction_id"),
+		TransactionID:      transactionID,
 	}); err != nil {
 		return fmt.Errorf("pkg.Receipt: RestoreEncoded restore: %w", err)
 	}
 
-	r.kind = MutationKind(stringField(fields, "kind"))
-	r.Manager = stringField(fields, "manager")
-	r.InstalledBefore = boolField(fields, "installed_before")
-	r.PreviousVersion = stringField(fields, "previous_version")
+	kind, err := stringField(fields, "kind")
+	if err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
+	}
+	r.kind = MutationKind(kind)
+
+	if r.Manager, err = stringField(fields, "manager"); err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
+	}
+	if r.InstalledBefore, err = boolField(fields, "installed_before"); err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
+	}
+	if r.PreviousVersion, err = stringField(fields, "previous_version"); err != nil {
+		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
+	}
 
 	return nil
 }
@@ -217,11 +236,22 @@ func (r *Receipt) RestoreEncoded(
 //   - `key`: the field name to read.
 //
 // Returns:
-//   - `string`: the value, or "" when absent or not a string.
-func stringField(fields map[string]any, key string) string {
+//   - `string`: the value, or "" when absent.
+//   - `error`: non-nil when the value is present but not a string — trace documents carry no integrity checksum, so
+//     a mistyped field is document corruption: an error, never a panic.
+func stringField(fields map[string]any, key string) (string, error) {
 
-	value, _ := fields[key].(string)
-	return value
+	raw, ok := fields[key]
+	if !ok {
+		return "", nil
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("field %q: expected string, got %T", key, raw)
+	}
+
+	return value, nil
 }
 
 // boolField returns the bool value at `key` in a decoded receipt sub-field, or false when absent or not a bool.
@@ -231,11 +261,22 @@ func stringField(fields map[string]any, key string) string {
 //   - `key`: the field name to read.
 //
 // Returns:
-//   - `bool`: the value, or false when absent or not a bool.
-func boolField(fields map[string]any, key string) bool {
+//   - `bool`: the value, or false when absent.
+//   - `error`: non-nil when the value is present but not a bool — trace documents carry no integrity checksum, so a
+//     mistyped field is document corruption: an error, never a panic.
+func boolField(fields map[string]any, key string) (bool, error) {
 
-	value, _ := fields[key].(bool)
-	return value
+	raw, ok := fields[key]
+	if !ok {
+		return false, nil
+	}
+
+	value, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("field %q: expected bool, got %T", key, raw)
+	}
+
+	return value, nil
 }
 
 // endregion

--- a/pkg/op/provider/plan/helpers.go
+++ b/pkg/op/provider/plan/helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"go.starlark.net/starlark"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/flow"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
@@ -68,7 +69,7 @@ func dispatchBuiltinBody(
 
 		goKwargs := make(map[string]any, len(filtered))
 		for _, kv := range filtered {
-			keyStr, _ := kv[0].(starlark.String)
+			keyStr := assert.Type[starlark.String]("kwarg key", kv[0])
 			value, err := starlarkbridge.StarlarkToGoTyped(env, kv[1], anyType)
 			if err != nil {
 				return nil, fmt.Errorf("%s: kwarg %q: %w", actionName, string(keyStr), err)
@@ -340,7 +341,7 @@ func splitReservedKwargs(
 
 	filtered := make([]starlark.Tuple, 0, len(kwargs))
 	for _, kv := range kwargs {
-		keyStr, _ := kv[0].(starlark.String)
+		keyStr := assert.Type[starlark.String]("kwarg key", kv[0])
 		key := string(keyStr)
 		if key == "label" || key == "retry_policy" || key == "on_error" || key == "on_retry" || key == "transition_policy" {
 			continue

--- a/pkg/op/provider/service/receipt.go
+++ b/pkg/op/provider/service/receipt.go
@@ -117,8 +117,21 @@ func (r *Receipt) RestoreEncoded(
 		return fmt.Errorf("service.Receipt: RestoreEncoded restore: %w", err)
 	}
 
-	r.WasRunning, _ = fields["was_running"].(bool)
-	r.WasEnabled, _ = fields["was_enabled"].(bool)
+	if raw, ok := fields["was_running"]; ok {
+		value, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("service.Receipt: RestoreEncoded field %q: expected bool, got %T", "was_running", raw)
+		}
+		r.WasRunning = value
+	}
+
+	if raw, ok := fields["was_enabled"]; ok {
+		value, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("service.Receipt: RestoreEncoded field %q: expected bool, got %T", "was_enabled", raw)
+		}
+		r.WasEnabled = value
+	}
 
 	return nil
 }

--- a/pkg/op/receiver_registry.go
+++ b/pkg/op/receiver_registry.go
@@ -645,6 +645,7 @@ func (r *receiverRegistry) TypeByReflectionOrDerive(reflectType reflect.Type) Re
 	derived, err := NewReceiverType(reflectType, deriveMethodParams(reflectType))
 
 	if err != nil {
+		//nolint:errcheck // diagnose-ignored-error: params fallback; see docs/architecture/2.8-eventing-infrastructure.md
 		derived, _ = NewReceiverType(reflectType, nil)
 	}
 

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -703,8 +703,10 @@ type recoveryEntry struct {
 //   - `Receipt`: the entry's receipt, or nil.
 func (e recoveryEntry) receiptOrNil() Receipt {
 
-	receipt, _ := e.compensator.(Receipt)
-	return receipt
+	if receipt, ok := e.compensator.(Receipt); ok {
+		return receipt
+	}
+	return nil
 }
 
 // recoveryStackOrNil returns the entry's compensator as a [*RecoveryStack], or nil when it is a receipt or absent.
@@ -713,8 +715,10 @@ func (e recoveryEntry) receiptOrNil() Receipt {
 //   - `*RecoveryStack`: the entry's nested stack, or nil.
 func (e recoveryEntry) recoveryStackOrNil() *RecoveryStack {
 
-	stack, _ := e.compensator.(*RecoveryStack)
-	return stack
+	if stack, ok := e.compensator.(*RecoveryStack); ok {
+		return stack
+	}
+	return nil
 }
 
 // toCompensate returns the [Compensator] to run at unwind, or nil for an audit-only entry.

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -181,6 +181,7 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) *R
 
 	if platformCapability == nil {
 		if detected, err := platform.Detect(); err == nil {
+			//nolint:errcheck // diagnose-ignored-error: optional detect; see docs/architecture/2.8-eventing-infrastructure.md
 			platformCapability, _ = platform.New(detected)
 		}
 	}

--- a/pkg/op/server/router.go
+++ b/pkg/op/server/router.go
@@ -245,6 +245,7 @@ func (s *Router) handleStatus(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, code int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
+	//nolint:errcheck // diagnose-ignored-error: response write; see docs/architecture/2.8-eventing-infrastructure.md
 	_ = json.NewEncoder(w).Encode(body)
 }
 
@@ -261,6 +262,7 @@ func writeSSE(w http.ResponseWriter, event op.ControlEvent) {
 	}
 
 	data := assert.Must(json.Marshal(payload))
+	//nolint:errcheck // diagnose-ignored-error: SSE write; see docs/architecture/2.8-eventing-infrastructure.md
 	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventKindName(event.Kind), data)
 }
 

--- a/pkg/platform/darwin_managers_darwin.go
+++ b/pkg/platform/darwin_managers_darwin.go
@@ -46,7 +46,7 @@ func (m *brewManager) available(name string) bool {
 func (m *brewManager) installRaw(names []string, kwargs map[string]any) PlatformResult {
 
 	command := "brew install "
-	if cask, _ := kwargs["cask"].(bool); cask {
+	if cask, ok := kwargs["cask"].(bool); ok && cask {
 		command = "brew install --cask "
 	}
 

--- a/pkg/platform/purl.go
+++ b/pkg/platform/purl.go
@@ -119,7 +119,11 @@ func ParsePURL(raw string) (*PURL, error) {
 	var version string
 
 	if i := strings.LastIndexByte(remainder, '@'); i >= 0 {
-		version, _ = url.PathUnescape(remainder[i+1:])
+		unescaped, err := url.PathUnescape(remainder[i+1:])
+		if err != nil {
+			return nil, fmt.Errorf("purl %q: version: %w", raw, err)
+		}
+		version = unescaped
 		remainder = remainder[:i]
 	}
 

--- a/tools/New-OpInventory/main.go
+++ b/tools/New-OpInventory/main.go
@@ -81,6 +81,7 @@ func findAnnouncingPackages(roots []string) []string {
 	fset := token.NewFileSet()
 
 	for _, root := range roots {
+		//nolint:errcheck // diagnose-ignored-error: walker skips; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			if err != nil || d.IsDir() {
 				return nil


### PR DESCRIPTION
Follow-up 4b-2 of `docs/plans/fix-windows-build-and-guide-category.md`, applying both 2026-07-26 rulings. Checksum trust boundary: graphs verify on load (`op.LoadGraph`) so annotation decodes assert on mistype; traces load unverified so receipt field decodes error on mistyped fields (absence stays contractual). Ignored errors are diagnostics: the 2.8 spec gains the convention section and canonical search string `diagnose-ignored-error`; all 31 deliberate ignores carry the marked, spec-linked suppression. 10 assert.Type conversions, 9 explicit comma-ok sites, 5 trace-decoder error-side findings, 31 markers, 6 restructures. errcheck uncapped 61 → 0; `make vet`/`make test` green. Chartered in the plan doc: trace-document checksum, an architecture home for the boundary ruling, resume-path `receipt.Commit` scrutiny, and the 281 findings for 4b-3.