### PR TITLE
docs(comments): single-line summaries in the three chartered files

### DIFF
--- a/docs/plans/docs-single-line-summaries.md
+++ b/docs/plans/docs-single-line-summaries.md
@@ -1,0 +1,32 @@
+---
+title: "Single-line doc summaries in the three chartered files"
+issue: TBD
+status: complete
+created: 2026-07-27
+updated: 2026-07-27
+---
+
+# Plan: Single-line doc summaries in the three chartered files
+
+Chartered follow-up 5 — the last of the original five — of
+[fix-windows-build-and-guide-category](fix-windows-build-and-guide-category.md).
+
+## Summary
+
+The mechanical sweep (first doc-comment line followed by a text line = violation) found
+nine pre-existing multi-line summaries in the three files the windows-build fix touched.
+Each is rewritten as a single-line summary, a blank comment line, then the elaboration —
+no content dropped, sentences relocated into the elaboration where the summary ran long.
+
+## Changes
+
+1. `pkg/op/default_funcs.go` — `fileModeType`, `defaultMode` (joined to one line),
+   `argFileMode` (list moved below the blank).
+2. `pkg/op/provider/file/helpers.go` — `errKindMismatch`, `buildCandidateAs`,
+   `internEntry`, `kindMismatchError`.
+3. `pkg/op/provider/file/provider.go` — `WriteFile`, `errConflictSkip`.
+
+## Verification
+
+- The sweep reports zero violations across all three files.
+- `make vet` pass (comment-only change); `gofmt -l` clean.

--- a/pkg/op/default_funcs.go
+++ b/pkg/op/default_funcs.go
@@ -9,8 +9,10 @@ import (
 	"reflect"
 )
 
-// fileModeType is the [reflect.Type] of [os.FileMode], cached so per-arg type-equality checks compare
-// pointers rather than reconstructing the type on every dispatch.
+// fileModeType is the cached [reflect.Type] of [os.FileMode].
+//
+// Caching lets per-arg type-equality checks compare pointers rather than reconstructing the type on
+// every dispatch.
 var fileModeType = reflect.TypeFor[os.FileMode]()
 
 func init() {
@@ -53,8 +55,7 @@ func defaultUmask(_ *RuntimeEnvironment, _ map[string]any, args []reflect.Value)
 	return reflect.ValueOf(base &^ processUmask()), nil
 }
 
-// defaultMode implements `{{ mode symbolic }}` — parses a 9-character POSIX permission string into
-// os.FileMode.
+// defaultMode implements `{{ mode symbolic }}` — parses a 9-character POSIX permission string into os.FileMode.
 //
 // The accepted form is exactly the 9-char `rwxrwxrwx` template with the dash character marking unset
 // bits, e.g., `"rwxr-x---"` (0o750). Position 0..2 is owner, 3..5 is group, 6..8 is other. Each
@@ -116,7 +117,9 @@ func defaultEnv(_ *RuntimeEnvironment, _ map[string]any, args []reflect.Value) (
 	return reflect.ValueOf(os.Getenv(args[0].String())), nil
 }
 
-// argFileMode extracts an os.FileMode from a reflect.Value. Accepts:
+// argFileMode extracts an os.FileMode from a reflect.Value.
+//
+// Accepts:
 //   - os.FileMode directly (type identity).
 //   - signed integer kinds (rejects negatives).
 //   - unsigned integer kinds.

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -24,8 +24,10 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// errKindMismatch marks a taxonomy kind-mismatch: the plan asserted one file kind, the disk shows another (phase-8
-// step 23, ruling 5e). Wrapped by [kindMismatchError]; test with errors.Is.
+// errKindMismatch marks a taxonomy kind-mismatch (phase-8 step 23, ruling 5e).
+//
+// The plan asserted one file kind, the disk shows another. Wrapped by [kindMismatchError]; test with
+// errors.Is.
 var errKindMismatch = errors.New("file kind mismatch")
 
 // applyChown changes the owner and/or group of path according to the Dockerfile-style ownership string spec.
@@ -71,8 +73,7 @@ func applyChown(path string, spec string) error {
 	return nil
 }
 
