### PR TITLE
fix(trace): stop serialization format leaking into trace identity

### DIFF
--- a/docs/architecture/5-receipt-integrity.md
+++ b/docs/architecture/5-receipt-integrity.md
@@ -105,6 +105,18 @@ Settled 2026-07-26/27. Every persisted run document carries a tier-1 checksum co
 authenticity verify independently. A document with a missing or mismatched checksum is refused at
 load — there is no unverified read path.
 
+**Format must never leak into identity** (settled 2026-07-27, after a leak was found and fixed):
+
+1. Every struct in a persisted document graph carries matching snake_case `json` and `yaml` tags —
+   an untagged field renders different keys per format (`name:` vs `Name`) and silently forks the
+   document. `Variable`/`VariableSource` were the violation; the cross-format identity tests
+   (`graph_format_identity_test.go`, `trace_format_identity_test.go`) are the regression net.
+2. Canonicalization normalizes format-variant scalars: timestamps render as UTC RFC3339Nano strings
+   (YAML parses unquoted RFC3339 into `time.Time`; JSON carries the same value as a string — see
+   `normalizeCanonicalValue` in `pkg/op/trace.go`).
+3. Still unlegislated (single-codec plan): non-integral float rendering, int64 beyond float64's 2^53
+   through `encoding/json`, and null-versus-absent semantics.
+
 ### The Checksum Trust Boundary
 
 Settled 2026-07-26: **the checksum is the trust boundary for documents read from disk.**

--- a/docs/plans/fix-trace-format-leak.md
+++ b/docs/plans/fix-trace-format-leak.md
@@ -1,0 +1,50 @@
+---
+title: "Fix the trace format leak"
+issue: TBD
+status: complete
+created: 2026-07-27
+updated: 2026-07-27
+---
+
+# Plan: Fix the trace format leak
+
+Escalated 2026-07-27 from the format-identity test evidence: a JSON-saved trace failed
+checksum verification while graphs passed all cross-format tests — serialization format
+was leaking into trace identity.
+
+## Root cause
+
+1. `Variable` and `VariableSource` serialized untagged, violating the snake_case-at-
+   serialization mandate: YAML lowercased their field names while JSON emitted Go names
+   (`name:` vs `"Name"`), forking the logical document per format.
+2. Timestamps: YAML parses unquoted RFC3339 scalars into `time.Time` while JSON documents
+   carry them as strings; the two re-marshal differently, so canonical bytes diverged
+   wherever `at:` appears.
+
+## Changes
+
+1. `pkg/op/variable.go` — `Variable` (`name`, `field` omitempty, `value`, `source`) and
+   `VariableSource` (`kind`, `name`) gain matching snake_case json+yaml tags.
+   (`VariableSourceKind` serializes as a number in both formats — symmetric, not a leak;
+   name-based serialization is a codec-plan candidate.)
+2. `pkg/op/trace.go` — `canonicalTraceBytes` normalizes format-variant scalars via
+   `normalizeCanonicalValue`: timestamps render as UTC RFC3339Nano strings.
+3. `pkg/op/trace_format_identity_test.go` — the two skipped tests un-skip; the fixture
+   gains a `Transitions` entry (proving the timestamp rule) and a populated
+   `VariableSource`. With `graph_format_identity_test.go` (all four passing since
+   creation), the eight tests are the permanent cross-format regression net.
+4. `docs/architecture/5-receipt-integrity.md` — "Format must never leak into identity"
+   rules recorded, including the still-unlegislated corners left to the single-codec plan
+   (non-integral floats, 2^53 through encoding/json, null-versus-absent).
+
+## Greenfield consequence
+
+Traces stamped under the broken canonical are refused after this lands (the recomputed
+canonical differs); new runs regenerate them. Same no-legacy stance as the checksum
+introduction.
+
+## Verification
+
+- All eight format-identity tests pass (graph 4, trace 4 — including JSON verify and
+  cross-format identity).
+- Full `make test` green; `make vet` pass; `gofmt -l` clean.

