### PR TITLE
ci(sync): retry sync-PR merges; registry --admin; correct the stated mechanism

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -81,7 +81,32 @@ jobs:
             --body "$BODY" \
             --base develop)
           echo "Created PR: $PR_URL"
-          # --admin: the site's branch policy blocks a plain merge until required checks
-          # finish, and policy prevents --auto (ruling 2026-07-27). Requires the
-          # automation app to hold admin on the site repo.
-          gh pr merge "$PR_URL" --admin --squash --delete-branch
+          # --admin disarms gh's client-side merge-state veto, which reads the PR as
+          # BLOCKED while required checks are pending (the race that stranded site PR
+          # #209); the server-side entitlement is the NobleFactor Automation app's
+          # "always" bypass on the org ruleset, not repository admin rights. The
+          # ruleset's review requirement is what rules out --auto (ruling 2026-07-27).
+          # Retry bounded: a transient GitHub 5xx must not strand a green PR (a 502
+          # stranded site PR #212), and a failed attempt may still have merged
+          # server-side, so the PR state is consulted before retrying.
+          merged=false
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$PR_URL" --admin --squash --delete-branch; then
+              merged=true
+              break
+            fi
+            state=$(gh pr view "$PR_URL" --json state --jq .state || echo UNKNOWN)
+            if [ "$state" = "MERGED" ]; then
+              echo "merge attempt $attempt reported failure but the PR is merged"
+              merged=true
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "merge attempt $attempt failed (state: $state); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$merged" != "true" ]; then
+            echo "merge failed after 5 attempts" >&2
+            exit 1
+          fi

--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -110,4 +110,33 @@ jobs:
             --body "Automated knowledge sync from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA})." \
             --base "${{ github.ref_name }}")
           echo "Created PR: $PR_URL"
-          gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --squash --delete-branch
+          # devlore-registry develop sits under the same org ruleset as the site repo,
+          # and the plain merge already failed live: registry PR #69 was app-created,
+          # its run failed on this step, and the PR was merged by hand two minutes
+          # later. --admin disarms gh's client-side merge-state veto; the server-side
+          # entitlement is the NobleFactor Automation app's "always" bypass on the org
+          # ruleset, not repository admin rights. Retry bounded: a transient GitHub
+          # 5xx must not strand a green PR (a 502 stranded site PR #212), and a failed
+          # attempt may still have merged server-side, so the PR state is consulted
+          # before retrying.
+          merged=false
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --admin --squash --delete-branch; then
+              merged=true
+              break
+            fi
+            state=$(gh pr view "$PR_URL" --repo NobleFactor/devlore-registry --json state --jq .state || echo UNKNOWN)
+            if [ "$state" = "MERGED" ]; then
+              echo "merge attempt $attempt reported failure but the PR is merged"
+              merged=true
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "merge attempt $attempt failed (state: $state); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$merged" != "true" ]; then
+            echo "merge failed after 5 attempts" >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,9 +186,35 @@ jobs:
           Source: ${{ github.repository }}@${{ github.sha }}
           Ref: ${{ github.ref }}")
           echo "Created PR: $PR_URL"
-          # Merge directly per the #289 sync philosophy; --admin because the site's
-          # branch policy blocks a plain merge and policy prevents --auto (ruling
-          # 2026-07-27). Requires the automation app to hold admin on the site repo.
-          gh pr merge "$PR_URL" --repo NobleFactor/devlore.noblefactor.com --admin --squash --delete-branch
+          # Merge directly per the #289 sync philosophy. --admin disarms gh's
+          # client-side merge-state veto, which reads the PR as BLOCKED while required
+          # checks are pending (the race that stranded site PR #209); the server-side
+          # entitlement is the NobleFactor Automation app's "always" bypass on the org
+          # ruleset, not repository admin rights. The ruleset's review requirement is
+          # what rules out --auto (ruling 2026-07-27). Retry bounded: a transient
+          # GitHub 5xx must not strand a green PR (a 502 stranded site PR #212), and a
+          # failed attempt may still have merged server-side, so the PR state is
+          # consulted before retrying.
+          merged=false
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$PR_URL" --repo NobleFactor/devlore.noblefactor.com --admin --squash --delete-branch; then
+              merged=true
+              break
+            fi
+            state=$(gh pr view "$PR_URL" --repo NobleFactor/devlore.noblefactor.com --json state --jq .state || echo UNKNOWN)
+            if [ "$state" = "MERGED" ]; then
+              echo "merge attempt $attempt reported failure but the PR is merged"
+              merged=true
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "merge attempt $attempt failed (state: $state); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$merged" != "true" ]; then
+            echo "merge failed after 5 attempts" >&2
+            exit 1
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/docs/plans/ci-admin-merge-sync-prs.md
+++ b/docs/plans/ci-admin-merge-sync-prs.md
@@ -3,7 +3,7 @@ title: "Sync PRs merge with --admin"
 issue: TBD
 status: complete
 created: 2026-07-27
