### PR TITLE
feat(trace): tier-1 checksum, verified on every load; strict panic zone

### DIFF
--- a/docs/architecture/5-receipt-integrity.md
+++ b/docs/architecture/5-receipt-integrity.md
@@ -90,6 +90,38 @@ Excluded from canonical content:
 - `signature` field
 - `summary` field (computed from nodes)
 
+## Document Integrity: Graphs and Traces
+
+Settled 2026-07-26/27. Every persisted run document carries a tier-1 checksum computed the same way:
+
+| Document | Checksum | Stamped | Verified |
+|---|---|---|---|
+| Graph | `GitStyleChecksum("graph", canonical)` | at build (`op.NewGraph`) | `op.LoadGraph` recomputes and compares |
+| Trace | `GitStyleChecksum("trace", canonical)` | at persist (`cli.WriteTrace`) | `op.LoadTrace` recomputes and compares |
+
+`GitStyleChecksum` is the git-object construction — `SHA256("<type> <len>\0" ‖ content)`, rendered
+`"sha256:<hex>"` (`pkg/op/helpers.go`). Each document's canonical form excludes both integrity fields
+(`checksum`, `signature`); the tier-2 signature covers the same canonical bytes, so integrity and
+authenticity verify independently. A document with a missing or mismatched checksum is refused at
+load — there is no unverified read path.
+
+### The Checksum Trust Boundary
+
+Settled 2026-07-26: **the checksum is the trust boundary for documents read from disk.**
+
+- **Up to and including checksum verification**, the bytes are untrusted. Unreadable file, malformed
+  encoding, digest mismatch — expected external conditions (corruption, tamper, partial write) — are
+  **errors**: returned and handled, never panics.
+- **After verification**, the document is proven byte-identical to what was written, so any
+  read-related failure — an absent-where-required field, a mistyped field, an unparseable embedded
+  value, a dangling intra-document reference — can only be a bug in our own serialization or
+  decoding, and **panics** via `pkg/assert` (strict extent, approved 2026-07-27). Interactions with
+  external systems during restore (package-manager discovery, filesystem probes) are not document
+  reads and stay on the error side.
+
+Decode helpers on the verified side assert; the load boundary itself errors. Delivery:
+[trace-checksum](../plans/trace-checksum.md).
+
 ## Receipt Storage
 
 ### Directory Structure