--- a/pkg/op/graph_format_identity_test.go
+++ b/pkg/op/graph_format_identity_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+)
+
+// formatIdentityGraph builds a graph whose origin annotations exercise the any-typed regions where JSON and
+// YAML decode differently (ints, bools, strings, lists, nested maps) — the risk surface for cross-format
+// checksum identity.
+func formatIdentityGraph(t *testing.T) *Graph {
+
+	t.Helper()
+
+	registry := ReceiverRegistry()
+
+	completeAction, err := registry.BuildAction("flow.complete")
+	if err != nil {
+		t.Fatalf("BuildAction(flow.complete): %v", err)
+	}
+
+	leaf, err := NewNode(NewNodeSpec().WithID("leaf").WithAction(completeAction))
+	if err != nil {
+		t.Fatalf("NewNode(leaf): %v", err)
+	}
+
+	origin := NewOriginBase("writ", "home", NewAnnotationMap(map[string]any{
+		"run_root": "/tmp/format-identity",
+		"order":    4,
+		"prune":    true,
+		"projects": []any{"alpha", "beta"},
+		"files": map[string]any{
+			"unit-1": map[string]any{"target": "/tmp/t", "layer": ""},
+		},
+	}))
+
+	graph, err := NewGraph(NewGraphSpec().WithOrigin(origin).WithUnits(leaf))
+	if err != nil {
+		t.Fatalf("NewGraph: %v", err)
+	}
+
+	return graph
+}
+
+// serializeGraph saves the graph through [Graph.Serialize] with the given encoder factory and returns the
+// document bytes — the same save surface WriteGraph and dry-run output use.
+func serializeGraph(t *testing.T, graph *Graph, format string) []byte {
+
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	var encoder Encoder
+	switch format {
+	case "json":
+		encoder = json.NewEncoder(&buf)
+	case "yaml":
+		encoder = yaml.NewEncoder(&buf)
+	default:
+		t.Fatalf("unsupported format %q", format)
+	}
+
+	if err := graph.Serialize(encoder); err != nil {
+		t.Fatalf("Serialize(%s): %v", format, err)
+	}
+
+	return buf.Bytes()
+}
+
+// formatIdentityEnvironment builds the loading environment LoadGraph requires.
+func formatIdentityEnvironment(t *testing.T) *RuntimeEnvironment {
+
+	t.Helper()
+
+	return NewRuntimeEnvironment(context.Background(),
+		NewRuntimeEnvironmentSpec("test").WithApplication(&application.Application{Name: "test"}))
+}
+
+func TestGraphChecksum_IdenticalAcrossJSONAndYAMLDocuments(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+
+	yamlDoc := serializeGraph(t, graph, "yaml")
+	jsonDoc := serializeGraph(t, graph, "json")
+
+	var fromYAML map[string]any
+	if err := yaml.Unmarshal(yamlDoc, &fromYAML); err != nil {
+		t.Fatalf("yaml decode: %v", err)
+	}
+
+	var fromJSON map[string]any
+	if err := json.Unmarshal(jsonDoc, &fromJSON); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+
+	yamlChecksum, _ := fromYAML["checksum"].(string)
+	jsonChecksum, _ := fromJSON["checksum"].(string)
+
+	if yamlChecksum == "" || jsonChecksum == "" {
+		t.Fatalf("stored checksums: yaml %q, json %q — want both non-empty", yamlChecksum, jsonChecksum)
+	}
+	if yamlChecksum != jsonChecksum {
+		t.Errorf("stored checksums differ: yaml %q, json %q", yamlChecksum, jsonChecksum)
+	}
+	if yamlChecksum != graph.Checksum() {
+		t.Errorf("stored checksum %q != live graph checksum %q", yamlChecksum, graph.Checksum())
+	}
+}
+
+func TestLoadGraph_YAMLDocumentVerifies(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+
+	loaded, err := LoadGraph(formatIdentityEnvironment(t), serializeGraph(t, graph, "yaml"), "yaml")
+	if err != nil {
+		t.Fatalf("LoadGraph(yaml): %v", err)
+	}
+
+	if loaded.Checksum() != graph.Checksum() {
+		t.Errorf("loaded checksum %q != original %q", loaded.Checksum(), graph.Checksum())
+	}
+}
+
+func TestLoadGraph_JSONDocumentVerifies(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+
+	loaded, err := LoadGraph(formatIdentityEnvironment(t), serializeGraph(t, graph, "json"), "json")
+	if err != nil {
+		t.Fatalf("LoadGraph(json): %v", err)
+	}
+
+	if loaded.Checksum() != graph.Checksum() {
+		t.Errorf("loaded checksum %q != original %q", loaded.Checksum(), graph.Checksum())
+	}
+}
+
+func TestLoadGraph_CrossFormatIdentity(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+	environment := formatIdentityEnvironment(t)
+
+	fromYAML, err := LoadGraph(environment, serializeGraph(t, graph, "yaml"), "yaml")
+	if err != nil {
+		t.Fatalf("LoadGraph(yaml): %v", err)
+	}
+
+	fromJSON, err := LoadGraph(environment, serializeGraph(t, graph, "json"), "json")
+	if err != nil {
+		t.Fatalf("LoadGraph(json): %v", err)
+	}
+
+	if fromYAML.Checksum() != fromJSON.Checksum() {
+		t.Errorf("cross-format checksums differ: yaml-loaded %q, json-loaded %q",
+			fromYAML.Checksum(), fromJSON.Checksum())
+	}
+	if fromYAML.Checksum() != graph.Checksum() {
+		t.Errorf("yaml-loaded checksum %q != original %q", fromYAML.Checksum(), graph.Checksum())
+	}
+}