-updated: 2026-07-27
+updated: 2026-07-28
 ---
 
 # Plan: Sync PRs merge with --admin
@@ -27,6 +27,13 @@ Both merges run under the NobleFactor automation app's token. `--admin` requires
 to hold admin on devlore.noblefactor.com; if it does not, the next docs sync fails the
 same way and the remediation is granting the app admin on the site repo (owner lever).
 The next merge to develop is the live proof.
+
+**Correction (2026-07-28, verified live):** repository admin rights are not the mechanism.
+`--admin` only disarms gh's client-side merge-state veto (which reads the PR as BLOCKED
+while required checks are pending — the race that stranded site PR #209); the merge API
+then admits the app through its "always" bypass on the org ruleset, proven by site PR
+#211 merging with checks pending and zero reviews. Workflow comments corrected in
+[ci-sync-merge-retry](ci-sync-merge-retry.md).
 
 ## Verification
 

--- a/docs/plans/ci-sync-merge-retry.md
+++ b/docs/plans/ci-sync-merge-retry.md
@@ -1,0 +1,38 @@
+---
+title: "Sync merges: retry, registry --admin, corrected mechanism"
+issue: TBD
+status: complete
+created: 2026-07-28
+updated: 2026-07-28
+---
+
+# Plan: Sync merges — retry, registry --admin, corrected mechanism
+
+Chartered 2026-07-28 from the #300 live proof, which cut both ways: the `--admin` merge
+worked (site PR #211, merged by the app with checks pending and zero reviews), then the
+very next run's merge died on a GitHub 502 and stranded site PR #212 open with green
+checks. Separately, the registry sync still ran the pre-ruling plain merge.
+
+## Changes
+
+1. `docs-publish.yaml`, `release.yaml`, `knowledge-extract.yaml` — each sync merge runs
+   in a bounded retry loop (5 attempts, 10/20/30/40s backoff). A failed attempt consults
+   the PR state before retrying, because a 5xx can arrive after the merge landed
+   server-side; a PR found merged ends the loop as success. Exhaustion fails the step.
+2. `knowledge-extract.yaml` — the registry merge gains `--admin`. devlore-registry
+   develop sits under the same org ruleset as the site repo, and the plain merge already
+   failed live: registry PR #69 was app-created at 2026-07-25T06:59, its Knowledge
+   Extract run (06:58:09) failed on the merge step, and the PR was merged by hand two
+   minutes later.
+3. Mechanism comments corrected in all three files: `--admin` disarms gh's client-side
+   merge-state veto; the server-side entitlement is the automation app's "always" bypass
+   on the org ruleset — not repository admin rights. A correction note is added to
+   [ci-admin-merge-sync-prs](ci-admin-merge-sync-prs.md), which stated the admin-rights
+   mechanism.
+
+## Verification
+
+Workflow-only change (no Go). The live proof is the next sync chain run. The retry loop
+covers the observed stranding shape directly: merge reports failure, PR is actually
+merged — the state consultation converts that to success instead of a retry storm or a
+false failure.


### PR DESCRIPTION
The #300 live proof cut both ways: `--admin` worked (site PR #211, app-merged with checks pending), then the next run's merge died on a GitHub 502 and stranded site PR #212 green-but-open. All three sync merges (`docs-publish`, `release` install-script, `knowledge-extract` registry) now retry bounded (5 attempts, 10/20/30/40s backoff), consulting the PR state before each retry since a 5xx can arrive after the merge landed server-side. The registry merge gains `--admin` — same org ruleset, and its plain merge already failed live (registry PR #69: app-created, run failed on the merge step, hand-merged two minutes later). Mechanism comments corrected everywhere: `--admin` disarms gh's client-side merge-state veto; the server-side entitlement is the automation app's "always" bypass on the org ruleset, not repository admin rights. Plan: `docs/plans/ci-sync-merge-retry.md`.