-// buildCandidateAs validates `value`, parses any file URI per RFC 8089, and constructs the [Resource] base carrying
-// the canonical type id of the requesting taxonomy variant.
+// buildCandidateAs validates `value`, parses any file URI per RFC 8089, and constructs the [Resource] base.
 //
 // The shared trunk of the variant constructors (phase-8 step 23): the returned base is embedded into the variant by
 // the caller, so the minted [op.ResourceBase] must already carry the variant's canonical type id — the key the
@@ -245,10 +246,10 @@ func contentDigest(root fsroot.Root, abs string) (digest op.Digest, err error) {
 	return op.Digest{Algorithm: "sha256", Bytes: h.Sum(nil)}, nil
 }
 
-// internEntry routes a constructed taxonomy candidate through the session catalog, asserting the canonical entry's
-// concrete type.
+// internEntry routes a constructed taxonomy candidate through the session catalog.
 //
-// The shared trunk of the variant constructors (phase-8 step 23). `claim` selects the catalog verb: true routes
+// It asserts the canonical entry's concrete type. The shared trunk of the variant constructors (phase-8
+// step 23). `claim` selects the catalog verb: true routes
 // through [op.ResourceCatalog.GetOrCreate] (a production claim stamped with `producerID`); false routes through
 // [op.ResourceCatalog.Discover] (no production claim; `producerID` is ignored). Nil-Catalog tolerance:
 // the unlinked candidate is returned as-is. A catalog entry of a different concrete type —
@@ -311,8 +312,9 @@ func isDirNotEmpty(err error) bool {
 	return errors.Is(err, syscall.ENOTEMPTY)
 }
 
-// kindMismatchError builds the taxonomy kind-mismatch error: the plan asserted one file kind, the disk shows another
-// (phase-8 step 23, ruling 5e).
+// kindMismatchError builds the taxonomy kind-mismatch error (phase-8 step 23, ruling 5e).
+//
+// The plan asserted one file kind, the disk shows another.
 //
 // Parameters:
 //   - `typeName`: the asserting variant's display name (e.g. "file.Regular").

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -906,10 +906,10 @@ func (p *Provider) WriteBytes(
 	return product, receipt, nil
 }
 
-// WriteFile creates or updates the file at `targetPath` by streaming `src` to disk, archiving any displaced
-// content for compensation.
+// WriteFile creates or updates the file at `targetPath` by streaming `src` to disk.
 //
-// It is the exported form of the streaming write core: bytes flow through [io.Copy] (constant memory, and the
+// Any displaced content is archived for compensation. It is the exported form of the streaming write
+// core: bytes flow through [io.Copy] (constant memory, and the
 // kernel copy_file_range/sendfile fast path when `src` is an [*os.File]), and any content already at `targetPath`
 // is archived to [op.RecoverySite] before the overwrite. Takes a path (step 23, ruling 2) and mints the
 // [*Regular] product internally with the activation's producer stamp. WriteFile applies no ownership change
@@ -1713,8 +1713,9 @@ func (p *Provider) openFile(abs string, flag int, perm os.FileMode) (*os.File, e
 	return root.OpenFile(root.NewPath(abs), flag, perm)
 }
 
-// errConflictSkip signals that the write-seam conflict policy elected to leave an occupied target untouched;
-// callers translate it to the no-op success shape (nil product, nil receipt, nil error), mirroring
+// errConflictSkip signals that the write-seam conflict policy elected to leave an occupied target untouched.
+//
+// Callers translate it to the no-op success shape (nil product, nil receipt, nil error), mirroring
 // [Provider.Remove]'s already-gone behavior.
 var errConflictSkip = errors.New("conflict policy skip: occupied target left untouched")
 


### PR DESCRIPTION
Chartered follow-up 5 — the last of the original five — of `docs/plans/fix-windows-build-and-guide-category.md`. Nine pre-existing multi-line doc summaries across `default_funcs.go`, `file/helpers.go`, and `file/provider.go` rewritten as single-line summary + blank + elaboration, no content dropped. The mechanical sweep reports zero violations; comment-only (vet passes, gofmt clean).