### PR TITLE
lint(review): class b — one real defect fixed, 19 mechanical, 10 justified

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -23,11 +23,19 @@ var binary string
 var scriptPath string
 
 func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}
+
+// testMain builds the binary and runs the suite, returning the process exit code.
+//
+// The extraction keeps TestMain's single os.Exit above every cleanup defer (gocritic
+// exitAfterDefer).
+func testMain(m *testing.M) int {
 	// Build the binary to a temp directory.
 	tmp, err := os.MkdirTemp("", "devlore-test-cli-*")
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
 
@@ -37,7 +45,7 @@ func TestMain(m *testing.M) {
 	root, err := findRepoRoot()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "finding repo root: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	scriptPath = filepath.Join(root, "cmd", "devlore-test", "devloretest", "data", "test_hello.star")
@@ -47,10 +55,10 @@ func TestMain(m *testing.M) {
 	build.Stderr = os.Stderr
 	if err := build.Run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "building devlore-test: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
-	os.Exit(m.Run())
+	return m.Run()
 }
 
 func findRepoRoot() (string, error) {

--- a/cmd/star/config/types.go
+++ b/cmd/star/config/types.go
@@ -266,10 +266,11 @@ func setPrimitiveValue(field reflect.Value, val interface{}) {
 	// Special case: YAML often parses numbers as float64
 	switch field.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if f, ok := val.(float64); ok {
-			field.SetInt(int64(f))
-		} else if i, ok := val.(int); ok {
-			field.SetInt(int64(i))
+		switch v := val.(type) {
+		case float64:
+			field.SetInt(int64(v))
+		case int:
+			field.SetInt(int64(v))
 		}
 	case reflect.Float32, reflect.Float64:
 		if i, ok := val.(int); ok {

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -141,8 +141,20 @@ Generate YAML index:
 `
 
 func main() {
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
 
-	var err error
+// run builds the star command tree and executes it, returning the execution error.
+//
+// The extraction keeps main's single os.Exit above every defer: an os.Exit inside this body would
+// skip the runtime's Close (gocritic exitAfterDefer).
+//
+// Returns:
+//   - `error`: the command execution error, or nil on success.
+func run() (err error) {
+
 	var silent bool
 
 	rootCmd := &cobra.Command{
@@ -323,9 +335,7 @@ Install them to your man path (e.g., /usr/local/share/man/man1/).`,
 		}
 	}
 
-	if err = rootCmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return rootCmd.Execute()
 }
 
 // loadStarlarkCommands discovers, deduplicates, and loads all extensions, then

--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -94,10 +94,8 @@ func (p *Provider) findScopeBody(scope string) (*token.FileSet, *ast.BlockStmt, 
 			if strings.TrimPrefix(recvType, "*") == strings.TrimPrefix(parts[0], "*") {
 				return fset, fn.Body, nil
 			}
-		} else {
-			if fn.Name.Name == name && fn.Recv == nil {
-				return fset, fn.Body, nil
-			}
+		} else if fn.Name.Name == name && fn.Recv == nil {
+			return fset, fn.Body, nil
 		}
 	}
 

--- a/cmd/star/provider/goast/production.go
+++ b/cmd/star/provider/goast/production.go
@@ -133,8 +133,7 @@ func (p *listProduction) Execute(blocks []comment.Block, cursor int, elem doctax
 
 	// If we found nothing and the element is required, emit stubs.
 	if len(output) == 0 && (elem.Required == "true" || elem.Required == "if_condition") {
-		output = append(output, makeHeaderParagraph(elem.Header))
-		output = append(output, makeStubList(ctx, elem))
+		output = append(output, makeHeaderParagraph(elem.Header), makeStubList(ctx, elem))
 	}
 
 	return output, pos

--- a/cmd/star/provider/setup/provider.go
+++ b/cmd/star/provider/setup/provider.go
@@ -130,6 +130,7 @@ func (p *Provider) PrecommitInstall() (PrecommitInstallResult, error) {
 
 	precommitPath, err := exec.LookPath("pre-commit")
 	if err != nil {
+		//nolint:nilerr // the absence is the result: the error becomes the user-facing message, not a failure.
 		return PrecommitInstallResult{Message: "pre-commit not installed. Run: star setup tools"}, nil
 	}
 
@@ -145,6 +146,7 @@ func (p *Provider) PrecommitInstall() (PrecommitInstallResult, error) {
 	cmd := exec.Command(precommitPath, "install")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		//nolint:nilerr // the failure is the result: the combined output becomes the message, not an error return.
 		return PrecommitInstallResult{Message: fmt.Sprintf("Failed to install hooks: %s", string(output))}, nil
 	}
 

--- a/cmd/star/provider/starcode/provider.go
+++ b/cmd/star/provider/starcode/provider.go
@@ -272,11 +272,7 @@ func captureFlat(absRoot, pattern string, tracker *gitignore.Tracker) ([]string,
 // Returns:
 //   - `bool`: true if the file is a Starlark source file.
 func isStarlarkFile(path string) bool {
-	ext := filepath.Ext(path)
-	if ext == ".star" {
-		return true
-	}
-	return false
+	return filepath.Ext(path) == ".star"
 }
 
 // flattenDoubleStar converts "**/*.star" to a pattern usable with filepath.Match.

--- a/cmd/star/star/command.go
+++ b/cmd/star/star/command.go
@@ -73,7 +73,8 @@ func (c *Command) Run(flags map[string]string, positional ...string) error {
 
 	// Map positional args to named entries using the arg spec.
 	for _, arg := range c.Args {
-		if arg.Variadic {
+		switch {
+		case arg.Variadic:
 			vals := make([]starlark.Value, len(positional))
 			for i, v := range positional {
 				vals[i] = starlark.String(v)
@@ -84,12 +85,12 @@ func (c *Command) Run(flags map[string]string, positional ...string) error {
 			if err := argsDict.SetKey(starlark.String(arg.Name), starlark.NewList(vals)); err != nil {
 				return fmt.Errorf("setting arg %q: %w", arg.Name, err)
 			}
-		} else if len(positional) > 0 {
+		case len(positional) > 0:
 			if err := argsDict.SetKey(starlark.String(arg.Name), starlark.String(positional[0])); err != nil {
 				return fmt.Errorf("setting arg %q: %w", arg.Name, err)
 			}
 			positional = positional[1:]
-		} else if arg.Default != "" {
+		case arg.Default != "":
 			if err := argsDict.SetKey(starlark.String(arg.Name), starlark.String(arg.Default)); err != nil {
 				return fmt.Errorf("setting arg %q: %w", arg.Name, err)
 			}

--- a/cmd/writ/writ/verify/verify.go
+++ b/cmd/writ/writ/verify/verify.go
@@ -166,6 +166,7 @@ func verifyDocument(ctx context.Context, cfg *Config, path string) (Report, erro
 			// an invalid verdict, not a command failure.
 			report.Outcome = signing.OutcomeInvalid.String()
 			report.Detail = err.Error()
+			//nolint:nilerr // an integrity-refused document IS the invalid verdict, not a command failure.
 			return report, nil
 		}
 		signature = graph.Signature()

--- a/cmd/writ/writ/verify/verify_integration_test.go
+++ b/cmd/writ/writ/verify/verify_integration_test.go
@@ -100,8 +100,7 @@ func TestExecute_TamperedExternalDocument(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tampered := strings.Replace(string(data), "run_status", "run_status", 1) // decode anchor stays
-	tampered = strings.Replace(tampered, "healthy", "degraded", 1)
+	tampered := strings.Replace(string(data), "healthy", "degraded", 1)
 	external := filepath.Join(t.TempDir(), "shared-trace.yaml")
 	if err := os.WriteFile(external, []byte(tampered), 0o644); err != nil {
 		t.Fatal(err)

--- a/docs/plans/lint-bug-smell-review.md
+++ b/docs/plans/lint-bug-smell-review.md
@@ -1,0 +1,48 @@
+---
+title: "Class b: the bug-smell review"
+issue: TBD
+status: complete
+created: 2026-08-01
+updated: 2026-08-01
+---
+
+# Plan: Class b — the bug-smell review
+
+Second rung of the 4b-3 ladder. All thirty sites read before ruling (approved 2026-08-01:
+19 mechanical, 2 restructures, 9 suppressions — one reclassified during implementation).
+
+## The one real defect
+
+`cmd/star/main.go` called `os.Exit(1)` below `defer iox.Close(&err, runtime)`: every
+error exit skipped the runtime's Close. Fixed with the standard extraction — `main` calls
+`run() (err error)` and owns the single `os.Exit`; the same shape applied to
+`cli_test.go`'s `TestMain` (`testMain(m) int`).
+
+## Mechanical fixes (19)
+
+bodyclose ×3 (test responses now closed), staticcheck ×4 (S1008 boolean return, two
+De Morgan applications, `WriteString(Sprintf)` → `Fprintf`), filepathJoin ×3 (test paths
+as components), nilValReturn ×1, a dead no-op `strings.Replace(x, "run_status",
+"run_status", 1)` deleted, `else{if}` → `else if`, if-else chain → switch, type-assert
+chain → type switch, append combine, nesting reduce (invert + continue), and the
+`file` parameter shadowing the file-provider import renamed to `backing`. The recurring
+`archive/provider_test.go` goimports finding is autofixed and rides along.
+
+## Suppressions with stated reasons (10)
+
+- nilerr ×6 — every one deliberate error-to-verdict conversion: LookPath/install
+  failures become the result message (setup ×2), an integrity-refused document IS the
+  invalid verdict (verify), unreconstructable produced types are tolerated on resume
+  (recovery stack), the inventory walker skips by design (×2). No bugs in the class.
+- dupArg ×1 — `r.Equal(r)` tests reflexivity.
+- ptrToRefParam ×2 — `iox.Close`'s pointer-to-error IS the defer idiom;
+  `dataSectionIterator.Next` implements starlark.Iterator's signature.
+- typeDefFirst ×1 — **reclassified from mechanical during implementation**:
+  `filteredReceiver` lives in the house SUPPORTING TYPES region; moving it above its
+  methods would break the mandated file layout, so house layout wins over the linter.
+
+## Verification
+
+- nilerr, staticcheck, bodyclose, goimports: all 0 uncapped; gocritic 48 → 31
+  (only unnamedResult — class c — remains).
+- `make vet` pass; full `make test` pass; `gofmt -l` clean. Total findings 247 → 216.

--- a/pkg/devconfig/config.go
+++ b/pkg/devconfig/config.go
@@ -462,6 +462,8 @@ func (it *dataSectionIterator) Done() {}
 //
 // Returns:
 //   - `bool`: true when a name was yielded; false when the iteration is exhausted.
+//
+//nolint:gocritic // ptrToRefParam: the signature implements starlark.Iterator; the out-parameter is the interface's.
 func (it *dataSectionIterator) Next(value *starlark.Value) bool {
 
 	if it.index >= len(it.names) {

--- a/pkg/fsroot/root_test.go
+++ b/pkg/fsroot/root_test.go
@@ -42,7 +42,7 @@ func TestRoot_NewPath_Relative(t *testing.T) {
 			if p.Rel() != "sub/file.txt" {
 				t.Errorf("Rel() = %q, want %q", p.Rel(), "sub/file.txt")
 			}
-			wantAbs := filepath.Join(dir, "sub/file.txt")
+			wantAbs := filepath.Join(dir, "sub", "file.txt")
 			if p.Abs() != wantAbs {
 				t.Errorf("Abs() = %q, want %q", p.Abs(), wantAbs)
 			}

--- a/pkg/iox/close.go
+++ b/pkg/iox/close.go
@@ -17,6 +17,8 @@ import (
 // Parameters:
 //   - err: pointer to the named error return; close errors are joined into *err
 //   - closers: values to close; nil entries are skipped
+//
+//nolint:gocritic // ptrToRefParam: the pointer-to-error out-parameter is the defer idiom this helper exists for.
 func Close(err *error, closers ...io.Closer) {
 
 	for _, c := range closers {

--- a/pkg/op/helpers_test.go
+++ b/pkg/op/helpers_test.go
@@ -26,7 +26,7 @@ func TestTopologicallySorted_ProducerBeforeConsumer(t *testing.T) {
 		position[unit.ID()] = i
 	}
 
-	if !(position["a"] < position["b"] && position["b"] < position["c"]) {
+	if position["a"] >= position["b"] || position["b"] >= position["c"] {
 		t.Errorf("order %v does not place producers before consumers (want a before b before c)", position)
 	}
 }

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -147,7 +147,7 @@ func NewMethod(
 				do.Name)
 		}
 
-		if p.Variadic && i != len(parameters)-1 && !(i == len(parameters)-2 && parameters[i+1].Kwargs) {
+		if p.Variadic && i != len(parameters)-1 && (i != len(parameters)-2 || !parameters[i+1].Kwargs) {
 			return nil, fmt.Errorf("variadic parameter %q must be the last or second-to-last (before **kwargs) parameter of method %s",
 				p.Name,
 				do.Name)

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -604,16 +604,16 @@ type tarArchiveReader struct {
 // Returns:
 //   - `*tarArchiveReader`: the entry iterator; the caller closes it.
 //   - `error`: a decompressor-header failure (the backing file, when present, is closed).
-func tarReaderFor(format archiveFormat, stream io.Reader, file *os.File) (*tarArchiveReader, error) {
+func tarReaderFor(format archiveFormat, stream io.Reader, backing *os.File) (*tarArchiveReader, error) {
 
 	closeFileOn := func(err error) error {
-		if file != nil {
-			return errors.Join(err, file.Close())
+		if backing != nil {
+			return errors.Join(err, backing.Close())
 		}
 		return err
 	}
 
-	reader := &tarArchiveReader{file: file, format: format}
+	reader := &tarArchiveReader{file: backing, format: format}
 
 	switch format {
 	case formatTar:

--- a/pkg/op/provider/pkg/resource_test.go
+++ b/pkg/op/provider/pkg/resource_test.go
@@ -291,6 +291,7 @@ func TestResource_Equal_StrictType(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
+	//nolint:gocritic // dupArg: reflexivity is the property under test.
 	if !r.Equal(r) {
 		t.Error("Equal(self) returned false")
 	}

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -372,25 +372,27 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 
 		for reflectedMethod := range methodType.Methods() {
 
-			if parameters, ok := methodParameters[reflectedMethod.Name]; ok {
-
-				method, err := methodFromReflectedMethod(methodType, reflectedMethod, parameters, isProvider)
-
-				if err != nil {
-					return receiverType{}, err
-				}
-
-				if planners != nil {
-					planner := planners[reflectedMethod.Name]
-					if planner == nil {
-						planner = ActionPlanner{}
-					}
-					method.setPlanner(planner)
-				}
-
-				methodMap[method.Name()] = method
-				methods = append(methods, method)
+			parameters, ok := methodParameters[reflectedMethod.Name]
+			if !ok {
+				continue
 			}
+
+			method, err := methodFromReflectedMethod(methodType, reflectedMethod, parameters, isProvider)
+
+			if err != nil {
+				return receiverType{}, err
+			}
+
+			if planners != nil {
+				planner := planners[reflectedMethod.Name]
+				if planner == nil {
+					planner = ActionPlanner{}
+				}
+				method.setPlanner(planner)
+			}
+
+			methodMap[method.Name()] = method
+			methods = append(methods, method)
 		}
 	} else {
 

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -946,6 +946,7 @@ func retypeResult(runtimeEnvironment *RuntimeEnvironment, receipt Receipt) error
 		// The produced-type-id is scoped to struct/scalar/resource; a value it cannot reconstruct -- notably an
 		// observation record, which round-trips by re-observe-and-verify, not reconstruction -- is left as-is rather
 		// than failing the resume. A consumer that needs the concrete type fails at its own dispatch.
+		//nolint:nilerr // deliberate: unreconstructable values are tolerated on resume, per the comment above.
 		return nil
 	}
 

--- a/pkg/op/server/router_test.go
+++ b/pkg/op/server/router_test.go
@@ -76,6 +76,7 @@ func TestServer_Command_Rejections(t *testing.T) {
 	t.Run("unknown verb", func(t *testing.T) {
 		ts := newTestServer(t, func() op.RunStatus { return op.RunStatus{Phase: op.PhaseRunning} })
 		resp := post(t, ts, `{"command":"levitate","request_id":"c-9"}`)
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("status = %d, want 400", resp.StatusCode)
 		}
@@ -87,6 +88,7 @@ func TestServer_Command_Rejections(t *testing.T) {
 	t.Run("run not running", func(t *testing.T) {
 		ts := newTestServer(t, func() op.RunStatus { return op.RunStatus{Phase: op.PhaseCompleted} })
 		resp := post(t, ts, `{"command":"pause"}`)
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusConflict {
 			t.Errorf("status = %d, want 409", resp.StatusCode)
 		}
@@ -95,6 +97,7 @@ func TestServer_Command_Rejections(t *testing.T) {
 	t.Run("bad body", func(t *testing.T) {
 		ts := newTestServer(t, func() op.RunStatus { return op.RunStatus{Phase: op.PhaseRunning} })
 		resp := post(t, ts, `{not json`)
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("status = %d, want 400", resp.StatusCode)
 		}

--- a/pkg/op/starlarkbridge/runtime.go
+++ b/pkg/op/starlarkbridge/runtime.go
@@ -412,6 +412,8 @@ type RuntimeOption func(*Runtime)
 // It embeds the wrapped surface (which itself embeds [starlark.Value]), so String / Type / Freeze / Truth / Hash pass
 // through untouched; only the two attribute methods are overridden to hide the denied names. The `global` field is the
 // wrapped global's name, used only to phrase a clear error.
+//
+//nolint:gocritic // typeDefFirst: filteredReceiver lives in the SUPPORTING TYPES region per the house file layout.
 type filteredReceiver struct {
 	starlark.HasAttrs
 	global string

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -71,7 +71,7 @@ func TestTriad_RootProducesPath(t *testing.T) {
 				t.Errorf("Rel() = %q, want %q", p.Rel(), "sub/file.txt")
 			}
 
-			wantAbs := filepath.Join(env.Dir, "sub/file.txt")
+			wantAbs := filepath.Join(env.Dir, "sub", "file.txt")
 
 			if p.Abs() != wantAbs {
 				t.Errorf("Abs() = %q, want %q", p.Abs(), wantAbs)
@@ -96,7 +96,7 @@ func TestTriad_RootProducesPathFromAbsolute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			env := tc.newTriad(t)
-			abs := filepath.Join(env.Dir, "deep/path.txt")
+			abs := filepath.Join(env.Dir, "deep", "path.txt")
 			p := env.Root.NewPath(abs)
 
 			if p.Rel() != "deep/path.txt" {

--- a/pkg/platform/helpers.go
+++ b/pkg/platform/helpers.go
@@ -99,7 +99,7 @@ var runShellCommand = func(command string, sudo bool) PlatformResult {
 	}
 
 	if ctx.Err() == context.DeadlineExceeded {
-		stderr.WriteString(fmt.Sprintf("\ncommand timed out after %s", commandTimeout))
+		fmt.Fprintf(&stderr, "\ncommand timed out after %s", commandTimeout)
 	}
 
 	return PlatformResult{

--- a/pkg/result/field_filter.go
+++ b/pkg/result/field_filter.go
@@ -83,7 +83,7 @@ func (f *FieldFilter) Apply(value any) (any, error) {
 		return value, nil
 	}
 	if value == nil {
-		return value, nil
+		return nil, nil
 	}
 
 	rv := reflect.ValueOf(value)

--- a/tools/New-OpInventory/main.go
+++ b/tools/New-OpInventory/main.go
@@ -83,6 +83,7 @@ func findAnnouncingPackages(roots []string) []string {
 	for _, root := range roots {
 		//nolint:errcheck // diagnose-ignored-error: walker skips; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			//nolint:nilerr // the walker skips unreadable entries by design; nothing to propagate.
 			if err != nil || d.IsDir() {
 				return nil
 			}
@@ -92,6 +93,7 @@ func findAnnouncingPackages(roots []string) []string {
 
 			f, parseErr := parser.ParseFile(fset, path, nil, 0)
 			if parseErr != nil {
+				//nolint:nilerr // unparseable files are skipped by design; the inventory covers what parses.
 				return nil
 			}
 


### PR DESCRIPTION
Second rung of the 4b-3 ladder, all thirty sites read before the ruling. The one real defect: `main.go`'s error exit skipped the runtime's Close (`os.Exit` below the defer) — fixed with the `run() (err error)` extraction, same shape for `TestMain`. 19 mechanical fixes (bodyclose, staticcheck, filepathJoin, dead no-op Replace deleted, style rewrites, import-shadow rename); 10 justified suppressions (all six nilerr are deliberate error-to-verdict conversions; reflexivity dupArg; two interface/idiom ptrToRefParam; typeDefFirst yields to the SUPPORTING TYPES house region). nilerr/staticcheck/bodyclose/goimports at 0, gocritic 48 → 31, total 247 → 216; vet + full suite green. Plan: `docs/plans/lint-bug-smell-review.md`.