--- a/pkg/op/trace.go
+++ b/pkg/op/trace.go
@@ -5,6 +5,7 @@ package op
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -112,7 +113,47 @@ func canonicalTraceBytes(document []byte) ([]byte, error) {
 	delete(generic, "checksum")
 	delete(generic, "signature")
 
+	for key, value := range generic {
+		generic[key] = normalizeCanonicalValue(value)
+	}
+
 	return yaml.Marshal(generic)
+}
+
+// normalizeCanonicalValue rewrites format-variant scalars into their canonical document form.
+//
+// YAML parses unquoted RFC3339 scalars into [time.Time] while the same logical value arrives from a JSON
+// document as a plain string, and the two re-marshal differently. Canonicalization renders every timestamp as
+// its UTC RFC3339Nano string, so both document families produce identical canonical bytes
+// (docs/architecture/5-receipt-integrity.md § Document Integrity).
+//
+// Parameters:
+//   - `value`: the generic-decoded value to normalize; maps and lists normalize recursively in place.
+//
+// Returns:
+//   - `any`: the normalized value.
+func normalizeCanonicalValue(value any) any {
+
+	switch v := value.(type) {
+
+	case time.Time:
+		return v.UTC().Format(time.RFC3339Nano)
+
+	case map[string]any:
+		for key, element := range v {
+			v[key] = normalizeCanonicalValue(element)
+		}
+		return v
+
+	case []any:
+		for i, element := range v {
+			v[i] = normalizeCanonicalValue(element)
+		}
+		return v
+
+	default:
+		return v
+	}
 }
 
 // SignWith signs the trace through `sign`, setting the signature exactly once.

--- a/pkg/op/trace_format_identity_test.go
+++ b/pkg/op/trace_format_identity_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// formatIdentityTrace builds a trace whose variables exercise the any-typed regions where JSON and YAML
+// decode differently (ints, bools, strings, lists, nested maps) — the risk surface for cross-format
+// checksum identity — and stamps its checksum the way WriteTrace does at persist.
+func formatIdentityTrace(t *testing.T) *Trace {
+
+	t.Helper()
+
+	trace := &Trace{
+		GraphChecksum: "sha256:0123",
+		Transitions: []RunStatusTransition{
+			{
+				Phase:     PhaseRunning,
+				Condition: ConditionHealthy,
+				At:        time.Date(2026, 7, 27, 1, 2, 3, 456789000, time.UTC),
+				UnitID:    "leaf",
+			},
+		},
+		Variables: map[string]Variable{
+			"order":    {Name: "order", Value: 4, Source: VariableSource{Kind: VariableSourceKindDefault, Name: "order"}},
+			"prune":    {Name: "prune", Value: true},
+			"run_root": {Name: "run_root", Value: "/tmp/format-identity"},
+			"projects": {Name: "projects", Value: []any{"alpha", "beta"}},
+			"files":    {Name: "files", Value: map[string]any{"unit-1": map[string]any{"target": "/tmp/t", "layer": ""}}},
+		},
+	}
+
+	if err := trace.StampChecksum(); err != nil {
+		t.Fatalf("StampChecksum: %v", err)
+	}
+
+	return trace
+}
+
+func TestTraceChecksum_IdenticalAcrossJSONAndYAMLDocuments(t *testing.T) {
+
+	trace := formatIdentityTrace(t)
+
+	yamlDoc, err := yaml.Marshal(trace)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+
+	jsonDoc, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	var fromYAML map[string]any
+	if err := yaml.Unmarshal(yamlDoc, &fromYAML); err != nil {
+		t.Fatalf("yaml decode: %v", err)
+	}
+
+	var fromJSON map[string]any
+	if err := json.Unmarshal(jsonDoc, &fromJSON); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+
+	yamlChecksum, _ := fromYAML["checksum"].(string)
+	jsonChecksum, _ := fromJSON["checksum"].(string)
+
+	if yamlChecksum == "" || jsonChecksum == "" {
+		t.Fatalf("stored checksums: yaml %q, json %q — want both non-empty", yamlChecksum, jsonChecksum)
+	}
+	if yamlChecksum != jsonChecksum {
+		t.Errorf("stored checksums differ: yaml %q, json %q", yamlChecksum, jsonChecksum)
+	}
+	if yamlChecksum != trace.Checksum {
+		t.Errorf("stored checksum %q != live trace checksum %q", yamlChecksum, trace.Checksum)
+	}
+}
+
+func TestLoadTrace_YAMLDocumentVerifies_RichTrace(t *testing.T) {
+
+	trace := formatIdentityTrace(t)
+
+	data, err := yaml.Marshal(trace)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+
+	loaded, err := LoadTrace(data)
+	if err != nil {
+		t.Fatalf("LoadTrace(yaml): %v", err)
+	}
+	if loaded.Checksum != trace.Checksum {
+		t.Errorf("loaded checksum %q != original %q", loaded.Checksum, trace.Checksum)
+	}
+}
+
+func TestLoadTrace_JSONDocumentVerifies(t *testing.T) {
+
+	trace := formatIdentityTrace(t)
+
+	data, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	loaded, err := LoadTrace(data)
+	if err != nil {
+		t.Fatalf("LoadTrace(json bytes): %v", err)
+	}
+	if loaded.Checksum != trace.Checksum {
+		t.Errorf("loaded checksum %q != original %q", loaded.Checksum, trace.Checksum)
+	}
+}
+
+func TestLoadTrace_CrossFormatIdentity(t *testing.T) {
+
+	trace := formatIdentityTrace(t)
+
+	yamlDoc, err := yaml.Marshal(trace)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+
+	jsonDoc, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	fromYAML, err := LoadTrace(yamlDoc)
+	if err != nil {
+		t.Fatalf("LoadTrace(yaml): %v", err)
+	}
+
+	fromJSON, err := LoadTrace(jsonDoc)
+	if err != nil {
+		t.Fatalf("LoadTrace(json bytes): %v", err)
+	}
+
+	if fromYAML.Checksum != fromJSON.Checksum {
+		t.Errorf("cross-format checksums differ: yaml-loaded %q, json-loaded %q",
+			fromYAML.Checksum, fromJSON.Checksum)
+	}
+	if fromYAML.Checksum != trace.Checksum {
+		t.Errorf("yaml-loaded checksum %q != original %q", fromYAML.Checksum, trace.Checksum)
+	}
+}

