### PR TITLE
lint(gocritic): eliminate range-value copies; suppress the map cases

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -406,8 +406,9 @@ func (r *Runner) buildResult(graph *op.Graph, tc *TestContext, tracer *Tracer, e
 // Returns:
 //   - `bool`: true if at least one expectation has kind "error".
 func hasErrorExpectation(tc *TestContext) bool {
-	for _, exp := range tc.Expectations() {
-		if exp.Kind == "error" {
+	expectations := tc.Expectations()
+	for i := range expectations {
+		if expectations[i].Kind == "error" {
 			return true
 		}
 	}

--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -116,16 +116,17 @@ func (tc *TestContext) SetResolvedVariables(v map[string]op.Variable) {
 func (tc *TestContext) Check(graph *op.Graph, execErr error) []Failure {
 	var failures []Failure
 
-	for _, exp := range tc.expectations {
+	for i := range tc.expectations {
+		exp := &tc.expectations[i]
 		switch exp.Kind {
 		case "file_exists":
-			f := tc.checkFileExists(exp)
+			f := tc.checkFileExists(*exp)
 			if f != nil {
 				failures = append(failures, *f)
 			}
 
 		case "no_file":
-			f := tc.checkNoFile(exp)
+			f := tc.checkNoFile(*exp)
 			if f != nil {
 				failures = append(failures, *f)
 			}
@@ -151,18 +152,18 @@ func (tc *TestContext) Check(graph *op.Graph, execErr error) []Failure {
 			}
 
 		case "error":
-			f := tc.checkError(exp, execErr)
+			f := tc.checkError(*exp, execErr)
 			if f != nil {
 				failures = append(failures, *f)
 			}
 
 		case "variable":
-			if f := tc.checkVariable(exp); f != nil {
+			if f := tc.checkVariable(*exp); f != nil {
 				failures = append(failures, *f)
 			}
 
 		case "variable_namespace":
-			if f := tc.checkVariableNamespace(exp); f != nil {
+			if f := tc.checkVariableNamespace(*exp); f != nil {
 				failures = append(failures, *f)
 			}
 

--- a/cmd/star/provider/goast/source_file.go
+++ b/cmd/star/provider/goast/source_file.go
@@ -610,12 +610,13 @@ func (sf *SourceFile) styleDoc(dc DocComment, ctx styleContext) DocComment {
 	// Execute productions in schema order.
 	var output []comment.Block
 	cursor := 0
-	for _, elem := range elems {
-		prod, err := NewProduction(elem)
+	for i := range elems {
+		elem := &elems[i]
+		prod, err := NewProduction(*elem)
 		if err != nil {
 			continue
 		}
-		out, next := prod.Execute(blocks, cursor, elem, ctx)
+		out, next := prod.Execute(blocks, cursor, *elem, ctx)
 		output = append(output, out...)
 		cursor = next
 	}

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -76,8 +76,9 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	byScope := make(map[string][]readback.Entry)
-	for _, entry := range selected {
-		byScope[entry.Scope] = append(byScope[entry.Scope], entry)
+	for i := range selected {
+		entry := &selected[i]
+		byScope[entry.Scope] = append(byScope[entry.Scope], *entry)
 	}
 
 	var graphs []*op.Graph
@@ -98,7 +99,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 		}()
 		encoder.SetIndent(2)
 		for _, graph := range graphs {
-			if err = graph.Serialize(encoder); err != nil {
+			if err := graph.Serialize(encoder); err != nil {
 				return err
 			}
 		}
@@ -159,8 +160,9 @@ func buildScopeGraph(
 		provider := plan.NewProvider(env)
 		fileMetas := make(map[string]any, len(entries))
 
-		for _, entry := range entries {
+		for i := range entries {
 
+			entry := &entries[i]
 			action := file.Remove
 			if entry.Action == string(file.Link) {
 				action = file.Unlink
@@ -297,6 +299,7 @@ func selectEntries(inventory *readback.Inventory, projects []string) []readback.
 	}
 
 	var selected []readback.Entry
+	//nolint:gocritic // rangeValCopy: map values are unaddressable; the per-iteration copy is the read.
 	for _, entry := range inventory.Entries {
 		if wanted[entry.Project] {
 			selected = append(selected, entry)

--- a/cmd/writ/writ/status/report.go
+++ b/cmd/writ/writ/status/report.go
@@ -257,12 +257,13 @@ func presentText(report *Report) error {
 func presentEntries(entries []Entry) {
 
 	byProject := make(map[string][]Entry)
-	for _, entry := range entries {
+	for i := range entries {
+		entry := &entries[i]
 		project := entry.Project
 		if project == "" {
 			project = "(unknown)"
 		}
-		byProject[project] = append(byProject[project], entry)
+		byProject[project] = append(byProject[project], *entry)
 	}
 
 	projects := make([]string, 0, len(byProject))
@@ -273,7 +274,9 @@ func presentEntries(entries []Entry) {
 
 	for _, project := range projects {
 		fmt.Printf("%s:\n", project)
-		for _, entry := range byProject[project] {
+		group := byProject[project]
+		for i := range group {
+			entry := &group[i]
 			line := fmt.Sprintf("  %s %s", entry.State, entry.Target)
 			if entry.Message != "" {
 				line += " (" + entry.Message + ")"
@@ -287,8 +290,8 @@ func presentEntries(entries []Entry) {
 	}
 
 	tally := make(map[State]int)
-	for _, entry := range entries {
-		tally[entry.State]++
+	for i := range entries {
+		tally[entries[i].State]++
 	}
 
 	ok := tally[StateLinked] + tally[StateCopied]

--- a/cmd/writ/writ/status/status.go
+++ b/cmd/writ/writ/status/status.go
@@ -105,6 +105,7 @@ func BuildReport(ctx context.Context, cfg *Config) (*Report, error) {
 		wanted[p] = true
 	}
 
+	//nolint:gocritic // rangeValCopy: map values are unaddressable; the per-iteration copy is the read.
 	for _, entry := range inventory.Entries {
 		if len(wanted) > 0 && !wanted[entry.Project] {
 			continue

--- a/cmd/writ/writ/status/status_integration_test.go
+++ b/cmd/writ/writ/status/status_integration_test.go
@@ -73,9 +73,9 @@ func statusConfig() *status.Config {
 func entryFor(t *testing.T, report *status.Report, target string) status.Entry {
 
 	t.Helper()
-	for _, entry := range report.Entries {
-		if entry.Target == target {
-			return entry
+	for i := range report.Entries {
+		if report.Entries[i].Target == target {
+			return report.Entries[i]
 		}
 	}
 	t.Fatalf("no entry for %s; entries: %+v", target, report.Entries)

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -112,8 +112,9 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	byScope := make(map[string][]readback.Entry)
-	for _, entry := range regenerate {
-		byScope[entry.Scope] = append(byScope[entry.Scope], entry)
+	for i := range regenerate {
+		entry := &regenerate[i]
+		byScope[entry.Scope] = append(byScope[entry.Scope], *entry)
 	}
 
 	scopes := make([]string, 0, len(byScope))
@@ -140,7 +141,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 		}()
 		encoder.SetIndent(2)
 		for _, graph := range graphs {
-			if err = graph.Serialize(encoder); err != nil {
+			if err := graph.Serialize(encoder); err != nil {
 				return err
 			}
 		}
@@ -192,18 +193,20 @@ func classify(cfg *Config, copied []readback.Entry, data map[string]any) ([]read
 	var regenerate []readback.Entry
 	var skipped []string
 
-	for _, entry := range copied {
+	for i := range copied {
 
-		switch classifyEntry(entry, data) {
+		entry := &copied[i]
+
+		switch classifyEntry(*entry, data) {
 
 		case classMissing:
-			regenerate = append(regenerate, entry)
+			regenerate = append(regenerate, *entry)
 
 		case classStale:
 			if cfg.Verbose {
 				cli.Note("%s: source changed, target unmodified — regenerating", entry.Target)
 			}
-			regenerate = append(regenerate, entry)
+			regenerate = append(regenerate, *entry)
 
 		case classUpToDate:
 			if cfg.Verbose {
@@ -215,14 +218,14 @@ func classify(cfg *Config, copied []readback.Entry, data map[string]any) ([]read
 
 		case classModified:
 			if cfg.Force {
-				regenerate = append(regenerate, entry)
+				regenerate = append(regenerate, *entry)
 			} else {
 				skipped = append(skipped, entry.Target+" (locally modified)")
 			}
 
 		default: // classDiffering, classUnverifiable — indeterminate
 			if cfg.Force {
-				regenerate = append(regenerate, entry)
+				regenerate = append(regenerate, *entry)
 			} else {
 				skipped = append(skipped, entry.Target+" (indeterminate)")
 			}
@@ -367,8 +370,8 @@ func buildScopeGraph(
 		return nil, fmt.Errorf("scope %q: deployed entries carry no target root; cannot confine the upgrade", scope)
 	}
 	targetRoot := runRoot
-	for _, entry := range entries {
-		runRoot = deploy.CommonAncestor(runRoot, filepath.Dir(entry.Source))
+	for i := range entries {
+		runRoot = deploy.CommonAncestor(runRoot, filepath.Dir(entries[i].Source))
 	}
 
 	spec, err := upgradeSpec(runRoot, cfg.DryRun)
@@ -381,8 +384,9 @@ func buildScopeGraph(
 		provider := plan.NewProvider(env)
 		fileMetas := make(map[string]any, len(entries))
 
-		for _, entry := range entries {
+		for i := range entries {
 
+			entry := &entries[i]
 			_, operations := tree.ProcessingPipeline(filepath.Base(entry.Source))
 
 			finalInvocation, action, err := deploy.PlanFileChain(provider, &tree.FileEntry{
@@ -518,6 +522,7 @@ func selectCopied(inventory *readback.Inventory, projects []string) []readback.E
 	}
 
 	var copied []readback.Entry
+	//nolint:gocritic // rangeValCopy: map values are unaddressable; the per-iteration copy is the read.
 	for _, entry := range inventory.Entries {
 		if entry.Action == string(file.Link) {
 			continue

--- a/docs/plans/lint-range-value-copies.md
+++ b/docs/plans/lint-range-value-copies.md
@@ -1,0 +1,39 @@
+---
+title: "Class a: range-value copies"
+issue: TBD
+status: complete
+created: 2026-07-31
+updated: 2026-07-31
+---
+
+# Plan: Class a — range-value copies
+
+First rung of the 4b-3 ladder (per-class discuss-then-fix, ruled 2026-07-30; this session
+owns the ladder). Class a's original mechanical checks (octalLiteral, sloppyReassign,
+paramTypeCombine, emptyStringTest, misspell, unlambda, sprintfQuotedString, errorlint,
+goimports) were retired by a parallel session; the residual is rangeValCopy.
+
+## Site survey
+
+All seventeen bodies read: every one is read-only (grouping appends, report formatting,
+tallies, plan construction, stack decode) — zero mutating-copy cases. Three of the
+seventeen range over `Inventory.Entries`, a `map[string]Entry`, whose values are
+unaddressable — the pointer transform is impossible there.
+
+## Changes
+
+1. Fourteen slice loops: `for i := range s` with `entry := &s[i]` (or direct indexing for
+   one-field bodies) — the per-iteration copy goes away; appends and by-value calls
+   dereference (`*entry`), netting one copy where the old form made two.
+2. Three map loops (`decommission.go` selectEntries, `status.go` report build,
+   `upgrade.go` copied-entry filter): justified suppression —
+   `//nolint:gocritic // rangeValCopy: map values are unaddressable; the per-iteration
+   copy is the read.`
+3. Value storage stays value storage (settled in discussion 2026-07-31: identity-as-data;
+   interning is reserved for multi-referent identities, which the ResourceCatalog already
+   implements).
+
+## Verification
+
+- rangeValCopy: 17 → 0 (uncapped).
+- `make vet` pass; full `make test` pass; `gofmt -l` clean.

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -478,7 +478,9 @@ func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) error {
 
 	s.entries = make([]recoveryEntry, 0, len(entries))
 
-	for _, e := range entries {
+	for i := range entries {
+
+		e := &entries[i]
 
 		if e.stack != nil {
 			s.entries = append(s.entries, recoveryEntry{compensator: e.stack})


### PR DESCRIPTION
Class a of the 4b-3 ladder (per-class discuss-then-fix; this session owns the ladder). Site survey: all seventeen bodies are read-only. Fourteen slice loops convert to index+pointer iteration — value storage stays, per the settled identity-as-data design; appends and by-value calls dereference, netting one copy where the old form made two. The three `map[string]Entry` loops get a justified suppression (map values are unaddressable). rangeValCopy 17 → 0; vet and full suite green. Plan: `docs/plans/lint-range-value-copies.md`.