### PR TITLE
refactor(complexity): phase 1 — writ commands and the test harness

### DIFF
--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -114,76 +114,107 @@ func (tc *TestContext) SetResolvedVariables(v map[string]op.Variable) {
 // Returns:
 //   - []Failure: failures for expectations that did not hold; never nil (empty when all pass).
 func (tc *TestContext) Check(graph *op.Graph, execErr error) []Failure {
+
 	var failures []Failure
 
 	for i := range tc.expectations {
-		exp := &tc.expectations[i]
-		switch exp.Kind {
-		case "file_exists":
-			f := tc.checkFileExists(*exp)
-			if f != nil {
-				failures = append(failures, *f)
-			}
-
-		case "no_file":
-			f := tc.checkNoFile(*exp)
-			if f != nil {
-				failures = append(failures, *f)
-			}
-
-		case "unit_count":
-			if graph == nil {
-				// Immediate-mode scripts assemble no graph; a nil graph means zero planned units, so
-				// expect_unit_count(0) is satisfied. A non-zero expectation against a nil graph is a
-				// genuine miss — the script meant to plan units but never assembled a graph.
-				if exp.Count != 0 {
-					failures = append(failures, Failure{
-						Expectation: fmt.Sprintf("unit_count(%d)", exp.Count),
-						Message:     "no graph assembled (script did not assign `graph = plan.assemble_definition([...])`)",
-					})
-				}
-				continue
-			}
-			if got := graph.UnitCount(); got != exp.Count {
-				failures = append(failures, Failure{
-					Expectation: fmt.Sprintf("unit_count(%d)", exp.Count),
-					Message:     fmt.Sprintf("got %d units", got),
-				})
-			}
-
-		case "error":
-			f := tc.checkError(*exp, execErr)
-			if f != nil {
-				failures = append(failures, *f)
-			}
-
-		case "variable":
-			if f := tc.checkVariable(*exp); f != nil {
-				failures = append(failures, *f)
-			}
-
-		case "variable_namespace":
-			if f := tc.checkVariableNamespace(*exp); f != nil {
-				failures = append(failures, *f)
-			}
-
-		case "equal":
-			eq, err := starlark.Equal(exp.Got, exp.Want)
-			if err != nil {
-				failures = append(failures, Failure{
-					Expectation: fmt.Sprintf("equal(%s, %s)", exp.Got, exp.Want),
-					Message:     fmt.Sprintf("comparison error: %v", err),
-				})
-			} else if !eq {
-				failures = append(failures, Failure{
-					Expectation: fmt.Sprintf("equal(%s, %s)", exp.Got, exp.Want),
-					Message:     fmt.Sprintf("got %s, want %s", exp.Got, exp.Want),
-				})
-			}
+		if f := tc.checkExpectation(tc.expectations[i], graph, execErr); f != nil {
+			failures = append(failures, *f)
 		}
 	}
 
 	return failures
+}
+
+// checkExpectation evaluates one expectation against the run, dispatching on its kind.
+//
+// Parameters:
+//   - `exp`: the expectation to evaluate.
+//   - `graph`: the assembled graph, or nil for immediate-mode scripts.
+//   - `execErr`: the script execution error, or nil.
+//
+// Returns:
+//   - `*Failure`: the failure, or nil when the expectation holds (or the kind is unknown).
+func (tc *TestContext) checkExpectation(exp Expectation, graph *op.Graph, execErr error) *Failure {
+
+	switch exp.Kind {
+	case "file_exists":
+		return tc.checkFileExists(exp)
+	case "no_file":
+		return tc.checkNoFile(exp)
+	case "unit_count":
+		return checkUnitCount(exp, graph)
+	case "error":
+		return tc.checkError(exp, execErr)
+	case "variable":
+		return tc.checkVariable(exp)
+	case "variable_namespace":
+		return tc.checkVariableNamespace(exp)
+	case "equal":
+		return checkEqual(exp)
+	}
+
+	return nil
+}
+
+// checkUnitCount asserts the graph's planned unit count.
+//
+// Immediate-mode scripts assemble no graph; a nil graph means zero planned units, so
+// expect_unit_count(0) is satisfied. A non-zero expectation against a nil graph is a genuine miss —
+// the script meant to plan units but never assembled a graph.
+//
+// Parameters:
+//   - `exp`: the unit_count expectation.
+//   - `graph`: the assembled graph, or nil.
+//
+// Returns:
+//   - `*Failure`: the failure, or nil when the count matches.
+func checkUnitCount(exp Expectation, graph *op.Graph) *Failure {
+
+	if graph == nil {
+		if exp.Count != 0 {
+			return &Failure{
+				Expectation: fmt.Sprintf("unit_count(%d)", exp.Count),
+				Message:     "no graph assembled (script did not assign `graph = plan.assemble_definition([...])`)",
+			}
+		}
+		return nil
+	}
+
+	if got := graph.UnitCount(); got != exp.Count {
+		return &Failure{
+			Expectation: fmt.Sprintf("unit_count(%d)", exp.Count),
+			Message:     fmt.Sprintf("got %d units", got),
+		}
+	}
+
+	return nil
+}
+
+// checkEqual asserts starlark equality of the expectation's got/want pair.
+//
+// Parameters:
+//   - `exp`: the equal expectation carrying the two starlark values.
+//
+// Returns:
+//   - `*Failure`: the failure (including comparison errors), or nil when the values are equal.
+func checkEqual(exp Expectation) *Failure {
+
+	eq, err := starlark.Equal(exp.Got, exp.Want)
+	if err != nil {
+		return &Failure{
+			Expectation: fmt.Sprintf("equal(%s, %s)", exp.Got, exp.Want),
+			Message:     fmt.Sprintf("comparison error: %v", err),
+		}
+	}
+	if !eq {
+		return &Failure{
+			Expectation: fmt.Sprintf("equal(%s, %s)", exp.Got, exp.Want),
+			Message:     fmt.Sprintf("got %s, want %s", exp.Got, exp.Want),
+		}
+	}
+
+	return nil
 }
 
 // Expectations returns the queued expectations.

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -75,6 +75,31 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 			"no deployed files found for projects %v; cannot decommission without deployment history", cfg.Projects)
 	}
 