--- a/docs/plans/trace-checksum.md
+++ b/docs/plans/trace-checksum.md
@@ -1,0 +1,81 @@
+---
+title: "Trace checksums: symmetric integrity with graphs"
+issue: TBD
+status: complete
+created: 2026-07-27
+updated: 2026-07-27
+---
+
+# Plan: Trace checksums — symmetric integrity with graphs
+
+Escalated from chartered follow-up 1 of
+[lint-errcheck-remainder](lint-errcheck-remainder.md) (2026-07-26): "Traces and graphs
+must each carry checksums that are computed the exact same way." Approved 2026-07-27 with
+the **strict panic extent**.
+
+## The gap
+
+Graphs carry `Checksum = GitStyleChecksum("graph", canonical)` and `op.LoadGraph`
+recomputes and compares on every load. Traces carry only `GraphChecksum` (the graph's
+identity, not their own) and load through `cli.LoadTrace` = `document.ReadFile[op.Trace]`
+— **no integrity verification at all**. Under the checksum trust boundary (settled
+2026-07-26), every trace consumer therefore operates in a permanently pre-verification
+zone.
+
+## Changes
+
+1. **`Trace.Checksum` field** — `"sha256:<hex>"`, computed as
+   `GitStyleChecksum("trace", canonical)`: the identical helper and header construction
+   the graph uses, domain string `"trace"`. `Trace.CanonicalContent` strips `checksum`
+   alongside `signature`, mirroring the graph's canonical form (which excludes both
+   integrity fields). Signature semantics unchanged: it covers
+   content-sans-integrity-fields.
+2. **Stamp at persist** — `cli.WriteTrace` computes and sets the checksum before signing
+   and writing. (A trace's document form is fixed at persist; the graph seals at build.
+   Mechanism and verification contract are identical.)
+3. **Verifying loader** — `op.LoadTrace`, mirroring `op.LoadGraph`: decode, recompute
+   over canonical, compare. Mismatch = error; **missing checksum = error**. Greenfield:
+   traces already in the store predate the field and are refused; new runs regenerate
+   them. No legacy tolerance.
+4. **Funnel** — `cli.LoadTrace` routes through `op.LoadTrace`; readback and
+   `LoadLatestTrace` inherit verification.
+5. **Strict panic-side flip (approved)** — with traces verified at load, the decode path
+   (recovery-stack decode, receipt `RestoreEncoded`, field decoders) sits post-checksum,
+   so per the boundary ruling all its read failures become panics: the 4b-2
+   `stringField`/`boolField` mistype errors flip to `assert.Type`, embedded
+   `uuid.Parse`/`ParseDigest` become `assert.Must`, and dangling intra-document id
+   lookups become asserts.
+6. **Tests** — checksum-mismatch and missing-checksum error tests at the load boundary;
+   decoder tests move from error to panic expectations; full `make test`.
+7. **Design documentation** — the checksum trust boundary and the graph/trace integrity
+   mechanism get a home in `docs/architecture` (location chosen during this work; this
+   also discharges chartered follow-up 2 of lint-errcheck-remainder).
+
+## Wrinkles found and fixed during implementation
+
+1. **Typed round-trip instability.** Canonical bytes derived from a *decoded* trace do not
+   re-marshal byte-identically (typed receipt results and catalog resources are not a
+   marshal fixed point), so the first implementation's stamp and verify disagreed on
+   every freshly written trace. Fix: `canonicalTraceBytes` canonicalizes the RAW document
+   bytes (generic decode → strip integrity fields → re-marshal); `Trace.CanonicalContent`
+   and `op.LoadTrace` both route through it.
+2. **`signing.CanonicalDocument` stripped only `signature`.** With the new `checksum`
+   field in trace documents, signature verification in `writ verify` failed until the
+   integrity-field pair was stripped there too — aligning it with the canonical
+   convention (5-receipt-integrity.md).
+
+## Verification
+
+- New `op.LoadTrace` boundary tests in `pkg/op/trace_test.go`: round-trip, stamp
+  idempotence, missing-checksum refusal, tampered-document refusal.
+- Full `make test` green (including `writ verify`'s store-document policy tests, which
+  now exercise checksummed traces end to end); `make vet` pass; `gofmt -l` clean;
+  errcheck stays at 0; no new lint findings in touched files.
+
+## Design documentation
+
+`docs/architecture/5-receipt-integrity.md` gains "§ Document Integrity: Graphs and
+Traces" and "§ The Checksum Trust Boundary" — the architecture home for both rulings
+(discharges chartered follow-up 2 of lint-errcheck-remainder). Noted there and here:
+the doc's older receipt-checksum algorithm text predates `GitStyleChecksum` and needs
+reconciliation (chartered).

