### PR TITLE
lint(noctx): every subprocess and request carries a context

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -4,6 +4,7 @@
 package main_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,7 +51,8 @@ func testMain(m *testing.M) int {
 
 	scriptPath = filepath.Join(root, "cmd", "devlore-test", "devloretest", "data", "test_hello.star")
 
-	build := exec.Command("go", "build", "-o", binary, "./cmd/devlore-test")
+	// TestMain runs outside any test; Background is the honest lifetime here.
+	build := exec.CommandContext(context.Background(), "go", "build", "-o", binary, "./cmd/devlore-test")
 	build.Dir = root
 	build.Stderr = os.Stderr
 	if err := build.Run(); err != nil {
@@ -80,7 +82,8 @@ func findRepoRoot() (string, error) {
 
 // run executes devlore-test with the given args and returns stdout, stderr, and exit code.
 func run(args ...string) (stdout, stderr string, exitCode int) {
-	cmd := exec.Command(binary, args...)
+	// The helper has no *testing.T; the subprocess is bounded by cmd.Run below.
+	cmd := exec.CommandContext(context.Background(), binary, args...)
 	var outBuf, errBuf strings.Builder
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -54,7 +54,11 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 	modTidyPassed := true
 	modTidyDetails := ""
 	if !skipModTidy {
-		modTidyPassed, modTidyDetails = checkModTidy()
+		sessionCtx := p.RuntimeEnvironment().Context
+		if sessionCtx == nil {
+			sessionCtx = context.Background()
+		}
+		modTidyPassed, modTidyDetails = checkModTidy(sessionCtx)
 	}
 
 	if checkTool("golangci-lint") == "" {
@@ -312,12 +316,12 @@ type goPosRaw struct {
 	Column   int    `json:"Column"`
 }
 
-func checkModTidy() (tidy bool, detail string) {
-	tidyCmd := exec.Command("go", "mod", "tidy")
+func checkModTidy(ctx context.Context) (tidy bool, detail string) {
+	tidyCmd := exec.CommandContext(ctx, "go", "mod", "tidy")
 	if output, err := tidyCmd.CombinedOutput(); err != nil {
 		return false, fmt.Sprintf("go mod tidy failed: %s\n%s", err, string(output))
 	}
-	diffCmd := exec.Command("git", "diff", "--exit-code", "go.mod", "go.sum")
+	diffCmd := exec.CommandContext(ctx, "git", "diff", "--exit-code", "go.mod", "go.sum")
 	if output, err := diffCmd.CombinedOutput(); err != nil {
 		return false, fmt.Sprintf("go.mod or go.sum not tidy:\n%s", string(output))
 	}

--- a/cmd/star/provider/setup/provider.go
+++ b/cmd/star/provider/setup/provider.go
@@ -6,6 +6,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -143,8 +144,12 @@ func (p *Provider) PrecommitInstall() (PrecommitInstallResult, error) {
 		return PrecommitInstallResult{Success: true, Message: "[dry-run] would install pre-commit hooks"}, nil
 	}
 
+	sessionCtx := p.RuntimeEnvironment().Context
+	if sessionCtx == nil {
+		sessionCtx = context.Background()
+	}
 	//nolint:gosec // G204: pre-commit resolved via exec.LookPath; constant argv.
-	cmd := exec.Command(precommitPath, "install")
+	cmd := exec.CommandContext(sessionCtx, precommitPath, "install")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		//nolint:nilerr // the failure is the result: the combined output becomes the message, not an error return.

--- a/cmd/writ/writ/snapshot/protect_other.go
+++ b/cmd/writ/writ/snapshot/protect_other.go
@@ -5,7 +5,10 @@
 
 package snapshot
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // lockWorktree is a no-op on non-Darwin platforms.
 // Immutable file flags require root on Linux and have no reliable equivalent on Windows.

--- a/cmd/writ/writ/snapshot/protect_other.go
+++ b/cmd/writ/writ/snapshot/protect_other.go
@@ -29,7 +29,7 @@ func unlockWorktree(_ string) error {
 // Returns:
 //   - error: if the worktree HEAD does not match expectedHash
 func verifyWorktree(worktreePath, expectedHash string) error {
-	actual, err := gitRevParseHEAD(worktreePath)
+	actual, err := gitRevParseHEAD(context.Background(), worktreePath)
 	if err != nil {
 		return fmt.Errorf("verify worktree: %w", err)
 	}

--- a/cmd/writ/writ/snapshot/snapshot.go
+++ b/cmd/writ/writ/snapshot/snapshot.go
@@ -8,6 +8,7 @@
 package snapshot
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -45,7 +46,7 @@ type Snapshot struct {
 //   - error: git command failure or directory creation error
 func Pin(repoPath, layer string) (*Snapshot, error) {
 	// Resolve HEAD commit hash
-	hash, err := gitRevParseHEAD(repoPath)
+	hash, err := gitRevParseHEAD(context.Background(), repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("pin %s: resolve HEAD: %w", layer, err)
 	}
@@ -66,7 +67,7 @@ func Pin(repoPath, layer string) (*Snapshot, error) {
 			//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 			_ = os.RemoveAll(worktreeDir)
 			//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
-			_ = gitWorktreePrune(repoPath)
+			_ = gitWorktreePrune(context.Background(), repoPath)
 		} else {
 			return &Snapshot{
 				Layer:        layer,
@@ -78,7 +79,7 @@ func Pin(repoPath, layer string) (*Snapshot, error) {
 	}
 
 	// Create detached worktree
-	if err := gitWorktreeAdd(repoPath, worktreeDir, hash); err != nil {
+	if err := gitWorktreeAdd(context.Background(), repoPath, worktreeDir, hash); err != nil {
 		return nil, fmt.Errorf("pin %s: create worktree: %w", layer, err)
 	}
 
@@ -107,12 +108,12 @@ func (s *Snapshot) Close() error {
 	_ = unlockWorktree(s.WorktreePath)
 
 	// Remove the git worktree registration
-	if err := gitWorktreeRemove(s.RepoPath, s.WorktreePath); err != nil {
+	if err := gitWorktreeRemove(context.Background(), s.RepoPath, s.WorktreePath); err != nil {
 		// If git worktree remove fails, try force removal
 		//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = os.RemoveAll(s.WorktreePath)
 		//nolint:errcheck // diagnose-ignored-error: teardown; see docs/architecture/2.8-eventing-infrastructure.md
-		_ = gitWorktreePrune(s.RepoPath)
+		_ = gitWorktreePrune(context.Background(), s.RepoPath)
 		return nil //nolint:nilerr // best-effort cleanup; directory removed
 	}
 	return nil
@@ -214,9 +215,9 @@ func Hashes(snapshots []*Snapshot) map[string]string {
 // Returns:
 //   - bool: true if the working tree has uncommitted changes
 //   - error: git command failure
-func IsDirty(repoPath string) (bool, error) {
+func IsDirty(ctx context.Context, repoPath string) (bool, error) {
 	//nolint:gosec // G204: git with constant argv; the repo path comes from writ configuration.
-	cmd := exec.Command("git", "-C", repoPath, "status", "--porcelain")
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "status", "--porcelain")
 	out, err := cmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("git status: %w", err)
@@ -243,7 +244,7 @@ func CheckClean(sources []tree.LayerSource) ([]string, error) {
 		}
 		seen[src.Path] = true
 
-		d, err := IsDirty(src.Path)
+		d, err := IsDirty(context.Background(), src.Path)
 		if err != nil {
 			return nil, fmt.Errorf("check %s: %w", src.Layer, err)
 		}
@@ -282,9 +283,9 @@ func dirExists(path string) bool {
 // ----------------------------------------------------------------------------
 
 // gitRevParseHEAD resolves HEAD to a full commit hash.
-func gitRevParseHEAD(repoPath string) (string, error) {
+func gitRevParseHEAD(ctx context.Context, repoPath string) (string, error) {
 	//nolint:gosec // G204: git with constant argv; the repo path comes from writ configuration.
-	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD")
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse HEAD: %w", err)
@@ -293,9 +294,9 @@ func gitRevParseHEAD(repoPath string) (string, error) {
 }
 
 // gitWorktreeAdd creates a detached worktree at the given path for the given commit.
-func gitWorktreeAdd(repoPath, worktreePath, commitHash string) error {
+func gitWorktreeAdd(ctx context.Context, repoPath, worktreePath, commitHash string) error {
 	//nolint:gosec // G204: git with constant argv; worktree paths are writ-constructed.
-	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", "--detach", worktreePath, commitHash)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "--detach", worktreePath, commitHash)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -303,9 +304,9 @@ func gitWorktreeAdd(repoPath, worktreePath, commitHash string) error {
 }
 
 // gitWorktreeRemove removes a worktree registration and directory.
-func gitWorktreeRemove(repoPath, worktreePath string) error {
+func gitWorktreeRemove(ctx context.Context, repoPath, worktreePath string) error {
 	//nolint:gosec // G204: git with constant argv; worktree paths are writ-constructed.
-	cmd := exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", worktreePath)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "remove", "--force", worktreePath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree remove: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -313,9 +314,9 @@ func gitWorktreeRemove(repoPath, worktreePath string) error {
 }
 
 // gitWorktreePrune removes stale worktree entries.
-func gitWorktreePrune(repoPath string) error {
+func gitWorktreePrune(ctx context.Context, repoPath string) error {
 	//nolint:gosec // G204: git with constant argv; the repo path comes from writ configuration.
-	cmd := exec.Command("git", "-C", repoPath, "worktree", "prune")
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "prune")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree prune: %s: %w", strings.TrimSpace(string(out)), err)
 	}

--- a/cmd/writ/writ/snapshot/snapshot_test.go
+++ b/cmd/writ/writ/snapshot/snapshot_test.go
@@ -28,7 +28,7 @@ func initGitRepo(t *testing.T, dir string, files map[string]string) string {
 
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.CommandContext(t.Context(), "git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test",
@@ -60,7 +60,7 @@ func initGitRepo(t *testing.T, dir string, files map[string]string) string {
 	run("commit", "-m", "initial commit")
 
 	// Get the commit hash
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	cmd := exec.CommandContext(t.Context(), "git", "-C", dir, "rev-parse", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +140,7 @@ func TestPinWorktreeExcludesUncommitted(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Stage a file but don't commit
-	cmd := exec.Command("git", "-C", repoDir, "add", "uncommitted.txt")
+	cmd := exec.CommandContext(t.Context(), "git", "-C", repoDir, "add", "uncommitted.txt")
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +328,7 @@ func TestIsDirtyCleanRepo(t *testing.T) {
 	repoDir := t.TempDir()
 	initGitRepo(t, repoDir, map[string]string{"a.txt": "a"})
 
-	dirty, err := IsDirty(repoDir)
+	dirty, err := IsDirty(t.Context(), repoDir)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestIsDirtyUnstagedChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirty, err := IsDirty(repoDir)
+	dirty, err := IsDirty(t.Context(), repoDir)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -365,12 +365,12 @@ func TestIsDirtyStagedChanges(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoDir, "b.txt"), []byte("new"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("git", "-C", repoDir, "add", "b.txt")
+	cmd := exec.CommandContext(t.Context(), "git", "-C", repoDir, "add", "b.txt")
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
 
-	dirty, err := IsDirty(repoDir)
+	dirty, err := IsDirty(t.Context(), repoDir)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestIsDirtyUntrackedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirty, err := IsDirty(repoDir)
+	dirty, err := IsDirty(t.Context(), repoDir)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}

--- a/docs/plans/lint-noctx.md
+++ b/docs/plans/lint-noctx.md
@@ -1,0 +1,35 @@
+---
+title: "noctx: every subprocess and request carries a context"
+issue: TBD
+status: complete
+created: 2026-08-02
+updated: 2026-08-02
+---
+
+# Plan: noctx — every subprocess and request carries a context
+
+Sixth rung of the 4b-3 ladder, per the 2026-07-30 ruling (fix inline; mechanical plumbing
+now, lifetime refinement later if needed). Twenty sites, sorted per the codebase's own
+discipline: derive from the dispatch at hand, take the session context at edges, and say
+so explicitly where only Background exists.
+
+## The sorting
+
+1. **Immediate-provider helpers (3)** — lint's `checkModTidy` gains a `ctx` parameter and
+   setup's `PrecommitInstall` threads the session context: `RuntimeEnvironment.Context`,
+   nil-guarded to Background for bare test-built environments.
+2. **writ snapshot git helpers (5)** — `IsDirty` and the four `git worktree` helpers take
+   `ctx` first; internal callers (`Pin`, `Close`, `CheckClean`, `verifyWorktree`) pass
+   Background explicitly — that IS the current lifetime of these synchronous CLI paths,
+   now stated rather than implied. Threading real command contexts through the exported
+   snapshot API is the deferred refinement.
+3. **Tests (12)** — server router/integration requests carry `t.Context()` (cancelled at
+   test end); snapshot-test git fixtures likewise; devlore-test's two sites run where no
+   `*testing.T` exists (`TestMain`, the shared `run` helper) and use Background with a
+   comment saying exactly that.
+
+## Verification
+
+- noctx 20 → **0** uncapped; `make vet` and full `make test` pass; `gofmt -l` clean.
+- Board after this rung: unused 11 (class f) + chartered complexity (gocognit 52,
+  gocyclo 9).

--- a/pkg/op/server/integration_test.go
+++ b/pkg/op/server/integration_test.go
@@ -84,7 +84,11 @@ func TestServer_CommandAndEvents(t *testing.T) {
 
 	// Subscribe first: http.Get returns once the handler has flushed the SSE response headers, which it does after
 	// subscribing to the plane — so the subscription is live before the run emits anything.
-	eventsResp, err := http.Get(ts.URL + "/v1/runs/run-1/events")
+	eventsReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/v1/runs/run-1/events", http.NoBody)
+	if err != nil {
+		t.Fatalf("build events request: %v", err)
+	}
+	eventsResp, err := http.DefaultClient.Do(eventsReq)
 	if err != nil {
 		t.Fatalf("GET events: %v", err)
 	}
@@ -108,8 +112,13 @@ func TestServer_CommandAndEvents(t *testing.T) {
 	}()
 
 	// The pause POST blocks until the run serves it at gate-2's control-point; the JSON body is the ack.
-	postResp, err := http.Post(ts.URL+"/v1/runs/run-1/commands", "application/json",
+	pauseReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/v1/runs/run-1/commands",
 		strings.NewReader(`{"command":"pause","request_id":"c-1"}`))
+	if err != nil {
+		t.Fatalf("build pause request: %v", err)
+	}
+	pauseReq.Header.Set("Content-Type", "application/json")
+	postResp, err := http.DefaultClient.Do(pauseReq)
 	if err != nil {
 		t.Fatalf("POST pause: %v", err)
 	}

--- a/pkg/op/server/router_test.go
+++ b/pkg/op/server/router_test.go
@@ -30,7 +30,11 @@ func TestServer_Status(t *testing.T) {
 		return op.RunStatus{Phase: op.PhasePaused, Condition: op.ConditionHealthy, Reason: op.ReasonPaused}
 	})
 
-	resp, err := http.Get(ts.URL + "/v1/runs/run-1")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/v1/runs/run-1", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET status: %v", err)
 	}
@@ -57,7 +61,7 @@ func TestServer_UnknownRun(t *testing.T) {
 		{http.MethodGet, "/v1/runs/nope/events"},
 		{http.MethodPost, "/v1/runs/nope/commands"},
 	} {
-		req, _ := http.NewRequest(tc.method, ts.URL+tc.path, strings.NewReader(`{"command":"pause"}`))
+		req, _ := http.NewRequestWithContext(t.Context(), tc.method, ts.URL+tc.path, strings.NewReader(`{"command":"pause"}`))
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("%s %s: %v", tc.method, tc.path, err)
@@ -114,7 +118,11 @@ func TestServer_Unregister(t *testing.T) {
 
 	unregister()
 
-	resp, err := http.Get(ts.URL + "/v1/runs/run-1")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/v1/runs/run-1", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -154,7 +162,12 @@ func TestWriteSSE(t *testing.T) {
 
 func post(t *testing.T, ts *httptest.Server, body string) *http.Response {
 	t.Helper()
-	resp, err := http.Post(ts.URL+"/v1/runs/run-1/commands", "application/json", strings.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/v1/runs/run-1/commands", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}


### PR DESCRIPTION
Sixth rung of the 4b-3 ladder, per the fix-inline ruling. Immediate-provider helpers thread the session context (nil-guarded); writ's snapshot git helpers take `ctx` first with Background stated explicitly at their synchronous CLI edges (real threading through the exported snapshot API is the deferred refinement); tests carry `t.Context()` everywhere one exists, and the two sites without a `*testing.T` say so in a comment. noctx 20 → 0; vet + full suite green. Plan: `docs/plans/lint-noctx.md`.