--- a/pkg/op/variable.go
+++ b/pkg/op/variable.go
@@ -50,11 +50,11 @@ func (k VariableSourceKind) String() string {
 type VariableSource struct {
 
 	// Kind identifies the source category. See [VariableSourceKind] for the enum.
-	Kind VariableSourceKind
+	Kind VariableSourceKind `json:"kind" yaml:"kind"`
 
 	// Name is the literal lookup key that matched. Examples: "WRIT_TARGET_ROOT" for an env hit;
 	// "target_root" for a flag/config/default hit.
-	Name string
+	Name string `json:"name" yaml:"name"`
 }
 
 // region EXPORTED METHODS
@@ -83,18 +83,18 @@ func (s VariableSource) String() string {
 type Variable struct {
 
 	// Name is the parameter name the variable satisfies. Matches the parameter declared via plan.variable(name).
-	Name string
+	Name string `json:"name" yaml:"name"`
 
 	// Field optionally projects one field out of a record-valued variable at resolve time — authored via
 	// plan.item(field) or plan.variable(name, field=...). Empty means the whole value (phase-8 step 45).
-	Field string
+	Field string `json:"field,omitempty" yaml:"field,omitempty"`
 
 	// Value is the resolved value, already parsed to the parameter's declared Go type by the resolver.
 	// Env-sourced strings are parsed; other sources supply already-typed values.
-	Value any
+	Value any `json:"value" yaml:"value"`
 
 	// Source records the source kind and lookup key that produced this value.
-	Source VariableSource
+	Source VariableSource `json:"source" yaml:"source"`
 }
 
 // region EXPORTED METHODS


### PR DESCRIPTION
The format-identity test evidence (graphs pass, JSON traces fail) pinned two leaks: `Variable`/`VariableSource` serialized untagged (YAML `name:` vs JSON `"Name"` — the snake_case mandate violation), and timestamps canonicalize differently per format. Fix: snake_case json+yaml tags on both structs, plus `normalizeCanonicalValue` in the trace canonicalization (timestamps → UTC RFC3339Nano strings). All eight cross-format identity tests now pass and ride along as the regression net. Rules recorded in `5-receipt-integrity.md` § Document Integrity; unlegislated corners (non-integral floats, 2^53 via encoding/json, null-vs-absent) chartered to the single-codec plan. Greenfield: pre-fix traces are refused and regenerate. Plan: `docs/plans/fix-trace-format-leak.md`.