--- a/internal/cli/receipts.go
+++ b/internal/cli/receipts.go
@@ -97,6 +97,10 @@ func WriteTrace(trace *op.Trace) (string, error) {
 	filename := time.Now().UTC().Format("20060102T150405Z") + ".yaml"
 	path := filepath.Join(directory, filename)
 
+	if err := trace.StampChecksum(); err != nil {
+		return "", fmt.Errorf("stamp trace checksum: %w", err)
+	}
+
 	signArtifact(trace.Signature == nil, signing.NamespaceTrace, trace.SignWith)
 
 	if err := document.Write(path, trace); err != nil {
@@ -146,16 +150,30 @@ func LoadLatestTrace(graphChecksum string) (*op.Trace, error) {
 	return LoadTrace(LatestTracePath(graphChecksum))
 }
 
-// LoadTrace loads a single trace from `path`.
+// LoadTrace loads a single trace from `path`, verifying its tier-1 checksum.
+//
+// Every trace read funnels through here into [op.LoadTrace] — the checksum trust boundary. A trace with a
+// missing or mismatched checksum is refused (docs/architecture/5-receipt-integrity.md).
 //
 // Parameters:
 //   - `path`: the trace file to read.
 //
 // Returns:
-//   - *op.Trace: the deserialized trace.
-//   - `error`: non-nil if the file cannot be read or decoded.
+//   - *op.Trace: the deserialized, integrity-verified trace.
+//   - `error`: non-nil if the file cannot be read, decoded, or verified.
 func LoadTrace(path string) (*op.Trace, error) {
-	return document.ReadFile[op.Trace](path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read trace %s: %w", path, err)
+	}
+
+	trace, err := op.LoadTrace(data)
+	if err != nil {
+		return nil, fmt.Errorf("trace %s: %w", path, err)
+	}
+
+	return trace, nil
 }
 
 // signArtifact signs an unsigned artifact best effort at persist time (phase-8 step 46).

--- a/pkg/op/provider/file/receipt.go
+++ b/pkg/op/provider/file/receipt.go
@@ -263,7 +263,8 @@ func (r *Receipt) MarshalYAML() (any, error) {
 //   - `fields`: the receipt's id-reference sub-field, decoded to a format-neutral map.
 //
 // Returns:
-//   - `error`: a missing catalog, an unresolved id, or a malformed recovery field.
+//   - `error`: a missing catalog. The envelope arrives post-[op.LoadTrace] — checksum-verified — so an unresolved
+//     id or malformed field is a serialization bug and panics (docs/architecture/5-receipt-integrity.md).
 func (r *Receipt) RestoreEncoded(
 	runtimeEnvironment *op.RuntimeEnvironment,
 	base op.ReceiptData,
@@ -274,23 +275,11 @@ func (r *Receipt) RestoreEncoded(
 		return fmt.Errorf("file.Receipt: RestoreEncoded requires a runtime environment with a catalog")
 	}
 
-	resourceID, err := stringField(fields, "resource_id")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-
-	resource, err := lookupResource(runtimeEnvironment, resourceID)
-	if err != nil {
-		return err
-	}
-
-	transactionID, err := stringField(fields, "transaction_id")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
+	resource, err := lookupResource(runtimeEnvironment, stringField(fields, "resource_id"))
+	assert.NoError("file.Receipt: resource lookup", err)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
-	if err := r.Restore(op.ReceiptData{
+	assert.NoError("file.Receipt: restore base", r.Restore(op.ReceiptData{
 		ForwardAction:      base.ForwardAction,
 		CompensatingAction: base.CompensatingAction,
 		UnitID:             base.UnitID,
@@ -299,56 +288,28 @@ func (r *Receipt) RestoreEncoded(
 		Status:             base.Status,
 		CompensationError:  base.CompensationError,
 		ResourceURI:        resource.URI(),
-		TransactionID:      transactionID,
-	}); err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded restore base: %w", err)
+		TransactionID:      stringField(fields, "transaction_id"),
+	}))
+
+	if boundaryID := stringField(fields, "boundary_id"); boundaryID != "" {
+		r.boundary, err = lookupResource(runtimeEnvironment, boundaryID)
+		assert.NoError("file.Receipt: boundary lookup", err)
 	}
 
-	boundaryID, err := stringField(fields, "boundary_id")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-	if boundaryID != "" {
-		if r.boundary, err = lookupResource(runtimeEnvironment, boundaryID); err != nil {
-			return err
-		}
+	if sourceID := stringField(fields, "source_id"); sourceID != "" {
+		r.source, err = lookupResource(runtimeEnvironment, sourceID)
+		assert.NoError("file.Receipt: source lookup", err)
 	}
 
-	sourceID, err := stringField(fields, "source_id")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-	if sourceID != "" {
-		if r.source, err = lookupResource(runtimeEnvironment, sourceID); err != nil {
-			return err
-		}
+	if recoveryID := stringField(fields, "recovery_id"); recoveryID != "" {
+		r.recoveryID = assert.Must(uuid.Parse(recoveryID))
 	}
 
-	recoveryID, err := stringField(fields, "recovery_id")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-	if recoveryID != "" {
-		if r.recoveryID, err = uuid.Parse(recoveryID); err != nil {
-			return fmt.Errorf("file.Receipt: RestoreEncoded parse recovery_id %q: %w", recoveryID, err)
-		}
+	if recoveryDigest := stringField(fields, "recovery_digest"); recoveryDigest != "" {
+		r.recoveryDigest = assert.Must(op.ParseDigest(recoveryDigest))
 	}
 
-	recoveryDigest, err := stringField(fields, "recovery_digest")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-	if recoveryDigest != "" {
-		if r.recoveryDigest, err = op.ParseDigest(recoveryDigest); err != nil {
-			return fmt.Errorf("file.Receipt: RestoreEncoded parse recovery_digest %q: %w", recoveryDigest, err)
-		}
-	}
-
-	kind, err := stringField(fields, "kind")
-	if err != nil {
-		return fmt.Errorf("file.Receipt: RestoreEncoded: %w", err)
-	}
-	r.kind = MutationKind(kind)
+	r.kind = MutationKind(stringField(fields, "kind"))
 
 	return nil
 }
@@ -460,9 +421,10 @@ func lookupResource(runtimeEnvironment *op.RuntimeEnvironment, id string) (Entry
 
 // stringField returns the string value at `key` in a decoded receipt subfield, or "" when absent.
 //
-// The subfield arrives as a format-neutral map (decoded by whichever codec read the trace). Trace documents carry no
-// integrity checksum, so a present value of the wrong type is document corruption — an error, never a panic. Absence
-// stays "not present".
+// The subfield arrives as a format-neutral map (decoded by whichever codec read the trace) after [op.LoadTrace]
+// verified the trace's checksum, so a present value of the wrong type can only be a serialization bug — it panics
+// via [assert.Type] (docs/architecture/5-receipt-integrity.md § The Checksum Trust Boundary). Absence stays "not
+// present".
 //
 // Parameters:
 //   - `fields`: the decoded id-reference subfield.
@@ -470,20 +432,14 @@ func lookupResource(runtimeEnvironment *op.RuntimeEnvironment, id string) (Entry
 //
 // Returns:
 //   - `string`: the value, or "" when absent.
-//   - `error`: non-nil when the value is present but not a string.
-func stringField(fields map[string]any, key string) (string, error) {
+func stringField(fields map[string]any, key string) string {
 
 	raw, ok := fields[key]
 	if !ok {
-		return "", nil
+		return ""
 	}
 
-	value, ok := raw.(string)
-	if !ok {
-		return "", fmt.Errorf("field %q: expected string, got %T", key, raw)
-	}
-
-	return value, nil
+	return assert.Type[string]("receipt field "+key, raw)
 }
 
 // endregion

--- a/pkg/op/provider/pkg/receipt.go
+++ b/pkg/op/provider/pkg/receipt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -161,7 +162,9 @@ func (r *Receipt) MarshalYAML() (any, error) {
 //   - `fields`: the receipt sub-field, decoded to a format-neutral map.
 //
 // Returns:
-//   - `error`: a missing catalog, an unwrappable URI, or an [op.ReceiptBase.Restore] failure.
+//   - `error`: a missing catalog or a [DiscoverResource] failure (an external-system interaction). The envelope
+//     itself arrives post-[op.LoadTrace] — checksum-verified — so document-derived failures panic
+//     (docs/architecture/5-receipt-integrity.md).
 func (r *Receipt) RestoreEncoded(
 	runtimeEnvironment *op.RuntimeEnvironment, base op.ReceiptData, fields map[string]any,
 ) error {
@@ -170,10 +173,7 @@ func (r *Receipt) RestoreEncoded(
 		return fmt.Errorf("pkg.Receipt: RestoreEncoded requires a runtime environment with a catalog")
 	}
 
-	resourceURI, err := stringField(fields, "resource_uri")
-	if err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
+	resourceURI := stringField(fields, "resource_uri")
 
 	var resource op.Resource
 	if resourceURI != "" {
@@ -184,13 +184,8 @@ func (r *Receipt) RestoreEncoded(
 		resource = got
 	}
 
-	transactionID, err := stringField(fields, "transaction_id")
-	if err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
-
 	r.ReceiptBase = op.NewReceiptBase(resource)
-	if err := r.Restore(op.ReceiptData{
+	assert.NoError("pkg.Receipt: restore base", r.Restore(op.ReceiptData{
 		ForwardAction:      base.ForwardAction,
 		CompensatingAction: base.CompensatingAction,
 		UnitID:             base.UnitID,
@@ -199,26 +194,13 @@ func (r *Receipt) RestoreEncoded(
 		Status:             base.Status,
 		CompensationError:  base.CompensationError,
 		ResourceURI:        resourceURI,
-		TransactionID:      transactionID,
-	}); err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded restore: %w", err)
-	}
+		TransactionID:      stringField(fields, "transaction_id"),
+	}))
 
-	kind, err := stringField(fields, "kind")
-	if err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
-	r.kind = MutationKind(kind)
-
-	if r.Manager, err = stringField(fields, "manager"); err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
-	if r.InstalledBefore, err = boolField(fields, "installed_before"); err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
-	if r.PreviousVersion, err = stringField(fields, "previous_version"); err != nil {
-		return fmt.Errorf("pkg.Receipt: RestoreEncoded: %w", err)
-	}
+	r.kind = MutationKind(stringField(fields, "kind"))
+	r.Manager = stringField(fields, "manager")
+	r.InstalledBefore = boolField(fields, "installed_before")
+	r.PreviousVersion = stringField(fields, "previous_version")
 
 	return nil
 }
@@ -236,22 +218,17 @@ func (r *Receipt) RestoreEncoded(
 //   - `key`: the field name to read.
 //
 // Returns:
-//   - `string`: the value, or "" when absent.
-//   - `error`: non-nil when the value is present but not a string — trace documents carry no integrity checksum, so
-//     a mistyped field is document corruption: an error, never a panic.
-func stringField(fields map[string]any, key string) (string, error) {
+//   - `string`: the value, or "" when absent. A present non-string panics via [assert.Type] — the envelope is
+//     checksum-verified by [op.LoadTrace], so a mistype is a serialization bug
+//     (docs/architecture/5-receipt-integrity.md § The Checksum Trust Boundary).
+func stringField(fields map[string]any, key string) string {
 
 	raw, ok := fields[key]
 	if !ok {
-		return "", nil
+		return ""
 	}
 
-	value, ok := raw.(string)
-	if !ok {
-		return "", fmt.Errorf("field %q: expected string, got %T", key, raw)
-	}
-
-	return value, nil
+	return assert.Type[string]("receipt field "+key, raw)
 }
 
 // boolField returns the bool value at `key` in a decoded receipt sub-field, or false when absent or not a bool.
@@ -261,22 +238,17 @@ func stringField(fields map[string]any, key string) (string, error) {
 //   - `key`: the field name to read.
 //
 // Returns:
-//   - `bool`: the value, or false when absent.
-//   - `error`: non-nil when the value is present but not a bool — trace documents carry no integrity checksum, so a
-//     mistyped field is document corruption: an error, never a panic.
-func boolField(fields map[string]any, key string) (bool, error) {
+//   - `bool`: the value, or false when absent. A present non-bool panics via [assert.Type] — the envelope is
+//     checksum-verified by [op.LoadTrace], so a mistype is a serialization bug
+//     (docs/architecture/5-receipt-integrity.md § The Checksum Trust Boundary).
+func boolField(fields map[string]any, key string) bool {
 
 	raw, ok := fields[key]
 	if !ok {
-		return false, nil
+		return false
 	}
 
-	value, ok := raw.(bool)
-	if !ok {
-		return false, fmt.Errorf("field %q: expected bool, got %T", key, raw)
-	}
-
-	return value, nil
+	return assert.Type[bool]("receipt field "+key, raw)
 }
 
 // endregion

--- a/pkg/op/provider/service/receipt.go
+++ b/pkg/op/provider/service/receipt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -89,7 +90,9 @@ func (r *Receipt) MarshalYAML() (any, error) {
 //   - `fields`: the receipt's whole decoded object; `was_running` / `was_enabled` are read from it.
 //
 // Returns:
-//   - `error`: a missing catalog, a [DiscoverResource] failure, or an [op.ReceiptBase.Restore] failure.
+//   - `error`: a missing catalog. The envelope and the rehydrated catalog arrive post-[op.LoadTrace] —
+//     checksum-verified — so a missing or mistyped resource entry, a base-restore failure, or a mistyped flag
+//     field is a serialization bug and panics (docs/architecture/5-receipt-integrity.md).
 func (r *Receipt) RestoreEncoded(
 	runtimeEnvironment *op.RuntimeEnvironment, base op.ReceiptData, fields map[string]any,
 ) error {
@@ -102,35 +105,19 @@ func (r *Receipt) RestoreEncoded(
 	// namespace (a Resource.URI() is a canonical tag URI, not a DiscoverResource input).
 	catalog := runtimeEnvironment.ResourceCatalog
 	got, ok := catalog.Lookup(catalog.Current(base.ResourceURI))
-	if !ok {
-		return fmt.Errorf("service.Receipt: RestoreEncoded: resource %q not in catalog", base.ResourceURI)
-	}
-	resource, ok := got.(*Resource)
-	if !ok {
-		return fmt.Errorf("service.Receipt: RestoreEncoded: catalog entry for %q is %T, want *service.Resource",
-			base.ResourceURI, got)
-	}
+	assert.True("service.Receipt: resource in catalog", ok)
+	resource := assert.Type[*Resource]("service catalog entry", got)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
 
-	if err := r.Restore(base); err != nil {
-		return fmt.Errorf("service.Receipt: RestoreEncoded restore: %w", err)
-	}
+	assert.NoError("service.Receipt: restore base", r.Restore(base))
 
 	if raw, ok := fields["was_running"]; ok {
-		value, ok := raw.(bool)
-		if !ok {
-			return fmt.Errorf("service.Receipt: RestoreEncoded field %q: expected bool, got %T", "was_running", raw)
-		}
-		r.WasRunning = value
+		r.WasRunning = assert.Type[bool]("receipt field was_running", raw)
 	}
 
 	if raw, ok := fields["was_enabled"]; ok {
-		value, ok := raw.(bool)
-		if !ok {
-			return fmt.Errorf("service.Receipt: RestoreEncoded field %q: expected bool, got %T", "was_enabled", raw)
-		}
-		r.WasEnabled = value
+		r.WasEnabled = assert.Type[bool]("receipt field was_enabled", raw)
 	}
 
 	return nil

--- a/pkg/op/trace.go
+++ b/pkg/op/trace.go
@@ -50,21 +50,27 @@ type Trace struct {
 	// content-identity pair (Etag/Digest, phase-8 step 48) drift attribution reads back.
 	Catalog *ResourceLedgerSnapshot `json:"catalog,omitempty" yaml:"catalog,omitempty"`
 
+	// Checksum is the trace's own tier-1 integrity hash — [GitStyleChecksum]("trace", canonical) over
+	// [Trace.CanonicalContent] — stamped at persist by the store's WriteTrace and recomputed and compared by
+	// [LoadTrace]. Excluded (with Signature) from the canonical bytes, so integrity and authenticity verify
+	// independently. See docs/architecture/5-receipt-integrity.md § Document Integrity.
+	Checksum string `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+
 	// Signature is the trace's publisher signature, or nil when unsigned (phase-8 step 46). The raw signature
 	// covers `devlore.trace.v1 ‖ CanonicalContent`; the store's [WriteTrace] signs at persist, and
 	// [Trace.CanonicalContent] excludes this field so verification round-trips.
 	Signature *Signature `json:"signature,omitempty" yaml:"signature,omitempty"`
 }
 
-// CanonicalContent returns the trace's canonical bytes: its YAML document form without the signature field.
+// CanonicalContent returns the trace's canonical bytes: its YAML document form without the integrity fields.
 //
-// The canonical bytes are what the trace's signature covers (prefixed with the devlore.trace.v1 namespace by
-// the signer — phase-8 step 46, mirroring [Graph.CanonicalContent]). Unlike the graph — whose canonical
-// serialization is hand-built and round-trip-stable — the trace's live form holds typed values (receipt
+// The canonical bytes are what the trace's checksum and signature both cover (the signer prefixes the
+// devlore.trace.v1 namespace — phase-8 step 46, mirroring [Graph.CanonicalContent]). Unlike the graph — whose
+// canonical serialization is hand-built and round-trip-stable — the trace's live form holds typed values (receipt
 // results, catalog resources) that are not a marshal fixed point with their decoded document forms. Canonical
-// is therefore defined over the DOCUMENT form: marshal, decode generically, strip `signature`, re-marshal —
-// which produces identical bytes from a live trace and from a decoded document (yaml key ordering is stable),
-// so one signature verifies on both sides.
+// is therefore defined over the DOCUMENT form: marshal, decode generically, strip `checksum` and `signature`,
+// re-marshal — which produces identical bytes from a live trace and from a decoded document (yaml key ordering
+// is stable), so one checksum and one signature verify on both sides.
 //
 // Returns:
 //   - `[]byte`: the canonical YAML bytes.
@@ -76,17 +82,37 @@ func (t *Trace) CanonicalContent() ([]byte, error) {
 		return nil, fmt.Errorf("op.Trace.CanonicalContent: %w", err)
 	}
 
-	var generic map[string]any
-	if err := yaml.Unmarshal(document, &generic); err != nil {
-		return nil, fmt.Errorf("op.Trace.CanonicalContent: %w", err)
-	}
-	delete(generic, "signature")
-
-	canonical, err := yaml.Marshal(generic)
+	canonical, err := canonicalTraceBytes(document)
 	if err != nil {
 		return nil, fmt.Errorf("op.Trace.CanonicalContent: %w", err)
 	}
 	return canonical, nil
+}
+
+// canonicalTraceBytes canonicalizes a trace document's bytes: generic decode, strip the integrity fields, re-marshal.
+//
+// Both integrity checks derive their input through this one helper. [Trace.CanonicalContent] feeds it the live
+// trace's marshaled bytes; [LoadTrace] feeds it the raw document bytes as read. Canonicalizing the DOCUMENT (not a
+// decoded-then-re-marshaled typed trace) is what makes stamp and verify agree: a decoded trace's typed values
+// (receipt results, catalog resources) do not re-marshal to byte-identical form, but the generic map of the same
+// document does.
+//
+// Parameters:
+//   - `document`: the trace document's YAML bytes.
+//
+// Returns:
+//   - `[]byte`: the canonical YAML bytes, integrity fields stripped.
+//   - `error`: non-nil if a marshaling step fails.
+func canonicalTraceBytes(document []byte) ([]byte, error) {
+
+	var generic map[string]any
+	if err := yaml.Unmarshal(document, &generic); err != nil {
+		return nil, err
+	}
+	delete(generic, "checksum")
+	delete(generic, "signature")
+
+	return yaml.Marshal(generic)
 }
 
 // SignWith signs the trace through `sign`, setting the signature exactly once.
@@ -117,6 +143,62 @@ func (t *Trace) SignWith(sign func(canonical []byte) (*Signature, error)) error 
 
 	t.Signature = signature
 	return nil
+}
+
+// StampChecksum computes and sets the trace's tier-1 checksum over its canonical bytes.
+//
+// Idempotent: the canonical bytes exclude the checksum field, so restamping recomputes the same value. The
+// store's WriteTrace stamps at persist; [LoadTrace] recomputes and compares.
+//
+// Returns:
+//   - `error`: non-nil when canonicalization fails.
+func (t *Trace) StampChecksum() error {
+
+	canonical, err := t.CanonicalContent()
+	if err != nil {
+		return fmt.Errorf("op.Trace.StampChecksum: %w", err)
+	}
+
+	t.Checksum = GitStyleChecksum("trace", canonical)
+	return nil
+}
+
+// LoadTrace decodes a persisted trace document and verifies its tier-1 checksum.
+//
+// The verification is the trust boundary for every downstream trace consumer: an unreadable document, a
+// missing checksum, or a mismatch is an error — expected external corruption. Past this gate, decode
+// failures are bugs and panic (docs/architecture/5-receipt-integrity.md § The Checksum Trust Boundary).
+// There is no unverified read path: a trace written before checksums existed is refused.
+//
+// Parameters:
+//   - `data`: the trace document's YAML bytes.
+//
+// Returns:
+//   - `*Trace`: the decoded, integrity-verified trace.
+//   - `error`: non-nil on decode failure, a missing checksum, or a checksum mismatch.
+func LoadTrace(data []byte) (*Trace, error) {
+
+	var t Trace
+	if err := yaml.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("op.LoadTrace: yaml decode: %w", err)
+	}
+
+	if t.Checksum == "" {
+		return nil, fmt.Errorf("op.LoadTrace: document carries no checksum")
+	}
+
+	// Canonicalize the RAW document bytes — not the decoded trace, whose typed values do not re-marshal to
+	// byte-identical form. See [canonicalTraceBytes].
+	canonical, err := canonicalTraceBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("op.LoadTrace: %w", err)
+	}
+
+	if recomputed := GitStyleChecksum("trace", canonical); recomputed != t.Checksum {
+		return nil, fmt.Errorf("op.LoadTrace: checksum mismatch: document %q, recomputed %q", t.Checksum, recomputed)
+	}
+
+	return &t, nil
 }
 
 // Summary is the per-action tally of an execution, reconstructed from a [Trace] by [Trace.Summarize].

--- a/pkg/op/trace_test.go
+++ b/pkg/op/trace_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadTrace_RoundTrip(t *testing.T) {
+
+	trace := &Trace{GraphChecksum: "sha256:0123"}
+	if err := trace.StampChecksum(); err != nil {
+		t.Fatalf("StampChecksum: %v", err)
+	}
+
+	data, err := yaml.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	loaded, err := LoadTrace(data)
+	if err != nil {
+		t.Fatalf("LoadTrace: %v", err)
+	}
+	if loaded.GraphChecksum != trace.GraphChecksum {
+		t.Errorf("GraphChecksum = %q, want %q", loaded.GraphChecksum, trace.GraphChecksum)
+	}
+	if loaded.Checksum != trace.Checksum {
+		t.Errorf("Checksum = %q, want %q", loaded.Checksum, trace.Checksum)
+	}
+}
+
+func TestLoadTrace_StampIsIdempotent(t *testing.T) {
+
+	trace := &Trace{GraphChecksum: "sha256:0123"}
+	if err := trace.StampChecksum(); err != nil {
+		t.Fatalf("StampChecksum: %v", err)
+	}
+	first := trace.Checksum
+
+	if err := trace.StampChecksum(); err != nil {
+		t.Fatalf("StampChecksum (second): %v", err)
+	}
+	if trace.Checksum != first {
+		t.Errorf("restamp changed checksum: %q -> %q", first, trace.Checksum)
+	}
+}
+
+func TestLoadTrace_RefusesMissingChecksum(t *testing.T) {
+
+	data, err := yaml.Marshal(&Trace{GraphChecksum: "sha256:0123"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = LoadTrace(data)
+	if err == nil || !strings.Contains(err.Error(), "no checksum") {
+		t.Fatalf("LoadTrace = %v, want no-checksum error", err)
+	}
+}
+
+func TestLoadTrace_RefusesTamperedDocument(t *testing.T) {
+
+	trace := &Trace{GraphChecksum: "sha256:0123"}
+	if err := trace.StampChecksum(); err != nil {
+		t.Fatalf("StampChecksum: %v", err)
+	}
+
+	data, err := yaml.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	tampered := bytes.Replace(data, []byte("sha256:0123"), []byte("sha256:4567"), 1)
+	if bytes.Equal(tampered, data) {
+		t.Fatal("tamper had no effect on the document bytes")
+	}
+
+	_, err = LoadTrace(tampered)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("LoadTrace = %v, want checksum-mismatch error", err)
+	}
+}

--- a/pkg/signing/verify.go
+++ b/pkg/signing/verify.go
@@ -114,7 +114,7 @@ func Verify(signature *op.Signature, namespace string, canonical []byte, allowed
 }
 
 // CanonicalDocument returns a serialized document's canonical bytes: the generically-decoded document with
-// its `signature` key removed, re-marshaled.
+// its integrity fields (`checksum`, `signature`) removed, re-marshaled.
 //
 // This is the verify-side dual of the live artifacts' CanonicalContent for document-form canonicalization
 // (traces): decoding into the typed struct can be lossy (custom unmarshalers), so verification canonicalizes
@@ -132,6 +132,7 @@ func CanonicalDocument(data []byte) ([]byte, error) {
 	if err := yaml.Unmarshal(data, &generic); err != nil {
 		return nil, fmt.Errorf("signing.CanonicalDocument: %w", err)
 	}
+	delete(generic, "checksum")
 	delete(generic, "signature")
 
 	canonical, err := yaml.Marshal(generic)


### PR DESCRIPTION
Closes the integrity gap escalated 2026-07-27: traces and graphs now each carry checksums computed the exact same way (`GitStyleChecksum`, canonical-sans-integrity-fields), stamped at persist and verified on every load via the new `op.LoadTrace` funnel — missing or mismatched checksums are refused, with no legacy tolerance for pre-checksum traces. Two wrinkles found and fixed en route: canonical bytes must derive from the RAW document (typed traces don't re-marshal byte-identically), and `signing.CanonicalDocument` had to strip the integrity-field pair or trace signatures stopped verifying. With loads verified, the receipt decode path flips to the strict panic zone per the trust-boundary ruling (approved). Design home: `docs/architecture/5-receipt-integrity.md` § Document Integrity / § The Checksum Trust Boundary. Boundary tests added; full suite green; errcheck stays 0. Plan: `docs/plans/trace-checksum.md`.