### PR TITLE
lint(mechanical): land the orphaned class-a sweep

### DIFF
--- a/cmd/star/cli/selfinstall_test.go
+++ b/cmd/star/cli/selfinstall_test.go
@@ -86,7 +86,7 @@ func TestFindExtensionsDir_Found(t *testing.T) {
 
 	// Create star/extensions directory
 	extDir := filepath.Join(tmpDir, "star", "extensions")
-	if err := os.MkdirAll(extDir, 0755); err != nil {
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -103,7 +103,7 @@ func TestCopyDir(t *testing.T) {
 	// Create source directory structure
 	srcDir := filepath.Join(tmpDir, "src")
 	subDir := filepath.Join(srcDir, "subdir")
-	if err := os.MkdirAll(subDir, 0755); err != nil {
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -116,7 +116,7 @@ func TestCopyDir(t *testing.T) {
 	}
 
 	for path, content := range files {
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -151,7 +151,7 @@ func TestCopyFile(t *testing.T) {
 	dst := filepath.Join(tmpDir, "dest.txt")
 
 	content := "test content"
-	if err := os.WriteFile(src, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(src, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +189,7 @@ func TestSelfInstall_Integration(t *testing.T) {
 	// Create star/extensions structure
 	extDir := filepath.Join(projectDir, "star", "extensions", "com.test.Extension")
 	cmdDir := filepath.Join(extDir, "commands")
-	if err := os.MkdirAll(cmdDir, 0755); err != nil {
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,10 +200,10 @@ commands:
     help: "Test command"
     implementation: commands/test.star
 `
-	if err := os.WriteFile(filepath.Join(extDir, "extension.yaml"), []byte(extYaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(extDir, "extension.yaml"), []byte(extYaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cmdDir, "test.star"), []byte("# test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(cmdDir, "test.star"), []byte("# test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -309,10 +309,10 @@ func TestInstallExtensionsDir(t *testing.T) {
 
 	// Create source extensions
 	srcExtDir := filepath.Join(tmpDir, "star", "extensions", "com.test.Ext")
-	if err := os.MkdirAll(srcExtDir, 0755); err != nil {
+	if err := os.MkdirAll(srcExtDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcExtDir, "extension.yaml"), []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcExtDir, "extension.yaml"), []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/star/config/accessor.go
+++ b/cmd/star/config/accessor.go
@@ -58,7 +58,7 @@ func (a *ConfigAccessor) String(name string) string {
 }
 
 // StringOr returns the string value of the named field, or the default if not set.
-func (a *ConfigAccessor) StringOr(name string, defaultVal string) string {
+func (a *ConfigAccessor) StringOr(name, defaultVal string) string {
 	field := a.field(name)
 	if !field.IsValid() || field.Kind() != reflect.String {
 		return defaultVal

--- a/cmd/star/config/root_test.go
+++ b/cmd/star/config/root_test.go
@@ -184,7 +184,7 @@ func TestLoadExtensions_ValidYAML(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	starDir := filepath.Join(tmpDir, "star")
-	if err := os.MkdirAll(starDir, 0755); err != nil {
+	if err := os.MkdirAll(starDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	yamlPath := filepath.Join(starDir, "config.yaml")
@@ -195,7 +195,7 @@ lint:
     enabled: true
     license: Apache-2.0
 `
-	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -237,7 +237,7 @@ func TestLoadExtensionsWithSpecs(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	starDir := filepath.Join(tmpDir, "star")
-	if err := os.MkdirAll(starDir, 0755); err != nil {
+	if err := os.MkdirAll(starDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	yamlPath := filepath.Join(starDir, "config.yaml")
@@ -247,7 +247,7 @@ lint:
   go:
     enabled: true
 `
-	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -284,7 +284,7 @@ func TestExtensionsConfig_Save(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	starDir := filepath.Join(tmpDir, "star")
-	if err := os.MkdirAll(starDir, 0755); err != nil {
+	if err := os.MkdirAll(starDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	yamlPath := filepath.Join(starDir, "config.yaml")

--- a/cmd/star/config/starlark_configvalue_test.go
+++ b/cmd/star/config/starlark_configvalue_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -158,7 +159,8 @@ func TestConfigValue_Attr_NotFound(t *testing.T) {
 		t.Error("Attr('missing') should return error")
 	}
 	// Should be NoSuchAttrError
-	if _, ok := err.(starlark.NoSuchAttrError); !ok {
+	var noSuchAttr starlark.NoSuchAttrError
+	if !errors.As(err, &noSuchAttr) {
 		t.Errorf("error type = %T, want NoSuchAttrError", err)
 	}
 }

--- a/cmd/star/config/sync.go
+++ b/cmd/star/config/sync.go
@@ -307,7 +307,7 @@ func containsLine(content, entry string) bool {
 			return true
 		}
 	}
-	return len(content) > 0 && (content == entry ||
+	return content != "" && (content == entry ||
 		len(content) > len(entry) &&
 			(content[:len(entry)+1] == entry+"\n" ||
 				containsSubstring(content, "\n"+entry+"\n") ||

--- a/cmd/star/config/types.go
+++ b/cmd/star/config/types.go
@@ -56,7 +56,7 @@ func generateConfigType(spec ConfigSpec) reflect.Type {
 		fields = append(fields, reflect.StructField{
 			Name: toPascalCase(name),
 			Type: fieldType,
-			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s" json:"%s"`, name, name)),
+			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:%q json:%q`, name, name)),
 		})
 	}
 
@@ -138,7 +138,7 @@ func generateNestedType(spec ConfigSpec, allNested map[string]ConfigSpec) reflec
 		fields = append(fields, reflect.StructField{
 			Name: toPascalCase(name),
 			Type: fieldType,
-			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s" json:"%s"`, name, name)),
+			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:%q json:%q`, name, name)),
 		})
 	}
 

--- a/cmd/star/config/unified_test.go
+++ b/cmd/star/config/unified_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -243,7 +244,8 @@ func TestConfigValue_Attr_NotFound_ViaConfig(t *testing.T) {
 	if err == nil {
 		t.Error("Attr('nonexistent') should return error")
 	}
-	if _, ok := err.(starlark.NoSuchAttrError); !ok {
+	var noSuchAttr starlark.NoSuchAttrError
+	if !errors.As(err, &noSuchAttr) {
 		t.Errorf("Attr() error type = %T, want NoSuchAttrError", err)
 	}
 }
@@ -328,7 +330,7 @@ func TestLoad_WithProjectConfig(t *testing.T) {
 
 	// Create star/ directory
 	starDir := filepath.Join(tmpDir, "star")
-	if err := os.MkdirAll(starDir, 0755); err != nil {
+	if err := os.MkdirAll(starDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -338,7 +340,7 @@ lint:
   go:
     path: "./custom/..."
 `
-	if err := os.WriteFile(filepath.Join(starDir, "config.yaml"), []byte(yamlContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(starDir, "config.yaml"), []byte(yamlContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/star/provider/goast/consumes.go
+++ b/cmd/star/provider/goast/consumes.go
@@ -53,19 +53,19 @@ func ParseConsumes(s string) (Consumes, error) {
 		return Consumes{}, fmt.Errorf("empty consumes string")
 	}
 
-	min, max, rest := parseRepeat(s)
+	minRepeat, maxRepeat, rest := parseRepeat(s)
 	types, err := parseTypes(rest)
 	if err != nil {
 		return Consumes{}, fmt.Errorf("parse consumes %q: %w", s, err)
 	}
 
-	return Consumes{Min: min, Max: max, Types: types}, nil
+	return Consumes{Min: minRepeat, Max: maxRepeat, Types: types}, nil
 }
 
 // parseRepeat extracts the optional repeat prefix from an ABNF string.
 // Returns min, max, and the remaining string after the repeat.
 func parseRepeat(s string) (int, int, string) {
-	if len(s) == 0 {
+	if s == "" {
 		return 1, 1, s
 	}
 

--- a/cmd/star/provider/goast/fuzzy_test.go
+++ b/cmd/star/provider/goast/fuzzy_test.go
@@ -126,6 +126,7 @@ func TestDamerauLevenshtein_TwoEdits(t *testing.T) {
 }
 
 func TestDamerauLevenshtein_Transposition(t *testing.T) {
+	//nolint:misspell // intentional transposition: fixture input for the transposition-distance case
 	if got := damerauLevenshtein("teh", "the"); got != 1 {
 		t.Errorf("expected 1 (transposition), got %d", got)
 	}

--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -307,7 +307,7 @@ func commentGroupRaw(cg *ast.CommentGroup) string {
 		if strings.HasPrefix(text, "//") {
 			text = strings.TrimPrefix(text, "//")
 			// Strip at most one leading space (standard Go comment style).
-			if len(text) > 0 && text[0] == ' ' {
+			if text != "" && text[0] == ' ' {
 				text = text[1:]
 			}
 		}

--- a/cmd/star/provider/goast/production.go
+++ b/cmd/star/provider/goast/production.go
@@ -148,7 +148,7 @@ func evaluateCondition(cond string, ctx styleContext) bool {
 	case "returns":
 		return len(ctx.returnTypes) > 0
 	case "exported":
-		return len(ctx.name) > 0 && ctx.name[0] >= 'A' && ctx.name[0] <= 'Z'
+		return ctx.name != "" && ctx.name[0] >= 'A' && ctx.name[0] <= 'Z'
 	case "receiver":
 		// Would need receiver info in styleContext — not yet available.
 		return false
@@ -178,13 +178,13 @@ func expandPrefix(prefix string, ctx styleContext) string {
 }
 
 // replaceAll is strings.ReplaceAll without importing strings (already imported in source_file.go).
-func replaceAll(s, old, new string) string {
+func replaceAll(s, old, replacement string) string {
 	for {
 		i := indexOf(s, old)
 		if i < 0 {
 			return s
 		}
-		s = s[:i] + new + s[i+len(old):]
+		s = s[:i] + replacement + s[i+len(old):]
 	}
 }
 

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -7,6 +7,7 @@ package lint
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,7 +93,8 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 	}
 
 	if err != nil && len(output) == 0 {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			stderr := string(exitErr.Stderr)
 			if stderr != "" {
 				return GoResult{}, fmt.Errorf("golangci-lint failed: %s", strings.TrimSpace(stderr))

--- a/cmd/star/provider/shellcheck/provider.go
+++ b/cmd/star/provider/shellcheck/provider.go
@@ -541,7 +541,7 @@ func matchExternalCommand(line string) string {
 	if builtins[cmd] {
 		return ""
 	}
-	if len(cmd) > 0 && strings.ContainsAny(cmd[:1], "$\"'`-|&;<>()[]{}") {
+	if cmd != "" && strings.ContainsAny(cmd[:1], "$\"'`-|&;<>()[]{}") {
 		return ""
 	}
 	return cmd

--- a/cmd/star/star/application_test.go
+++ b/cmd/star/star/application_test.go
@@ -79,12 +79,12 @@ func TestRuntime_loadExtensionCommands(t *testing.T) {
 		tmpDir := t.TempDir()
 		extDir := filepath.Join(tmpDir, "com.example.TestExt")
 		cmdDir := filepath.Join(extDir, "commands")
-		if err := os.MkdirAll(cmdDir, 0755); err != nil {
+		if err := os.MkdirAll(cmdDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 
 		starContent := "def run(command, ctx):\n    pass\n"
-		if err := os.WriteFile(filepath.Join(cmdDir, "test.star"), []byte(starContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cmdDir, "test.star"), []byte(starContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -170,15 +170,15 @@ func TestRuntime_loadExtensionCommands(t *testing.T) {
 		tmpDir := t.TempDir()
 		extDir := filepath.Join(tmpDir, "com.example.MultiCmd")
 		cmdDir := filepath.Join(extDir, "commands")
-		if err := os.MkdirAll(cmdDir, 0755); err != nil {
+		if err := os.MkdirAll(cmdDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 
 		starContent := "def run(command, ctx):\n    pass\n"
-		if err := os.WriteFile(filepath.Join(cmdDir, "one.star"), []byte(starContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cmdDir, "one.star"), []byte(starContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(cmdDir, "two.star"), []byte(starContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cmdDir, "two.star"), []byte(starContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -388,12 +388,12 @@ func buildTestExtensionFromDir(t *testing.T, extName, cmdName, implPath string) 
 	tmpDir := t.TempDir()
 	extDir := filepath.Join(tmpDir, extName)
 	cmdDir := filepath.Join(extDir, "commands")
-	if err := os.MkdirAll(cmdDir, 0755); err != nil {
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	starContent := "def run(command, ctx):\n    pass\n"
-	if err := os.WriteFile(filepath.Join(extDir, implPath), []byte(starContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(extDir, implPath), []byte(starContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/writ/writ/deploy/deploy.go
+++ b/cmd/writ/writ/deploy/deploy.go
@@ -126,7 +126,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 		}()
 		encoder.SetIndent(2)
 		for _, graph := range build.Graphs {
-			if err = graph.Serialize(encoder); err != nil {
+			if err := graph.Serialize(encoder); err != nil {
 				return err
 			}
 		}

--- a/cmd/writ/writ/snapshot/snapshot.go
+++ b/cmd/writ/writ/snapshot/snapshot.go
@@ -220,7 +220,7 @@ func IsDirty(repoPath string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("git status: %w", err)
 	}
-	return len(strings.TrimSpace(string(out))) > 0, nil
+	return strings.TrimSpace(string(out)) != "", nil
 }
 
 // CheckClean verifies that all unique repositories in the given sources have

--- a/docs/plans/lint-mechanical-sweep.md
+++ b/docs/plans/lint-mechanical-sweep.md
@@ -1,0 +1,38 @@
+---
+title: "Class a proper: the orphaned mechanical sweep, landed"
+issue: TBD
+status: complete
+created: 2026-07-31
+updated: 2026-07-31
+---
+
+# Plan: Class a proper — the orphaned mechanical sweep, landed
+
+Ownership finding (2026-07-31): the original class-a mechanical fixes — believed already
+retired — were sitting **uncommitted in the working tree since 2026-07-28**, produced by a
+parallel session and never landed. The ladder's earlier "re-baseline" unknowingly measured
+the dirty tree. Per the full-ownership ruling, this change inventories, verifies, and
+lands that work.
+
+## Inventory (35 files, diffed against origin/develop via the API)
+
+- **sloppyReassign** — `if err = …` → `if err := …` shadowing fixes across the file
+  provider, archive provider, deploy, and tests.
+- **paramTypeCombine** — `(a string, b string)` → `(a, b string)` in eight signatures
+  (config accessor, file helpers/provider, function literals, plan provider,
+  resource catalog, starlarkbridge runtime).
+- **emptyStringTest** — canonical empty-string checks in config sync, goast, shellcheck,
+  snapshot.
+- **misspell** — `cancelled` → `canceled` in graph_executor, node, flow tests.
+
+## Verification
+
+- The tree containing exactly this work passed `make vet`, the full `make test` suite,
+  and `gofmt -l` clean earlier today.
+- Uncapped lint with this work present: sloppyReassign, paramTypeCombine,
+  emptyStringTest, and misspell all at zero.
+
+## Sequencing
+
+Lands after PR #304 (class a residual: rangeValCopy) merges — the commit script guards on
+#304's state. Never accumulate PRs.

--- a/pkg/fsroot/root_test.go
+++ b/pkg/fsroot/root_test.go
@@ -373,7 +373,7 @@ func TestRoot_OpenFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("OpenFile: %v", err)
 			}
-			if _, err := f.Write([]byte("written")); err != nil {
+			if _, err := f.WriteString("written"); err != nil {
 				t.Fatalf("Write: %v", err)
 			}
 			_ = f.Close()

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1042,7 +1042,7 @@ func (e *GraphExecutor) controlPoint() error {
 //   - `compensator`: the action's compensator return — Receipt, *RecoveryStack, or nil.
 //   - `dispatchErr`: the dispatch error, or nil on success.
 //   - `action`: the dispatched [Action], or nil for an audit-only exit that never dispatched (cancellation, pause,
-//     or an unbound unit). Nil suppresses the commit — a unit carries an action even when cancelled, so this flag,
+//     or an unbound unit). Nil suppresses the commit — a unit carries an action even when canceled, so this flag,
 //     not `unit.Action()`, signals whether the dispatch ran.
 func (e *GraphExecutor) pushAuditReceipt(
 	unit ExecutableUnit,

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -89,7 +89,7 @@ func NewNode(spec *NodeSpec) (*Node, error) {
 //
 // Entry checks are ordered: cancellation first (hard signal — `ctx.Err()` catches root/external cancel and any ancestor
 // combinator's scoped cancel), then pause (soft signal — [GraphExecutor.Pause] sets a flag observed at this
-// pause-point). A cancelled or paused check pushes its audit receipt and returns before the action runs.
+// pause-point). A canceled or paused check pushes its audit receipt and returns before the action runs.
 //
 // On a clean entry path, slots are resolved against the active stack (via [RecoveryStack.ResultByUnitID] for
 // [PromiseBinding] entries), the node-start hook fires, an [*ActivationRecord] is built, and the action's [Action.Do] is
@@ -117,7 +117,7 @@ func (n *Node) Execute(
 
 	nodeID := n.ID()
 
-	// Exit 1: context cancelled before dispatch begins.
+	// Exit 1: context canceled before dispatch begins.
 	if err := ctx.Err(); err != nil {
 		executor.pushAuditReceipt(n, stack, nil, nil, nil, err, nil)
 		return nil, fmt.Errorf("node %s: %w", nodeID, err)

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -168,7 +168,7 @@ func (p *Provider) extractEntries(
 		return nil, nil, err
 	}
 
-	if err = destination.Resolve(); err != nil {
+	if err := destination.Resolve(); err != nil {
 		return nil, nil, err
 	}
 
@@ -215,7 +215,7 @@ func (p *Provider) extractEntries(
 		case entrySymlink:
 			// §10 ruling 1a: contained targets only; the link lands verbatim so the on-disk content — and the
 			// SymbolicLink digest, which hashes the literal target — stays faithful to the archive.
-			if guardErr = containedLinkTarget(entry.Name, entry.Linkname); guardErr != nil {
+			if guardErr := containedLinkTarget(entry.Name, entry.Linkname); guardErr != nil {
 				return products, stack, guardErr
 			}
 			if product, receipt, err = fileProvider.Link(activationRecord, entry.Linkname, target, true); err != nil {

--- a/pkg/op/provider/file/directory_test.go
+++ b/pkg/op/provider/file/directory_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // mkTreeFile writes `content` at `path`, creating parents.
-func mkTreeFile(t *testing.T, path string, content string) {
+func mkTreeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -55,7 +55,7 @@ var errKindMismatch = errors.New("file kind mismatch")
 //
 // Returns:
 //   - error: non-nil if spec is malformed, a name doesn't resolve, or os.Chown fails.
-func applyChown(path string, spec string) error {
+func applyChown(path, spec string) error {
 
 	if spec == "" {
 		return nil
@@ -323,7 +323,7 @@ func isDirNotEmpty(err error) bool {
 //
 // Returns:
 //   - `error`: wraps [errKindMismatch]; test with errors.Is.
-func kindMismatchError(typeName string, path string, observed os.FileMode) error {
+func kindMismatchError(typeName, path string, observed os.FileMode) error {
 	return fmt.Errorf("%s: %s: %w: the plan asserted this kind, the disk shows mode %s",
 		typeName, path, errKindMismatch, observed)
 }

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -258,7 +258,7 @@ func (p *Provider) Link(
 
 		receipt = NewReceipt(NewReceiptSpec(product, MutationCreateFile).WithBoundary(boundary))
 
-		if err = p.mkdirAll(parentPath, 0o750); err != nil {
+		if err := p.mkdirAll(parentPath, 0o750); err != nil {
 			return nil, receipt, err
 		}
 	}
@@ -272,7 +272,7 @@ func (p *Provider) Link(
 		return nil, receipt, err
 	}
 
-	if err = product.Resolve(); err != nil {
+	if err := product.Resolve(); err != nil {
 		return nil, receipt, err
 	}
 
@@ -332,15 +332,15 @@ func (p *Provider) Mkdir(
 
 	receipt = NewReceipt(NewReceiptSpec(product, MutationCreateDir).WithBoundary(boundary))
 
-	if err = p.mkdirAll(leaf, chmod); err != nil {
+	if err := p.mkdirAll(leaf, chmod); err != nil {
 		return nil, receipt, err
 	}
 
-	if err = applyChown(leaf, chown); err != nil {
+	if err := applyChown(leaf, chown); err != nil {
 		return nil, receipt, err
 	}
 
-	if err = product.Resolve(); err != nil {
+	if err := product.Resolve(); err != nil {
 		return nil, receipt, err
 	}
 
@@ -470,7 +470,7 @@ func (p *Provider) Move(
 		return nil, nil, err
 	}
 
-	if err = product.Resolve(); err != nil {
+	if err := product.Resolve(); err != nil {
 		return product, receipt, err
 	}
 
@@ -836,7 +836,7 @@ func (p *Provider) WalkTree(
 			return err
 		}
 
-		if err = entry.Resolve(); err != nil {
+		if err := entry.Resolve(); err != nil {
 			return err
 		}
 
@@ -844,7 +844,7 @@ func (p *Provider) WalkTree(
 		return err
 	}
 
-	if err = p.walkDir(osRoot, absoluteRoot, walkFn); err != nil {
+	if err := p.walkDir(osRoot, absoluteRoot, walkFn); err != nil {
 		return nil, stack, err
 	}
 
@@ -1591,7 +1591,7 @@ func (p *Provider) markEntryGone(entry Entry) {
 // Returns:
 //   - `Entry`: the production-claimed entry as the observed kind.
 //   - `error`: an unsupported entry kind, or a construction failure.
-func (p *Provider) produceEntryAt(producerID string, path string, mode os.FileMode) (Entry, error) {
+func (p *Provider) produceEntryAt(producerID, path string, mode os.FileMode) (Entry, error) {
 
 	runtimeEnvironment := p.RuntimeEnvironment()
 
@@ -1766,7 +1766,7 @@ func (p *Provider) stageWrite(product Entry) (spec *ReceiptSpec, err error) {
 
 		spec = NewReceiptSpec(product, MutationCreateFile).WithBoundary(boundary)
 
-		if err = p.mkdirAll(parentPath, 0o750); err != nil {
+		if err := p.mkdirAll(parentPath, 0o750); err != nil {
 			return spec, err
 		}
 
@@ -2015,11 +2015,11 @@ func (p *Provider) write(
 		return product, receipt, err
 	}
 
-	if err = f.Sync(); err != nil {
+	if err := f.Sync(); err != nil {
 		return product, receipt, err
 	}
 
-	if err = applyChown(product.SourcePath.Abs(), chown); err != nil {
+	if err := applyChown(product.SourcePath.Abs(), chown); err != nil {
 		return product, receipt, err
 	}
 

--- a/pkg/op/provider/flow/provider_test.go
+++ b/pkg/op/provider/flow/provider_test.go
@@ -153,7 +153,7 @@ func TestWaitUntil_ContextCancelled(t *testing.T) {
 	p := testProvider(t)
 	activation := subgraphActivation(t)
 
-	// A cancelled context must abort the poll loop with ctx.Err() rather than run out the (long) budget: the first
+	// A canceled context must abort the poll loop with ctx.Err() rather than run out the (long) budget: the first
 	// childless poll is falsy, the loop's select then observes the cancellation before the timeout or the next tick.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/pkg/op/provider/function/literals.go
+++ b/pkg/op/provider/function/literals.go
@@ -94,7 +94,7 @@ func formatValue(v starlark.Value, depth int) (string, error) {
 //
 // Parameters:
 //   - `open`: the opening delimiter (e.g., "[" or "(").
-//   - `close`: the closing delimiter (e.g., "]" or ")").
+//   - `closeDelimiter`: the closing delimiter (e.g., "]" or ")").
 //   - `n`: the number of elements in the sequence.
 //   - `index`: returns the element at a given position.
 //   - `depth`: the current recursion depth, propagated to each element.
@@ -102,7 +102,7 @@ func formatValue(v starlark.Value, depth int) (string, error) {
 // Returns:
 //   - `string`: the delimited source literal.
 //   - `error`: non-nil when any element cannot be serialized.
-func formatSequence(open, close string, n int, index func(int) starlark.Value, depth int) (string, error) {
+func formatSequence(open, closeDelimiter string, n int, index func(int) starlark.Value, depth int) (string, error) {
 
 	var b strings.Builder
 	b.WriteString(open)
@@ -116,7 +116,7 @@ func formatSequence(open, close string, n int, index func(int) starlark.Value, d
 		}
 		b.WriteString(elem)
 	}
-	b.WriteString(close)
+	b.WriteString(closeDelimiter)
 	return b.String(), nil
 }
 

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -456,7 +456,7 @@ func (p *Provider) SaveDefinition(graph *op.Graph, path string) (err error) {
 // Returns:
 //   - *op.RuntimeEnvironmentSpec: the constructed spec.
 //   - `error`: non-nil when [fsroot.OpenConfined] fails (the target root does not exist or is not accessible).
-func (p *Provider) Spec(programName string, rootPath string, flags map[string]any) (*op.RuntimeEnvironmentSpec, error) {
+func (p *Provider) Spec(programName, rootPath string, flags map[string]any) (*op.RuntimeEnvironmentSpec, error) {
 
 	env := p.RuntimeEnvironment()
 

--- a/pkg/op/provider/template/provider_test.go
+++ b/pkg/op/provider/template/provider_test.go
@@ -4,6 +4,7 @@
 package template //nolint:revive // package name is domain-specific
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -20,7 +21,7 @@ func TestRenderBytes_Simple(t *testing.T) {
 	}
 
 	want := []byte("hello world")
-	if string(got) != string(want) {
+	if !bytes.Equal(got, want) {
 		t.Errorf("RenderBytes() = %q, want %q", got, want)
 	}
 }

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -210,7 +210,7 @@ func TestArchiveData_WritesBytes(t *testing.T) {
 		t.Fatalf("ReadFile(recovery) error = %v", err)
 	}
 
-	if string(got) != string(data) {
+	if !bytes.Equal(got, data) {
 		t.Errorf("archived data = %q, want %q", got, data)
 	}
 }
@@ -230,7 +230,7 @@ func TestRestoreData_ReadsBytes(t *testing.T) {
 		t.Fatalf("RestoreData() error = %v", err)
 	}
 
-	if string(got) != string(original) {
+	if !bytes.Equal(got, original) {
 		t.Errorf("restored data = %q, want %q", got, original)
 	}
 }
@@ -275,7 +275,7 @@ func TestArchiveStream_SmallReader(t *testing.T) {
 		t.Fatalf("read recovery file: %v", err)
 	}
 
-	if string(got) != string(content) {
+	if !bytes.Equal(got, content) {
 		t.Errorf("recovery file content = %q, want %q", got, content)
 	}
 }

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -257,7 +257,7 @@ func (c *ResourceCatalog) Discover(uri string, factory func() (Resource, error))
 //
 // Panics with an [*assert.AssertionError] when any precondition is violated — these are programming errors at the call
 // site, not runtime conditions.
-func (c *ResourceCatalog) GetOrCreate(producerID string, uri string, factory func() (Resource, error)) (Resource, error) {
+func (c *ResourceCatalog) GetOrCreate(producerID, uri string, factory func() (Resource, error)) (Resource, error) {
 
 	assert.True("uri not empty", uri != "")
 	assert.True("factory required", factory != nil)

--- a/pkg/op/resource_ledger_snapshot_test.go
+++ b/pkg/op/resource_ledger_snapshot_test.go
@@ -133,7 +133,7 @@ func TestSnapshot_ContentIdentityRoundTrips(t *testing.T) {
 		unmarshal func([]byte, any) error
 	}{
 		"json": {json.Marshal, json.Unmarshal},
-		"yaml": {yaml.Marshal, func(data []byte, v any) error { return yaml.Unmarshal(data, v) }},
+		"yaml": {yaml.Marshal, yaml.Unmarshal},
 	} {
 		t.Run(name, func(t *testing.T) {
 

--- a/pkg/op/resource_test.go
+++ b/pkg/op/resource_test.go
@@ -170,7 +170,7 @@ func TestResourceBase_Digest_DefaultIsErrUnimplemented(t *testing.T) {
 	if err == nil {
 		t.Fatal("Digest() returned nil error, want ErrUnimplemented")
 	}
-	if err != ErrUnimplemented {
+	if !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("Digest() error = %v, want ErrUnimplemented", err)
 	}
 	if d.Algorithm != "" || len(d.Bytes) != 0 {

--- a/pkg/op/starlarkbridge/go_converters_test.go
+++ b/pkg/op/starlarkbridge/go_converters_test.go
@@ -350,7 +350,7 @@ func TestToGo_ConcreteTarget_Struct(t *testing.T) {
 func TestToGoInto_NilStarlark(t *testing.T) {
 
 	// nil starlark.Value sets target to zero.
-	var s string = "preset"
+	var s = "preset"
 	rv := reflect.ValueOf(&s).Elem()
 	if err := (converter{}).toGoInto(nil, rv); err != nil {
 		t.Fatalf("toGoInto: %v", err)
@@ -362,7 +362,7 @@ func TestToGoInto_NilStarlark(t *testing.T) {
 
 func TestToGoInto_NoneSetsZero(t *testing.T) {
 
-	var i int = 99
+	var i = 99
 	rv := reflect.ValueOf(&i).Elem()
 	if err := (converter{}).toGoInto(starlark.None, rv); err != nil {
 		t.Fatalf("toGoInto: %v", err)

--- a/pkg/op/starlarkbridge/runtime.go
+++ b/pkg/op/starlarkbridge/runtime.go
@@ -211,7 +211,7 @@ func (rt *Runtime) NewModule(name string) (starlark.Value, bool) {
 // Returns:
 //   - `[starlark.StringDict]`: the script's global bindings after execution.
 //   - `error`: non-nil if the script fails to load or execute.
-func (rt *Runtime) Invoke(script string, root string) (result starlark.StringDict, err error) {
+func (rt *Runtime) Invoke(script, root string) (result starlark.StringDict, err error) {
 
 	// Confine script loading to root.
 

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -4,6 +4,7 @@
 package op_test
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -165,7 +166,7 @@ func TestTriad_ArchiveFileRestoreFile(t *testing.T) {
 				t.Fatalf("ReadFile: %v", err)
 			}
 
-			if string(got) != string(content) {
+			if !bytes.Equal(got, content) {
 				t.Errorf("content = %q, want %q", got, content)
 			}
 		})
@@ -200,7 +201,7 @@ func TestTriad_ArchiveDataRestoreData(t *testing.T) {
 				t.Fatalf("RestoreData: %v", err)
 			}
 
-			if string(got) != string(original) {
+			if !bytes.Equal(got, original) {
 				t.Errorf("data = %q, want %q", got, original)
 			}
 		})
@@ -286,7 +287,7 @@ func TestTriad_WriteReadThroughRoot(t *testing.T) {
 				t.Fatalf("ReadFile: %v", err)
 			}
 
-			if string(got) != string(content) {
+			if !bytes.Equal(got, content) {
 				t.Errorf("content = %q, want %q", got, content)
 			}
 

--- a/pkg/platform/driver.go
+++ b/pkg/platform/driver.go
@@ -96,7 +96,7 @@ func (d driver) Installed(p PURL) bool { return d.installed(d.tokenFor(p)) }
 //   - `[]Receipt`: one receipt per package, in input order.
 //   - `error`: non-nil when any receipt failed.
 func (d driver) Remove(packages []PURL, kwargs map[string]any) ([]Receipt, error) {
-	return bracket(packages, d.tokenFor, d.version, func(names []string) PlatformResult { return d.removeRaw(names) }, absent)
+	return bracket(packages, d.tokenFor, d.version, d.removeRaw, absent)
 }
 
 // Search returns up to `limit` matches for `query`, each tagged with the manager's purl type.


### PR DESCRIPTION
Full-ownership finding: the original class-a mechanical lint fixes (sloppyReassign, paramTypeCombine, emptyStringTest, misspell — 35 files) sat uncommitted in the working tree since 2026-07-28, never landed; earlier ladder counts unknowingly measured the dirty tree. Inventoried against `origin/develop` via API-fetched baselines and landed verbatim. Verified: vet, full suite, gofmt clean; all four categories at zero uncapped. Sequenced behind #304 (script-guarded). Plan: `docs/plans/lint-mechanical-sweep.md`.