### PR TITLE
lint(signatures): class c — named results adopted, unparam retired

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -126,19 +126,19 @@ func TestCLI_RunMissingFile(t *testing.T) {
 func TestCLI_ScriptFirst(t *testing.T) {
 	stdout, _, code := run("run", scriptPath, "--output", "receipt=/dev/null", "--output", "graph=/dev/null")
 	assertExit(t, 0, code)
-	assertValidSummary(t, stdout, true)
+	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptMiddle(t *testing.T) {
 	stdout, _, code := run("run", "--output", "receipt=/dev/null", scriptPath, "--output", "graph=/dev/null")
 	assertExit(t, 0, code)
-	assertValidSummary(t, stdout, true)
+	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptLast(t *testing.T) {
 	stdout, _, code := run("run", "--output", "receipt=/dev/null", "--output", "graph=/dev/null", scriptPath)
 	assertExit(t, 0, code)
-	assertValidSummary(t, stdout, true)
+	assertValidSummary(t, stdout)
 }
 
 // --- Output routing ---
@@ -154,7 +154,7 @@ func TestCLI_DefaultAllToStdout(t *testing.T) {
 func TestCLI_SummaryOnly(t *testing.T) {
 	stdout, _, code := run("run", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
 	assertExit(t, 0, code)
-	assertValidSummary(t, stdout, true)
+	assertValidSummary(t, stdout)
 	assertNotContains(t, stdout, "Hello World!")
 	assertNotContains(t, stdout, "version:")
 }
@@ -200,7 +200,7 @@ func TestCLI_RoutToFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading summary: %v", err)
 	}
-	assertValidSummary(t, string(summary), true)
+	assertValidSummary(t, string(summary))
 
 	receipt, err := os.ReadFile(receiptPath)
 	if err != nil {
@@ -240,7 +240,7 @@ func TestCLI_JSONReceiptToFile(t *testing.T) {
 func TestCLI_DryRun(t *testing.T) {
 	stdout, _, code := run("run", "--dry-run", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
 	assertExit(t, 0, code)
-	assertValidSummary(t, stdout, true)
+	assertValidSummary(t, stdout)
 }
 
 func TestCLI_Trace(t *testing.T) {
@@ -356,7 +356,7 @@ func assertNotContains(t *testing.T, s, substr string) {
 	}
 }
 
-func assertValidSummary(t *testing.T, s string, wantPassed bool) {
+func assertValidSummary(t *testing.T, s string) {
 	t.Helper()
 	// Summary line is the first JSON line in the output.
 	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
@@ -371,8 +371,8 @@ func assertValidSummary(t *testing.T, s string, wantPassed bool) {
 			t.Errorf("summary is not valid JSON: %v", err)
 			return
 		}
-		if result.Passed != wantPassed {
-			t.Errorf("summary.passed = %v, want %v", result.Passed, wantPassed)
+		if !result.Passed {
+			t.Errorf("summary.passed = %v, want true", result.Passed)
 		}
 		return
 	}

--- a/cmd/star/config/root.go
+++ b/cmd/star/config/root.go
@@ -192,7 +192,7 @@ func (c *extensionsConfig) save() error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(c.source, data, 0644); err != nil {
+	if err := os.WriteFile(c.source, data, 0o644); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/cmd/star/provider/goast/consumes.go
+++ b/cmd/star/provider/goast/consumes.go
@@ -64,7 +64,7 @@ func ParseConsumes(s string) (Consumes, error) {
 
 // parseRepeat extracts the optional repeat prefix from an ABNF string.
 // Returns min, max, and the remaining string after the repeat.
-func parseRepeat(s string) (int, int, string) {
+func parseRepeat(s string) (minRepeat, maxRepeat int, rest string) {
 	if s == "" {
 		return 1, 1, s
 	}

--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -57,7 +57,7 @@ func encodeScope(filePath, name string) string {
 }
 
 // decodeScope splits a scope string into file path and function name.
-func decodeScope(scope string) (string, string, error) {
+func decodeScope(scope string) (filePath, name string, err error) {
 	parts := strings.SplitN(scope, "::", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid scope: %s", scope)
@@ -722,7 +722,7 @@ func renderLCFirst(s string) string {
 // parseScopeRange parses a scope string into a line range.
 //
 // Supports "file" for the entire file and "lines:START-END" for a specific line range (1-indexed, inclusive).
-func parseScopeRange(scope string, totalLines int) (int, int, error) {
+func parseScopeRange(scope string, totalLines int) (start, end int, err error) {
 
 	if scope == "file" || scope == "" {
 		return 1, totalLines, nil

--- a/cmd/star/provider/goast/production.go
+++ b/cmd/star/provider/goast/production.go
@@ -41,8 +41,10 @@ type itemProduction struct {
 // Execute scans blocks from cursor, consuming those whose type matches the consumes spec.
 // If a prefix is specified on the schema element, only the first matching block must have
 // that prefix. Returns consumed blocks and the new cursor.
-func (p *itemProduction) Execute(blocks []comment.Block, cursor int, elem doctaxonomy.SchemaElement, ctx styleContext) ([]comment.Block, int) {
-	var output []comment.Block
+func (p *itemProduction) Execute(
+	blocks []comment.Block, cursor int, elem doctaxonomy.SchemaElement, ctx styleContext,
+) (output []comment.Block, next int) {
+
 	pos := cursor
 	count := 0
 
@@ -89,7 +91,7 @@ func (p *itemProduction) Execute(blocks []comment.Block, cursor int, elem doctax
 
 	// If required and nothing matched, emit a stub.
 	if count == 0 && elem.Required == "true" {
-		stub := makeStubParagraph(ctx.name, elem)
+		stub := makeStubParagraph(ctx.name)
 		output = append(output, stub)
 	}
 
@@ -104,13 +106,14 @@ type listProduction struct {
 
 // Execute scans for a heading paragraph matching the schema's Header field, followed by a List.
 // If condition is specified and not met, skips entirely. Slot filling is a placeholder until Step 8c.
-func (p *listProduction) Execute(blocks []comment.Block, cursor int, elem doctaxonomy.SchemaElement, ctx styleContext) ([]comment.Block, int) {
+func (p *listProduction) Execute(
+	blocks []comment.Block, cursor int, elem doctaxonomy.SchemaElement, ctx styleContext,
+) (output []comment.Block, next int) {
 	// Check condition.
 	if elem.Condition != "" && !evaluateCondition(elem.Condition, ctx) {
 		return nil, cursor
 	}
 
-	var output []comment.Block
 	pos := cursor
 
 	// Look for heading paragraph.
@@ -234,7 +237,7 @@ func blockText(b comment.Block) string {
 // splitSentence splits text at the first sentence boundary (". " or ".\n").
 // Returns the first sentence and the remainder. If there's only one sentence,
 // remainder is empty.
-func splitSentence(text string) (string, string) {
+func splitSentence(text string) (first, remainder string) {
 	for i := 0; i < len(text)-1; i++ {
 		if text[i] == '.' && (text[i+1] == ' ' || text[i+1] == '\n') {
 			summary := strings.TrimSpace(text[:i+1])
@@ -246,7 +249,7 @@ func splitSentence(text string) (string, string) {
 }
 
 // makeStubParagraph creates a TODO stub paragraph for a missing required element.
-func makeStubParagraph(name string, elem doctaxonomy.SchemaElement) *comment.Paragraph {
+func makeStubParagraph(name string) *comment.Paragraph {
 	text := name + " TODO(go-style): add summary"
 	return &comment.Paragraph{
 		Text: []comment.Text{comment.Plain(text)},

--- a/cmd/star/provider/goast/slotassign.go
+++ b/cmd/star/provider/goast/slotassign.go
@@ -16,7 +16,7 @@ type Match struct {
 // Forced assignment when exactly one slot and one item remain.
 //
 // Returns matched pairs, unmatched slots, and unmatched items.
-func assignSlots(slots []string, items []string) (matched []Match, unmatchedSlots []string, unmatchedItems []string) {
+func assignSlots(slots, items []string) (matched []Match, unmatchedSlots, unmatchedItems []string) {
 	n := len(slots)
 	m := len(items)
 

--- a/cmd/star/provider/goast/source_file.go
+++ b/cmd/star/provider/goast/source_file.go
@@ -4,7 +4,6 @@
 package goast
 
 import (
-	"fmt"
 	"go/ast"
 	"go/doc/comment"
 	"go/parser"
@@ -215,11 +214,7 @@ func LoadSourceFile(content string) (*SourceFile, error) {
 		}
 
 		rawText := cg.Text()
-		style, err := classifyFloatingComment(rawText)
-
-		if err != nil {
-			return nil, fmt.Errorf("LoadSourceFile: %w", err)
-		}
+		style := classifyFloatingComment(rawText)
 
 		items = append(items, positioned{
 			pos: cg.Pos(),
@@ -346,7 +341,7 @@ func (sf *SourceFile) Cleanup() {
 				continue
 			}
 			gd.comment = sf.styleDoc(gd.comment, styleContext{
-				nodeType: genDeclNodeType(gd.genDecl.Tok),
+				nodeType: "GenDecl",
 				name:     genDeclName(gd.genDecl),
 			})
 
@@ -984,26 +979,25 @@ type styleContext struct {
 //
 // Returns:
 //   - `CommentStyle`: the classified style.
-//   - `error`: non-nil if the comment cannot be classified.
-func classifyFloatingComment(text string) (CommentStyle, error) {
+func classifyFloatingComment(text string) CommentStyle {
 
 	if strings.HasPrefix(text, "SPDX-License-Identifier") {
-		return StyleCopyright, nil
+		return StyleCopyright
 	}
 
 	if isDelineatorBlock(text) {
-		return StyleDelineator, nil
+		return StyleDelineator
 	}
 
 	if strings.HasPrefix(text, "region ") || text == "endregion" || strings.HasPrefix(text, "endregion ") {
-		return StyleRegionMarker, nil
+		return StyleRegionMarker
 	}
 
 	if !strings.Contains(text, "\n") {
-		return StyleSectionHeader, nil
+		return StyleSectionHeader
 	}
 
-	return StyleProse, nil
+	return StyleProse
 }
 
 // constEntries extracts const entry details (name + value) for a CONST GenDecl, or nil otherwise.
@@ -1118,29 +1112,6 @@ func extractCodeDecl(source string, fileSet *token.FileSet, declaration ast.Node
 	}
 
 	return source[start:end]
-}
-
-// genDeclNodeType returns the schema node type for a GenDecl token.
-//
-// Parameters:
-//   - `tok`: the GenDecl token kind.
-//
-// Returns:
-//   - `string`: the schema node type (always "GenDecl").
-func genDeclNodeType(tok token.Token) string {
-
-	switch tok {
-	case token.TYPE:
-		return "GenDecl"
-	case token.VAR:
-		return "GenDecl"
-	case token.CONST:
-		return "GenDecl"
-	case token.IMPORT:
-		return "GenDecl"
-	default:
-		return "GenDecl"
-	}
 }
 
 // genDeclsByTok filters GenDecl nodes to those of the given token kind.

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -311,7 +311,7 @@ type goPosRaw struct {
 	Column   int    `json:"Column"`
 }
 
-func checkModTidy() (bool, string) {
+func checkModTidy() (tidy bool, detail string) {
 	tidyCmd := exec.Command("go", "mod", "tidy")
 	if output, err := tidyCmd.CombinedOutput(); err != nil {
 		return false, fmt.Sprintf("go mod tidy failed: %s\n%s", err, string(output))
@@ -476,7 +476,7 @@ output:
   sort-results: true
 `
 
-func ensureGolangciConfig() (string, bool, error) {
+func ensureGolangciConfig() (path string, created bool, err error) {
 	configPath := ".golangci.yaml"
 	if _, err := os.Stat(configPath); err == nil {
 		return configPath, false, nil

--- a/cmd/star/provider/shellcheck/provider.go
+++ b/cmd/star/provider/shellcheck/provider.go
@@ -115,7 +115,7 @@ func (p *Provider) Format(path string, indent int, fix bool) (any, error) {
 	if fix {
 		return formatFix(files, indent)
 	}
-	return formatCheck(files, indent)
+	return formatCheck(files, indent), nil
 }
 
 // Parse parses shell scripts and extracts structural information.
@@ -214,7 +214,7 @@ func runShellcheck(path, severity string) ([]LintIssue, error) {
 }
 
 // formatCheck runs shfmt -d (diff mode) and returns failures.
-func formatCheck(files []string, indent int) (FormatCheckResult, error) {
+func formatCheck(files []string, indent int) FormatCheckResult {
 	result := FormatCheckResult{FilesChecked: len(files), Passed: true}
 	for _, file := range files {
 		cmd := exec.CommandContext(context.Background(), "shfmt", "-d", "-i", fmt.Sprintf("%d", indent), "-ci", file)
@@ -227,7 +227,7 @@ func formatCheck(files []string, indent int) (FormatCheckResult, error) {
 			})
 		}
 	}
-	return result, nil
+	return result
 }
 
 // formatFix runs shfmt -w (write mode) and returns formatted file count.

--- a/cmd/writ/writ/commands.go
+++ b/cmd/writ/writ/commands.go
@@ -221,10 +221,7 @@ Status indicators:
 // runStatus implements the status command on the status package (phase-8 step 47 slice 3).
 func runStatus(cmd *cobra.Command, args []string) error {
 
-	cfg, err := parseStatusConfig(cmd, args)
-	if err != nil {
-		return err
-	}
+	cfg := parseStatusConfig(cmd, args)
 
 	return status.Execute(cmd.Context(), &status.Config{
 		Projects: cfg.Projects,

--- a/cmd/writ/writ/config.go
+++ b/cmd/writ/writ/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/identity"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/segment"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -139,14 +140,14 @@ func parseUpgradeConfig(cmd *cobra.Command, args []string) (*UpgradeConfig, erro
 }
 
 // parseReconcileConfig resolves all settings for a reconcile operation.
-func parseStatusConfig(cmd *cobra.Command, args []string) (*StatusConfig, error) {
+func parseStatusConfig(cmd *cobra.Command, args []string) *StatusConfig {
 	cfg := &StatusConfig{}
 	cfg.Tool = "writ"
 	cfg.Projects = args
 
 	// Behavior flags
 	cfg.Verbose = viper.GetBool("writ.verbose")
-	cfg.JSONOutput, _ = cmd.Flags().GetBool("json") //nolint:errcheck // flag registered by AddCommand
+	cfg.JSONOutput = assert.Must(cmd.Flags().GetBool("json"))
 
 	// Segments and template variables feed the freshness comparison; status needs no repo — the deployed
 	// inventory (sources included) comes from the store readback.
@@ -158,7 +159,7 @@ func parseStatusConfig(cmd *cobra.Command, args []string) (*StatusConfig, error)
 		}
 	}
 
-	return cfg, nil
+	return cfg
 }
 
 // parseDecommissionConfig resolves all settings for a decommission operation.
@@ -170,7 +171,7 @@ func parseDecommissionConfig(cmd *cobra.Command, args []string) (*DecommissionCo
 	// Behavior flags
 	cfg.DryRun = viper.GetBool("writ.dry-run")
 	cfg.Verbose = viper.GetBool("writ.verbose")
-	cfg.Prune, _ = cmd.Flags().GetBool("prune") //nolint:errcheck // flag registered by AddCommand
+	cfg.Prune = assert.Must(cmd.Flags().GetBool("prune"))
 
 	// Target root
 	cfg.TargetRoot = os.Getenv("HOME")

--- a/cmd/writ/writ/deploy/sops_integration_test.go
+++ b/cmd/writ/writ/deploy/sops_integration_test.go
@@ -100,10 +100,10 @@ func TestExecute_SopsChains(t *testing.T) {
 // sopsEncrypt generates an age identity and encrypts plainYAML with SOPS, returning the encrypted bytes and
 // the identity string for decryption. Lifted from the encryption provider's test fixture pattern
 // (pkg/op/provider/encryption/provider_test.go) per the slice-4 ruling.
-func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
+func sopsEncrypt(t *testing.T, plainYAML []byte) (encrypted []byte, identity string) {
 	t.Helper()
 
-	identity, err := age.GenerateX25519Identity()
+	ageIdentity, err := age.GenerateX25519Identity()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
 	}
 
 	masterKey := &sopsage.MasterKey{
-		Recipient: identity.Recipient().String(),
+		Recipient: ageIdentity.Recipient().String(),
 	}
 
 	tree := sops.Tree{
@@ -143,10 +143,10 @@ func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
 	}
 	tree.Metadata.MessageAuthenticationCode = encryptedMac
 
-	encrypted, err := store.EmitEncryptedFile(tree)
+	encrypted, err = store.EmitEncryptedFile(tree)
 	if err != nil {
 		t.Fatalf("emitting encrypted file: %v", err)
 	}
 
-	return encrypted, identity.String()
+	return encrypted, ageIdentity.String()
 }

--- a/cmd/writ/writ/migrate/plan_builder.go
+++ b/cmd/writ/writ/migrate/plan_builder.go
@@ -42,6 +42,8 @@ type orderingEdge struct {
 // Returns:
 //   - *planBuilder: the ready builder.
 //   - `error`: always nil today; retained so callers need not change if construction grows fallible.
+//
+//nolint:unparam // the error is always nil today; retained so callers need not change if construction grows fallible (documented above).
 func newPlanBuilder(env *op.RuntimeEnvironment, project string) (*planBuilder, error) {
 	return &planBuilder{
 		planProvider: plan.NewProvider(env),

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -188,10 +188,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 // Returns:
 //   - `[]readback.Entry`: the entries to regenerate.
 //   - `[]string`: the skipped targets (differing or unverifiable, without --force).
-func classify(cfg *Config, copied []readback.Entry, data map[string]any) ([]readback.Entry, []string) {
-
-	var regenerate []readback.Entry
-	var skipped []string
+func classify(cfg *Config, copied []readback.Entry, data map[string]any) (regenerate []readback.Entry, skipped []string) {
 
 	for i := range copied {
 

--- a/cmd/writ/writ/upgrade/upgrade_integration_test.go
+++ b/cmd/writ/writ/upgrade/upgrade_integration_test.go
@@ -21,7 +21,7 @@ import (
 var fixtureSegments = segment.Segments{{Name: "OS", Value: "Darwin"}}
 
 // deployFixture runs one real deploy: a plain link and a template, returning the roots and the template source.
-func deployFixture(t *testing.T) (sourceRoot, targetRoot, templateSource string) {
+func deployFixture(t *testing.T) (targetRoot, templateSource string) {
 
 	t.Helper()
 
@@ -30,7 +30,7 @@ func deployFixture(t *testing.T) (sourceRoot, targetRoot, templateSource string)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
 	t.Setenv("HOME", root)
 
-	sourceRoot = filepath.Join(root, "src")
+	sourceRoot := filepath.Join(root, "src")
 	targetRoot = filepath.Join(root, "home")
 
 	if err := os.MkdirAll(filepath.Join(sourceRoot, "myproj"), 0o755); err != nil {
@@ -58,7 +58,7 @@ func deployFixture(t *testing.T) (sourceRoot, targetRoot, templateSource string)
 		t.Fatalf("deploy fixture: %v", err)
 	}
 
-	return sourceRoot, targetRoot, templateSource
+	return targetRoot, templateSource
 }
 
 // upgradeConfig returns the baseline upgrade configuration for the fixture.
@@ -69,7 +69,7 @@ func upgradeConfig() *upgrade.Config {
 // TestExecute_UpToDateDoesNothing pins the clean case: an unchanged deployment upgrades to a no-op.
 func TestExecute_UpToDateDoesNothing(t *testing.T) {
 
-	_, targetRoot, _ := deployFixture(t)
+	targetRoot, _ := deployFixture(t)
 	rendered := filepath.Join(targetRoot, ".gitconfig")
 
 	before, err := os.Stat(rendered)
@@ -94,7 +94,7 @@ func TestExecute_UpToDateDoesNothing(t *testing.T) {
 // without --force.
 func TestExecute_MissingTargetRegeneratesFreely(t *testing.T) {
 
-	_, targetRoot, _ := deployFixture(t)
+	targetRoot, _ := deployFixture(t)
 	rendered := filepath.Join(targetRoot, ".gitconfig")
 
 	if err := os.Remove(rendered); err != nil {
@@ -118,7 +118,7 @@ func TestExecute_MissingTargetRegeneratesFreely(t *testing.T) {
 // target (its digest matches the run's recorded as-deployed identity) regenerates WITHOUT --force.
 func TestExecute_StaleSourceRegeneratesFreely(t *testing.T) {
 
-	_, targetRoot, templateSource := deployFixture(t)
+	targetRoot, templateSource := deployFixture(t)
 	rendered := filepath.Join(targetRoot, ".gitconfig")
 
 	if err := os.WriteFile(templateSource, []byte("os={{ .Segments.OS }} v2"), 0o644); err != nil {
@@ -140,7 +140,7 @@ func TestExecute_StaleSourceRegeneratesFreely(t *testing.T) {
 // also changed.
 func TestExecute_ModifiedTargetIsForceGated(t *testing.T) {
 
-	_, targetRoot, templateSource := deployFixture(t)
+	targetRoot, templateSource := deployFixture(t)
 	rendered := filepath.Join(targetRoot, ".gitconfig")
 
 	if err := os.WriteFile(rendered, []byte("my local edits"), 0o644); err != nil {
@@ -174,7 +174,7 @@ func TestExecute_ModifiedTargetIsForceGated(t *testing.T) {
 // TestExecute_SymlinksAreNeverTouched pins the link exclusion: upgrade only considers copied entries.
 func TestExecute_SymlinksAreNeverTouched(t *testing.T) {
 
-	_, targetRoot, _ := deployFixture(t)
+	targetRoot, _ := deployFixture(t)
 	link := filepath.Join(targetRoot, ".zshrc")
 
 	before, err := os.Lstat(link)

--- a/docs/plans/lint-signatures.md
+++ b/docs/plans/lint-signatures.md
@@ -1,0 +1,57 @@
+---
+title: "Class c: signatures — named results adopted, unparam retired"
+issue: TBD
+status: complete
+created: 2026-08-01
+updated: 2026-08-01
+---
+
+# Plan: Class c — signatures
+
+Third rung of the 4b-3 ladder (rulings 2026-07-30/08-01: adopt named results; noctx stays
+inline for a later rung; per-class discuss-then-fix).
+
+## unnamedResult: 31 → 0 (+2 discovered)
+
+Every flagged signature adopts result names drawn from its documented `Returns:` bullets
+(or documented prose where a helper had no bullets) — e.g. `callerFrame(skip) (function,
+file string, line int)`, `canonicalize(data) (canonical []byte, parsed any, err error)`,
+`Subscribe() (events <-chan ControlEvent, cancel func())`. No naked returns introduced.
+Body collisions (locals shadowing new result names) resolved by assignment or renames —
+notably `Subscribe`'s bidirectional channel local (`ch`) versus its receive-only result,
+and `sopsEncrypt`'s age-identity object renamed `ageIdentity` so the `identity` string
+result keeps the documented name. Two same-shape siblings discovered mid-sweep
+(`itemProduction.Execute`, `assignSlots`) named as well.
+
+## unparam: 15 → 0 (12 removals, 1 constant-inline, 2 suppressions)
+
+- Dead parameters removed with caller updates: `makeStubParagraph`'s `elem`;
+  `resolvePayloadAction` and `subgraphFromInvocations` each lose an unused `env` (killing
+  two banned identifiers), which cascaded to `assembleNode`/`assembleSubgraph` losing
+  theirs.
+- Always-nil/constant results removed: `classifyFloatingComment` (error),
+  `formatCheck` (error), `parseStatusConfig` (error), `deployFixture` (`sourceRoot`);
+  `genDeclNodeType` (constant "GenDecl") deleted outright, caller inlines the literal.
+- Constant parameters inlined: `locate`'s `name` (→ `sopsConfigName`) and, by cascade,
+  `xdgRelPath` (→ `xdgFallbackRelPath`); test-helper constants `wantPassed`,
+  `resolveErr`, `slots`, `id` dropped at their definitions and callers.
+- Suppressed with stated reasons: `assert.raise`'s `skip` (the stack-depth contract —
+  hardcoding would break the first two-level helper) and `newPlanBuilder`'s always-nil
+  error (its own doc records the intent).
+- Drive-by per the class-1 ruling: two flag getters under bare
+  `//nolint:errcheck // flag registered` converted to `assert.Must` (config.go).
+
+## Open structure question (awaiting ruling)
+
+`splitReservedKwargs` returns seven values; gocritic's tooManyResultsChecker wants a
+carrier struct. Folding the five reserved kwargs into a struct is a structure decision
+(not made unilaterally) — suppressed with a pointer to this doc until ruled.
+
+## Verification
+
+- gocritic 0 (was 31 + strays), unparam 0 (was 15), goimports/gofmt/whitespace 0.
+- Remaining ladder: gosec 56 (d), revive 28 (e), noctx 14, unused 11 (f), complexity 61
+  (chartered). Total 170.
+- `make vet` pass; full `make test` pass (one live-caught regression during the sweep —
+  a global rename briefly collapsed test-node IDs — found by the suite, fixed, re-run
+  green); `gofmt -l` clean.

--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -243,7 +243,7 @@ func Unreachablef(format string, args ...any) {
 //   - `string`: the short function name (last path segment plus function), or "?" if unknown.
 //   - `string`: the source file, or "?" if unknown.
 //   - `int`: the line number, or 0 if unknown.
-func callerFrame(skip int) (string, string, int) {
+func callerFrame(skip int) (function, file string, line int) {
 
 	var pcs [1]uintptr
 
@@ -261,6 +261,10 @@ func callerFrame(skip int) (string, string, int) {
 // Parameters:
 //   - `skip`: number of frames between raise and the user's call site (2 for the public helpers).
 //   - `message`: the formatted invariant description.
+//
+// (one frame between helper and user call site) and hardcoding it would break the first two-level helper.
+//
+//nolint:unparam // every public helper passes skip=2 today; the parameter is the stack-depth contract
 func raise(skip int, message string) {
 
 	fn, file, line := callerFrame(skip + 1)

--- a/pkg/op/control_plane.go
+++ b/pkg/op/control_plane.go
@@ -92,24 +92,24 @@ func (p *ControlPlane) Request(cmd ControlCommand) <-chan ControlResponse {
 // Returns:
 //   - `<-chan ControlEvent`: the pushed event stream.
 //   - `func()`: the unsubscribe; idempotent.
-func (p *ControlPlane) Subscribe() (<-chan ControlEvent, func()) {
+func (p *ControlPlane) Subscribe() (events <-chan ControlEvent, cancel func()) {
 
-	events := make(chan ControlEvent, 64)
+	ch := make(chan ControlEvent, 64)
 
 	p.mu.Lock()
-	p.subscribers[events] = struct{}{}
+	p.subscribers[ch] = struct{}{}
 	p.mu.Unlock()
 
-	cancel := func() {
+	cancel = func() {
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		if _, live := p.subscribers[events]; live {
-			delete(p.subscribers, events)
-			close(events)
+		if _, live := p.subscribers[ch]; live {
+			delete(p.subscribers, ch)
+			close(ch)
 		}
 	}
 
-	return events, cancel
+	return ch, cancel
 }
 
 // endregion

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -174,7 +174,7 @@ func tryConvertSlice(
 	runtimeEnvironment *RuntimeEnvironment,
 	elem reflect.Value,
 	target reflect.Type,
-) (any, bool, error) {
+) (converted any, applied bool, err error) {
 
 	if elem.Kind() != reflect.Slice || target.Kind() != reflect.Slice {
 		return nil, false, nil
@@ -213,7 +213,7 @@ func tryConvertMap(
 	runtimeEnvironment *RuntimeEnvironment,
 	elem reflect.Value,
 	target reflect.Type,
-) (any, bool, error) {
+) (converted any, applied bool, err error) {
 
 	if elem.Kind() != reflect.Map || target.Kind() != reflect.Map {
 		return nil, false, nil
@@ -272,7 +272,7 @@ func tryConstructResource(
 	runtimeEnvironment *RuntimeEnvironment,
 	value any,
 	target reflect.Type,
-) (any, bool, error) {
+) (constructed any, applied bool, err error) {
 
 	if !target.Implements(resourceInterfaceType) || runtimeEnvironment == nil {
 		return nil, false, nil
@@ -337,7 +337,7 @@ func tryConstructResource(
 //   - `bool`: true when this step applied; false when the target does not opt into [TargetConverter] for
 //     `value`'s type.
 //   - `error`: non-nil when [TargetConverter.ConvertFrom] fails.
-func tryTargetConverter(value any, target reflect.Type) (any, bool, error) {
+func tryTargetConverter(value any, target reflect.Type) (converted any, applied bool, err error) {
 
 	var probe any
 	if target.Kind() == reflect.Pointer {
@@ -369,7 +369,7 @@ func tryTargetConverter(value any, target reflect.Type) (any, bool, error) {
 //   - `any`: the unmarshaled value (target kind, or its pointer when the target is a pointer); nil otherwise.
 //   - `bool`: true when this step applied (regardless of error); false when it does not apply.
 //   - `error`: non-nil when [encoding.TextUnmarshaler.UnmarshalText] fails.
-func tryTextUnmarshaler(value any, target reflect.Type) (any, bool, error) {
+func tryTextUnmarshaler(value any, target reflect.Type) (unmarshaled any, applied bool, err error) {
 
 	text, isString := value.(string)
 	if !isString {
@@ -416,7 +416,7 @@ func tryTextUnmarshaler(value any, target reflect.Type) (any, bool, error) {
 //   - `error`: non-nil when a field conversion fails.
 func tryHydrateStruct(
 	runtimeEnvironment *RuntimeEnvironment, elem reflect.Value, target reflect.Type,
-) (any, bool, error) {
+) (hydrated any, applied bool, err error) {
 
 	concrete := target
 	if concrete.Kind() == reflect.Pointer {

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -306,7 +306,7 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 	unitsByID := make(map[string]ExecutableUnit, len(p.Nodes)+len(p.Subgraphs))
 
 	for i := range p.Nodes {
-		node, err := assembleNode(env, &p.Nodes[i])
+		node, err := assembleNode(&p.Nodes[i])
 		if err != nil {
 			violations = append(violations, err)
 			continue
@@ -315,7 +315,7 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 	}
 
 	for i := range p.Subgraphs {
-		sg, err := assembleSubgraph(env, &p.Subgraphs[i])
+		sg, err := assembleSubgraph(&p.Subgraphs[i])
 		if err != nil {
 			violations = append(violations, err)
 			continue

--- a/pkg/op/graph_executor_test.go
+++ b/pkg/op/graph_executor_test.go
@@ -310,7 +310,7 @@ func TestRun_PreflightResolvesPendingResources(t *testing.T) {
 
 	present := &lifecycleResource{ResourceBase: presentBase, addressingMode: AddressingLocation, present: true}
 	missing := &lifecycleResource{ResourceBase: missingBase, addressingMode: AddressingLocation, present: false}
-	unenrolled := newLifecycle("test:///unenrolled", AddressingLocation, nil) // bare base: type id "", not enrolled
+	unenrolled := newLifecycle("test:///unenrolled", AddressingLocation) // bare base: type id "", not enrolled
 
 	// Enroll the fixture type in the staged-rollout gate for the duration of this test.
 	typeID := present.ResourceType()

--- a/pkg/op/helpers.go
+++ b/pkg/op/helpers.go
@@ -300,12 +300,11 @@ func parseParameters(providerType reflect.Type, methodParameters map[string][]st
 	return out, nil
 }
 
-// resolvePayloadAction resolves a wire-payload action name through env's registry to its bound [Action].
+// resolvePayloadAction resolves a wire-payload action name through the registry to its bound [Action].
 //
 // Shared by [assembleNode] and [assembleSubgraph] on the deserialization path.
 //
 // Parameters:
-//   - `env`: the runtime environment whose registry resolves action names.
 //   - `name`: the short dotted action name from the payload.
 //   - `kind`: a label used in error messages — "node" or "subgraph".
 //   - `id`: the unit's ID, included in error messages for context.
@@ -313,7 +312,7 @@ func parseParameters(providerType reflect.Type, methodParameters map[string][]st
 // Returns:
 //   - `Action`: the resolved action.
 //   - `error`: non-nil if `name` is empty or the registry does not recognize it.
-func resolvePayloadAction(env *RuntimeEnvironment, name, kind, id string) (Action, error) {
+func resolvePayloadAction(name, kind, id string) (Action, error) {
 
 	if name == "" {
 		return nil, fmt.Errorf("op.LoadGraph: %s %q has no action_name in wire form", kind, id)

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -616,7 +616,7 @@ func (m *Method) Invoke(activation *ActivationRecord, receiver any) (Result, Com
 //   - `reflect.Value`: the method's first result, or the zero Value for actions.
 //   - `reflect.Value`: the method's compensator (compensable third return), or the zero Value.
 //   - `error`: non-nil if the argument count is wrong or the method returned a non-nil error.
-func (m *Method) Do(receiver any, args []any) (reflect.Value, reflect.Value, error) {
+func (m *Method) Do(receiver any, args []any) (result, compensator reflect.Value, err error) {
 
 	v := reflect.ValueOf(receiver)
 

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -319,15 +319,14 @@ func assembleBindings(data map[string]bindingData) map[string]Binding {
 // [assembleGraph] once per node in the decoded payload's flat node list.
 //
 // Parameters:
-//   - `env`: the runtime environment whose registry resolves action names.
 //   - `p`: the decoded node payload.
 //
 // Returns:
 //   - `*Node`: the constructed node, with action bound.
 //   - `error`: non-nil if the action name cannot be resolved.
-func assembleNode(env *RuntimeEnvironment, p *nodeData) (*Node, error) {
+func assembleNode(p *nodeData) (*Node, error) {
 
-	action, err := resolvePayloadAction(env, p.ActionName, "node", p.ID)
+	action, err := resolvePayloadAction(p.ActionName, "node", p.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	// The blank gen import registers file.Provider so Instance + the compensator index resolve.

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -128,10 +128,10 @@ func TestDecryptSopsFile_NilSopsClient(t *testing.T) {
 
 // sopsEncrypt generates age keys and encrypts plainYAML with SOPS.
 // Returns the encrypted bytes and the age identity string for decryption.
-func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
+func sopsEncrypt(t *testing.T, plainYAML []byte) (encrypted []byte, identity string) {
 	t.Helper()
 
-	identity, err := age.GenerateX25519Identity()
+	ageIdentity, err := age.GenerateX25519Identity()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
 	}
 
 	masterKey := &sopsage.MasterKey{
-		Recipient: identity.Recipient().String(),
+		Recipient: ageIdentity.Recipient().String(),
 	}
 
 	tree := sops.Tree{
@@ -171,12 +171,12 @@ func sopsEncrypt(t *testing.T, plainYAML []byte) ([]byte, string) {
 	}
 	tree.Metadata.MessageAuthenticationCode = encryptedMac
 
-	encrypted, err := store.EmitEncryptedFile(tree)
+	encrypted, err = store.EmitEncryptedFile(tree)
 	if err != nil {
 		t.Fatalf("emitting encrypted file: %v", err)
 	}
 
-	return encrypted, identity.String()
+	return encrypted, ageIdentity.String()
 }
 
 func TestDecryptSopsFile_RoundTrip(t *testing.T) {

--- a/pkg/op/provider/encryption/receipt_test.go
+++ b/pkg/op/provider/encryption/receipt_test.go
@@ -45,13 +45,12 @@ func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 
 // marshalThenDecodeReceipt marshals `receipt` in `format`, then decodes it into the (base, fields) pair the recovery
 // stack hands RestoreEncoded — proving RestoreEncoded consumes values from either codec identically.
-func marshalThenDecodeReceipt(t *testing.T, format string, receipt any) (op.ReceiptData, map[string]any) {
+func marshalThenDecodeReceipt(t *testing.T, format string, receipt any) (base op.ReceiptData, fields map[string]any) {
 	t.Helper()
 
 	var data []byte
 	var err error
-	var base op.ReceiptData
-	fields := map[string]any{}
+	fields = map[string]any{}
 
 	switch format {
 	case "json":

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -402,11 +402,11 @@ func matchDoubleStarSingle(rawPrefix, rawSuffix, path string) bool {
 //   - int:   resolved uid, or -1 if the user side is empty.
 //   - int:   resolved gid, or -1 if the group side is empty.
 //   - error: non-nil if either side fails to resolve.
-func parseChown(spec string) (int, int, error) {
+func parseChown(spec string) (uid, gid int, err error) {
 
 	userSide, groupSide, hasColon := strings.Cut(spec, ":")
 
-	uid := -1
+	uid = -1
 	if userSide != "" {
 		resolved, err := resolveUser(userSide)
 		if err != nil {
@@ -415,7 +415,7 @@ func parseChown(spec string) (int, int, error) {
 		uid = resolved
 	}
 
-	gid := -1
+	gid = -1
 	if hasColon && groupSide != "" {
 		resolved, err := resolveGroup(groupSide)
 		if err != nil {

--- a/pkg/op/provider/file/helpers_unix.go
+++ b/pkg/op/provider/file/helpers_unix.go
@@ -18,7 +18,7 @@ import (
 // Returns:
 //   - `uint64`: the inode number.
 //   - `uint64`: the device number.
-func statIdentity(info os.FileInfo) (uint64, uint64) {
+func statIdentity(info os.FileInfo) (inode, device uint64) {
 
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/pkg/op/provider/function/synthesize.go
+++ b/pkg/op/provider/function/synthesize.go
@@ -167,7 +167,7 @@ func extractDefStmt(fn *starlark.Function) (string, error) {
 //     the result).
 //   - `T`: the matched node, or the zero value of T when no node at pos has type T.
 //   - `error`: read failure or parse failure; nil otherwise (including the no-match case).
-func extractNodeAt[T syntax.Node](pos syntax.Position) ([]byte, T, error) {
+func extractNodeAt[T syntax.Node](pos syntax.Position) (source []byte, node T, err error) {
 
 	var result T
 

--- a/pkg/op/provider/json/resource.go
+++ b/pkg/op/provider/json/resource.go
@@ -292,14 +292,13 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 //   - `[]byte`: canonical JSON bytes.
 //   - `any`: the decoded Go value (map[string]any / []any / scalar), cached for [Resource.Parsed].
 //   - `error`: parse failure or re-marshal failure.
-func canonicalize(data []byte) ([]byte, any, error) {
+func canonicalize(data []byte) (canonical []byte, parsed any, err error) {
 
-	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return nil, nil, fmt.Errorf("json parse: %w", err)
 	}
 
-	canonical, err := json.Marshal(parsed)
+	canonical, err = json.Marshal(parsed)
 	if err != nil {
 		return nil, nil, fmt.Errorf("json canonicalize: %w", err)
 	}

--- a/pkg/op/provider/plan/helpers.go
+++ b/pkg/op/provider/plan/helpers.go
@@ -105,7 +105,6 @@ func dispatchBuiltinBody(
 // Any other shape is an error.
 //
 // Parameters:
-//   - `env`: the runtime environment for the conversion cascade.
 //   - `value`: the starlark value bound to `on_error=`.
 //
 // Returns:
@@ -141,7 +140,7 @@ func onErrorSubgraph(env *op.RuntimeEnvironment, value starlark.Value) (*op.Subg
 		invocations = append(invocations, invocation)
 	}
 
-	return subgraphFromInvocations(env, "on_error", invocations)
+	return subgraphFromInvocations("on_error", invocations)
 }
 
 // onRetrySubgraph converts the value bound to `on_retry=` into a *op.Subgraph.
@@ -189,7 +188,7 @@ func onRetrySubgraph(env *op.RuntimeEnvironment, value starlark.Value) (*op.Subg
 		invocations = append(invocations, invocation)
 	}
 
-	return subgraphFromInvocations(env, "on_retry", invocations)
+	return subgraphFromInvocations("on_retry", invocations)
 }
 
 // projectToBinding projects a Go value into an [op.Binding] (PromiseBinding / VariableBinding / ImmediateBinding).
@@ -253,6 +252,10 @@ func projectToBinding(value any) op.Binding {
 //   - *op.Subgraph: the materialized retry-handler subgraph, or nil.
 //   - *op.TransitionPolicy: the supplied transition policy, or nil.
 //   - `error`: non-nil when any reserved entry has an invalid shape or fails conversion.
+//
+// struct is a structure decision awaiting a ruling (see docs/plans/lint-signatures.md).
+//
+//nolint:gocritic // tooManyResultsChecker: the reserved kwargs are one splice; folding them into a carrier
 func splitReservedKwargs(
 	env *op.RuntimeEnvironment,
 	kwargs []starlark.Tuple,
@@ -366,10 +369,8 @@ func splitReservedKwargs(
 //
 // Returns:
 //   - *op.Subgraph: the assembled Subgraph.
-//   - `error`: non-nil if the flow.subgraph action cannot be resolved through env's registry.
-func subgraphFromInvocations(
-	env *op.RuntimeEnvironment, label string, invocations []*op.Invocation,
-) (*op.Subgraph, error) {
+//   - `error`: non-nil if the flow.subgraph action cannot be resolved through the registry.
+func subgraphFromInvocations(label string, invocations []*op.Invocation) (*op.Subgraph, error) {
 
 	action, err := op.ReceiverRegistry().BuildAction(flow.Subgraph)
 	if err != nil {

--- a/pkg/op/provider/plan/lifecycle_e2e_test.go
+++ b/pkg/op/provider/plan/lifecycle_e2e_test.go
@@ -171,11 +171,11 @@ func scenarioFailAndRollback(t *testing.T, makeGraph graphMaker) {
 }
 
 // goGraphMaker builds the two-`mkdir` graph through the Go plan API.
-func goGraphMaker(t *testing.T, tmp string) (*op.Graph, *plan.Provider, string, string) {
+func goGraphMaker(t *testing.T, tmp string) (graph *op.Graph, provider *plan.Provider, dirA, dirB string) {
 	t.Helper()
 
-	_, provider := newLifecycleEnv(t, tmp)
-	dirA, dirB := filepath.Join(tmp, "a"), filepath.Join(tmp, "b")
+	_, provider = newLifecycleEnv(t, tmp)
+	dirA, dirB = filepath.Join(tmp, "a"), filepath.Join(tmp, "b")
 
 	inv1, err := provider.Plan(file.Mkdir, nil, map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
 	if err != nil {
@@ -186,7 +186,7 @@ func goGraphMaker(t *testing.T, tmp string) (*op.Graph, *plan.Provider, string, 
 		t.Fatalf("Plan(b): %v", err)
 	}
 
-	graph, err := provider.AssembleDefinition([]*op.Invocation{inv1, inv2}, nil, nil, nil, nil, nil, provider.Origin("test"))
+	graph, err = provider.AssembleDefinition([]*op.Invocation{inv1, inv2}, nil, nil, nil, nil, nil, provider.Origin("test"))
 	if err != nil {
 		t.Fatalf("AssembleDefinition: %v", err)
 	}

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -165,7 +165,7 @@ func (p *Provider) AssembleDefinition(
 	var onErrorSg *op.Subgraph
 	if len(onError) > 0 {
 		var err error
-		onErrorSg, err = subgraphFromInvocations(p.RuntimeEnvironment(), "on_error", onError)
+		onErrorSg, err = subgraphFromInvocations("on_error", onError)
 		if err != nil {
 			return nil, fmt.Errorf("plan.assemble_definition: %w", err)
 		}
@@ -174,7 +174,7 @@ func (p *Provider) AssembleDefinition(
 	var onRetrySg *op.Subgraph
 	if len(onRetry) > 0 {
 		var err error
-		onRetrySg, err = subgraphFromInvocations(p.RuntimeEnvironment(), "on_retry", onRetry)
+		onRetrySg, err = subgraphFromInvocations("on_retry", onRetry)
 		if err != nil {
 			return nil, fmt.Errorf("plan.assemble_definition: %w", err)
 		}

--- a/pkg/op/provider/service/receipt_test.go
+++ b/pkg/op/provider/service/receipt_test.go
@@ -44,13 +44,12 @@ func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 
 // marshalThenDecodeReceipt marshals `receipt` in `format`, then decodes it into the (base, fields) pair the recovery
 // stack hands RestoreEncoded — proving RestoreEncoded consumes values from either codec identically.
-func marshalThenDecodeReceipt(t *testing.T, format string, receipt any) (op.ReceiptData, map[string]any) {
+func marshalThenDecodeReceipt(t *testing.T, format string, receipt any) (base op.ReceiptData, fields map[string]any) {
 	t.Helper()
 
 	var data []byte
 	var err error
-	var base op.ReceiptData
-	fields := map[string]any{}
+	fields = map[string]any{}
 
 	switch format {
 	case "json":

--- a/pkg/op/provider/yaml/resource.go
+++ b/pkg/op/provider/yaml/resource.go
@@ -290,9 +290,8 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 //   - `[]byte`: canonical JSON bytes of the YAML document's Go-value form.
 //   - `any`: the decoded Go value (map[string]any / []any / scalar), cached for [Resource.Parsed].
 //   - `error`: YAML parse failure, JSON re-marshal failure, or normalization failure.
-func canonicalize(data []byte) ([]byte, any, error) {
+func canonicalize(data []byte) (canonical []byte, parsed any, err error) {
 
-	var parsed any
 	if err := yaml.Unmarshal(data, &parsed); err != nil {
 		return nil, nil, fmt.Errorf("yaml parse: %w", err)
 	}
@@ -304,7 +303,7 @@ func canonicalize(data []byte) ([]byte, any, error) {
 		return nil, nil, fmt.Errorf("yaml normalize: %w", err)
 	}
 
-	canonical, err := json.Marshal(normalized)
+	canonical, err = json.Marshal(normalized)
 	if err != nil {
 		return nil, nil, fmt.Errorf("yaml canonicalize: %w", err)
 	}

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -198,7 +198,7 @@ func (t *receiverType) Name() string { return t.name }
 //   - reflect.Value: the result (invalid if the method returns nothing).
 //   - reflect.Value: the compensation state (invalid unless compensable).
 //   - error: the method's error return, or a lookup error if the method doesn't exist.
-func (t *receiverType) Do(method string, receiver any, args []any) (reflect.Value, reflect.Value, error) {
+func (t *receiverType) Do(method string, receiver any, args []any) (result, compensation reflect.Value, err error) {
 
 	fn, ok := t.dispatchTable.Load(method)
 

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -390,7 +390,7 @@ func (c *ResourceCatalog) MarkGone(r Resource) {
 // Returns:
 //   - `Resource`: the canonical entry for `r`'s URI.
 //   - `string`: the canonical entry's catalog ID.
-func (c *ResourceCatalog) Resolve(r Resource) (Resource, string) {
+func (c *ResourceCatalog) Resolve(r Resource) (canonical Resource, id string) {
 
 	canonical, id, hit := c.lookupOrCatalog(r)
 	if !hit {

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -325,7 +325,7 @@ func TestCatalog_Clone_CopiesLedgerAndNamespace(t *testing.T) {
 func TestCatalog_Clone_StatesAreIndependent(t *testing.T) {
 
 	src := NewResourceCatalog()
-	r := newLifecycle("file:///shared", AddressingLocation, nil)
+	r := newLifecycle("file:///shared", AddressingLocation)
 	_, id := src.Resolve(r)
 
 	clone := src.Clone()
@@ -574,15 +574,13 @@ func (r *lifecycleResource) Exists() bool {
 // Parameters:
 //   - `uri`: the resource URI to seed [ResourceBase] with.
 //   - `mode`: the [AddressingMode] to report from [lifecycleResource.Addressing].
-//   - `resolveErr`: the error to return from [lifecycleResource.Resolve]; nil for success paths.
 //
 // Returns:
 //   - *lifecycleResource: the constructed fixture.
-func newLifecycle(uri string, mode AddressingMode, resolveErr error) *lifecycleResource {
+func newLifecycle(uri string, mode AddressingMode) *lifecycleResource {
 	return &lifecycleResource{
 		ResourceBase:   ResourceBase{uri: uri},
 		addressingMode: mode,
-		resolveErr:     resolveErr,
 	}
 }
 
@@ -596,7 +594,7 @@ func TestState_ZeroValueIsPending(t *testing.T) {
 func TestCatalog_FreshlyCatalogedEntryIsPending(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 
 	_, id := c.Resolve(r)
 	if got := c.State(id); got != Pending {
@@ -607,7 +605,7 @@ func TestCatalog_FreshlyCatalogedEntryIsPending(t *testing.T) {
 func TestCatalog_markActive_TransitionsToActive(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 	c.markActive(r)
 
 	if got := c.State(r.ID()); got != Active {
@@ -618,7 +616,7 @@ func TestCatalog_markActive_TransitionsToActive(t *testing.T) {
 func TestCatalog_markGone_TransitionsToGone(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 	c.markGone(r)
 
 	if got := c.State(r.ID()); got != Gone {
@@ -633,7 +631,7 @@ func TestMarkGone_RecordsDeletionFromAnyState(t *testing.T) {
 
 	c := NewResourceCatalog()
 
-	pending := newLifecycle("file:///pending", AddressingLocation, nil)
+	pending := newLifecycle("file:///pending", AddressingLocation)
 	_, pendingID := c.Resolve(pending)
 	if got := c.State(pendingID); got != Pending {
 		t.Fatalf("precondition: State = %v, want Pending", got)
@@ -643,7 +641,7 @@ func TestMarkGone_RecordsDeletionFromAnyState(t *testing.T) {
 		t.Errorf("State after MarkGone from Pending = %v, want Gone", got)
 	}
 
-	active := newLifecycle("file:///active", AddressingLocation, nil)
+	active := newLifecycle("file:///active", AddressingLocation)
 	_, activeID := c.Resolve(active)
 	c.markActive(active)
 	c.MarkGone(active)
@@ -662,12 +660,12 @@ func TestMarkGone_RecordsDeletionFromAnyState(t *testing.T) {
 func TestMarkGone_GoneIsTerminalForDiscovery(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///deleted", AddressingLocation, nil)
+	r := newLifecycle("file:///deleted", AddressingLocation)
 	c.Resolve(r)
 	c.MarkGone(r)
 
 	_, err := c.Discover(r.URI(), func() (Resource, error) {
-		return newLifecycle("file:///deleted", AddressingLocation, nil), nil
+		return newLifecycle("file:///deleted", AddressingLocation), nil
 	})
 	if err == nil || !strings.Contains(err.Error(), "known-gone") {
 		t.Errorf("Discover over a Gone entry = %v, want the known-gone refusal", err)
@@ -679,12 +677,12 @@ func TestMarkGone_GoneIsTerminalForDiscovery(t *testing.T) {
 func TestMarkGone_RevivalIsAProductionAct(t *testing.T) {
 
 	c := NewResourceCatalog()
-	first := newLifecycle("file:///revived", AddressingLocation, nil)
+	first := newLifecycle("file:///revived", AddressingLocation)
 	_, firstID := c.Resolve(first)
 	c.MarkGone(first)
 
 	revived, err := c.GetOrCreate("", first.URI(), func() (Resource, error) {
-		return newLifecycle("file:///revived", AddressingLocation, nil), nil
+		return newLifecycle("file:///revived", AddressingLocation), nil
 	})
 	if err != nil {
 		t.Fatalf("GetOrCreate over a Gone entry: %v", err)
@@ -712,13 +710,13 @@ func TestMarkGone_UncatalogedIsAProgrammingError(t *testing.T) {
 		}
 	}()
 
-	c.MarkGone(newLifecycle("file:///never-interned", AddressingLocation, nil))
+	c.MarkGone(newLifecycle("file:///never-interned", AddressingLocation))
 }
 
 func TestCatalog_VerifyExistence_PresentMarksActive(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 	r.present = true
 	_, id := c.Resolve(r)
 
@@ -733,7 +731,7 @@ func TestCatalog_VerifyExistence_PresentMarksActive(t *testing.T) {
 func TestCatalog_VerifyExistence_MissingMarksGone(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 	r.present = false
 	_, id := c.Resolve(r)
 
@@ -748,7 +746,7 @@ func TestCatalog_VerifyExistence_MissingMarksGone(t *testing.T) {
 func TestCatalog_VerifyExistence_ActiveShortCircuits(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///x", AddressingLocation, nil)
+	r := newLifecycle("file:///x", AddressingLocation)
 	r.present = true
 	c.Resolve(r)
 
@@ -772,7 +770,7 @@ func TestCatalog_VerifyExistence_ActiveShortCircuits(t *testing.T) {
 func TestCatalog_Discover_CacheMiss_InternsAsPending(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///hit", AddressingLocation, nil)
+	r := newLifecycle("file:///hit", AddressingLocation)
 	factory := func() (Resource, error) { return r, nil }
 
 	got, err := c.Discover(r.URI(), factory)
@@ -789,11 +787,11 @@ func TestCatalog_Discover_CacheMiss_InternsAsPending(t *testing.T) {
 func TestCatalog_Discover_CacheHitActive_ReturnsExisting(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///active", AddressingLocation, nil)
+	r := newLifecycle("file:///active", AddressingLocation)
 	c.Resolve(r)
 	c.markActive(r)
 
-	probe := newLifecycle("file:///active", AddressingLocation, nil)
+	probe := newLifecycle("file:///active", AddressingLocation)
 	factory := func() (Resource, error) { return probe, nil }
 
 	got, err := c.Discover(r.URI(), factory)
@@ -810,7 +808,7 @@ func TestCatalog_Discover_CacheHitActive_ReturnsExisting(t *testing.T) {
 func TestCatalog_Discover_CacheHitGone_ReturnsError(t *testing.T) {
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///gone", AddressingLocation, nil)
+	r := newLifecycle("file:///gone", AddressingLocation)
 	c.Resolve(r)
 	c.markGone(r)
 	factory := func() (Resource, error) { return r, nil }
@@ -831,7 +829,7 @@ func TestCatalog_Shadow_StampsActiveAndProducer(t *testing.T) {
 	// without needing to construct a Unit-bearing activation.
 
 	c := NewResourceCatalog()
-	r := newLifecycle("file:///out", AddressingLocation, nil)
+	r := newLifecycle("file:///out", AddressingLocation)
 
 	if _, err := c.Shadow(r, "node-A"); err != nil {
 		t.Fatalf("Shadow: %v", err)
@@ -854,13 +852,13 @@ func TestCatalog_GetOrCreate_CASHit_ReturnsExisting(t *testing.T) {
 	// unchanged.
 
 	c := NewResourceCatalog()
-	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent, nil)
+	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
 	if _, err := c.Shadow(first, "node-A"); err != nil {
 		t.Fatalf("Shadow: %v", err)
 	}
 	c.markActive(first)
 
-	probe := newLifecycle("tag:..:sha256:abc#mem", AddressingContent, nil)
+	probe := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
 	got, err := c.GetOrCreate("", probe.URI(), func() (Resource, error) { return probe, nil })
 	if err != nil {
 		t.Fatalf("GetOrCreate: %v", err)
@@ -877,14 +875,14 @@ func TestCatalog_GetOrCreate_CASHit_ReturnsExisting(t *testing.T) {
 func TestCatalog_GetOrCreate_LocationHit_Shadows(t *testing.T) {
 
 	c := NewResourceCatalog()
-	first := newLifecycle("file:///out", AddressingLocation, nil)
+	first := newLifecycle("file:///out", AddressingLocation)
 	if _, err := c.Shadow(first, "node-A"); err != nil {
 		t.Fatalf("Shadow first: %v", err)
 	}
 	c.markActive(first)
 
 	// Same URI, second producer. Should shadow.
-	second := newLifecycle("file:///out", AddressingLocation, nil)
+	second := newLifecycle("file:///out", AddressingLocation)
 
 	got, err := c.GetOrCreate("", second.URI(), func() (Resource, error) { return second, nil })
 	if err != nil {
@@ -902,7 +900,7 @@ func TestCatalog_GetOrCreate_LocationHit_Shadows(t *testing.T) {
 func TestCatalog_GetOrCreate_GoneHit_RevivesByShadow(t *testing.T) {
 
 	c := NewResourceCatalog()
-	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent, nil)
+	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
 	if _, err := c.Shadow(first, "node-A"); err != nil {
 		t.Fatalf("Shadow first: %v", err)
 	}
@@ -910,7 +908,7 @@ func TestCatalog_GetOrCreate_GoneHit_RevivesByShadow(t *testing.T) {
 	c.markGone(first)
 
 	// Same URI, Gone state. Should shadow (revive).
-	revival := newLifecycle("tag:..:sha256:abc#mem", AddressingContent, nil)
+	revival := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
 
 	got, err := c.GetOrCreate("", revival.URI(), func() (Resource, error) { return revival, nil })
 	if err != nil {

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -796,7 +796,7 @@ func (s *Subgraph) populate(spec *SubgraphSpec) {
 //   - `reflect.Type`: the declared type of the named parameter, or nil when no bound action / method / matching
 //     parameter exists.
 //   - `any`: the parameter's default value, or nil under the same conditions.
-func (s *Subgraph) slotParameterType(name string) (reflect.Type, any) {
+func (s *Subgraph) slotParameterType(name string) (parameterType reflect.Type, defaultValue any) {
 
 	action := s.Action()
 	if action == nil {
@@ -1280,15 +1280,14 @@ type subgraphData struct {
 // per subgraph in the decoded payload's flat subgraph list.
 //
 // Parameters:
-//   - `env`: the runtime environment whose registry resolves action names.
 //   - `p`: the decoded subgraph payload.
 //
 // Returns:
 //   - `*Subgraph`: the constructed subgraph, with action bound and placeholder children.
 //   - `error`: non-nil if the action name cannot be resolved.
-func assembleSubgraph(env *RuntimeEnvironment, p *subgraphData) (*Subgraph, error) {
+func assembleSubgraph(p *subgraphData) (*Subgraph, error) {
 
-	action, err := resolvePayloadAction(env, p.ActionName, "subgraph", p.ID)
+	action, err := resolvePayloadAction(p.ActionName, "subgraph", p.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/op/validate_test.go
+++ b/pkg/op/validate_test.go
@@ -63,12 +63,9 @@ func makeNode(id string, name ActionName, specs []paramSpec, slots map[string]Bi
 
 // makeBoundSubgraph builds a [*Subgraph] bound to a synthesized [Action] whose method declares the
 // given parameter specs and slot fills.
-func makeBoundSubgraph(id string, name ActionName, specs []paramSpec, slots map[string]Binding) *Subgraph {
+func makeBoundSubgraph(id string, name ActionName, specs []paramSpec) *Subgraph {
 
 	spec := NewSubgraphSpec().WithID(id).WithAction(&action{name: name, method: makeMethod(specs...)})
-	for k, v := range slots {
-		spec.WithSlot(k, v)
-	}
 
 	sg, err := NewSubgraph(spec)
 	if err != nil {
@@ -110,7 +107,7 @@ func (promiseProducerFixture) ProduceString() (string, error)    { return "", ni
 
 // producerNode builds a [*Node] whose action's method is the named real method on promiseProducerFixture, so its
 // declared result type participates in the promise type-check.
-func producerNode(t *testing.T, id, methodName string) *Node {
+func producerNode(t *testing.T, methodName string) *Node {
 
 	t.Helper()
 
@@ -124,9 +121,9 @@ func producerNode(t *testing.T, id, methodName string) *Node {
 		t.Fatalf("NewMethod(%s): %v", methodName, err)
 	}
 
-	node, err := NewNode(NewNodeSpec().WithID(id).WithAction(&action{name: "test.produce", method: method}))
+	node, err := NewNode(NewNodeSpec().WithID("producer").WithAction(&action{name: "test.produce", method: method}))
 	if err != nil {
-		t.Fatalf("NewNode(%s): %v", id, err)
+		t.Fatalf("NewNode(%s): %v", methodName, err)
 	}
 
 	return node
@@ -220,7 +217,6 @@ func TestValidateGraph_BoundSubgraph_MissingRequired_ReturnsViolation(t *testing
 
 	sg := makeBoundSubgraph("iter-1", "flow.gather",
 		[]paramSpec{{name: "items", typ: reflect.TypeFor[[]any]()}},
-		nil,
 	)
 	g := newTestGraph(t, sg)
 
@@ -279,7 +275,6 @@ func TestValidateGraph_MultipleViolations_AllJoined(t *testing.T) {
 		),
 		makeBoundSubgraph("iter-c", "flow.gather",
 			[]paramSpec{{name: "items", typ: reflect.TypeFor[[]any]()}},
-			nil,
 		),
 	)
 
@@ -309,7 +304,7 @@ func TestValidateGraph_MultipleViolations_AllJoined(t *testing.T) {
 func TestValidateGraph_PromiseType_Compatible_NoError(t *testing.T) {
 
 	g := newTestGraph(t,
-		producerNode(t, "producer", "ProduceString"),
+		producerNode(t, "ProduceString"),
 		makeNode("consumer", "test.consume",
 			[]paramSpec{{name: "input", typ: reflect.TypeFor[string]()}},
 			map[string]Binding{"input": NewPromiseBinding("producer")},
@@ -324,7 +319,7 @@ func TestValidateGraph_PromiseType_Compatible_NoError(t *testing.T) {
 func TestValidateGraph_PromiseType_Incompatible_ReturnsViolation(t *testing.T) {
 
 	g := newTestGraph(t,
-		producerNode(t, "producer", "ProduceChannel"),
+		producerNode(t, "ProduceChannel"),
 		makeNode("consumer", "test.consume",
 			[]paramSpec{{name: "input", typ: reflect.TypeFor[string]()}},
 			map[string]Binding{"input": NewPromiseBinding("producer")},
@@ -351,7 +346,7 @@ func TestValidateGraph_PromiseType_ReverseOnlyConvertible_Passes(t *testing.T) {
 	// binding passes the plan-time check. A directional check would reject this binding; whether D8 wants one is
 	// tracked in the step-15/16 docs.
 	g := newTestGraph(t,
-		producerNode(t, "producer", "ProduceInt"),
+		producerNode(t, "ProduceInt"),
 		makeNode("consumer", "test.consume",
 			[]paramSpec{{name: "input", typ: reflect.TypeFor[sourceConverter]()}},
 			map[string]Binding{"input": NewPromiseBinding("producer")},
@@ -414,7 +409,7 @@ func TestValidateGraph_CheckPromiseTypes_NoMethod(t *testing.T) {
 func TestValidateGraph_CheckPromiseTypes_NoParameter(t *testing.T) {
 
 	g := newTestGraph(t,
-		producerNode(t, "producer", "ProduceChannel"),
+		producerNode(t, "ProduceChannel"),
 		makeNode("consumer", "test.consume",
 			[]paramSpec{{name: "input", typ: reflect.TypeFor[string](), optional: true}},
 			map[string]Binding{"frame_only": NewPromiseBinding("producer")},
@@ -430,7 +425,7 @@ func TestValidateGraph_CheckPromiseTypes_NoParameter(t *testing.T) {
 // coexist without error, and a resource-typed candidate does not displace an existing source-side type.
 func TestSubgraph_MergeBubbled_Convertible(t *testing.T) {
 
-	sg := makeBoundSubgraph("sg", "test.subgraph", nil, nil)
+	sg := makeBoundSubgraph("sg", "test.subgraph", nil)
 	seen := map[string]Parameter{}
 
 	if err := sg.mergeBubbled(seen, Parameter{Name: "path", Type: reflect.TypeFor[string]()}); err != nil {
@@ -448,7 +443,7 @@ func TestSubgraph_MergeBubbled_Convertible(t *testing.T) {
 // abstraction and the candidate is the source-side primitive, the primitive wins.
 func TestSubgraph_MergeBubbled_PreferSourceSide(t *testing.T) {
 
-	sg := makeBoundSubgraph("sg", "test.subgraph", nil, nil)
+	sg := makeBoundSubgraph("sg", "test.subgraph", nil)
 	seen := map[string]Parameter{"path": {Name: "path", Type: reflect.TypeFor[*fakeResource]()}}
 
 	if err := sg.mergeBubbled(seen, Parameter{Name: "path", Type: reflect.TypeFor[string]()}); err != nil {
@@ -463,7 +458,7 @@ func TestSubgraph_MergeBubbled_PreferSourceSide(t *testing.T) {
 // to merge, naming the variable and both types, and the seen map is not mutated.
 func TestSubgraph_MergeBubbled_IrreconcilableTypes(t *testing.T) {
 
-	sg := makeBoundSubgraph("sg", "test.subgraph", nil, nil)
+	sg := makeBoundSubgraph("sg", "test.subgraph", nil)
 	seen := map[string]Parameter{"path": {Name: "path", Type: reflect.TypeFor[chan int]()}}
 
 	err := sg.mergeBubbled(seen, Parameter{Name: "path", Type: reflect.TypeFor[string]()})

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -15,7 +15,7 @@ import (
 
 // isolate redirects HOME and XDG_CONFIG_HOME into the test sandbox so key resolution and generation never
 // touch the developer's real keys, and returns a signer plus its seeded allowed_signers path.
-func isolate(t *testing.T) (Signer, string) {
+func isolate(t *testing.T) (signer Signer, allowedSigners string) {
 
 	t.Helper()
 

--- a/pkg/sops/encrypter.go
+++ b/pkg/sops/encrypter.go
@@ -117,7 +117,7 @@ func (e *Encrypter) resolve(sourcePath, rootDir string) []string {
 		return chain
 	}
 
-	chain := locate(rootDir, dir, sopsConfigName, xdgFallbackRelPath)
+	chain := locate(rootDir, dir)
 	e.visited[dir] = chain
 	return chain
 }

--- a/pkg/sops/locate.go
+++ b/pkg/sops/locate.go
@@ -24,13 +24,11 @@ import (
 // Parameters:
 //   - `root`: the upper boundary of the upward walk; the walk stops here.
 //   - `startDir`: the directory whose governing config chain is wanted.
-//   - `name`: the config file name collected at each directory (e.g. `.sops.yaml`).
-//   - `xdgRelPath`: the global-fallback path relative to `$XDG_CONFIG_HOME`; empty skips the fallback.
 //
 // Returns:
 //   - `[]string`: absolute paths of the existing config files, deepest in-tree first and the XDG fallback last; nil
 //     when none exist.
-func locate(root, startDir, name, xdgRelPath string) []string {
+func locate(root, startDir string) []string {
 
 	var chain []string
 
@@ -42,7 +40,7 @@ func locate(root, startDir, name, xdgRelPath string) []string {
 
 	if withinRoot {
 		for {
-			if candidate := filepath.Join(dir, name); fileExists(candidate) {
+			if candidate := filepath.Join(dir, sopsConfigName); fileExists(candidate) {
 				chain = append(chain, candidate)
 			}
 			if dir == absRoot {
@@ -52,10 +50,8 @@ func locate(root, startDir, name, xdgRelPath string) []string {
 		}
 	}
 
-	if xdgRelPath != "" {
-		if fallback := xdgConfigPath(xdgRelPath); fallback != "" && fileExists(fallback) {
-			chain = append(chain, fallback)
-		}
+	if fallback := xdgConfigPath(xdgFallbackRelPath); fallback != "" && fileExists(fallback) {
+		chain = append(chain, fallback)
 	}
 
 	return chain

--- a/pkg/sops/locate_test.go
+++ b/pkg/sops/locate_test.go
@@ -26,7 +26,7 @@ func TestLocate_NearestInTree(t *testing.T) {
 	deep := filepath.Join(root, "a", "b")
 	writeLocateFixture(t, filepath.Join(deep, ".sops.yaml"))
 
-	got := locate(root, deep, ".sops.yaml", "devlore/sops.yaml")
+	got := locate(root, deep)
 	assertChain(t, got, []string{filepath.Join(deep, ".sops.yaml")})
 }
 
@@ -40,7 +40,7 @@ func TestLocate_AncestorWins_DeepestFirst(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := locate(root, start, ".sops.yaml", "devlore/sops.yaml")
+	got := locate(root, start)
 	assertChain(t, got, []string{
 		filepath.Join(root, "a", ".sops.yaml"), // deepest first
 		filepath.Join(root, ".sops.yaml"),
@@ -57,7 +57,7 @@ func TestLocate_BoundedByRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertChain(t, locate(root, start, ".sops.yaml", "devlore/sops.yaml"), nil)
+	assertChain(t, locate(root, start), nil)
 }
 
 func TestLocate_XDGFallback(t *testing.T) {
@@ -66,7 +66,7 @@ func TestLocate_XDGFallback(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	writeLocateFixture(t, filepath.Join(xdg, "devlore", "sops.yaml"))
 
-	got := locate(root, root, ".sops.yaml", "devlore/sops.yaml") // no in-tree config
+	got := locate(root, root) // no in-tree config
 	assertChain(t, got, []string{filepath.Join(xdg, "devlore", "sops.yaml")})
 }
 
@@ -77,7 +77,7 @@ func TestLocate_InTreeThenFallback(t *testing.T) {
 	writeLocateFixture(t, filepath.Join(root, ".sops.yaml"))
 	writeLocateFixture(t, filepath.Join(xdg, "devlore", "sops.yaml"))
 
-	got := locate(root, root, ".sops.yaml", "devlore/sops.yaml")
+	got := locate(root, root)
 	assertChain(t, got, []string{
 		filepath.Join(root, ".sops.yaml"),          // in-tree first
 		filepath.Join(xdg, "devlore", "sops.yaml"), // fallback last
@@ -87,7 +87,7 @@ func TestLocate_InTreeThenFallback(t *testing.T) {
 func TestLocate_None(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	assertChain(t, locate(root, root, ".sops.yaml", "devlore/sops.yaml"), nil)
+	assertChain(t, locate(root, root), nil)
 }
 
 func TestLocate_StartDirOutsideRoot_OnlyFallback(t *testing.T) {
@@ -98,7 +98,7 @@ func TestLocate_StartDirOutsideRoot_OnlyFallback(t *testing.T) {
 	writeLocateFixture(t, filepath.Join(outside, ".sops.yaml")) // must NOT be collected
 	writeLocateFixture(t, filepath.Join(xdg, "devlore", "sops.yaml"))
 
-	got := locate(root, outside, ".sops.yaml", "devlore/sops.yaml")
+	got := locate(root, outside)
 	assertChain(t, got, []string{filepath.Join(xdg, "devlore", "sops.yaml")})
 }
 


### PR DESCRIPTION
Third rung of the 4b-3 ladder. unnamedResult 31 → 0 (+2 discovered siblings): result names adopted from the documented Returns bullets, no naked returns. unparam 15 → 0: dead params/results removed with caller updates (two banned `env` identifiers die with their parameters), constants inlined, two reasoned suppressions (assert.raise's stack-depth contract; newPlanBuilder's documented reserve). Drive-by per the class-1 ruling: two bare-nolint flag getters → `assert.Must`. One structure question parked in the plan doc (splitReservedKwargs' seven results). gocritic and unparam at 0; vet + full suite green. Plan: `docs/plans/lint-signatures.md`.