+	graphs, err := buildScopeGraphs(ctx, cfg, selected)
+	if err != nil {
+		return err
+	}
+
+	if cfg.DryRun {
+		return emitGraphs(graphs)
+	}
+
+	return runAll(ctx, cfg, graphs)
+}
+
+// buildScopeGraphs groups the entries by scope and assembles one removal graph per scope, in removal
+// priority order.
+//
+// Parameters:
+//   - `ctx`: the planning context.
+//   - `cfg`: the decommission configuration.
+//   - `selected`: the deployed entries selected for removal.
+//
+// Returns:
+//   - `[]*op.Graph`: one assembled graph per scope, in removal order.
+//   - `error`: non-nil when any scope's planning or assembly fails.
+func buildScopeGraphs(ctx context.Context, cfg *Config, selected []readback.Entry) ([]*op.Graph, error) {
+
 	byScope := make(map[string][]readback.Entry)
 	for i := range selected {
 		entry := &selected[i]
@@ -85,28 +110,53 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	for _, scope := range scopesInOrder(byScope) {
 		graph, err := buildScopeGraph(ctx, cfg, scope, byScope[scope])
 		if err != nil {
-			return err
+			return nil, err
 		}
 		graphs = append(graphs, graph)
 	}
 
-	if cfg.DryRun {
-		encoder := yaml.NewEncoder(os.Stdout)
-		defer func() {
-			if closeErr := encoder.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-		}()
-		encoder.SetIndent(2)
-		for _, graph := range graphs {
-			if err := graph.Serialize(encoder); err != nil {
-				return err
-			}
+	return graphs, nil
+}
+
+// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
+//
+// Parameters:
+//   - `graphs`: the assembled graphs, in removal order.
+//
+// Returns:
+//   - `err`: a serialization or encoder-close failure.
+func emitGraphs(graphs []*op.Graph) (err error) {
+
+	encoder := yaml.NewEncoder(os.Stdout)
+	defer func() {
+		if closeErr := encoder.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
-		return nil
+	}()
+	encoder.SetIndent(2)
+
+	for _, graph := range graphs {
+		if err := graph.Serialize(encoder); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+// runAll executes every graph, collecting per-scope failures.
+//
+// Parameters:
+//   - `ctx`: the execution context.
+//   - `cfg`: the decommission configuration.
+//   - `graphs`: the assembled graphs, in removal order.
+//
+// Returns:
+//   - `error`: the joined per-scope failures, or nil when every scope succeeds.
+func runAll(ctx context.Context, cfg *Config, graphs []*op.Graph) error {
+
 	var failures []error
+
 	for _, graph := range graphs {
 		if runErr := runGraph(ctx, cfg, graph); runErr != nil {
 			scope := graph.Origin().Scope()

--- a/cmd/writ/writ/deploy/deploy.go
+++ b/cmd/writ/writ/deploy/deploy.go
@@ -118,19 +118,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	if cfg.DryRun {
-		encoder := yaml.NewEncoder(os.Stdout)
-		defer func() {
-			if closeErr := encoder.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-		}()
-		encoder.SetIndent(2)
-		for _, graph := range build.Graphs {
-			if err := graph.Serialize(encoder); err != nil {
-				return err
-			}
-		}
-		return nil
+		return emitGraphs(build.Graphs)
 	}
 
 	sortGraphsByScope(build.Graphs)
@@ -140,9 +128,50 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 		return err
 	}
 
+	return runAll(ctx, cfg, build.Graphs, runPolicy)
+}
+
+// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
+//
+// Parameters:
+//   - `graphs`: the assembled graphs, in run order.
+//
+// Returns:
+//   - `err`: a serialization or encoder-close failure.
+func emitGraphs(graphs []*op.Graph) (err error) {
+
+	encoder := yaml.NewEncoder(os.Stdout)
+	defer func() {
+		if closeErr := encoder.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	encoder.SetIndent(2)
+
+	for _, graph := range graphs {
+		if err := graph.Serialize(encoder); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runAll executes every graph under the run policy, collecting per-scope failures.
+//
+// Parameters:
+//   - `ctx`: the execution context.
+//   - `cfg`: the deploy configuration.
+//   - `graphs`: the assembled graphs, in run order.
+//   - `runPolicy`: the conflict policy resolved by the preflight pass.
+//
+// Returns:
+//   - `error`: the joined per-scope failures, or nil when every scope succeeds.
+func runAll(ctx context.Context, cfg *Config, graphs []*op.Graph, runPolicy op.ConflictPolicy) error {
+
 	var failures []error
 
-	for _, graph := range build.Graphs {
+	for _, graph := range graphs {
 		if runErr := runGraph(ctx, cfg, graph, runPolicy); runErr != nil {
 			scope := scopeLabel(graph)
 			cli.Warn("scope %s failed: %v", scope, runErr)

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -271,52 +271,20 @@ func buildScopeGraph(
 
 		provider := plan.NewProvider(env)
 
-		// Manifest-resolved package units first: their planner drains its own invocations into phase
-		// subgraphs, so they must plan before the file chains land in the shared registry.
-		var manifests []string
-		var chains []*tree.FileEntry
-		for _, f := range files {
-			if len(f.Operations) == 1 && f.Operations[0] == "manifest.resolve" {
-				manifests = append(manifests, f.Source)
-				continue
-			}
-			chains = append(chains, f)
-		}
+		manifests, chains := splitManifests(files)
 
-		var units []op.ExecutableUnit
-		if len(manifests) > 0 {
-			if cfg.ManifestPlanner == nil {
-				cli.Note("Skipping %d packages-manifest file(s): no manifest planner configured", len(manifests))
-			} else {
-				for _, m := range manifests {
-					_, packageUnits, err := cfg.ManifestPlanner.PlanPackages(provider, env, m)
-					if err != nil {
-						return nil, fmt.Errorf("manifest %s: %w", m, err)
-					}
-					units = append(units, packageUnits...)
-				}
-			}
+		units, err := planManifests(cfg, provider, env, manifests)
+		if err != nil {
+			return nil, err
 		}
 
 		if err := planParentDirectories(provider, chains); err != nil {
 			return nil, err
 		}
 
-		data := templateData(cfg)
-		fileMetas := make(map[string]any, len(chains))
-
-		for _, f := range chains {
-			finalInvocation, action, err := PlanFileChain(provider, f, data)
-			if err != nil {
-				return nil, fmt.Errorf("plan %s: %w", f.ID, err)
-			}
-			fileMetas[finalInvocation.Target.ID()] = map[string]any{
-				"target":  f.Target,
-				"source":  f.Source,
-				"project": f.Project,
-				"layer":   f.Layer,
-				"action":  action,
-			}
+		fileMetas, err := planChains(provider, chains, templateData(cfg))
+		if err != nil {
+			return nil, err
 		}
 
 		units = append(units, parentlessUnits(provider)...)
@@ -450,6 +418,99 @@ func runSpec(graph *op.Graph, dryRun bool, conflict op.ConflictPolicy) (*op.Runt
 	}
 
 	return deploySpec(root, dryRun, conflict)
+}
+
+// splitManifests partitions the file entries into packages-manifest sources and file chains.
+//
+// Manifest-resolved package units plan first: their planner drains its own invocations into phase
+// subgraphs, so they must plan before the file chains land in the shared registry.
+//
+// Parameters:
+//   - `files`: the scope's file entries.
+//
+// Returns:
+//   - `manifests`: the packages-manifest source paths.
+//   - `chains`: the remaining file-chain entries.
+func splitManifests(files []*tree.FileEntry) (manifests []string, chains []*tree.FileEntry) {
+
+	for _, f := range files {
+		if len(f.Operations) == 1 && f.Operations[0] == "manifest.resolve" {
+			manifests = append(manifests, f.Source)
+			continue
+		}
+		chains = append(chains, f)
+	}
+
+	return manifests, chains
+}
+
+// planManifests plans the package units for every manifest through the configured manifest planner.
+//
+// With no planner configured the manifests are skipped with a note — file chains still deploy.
+//
+// Parameters:
+//   - `cfg`: the deploy configuration carrying the planner.
+//   - `provider`: the scope's plan provider.
+//   - `env`: the planning runtime environment.
+//   - `manifests`: the packages-manifest source paths.
+//
+// Returns:
+//   - `[]op.ExecutableUnit`: the planned package units, in manifest order.
+//   - `error`: non-nil when any manifest fails to plan.
+func planManifests(
+	cfg *Config, provider *plan.Provider, env *op.RuntimeEnvironment, manifests []string,
+) ([]op.ExecutableUnit, error) {
+
+	if len(manifests) == 0 {
+		return nil, nil
+	}
+
+	if cfg.ManifestPlanner == nil {
+		cli.Note("Skipping %d packages-manifest file(s): no manifest planner configured", len(manifests))
+		return nil, nil
+	}
+
+	var units []op.ExecutableUnit
+	for _, m := range manifests {
+		_, packageUnits, err := cfg.ManifestPlanner.PlanPackages(provider, env, m)
+		if err != nil {
+			return nil, fmt.Errorf("manifest %s: %w", m, err)
+		}
+		units = append(units, packageUnits...)
+	}
+
+	return units, nil
+}
+
+// planChains plans every file chain and collects the per-target file metadata for the graph origin.
+//
+// Parameters:
+//   - `provider`: the scope's plan provider.
+//   - `chains`: the file-chain entries.
+//   - `data`: the template render data.
+//
+// Returns:
+//   - `map[string]any`: per-target metadata keyed by the final invocation's target ID.
+//   - `error`: non-nil when any chain fails to plan.
+func planChains(provider *plan.Provider, chains []*tree.FileEntry, data map[string]any) (map[string]any, error) {
+
+	fileMetas := make(map[string]any, len(chains))
+
+	for _, f := range chains {
+		finalInvocation, action, err := PlanFileChain(provider, f, data)
+		if err != nil {
+			return nil, fmt.Errorf("plan %s: %w", f.ID, err)
+		}
+		fileMetas[finalInvocation.Target.ID()] = map[string]any{
+			"target":  f.Target,
+			"source":  f.Source,
+			"project": f.Project,
+			"layer":   f.Layer,
+			"action":  action,
+		}
+	}
+
+	return fileMetas, nil
 }
 
 // runRootFor computes the confinement root for one scope: the deepest common ancestor of the scope's target

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -96,20 +96,71 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	data := deploy.RenderData(cfg.Segments, cfg.Vars)
 
 	regenerate, skipped := classify(cfg, copied, data)
-
-	if len(skipped) > 0 {
-		cli.Note("Skipped %d file(s):", len(skipped))
-		for _, target := range skipped {
-			cli.Note("  %s", target)
-		}
-		cli.Note("Use --force to overwrite. (\"indeterminate\" entries predate the recorded content identity or are" +
-			" encrypted without a cataloged source.)")
-	}
+	reportSkipped(skipped)
 
 	if len(regenerate) == 0 {
 		cli.Success("Nothing to regenerate.")
 		return nil
 	}
+
+	graphs, err := buildScopeGraphs(ctx, cfg, regenerate, data)
+	if err != nil {
+		return err
+	}
+
+	if cfg.DryRun {
+		return emitGraphs(graphs)
+	}
+
+	regenerated, err := runAll(ctx, cfg, graphs)
+	if err != nil {
+		return err
+	}
+
+	if len(skipped) > 0 {
+		cli.Success("%d file(s) regenerated, %d skipped", regenerated, len(skipped))
+	} else {
+		cli.Success("%d file(s) regenerated", regenerated)
+	}
+
+	return nil
+}
+
+// region HELPER FUNCTIONS
+
+// reportSkipped notes the skipped targets and the --force hint; an empty slice notes nothing.
+//
+// Parameters:
+//   - `skipped`: the skipped target paths from classification.
+func reportSkipped(skipped []string) {
+
+	if len(skipped) == 0 {
+		return
+	}
+
+	cli.Note("Skipped %d file(s):", len(skipped))
+	for _, target := range skipped {
+		cli.Note("  %s", target)
+	}
+	cli.Note("Use --force to overwrite. (\"indeterminate\" entries predate the recorded content identity or are" +
+		" encrypted without a cataloged source.)")
+}
+
+// buildScopeGraphs groups the entries by scope and assembles one regeneration graph per scope, in
+// sorted scope order.
+//
+// Parameters:
+//   - `ctx`: the planning context.
+//   - `cfg`: the upgrade configuration.
+//   - `regenerate`: the entries to regenerate.
+//   - `data`: the render data for the chains.
+//
+// Returns:
+//   - `[]*op.Graph`: one assembled graph per scope, in sorted scope order.
+//   - `error`: non-nil when any scope's planning or assembly fails.
+func buildScopeGraphs(
+	ctx context.Context, cfg *Config, regenerate []readback.Entry, data map[string]any,
+) ([]*op.Graph, error) {
 
 	byScope := make(map[string][]readback.Entry)
 	for i := range regenerate {
@@ -127,29 +178,55 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	for _, scope := range scopes {
 		graph, err := buildScopeGraph(ctx, cfg, scope, byScope[scope], data)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		graphs = append(graphs, graph)
 	}
 
-	if cfg.DryRun {
-		encoder := yaml.NewEncoder(os.Stdout)
-		defer func() {
-			if closeErr := encoder.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-		}()
-		encoder.SetIndent(2)
-		for _, graph := range graphs {
-			if err := graph.Serialize(encoder); err != nil {
-				return err
-			}
+	return graphs, nil
+}
+
+// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
+//
+// Parameters:
+//   - `graphs`: the assembled graphs, in run order.
+//
+// Returns:
+//   - `err`: a serialization or encoder-close failure.
+func emitGraphs(graphs []*op.Graph) (err error) {
+
+	encoder := yaml.NewEncoder(os.Stdout)
+	defer func() {
+		if closeErr := encoder.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
-		return nil
+	}()
+	encoder.SetIndent(2)
+
+	for _, graph := range graphs {
+		if err := graph.Serialize(encoder); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+// runAll executes every graph, collecting per-scope failures; the regenerated count accumulates even
+// when scopes fail.
+//
+// Parameters:
+//   - `ctx`: the execution context.
+//   - `cfg`: the upgrade configuration.
+//   - `graphs`: the assembled graphs, in run order.
+//
+// Returns:
+//   - `regenerated`: the number of files regenerated across all scopes.
+//   - `err`: the joined per-scope failures, or nil when every scope succeeds.
+func runAll(ctx context.Context, cfg *Config, graphs []*op.Graph) (regenerated int, err error) {
+
 	var failures []error
-	regenerated := 0
+
 	for _, graph := range graphs {
 		count, runErr := runGraph(ctx, cfg, graph)
 		regenerated += count
@@ -164,19 +241,11 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	if len(failures) > 0 {
-		return fmt.Errorf("%d scope(s) failed: %w", len(failures), errors.Join(failures...))
+		return regenerated, fmt.Errorf("%d scope(s) failed: %w", len(failures), errors.Join(failures...))
 	}
 
-	if len(skipped) > 0 {
-		cli.Success("%d file(s) regenerated, %d skipped", regenerated, len(skipped))
-	} else {
-		cli.Success("%d file(s) regenerated", regenerated)
-	}
-
-	return nil
+	return regenerated, nil
 }
-
-// region HELPER FUNCTIONS
 
 // classify partitions the copied entries into regeneration candidates and force-gated skips.
 //
@@ -315,26 +384,16 @@ func classifyEntry(entry readback.Entry, data map[string]any) classification {
 	var fresh []byte
 	switch pipeline {
 	case "template.render_bytes+file.copy":
-		provider := &template.Provider{}
-		rendered, renderErr := provider.RenderText(string(source), data)
-		if renderErr != nil {
+		rendered, ok := renderedFresh(source, data)
+		if !ok {
 			return classUnverifiable
 		}
-		fresh = []byte(rendered)
+		fresh = rendered
 	case "file.link":
 		// A source with no processing suffix deployed as a plain copy entry: compare bytes directly.
 		fresh = source
 	default:
-		// Encrypted chains: the fresh result is not computable without decrypting, but the ENCRYPTED source's
-		// bytes are hashable — when the run cataloged the source, source movement attributes without any
-		// decryption.
-		if targetUnchanged && entry.RecordedSourceDigest != "" {
-			if readback.ContentDigest(source) == entry.RecordedSourceDigest {
-				return classUpToDate
-			}
-			return classStale
-		}
-		return classUnverifiable
+		return classifyEncryptedChain(entry, source, targetUnchanged)
 	}
 
 	if bytes.Equal(current, fresh) {
@@ -344,6 +403,50 @@ func classifyEntry(entry readback.Entry, data map[string]any) classification {
 		return classStale
 	}
 	return classDiffering
+}
+
+// renderedFresh recomputes a templated entry's fresh content from its source and the render data.
+//
+// Parameters:
+//   - `source`: the template source bytes.
+//   - `data`: the render data.
+//
+// Returns:
+//   - `[]byte`: the rendered content.
+//   - `bool`: false when rendering fails (the entry is unverifiable).
+func renderedFresh(source []byte, data map[string]any) ([]byte, bool) {
+
+	provider := &template.Provider{}
+	rendered, err := provider.RenderText(string(source), data)
+	if err != nil {
+		return nil, false
+	}
+
+	return []byte(rendered), true
+}
+
+// classifyEncryptedChain classifies an entry whose fresh result is not computable without decrypting.
+//
+// The ENCRYPTED source's bytes are hashable — when the run cataloged the source, source movement
+// attributes without any decryption.
+//
+// Parameters:
+//   - `entry`: the deployed entry under classification.
+//   - `source`: the encrypted source bytes.
+//   - `targetUnchanged`: whether the target matches its recorded as-deployed digest.
+//
+// Returns:
+//   - `classification`: up-to-date, stale, or unverifiable.
+func classifyEncryptedChain(entry readback.Entry, source []byte, targetUnchanged bool) classification {
+
+	if targetUnchanged && entry.RecordedSourceDigest != "" {
+		if readback.ContentDigest(source) == entry.RecordedSourceDigest {
+			return classUpToDate
+		}
+		return classStale
+	}
+
+	return classUnverifiable
 }
 
 // buildScopeGraph re-plans the regeneration chains for one scope's entries.

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -1,0 +1,83 @@
+---
+title: "Complexity refactors: 61 functions under the thresholds"
+issue: "#312"
+status: in-progress
+created: 2026-08-02
+updated: 2026-08-02
+---
+
+# Plan: Complexity refactors
+
+The 4b-3 ladder's chartered remainder: 52 gocognit findings (threshold 20) and 9 gocyclo
+findings (threshold 15) — every function in the repository that exceeds the configured
+complexity limits. This is the repository's only remaining lint debt.
+
+## Discipline (applies to every phase)
+
+1. **Behavior-preserving decomposition only.** Extract-method into unexported same-file
+   helpers (or `helpers.go` per style §10 when multi-file), early-return flattening,
+   and table-driven dispatch where a switch IS the complexity. No public signature
+   changes, no semantic changes; the existing test suite must pass unmodified.
+2. **The PR diff is the review surface.** Each extracted helper's name and single
+   responsibility are visible in the diff; anything that smells like a design decision
+   rather than a mechanical seam gets surfaced in the phase's plan-doc notes before the
+   commit script is written.
+3. **Verification per phase:** the phase's findings enumerate to zero (uncapped), no new
+   findings introduced anywhere, `make vet` + full `make test` green, gofmt clean.
+4. **This document is updated as each phase completes** — status flipped, actuals
+   recorded — before the next phase begins.
+
+## Phases (leaf → core; one PR each)
+
+| # | Branch | Scope | Findings | Status |
+|---|---|---|---|---|
+| 1 | `refactor/complexity-writ` | writ commands: upgrade `Execute` 30 + `classifyEntry` 21, deploy `Execute` 22 + `buildScopeGraph` 29, decommission `Execute` 23; devlore-test `TestContext.Check` 32 | 6 | **complete** |
+| 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | pending |
+| 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | pending |
+| 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | pending |
+| 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | pending |
+| 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | pending |
+| 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16 | 15 | pending |
+
+Total: 60 listed + `TestContext.Check` counted in phase 1 = 61.
+
+## Phase notes
+
+**Phase 1 (complete):** the three writ `Execute`s decomposed onto the same narrative shape
+— fold/build → group (`buildScopeGraphs`) → dry-run (`emitGraphs`) → run-and-collect
+(`runAll`) — as per-package unexported helpers. The dry-run emitter is now verbatim-
+identical in three packages; deduplicating it into a shared location is a structure
+decision available for a ruling, deliberately not taken unilaterally. `classifyEntry`
+split its encrypted-chain arm (`classifyEncryptedChain`) and render arm (`renderedFresh`);
+`TestContext.Check` became a uniform per-kind dispatch (`checkExpectation`), extracting
+`checkUnitCount` and `checkEqual` to match the existing check-helper family;
+deploy's plan closure extracted `splitManifests` / `planManifests` / `planChains`.
+
+## Ordering rationale
+
+Leaf-to-core: the writ/star/goast phases build the decomposition pattern on
+self-contained, well-tested surfaces before the engine phase touches dispatch, planning,
+and recovery — the code where a behavioral slip costs the most. The conversion phase
+(6) immediately precedes the engine because the engine's planners lean on the conversion
+cascade; refactoring the cascade first means phase 7 reads its final shape.
+
+## Risks, stated
+
+1. **The engine phase.** `ActionPlanner.Plan`, `dispatchWithPolicy`, and `rearm` sit on
+   the saga/recovery path; their tests are strong (lifecycle e2e, resume, rollback), but
+   any seam that changes evaluation order is a defect even if tests stay green. Extracted
+   helpers must preserve exact ordering and short-circuit behavior; anything ambiguous
+   gets surfaced before committing.
+2. **goast's build-tag-free bulk** is safe ground, but its provider methods share walk
+   patterns — phase 3 may reveal a shared-walk helper wanted by five methods. That is a
+   structure decision: proposed in the phase notes, ruled before adoption.
+3. **splitReservedKwargs** carries a pre-existing ruling request (the carrier struct);
+   phase 5's notes present the struct shape for sign-off as part of the phase, not as a
+   silent side effect.
+
+## Not in scope
+
+Raising thresholds, suppressing findings, or semantic redesigns. Every function ends at
+or under gocognit 20 / gocyclo 15 by decomposition alone; if any function genuinely
+cannot be decomposed without semantic change, that finding comes back here with the
+evidence for a ruling.


### PR DESCRIPTION
Phase 1 of docs/plans/complexity-refactors.md (#312): six functions decomposed under gocognit 20 / gocyclo 15, behavior-preserving — the suite passes unmodified. The three writ `Execute`s share one narrative shape via per-package helpers (`buildScopeGraphs` / `emitGraphs` / `runAll`); the verbatim-identical emitter is flagged in the plan doc as an available cross-package dedup ruling. `classifyEntry` splits its encrypted-chain and render arms; deploy's plan closure extracts manifest/chain planning; `TestContext.Check` becomes uniform per-kind dispatch. Plan doc rides along with phase 1 marked complete.