### PR TITLE
refactor(complexity): phase 2 — star app and the shellcheck provider

### DIFF
--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -367,68 +367,14 @@ func loadStarlarkCommands(rootCmd *cobra.Command, runtime *starruntime.Applicati
 func registerStarlarkCommand(rootCmd *cobra.Command, cmd *starruntime.Command) {
 	// Parse command name (e.g., "registry.index-knowledge" -> registry subcommand with index-knowledge)
 	parts := strings.Split(cmd.Name, ".")
-
-	// Build the command path
-	parent := rootCmd
-	for i := 0; i < len(parts)-1; i++ {
-		// Find or create parent command
-		found := false
-		for _, child := range parent.Commands() {
-			if child.Use == parts[i] || strings.HasPrefix(child.Use, parts[i]+" ") {
-				parent = child
-				found = true
-				break
-			}
-		}
-		if !found {
-			// Create intermediate command
-			newCmd := &cobra.Command{
-				Use:   parts[i],
-				Short: fmt.Sprintf("%s commands", parts[i]),
-			}
-			parent.AddCommand(newCmd)
-			parent = newCmd
-		}
-	}
-
-	// Build Use string with arg placeholders (e.g., "go-style [path ...]").
-	leafName := parts[len(parts)-1]
-	useLine := leafName
-	for _, arg := range cmd.Args {
-		if arg.Variadic {
-			useLine += fmt.Sprintf(" [%s ...]", arg.Name)
-		} else {
-			useLine += fmt.Sprintf(" [%s]", arg.Name)
-		}
-	}
+	parent := findOrCreateParent(rootCmd, parts)
 
 	// Create the leaf command
 	cobraCmd := &cobra.Command{
-		Use:   useLine,
+		Use:   useLineFor(parts[len(parts)-1], cmd.Args),
 		Short: cmd.Help,
 		RunE: func(c *cobra.Command, args []string) error {
-			// Collect flag values as strings (Command.Run converts to native starlark types).
-			flagValues := make(map[string]string)
-			for _, flag := range cmd.Flags {
-				switch flag.Type {
-				case "bool":
-					val, err := c.Flags().GetBool(flag.Name)
-					if err == nil {
-						flagValues[flag.Name] = strconv.FormatBool(val)
-					}
-				case "int":
-					val, err := c.Flags().GetInt(flag.Name)
-					if err == nil {
-						flagValues[flag.Name] = strconv.Itoa(val)
-					}
-				default:
-					val, err := c.Flags().GetString(flag.Name)
-					if err == nil {
-						flagValues[flag.Name] = val
-					}
-				}
-			}
-			return cmd.Run(flagValues, args...)
+			return cmd.Run(collectFlagValues(c, cmd.Flags), args...)
 		},
 	}
 
@@ -439,8 +385,109 @@ func registerStarlarkCommand(rootCmd *cobra.Command, cmd *starruntime.Command) {
 		cobraCmd.Args = cobra.NoArgs
 	}
 
-	// Add flags with proper cobra types.
-	for _, flag := range cmd.Flags {
+	defineFlags(cobraCmd, cmd.Flags)
+
+	parent.AddCommand(cobraCmd)
+}
+
+// findOrCreateParent walks the dotted command path, creating intermediate cobra commands as needed.
+//
+// Parameters:
+//   - `rootCmd`: the root command the path hangs from.
+//   - `parts`: the dotted-name segments; the last is the leaf and is not walked.
+//
+// Returns:
+//   - `*cobra.Command`: the leaf's parent command.
+func findOrCreateParent(rootCmd *cobra.Command, parts []string) *cobra.Command {
+
+	parent := rootCmd
+	for i := 0; i < len(parts)-1; i++ {
+		found := false
+		for _, child := range parent.Commands() {
+			if child.Use == parts[i] || strings.HasPrefix(child.Use, parts[i]+" ") {
+				parent = child
+				found = true
+				break
+			}
+		}
+		if !found {
+			newCmd := &cobra.Command{
+				Use:   parts[i],
+				Short: fmt.Sprintf("%s commands", parts[i]),
+			}
+			parent.AddCommand(newCmd)
+			parent = newCmd
+		}
+	}
+
+	return parent
+}
+
+// useLineFor builds the leaf's Use string with arg placeholders (e.g., "go-style [path ...]").
+//
+// Parameters:
+//   - `leafName`: the leaf command name.
+//   - `args`: the command's positional arg specs.
+//
+// Returns:
+//   - `string`: the cobra Use line.
+func useLineFor(leafName string, args []starruntime.Arg) string {
+
+	useLine := leafName
+	for _, arg := range args {
+		if arg.Variadic {
+			useLine += fmt.Sprintf(" [%s ...]", arg.Name)
+		} else {
+			useLine += fmt.Sprintf(" [%s]", arg.Name)
+		}
+	}
+
+	return useLine
+}
+
+// collectFlagValues reads the parsed flag values as strings (Command.Run converts to native
+// starlark types).
+//
+// Parameters:
+//   - `c`: the invoked cobra command carrying the parsed flags.
+//   - `flags`: the command's flag specs.
+//
+// Returns:
+//   - `map[string]string`: flag name to string value; unreadable flags are omitted.
+func collectFlagValues(c *cobra.Command, flags []starruntime.Flag) map[string]string {
+
+	flagValues := make(map[string]string)
+	for _, flag := range flags {
+		switch flag.Type {
+		case "bool":
+			val, err := c.Flags().GetBool(flag.Name)
+			if err == nil {
+				flagValues[flag.Name] = strconv.FormatBool(val)
+			}
+		case "int":
+			val, err := c.Flags().GetInt(flag.Name)
+			if err == nil {
+				flagValues[flag.Name] = strconv.Itoa(val)
+			}
+		default:
+			val, err := c.Flags().GetString(flag.Name)
+			if err == nil {
+				flagValues[flag.Name] = val
+			}
+		}
+	}
+
+	return flagValues
+}
+
+// defineFlags registers the command's flags on the cobra command with proper cobra types.
+//
+// Parameters:
+//   - `cobraCmd`: the leaf cobra command.
+//   - `flags`: the command's flag specs.
+func defineFlags(cobraCmd *cobra.Command, flags []starruntime.Flag) {
+
+	for _, flag := range flags {
 		switch flag.Type {
 		case "bool":
 			cobraCmd.Flags().Bool(flag.Name, flag.Default == "true", flag.Help)
@@ -456,6 +503,4 @@ func registerStarlarkCommand(rootCmd *cobra.Command, cmd *starruntime.Command) {
 			assert.NoError(fmt.Sprintf("MarkFlagRequired(%q)", flag.Name), err)
 		}
 	}
-
-	parent.AddCommand(cobraCmd)
 }

--- a/cmd/star/provider/shellcheck/provider.go
+++ b/cmd/star/provider/shellcheck/provider.go
@@ -261,10 +261,7 @@ func parseShellFile(path string) (ParsedFile, error) {
 	lines := strings.Split(string(content), "\n")
 	result.LOC = len(lines)
 
-	inFunction := false
-	functionStartLine := 0
-	functionName := ""
-	braceDepth := 0
+	tracker := functionTracker{}
 	commandsSeen := make(map[string]bool)
 	sourcesSeen := make(map[string]bool)
 
@@ -281,49 +278,11 @@ func parseShellFile(path string) (ParsedFile, error) {
 			continue
 		}
 
-		if !inFunction {
-			if matched := matchFunctionDef(trimmed); matched != "" {
-				inFunction = true
-				functionName = matched
-				functionStartLine = lineNum
-				braceDepth = strings.Count(line, "{") - strings.Count(line, "}")
-				if braceDepth <= 0 {
-					result.Functions = append(result.Functions, ShellFunction{
-						Name: functionName, Line: functionStartLine, EndLine: lineNum, BodyLines: 1,
-					})
-					inFunction = false
-				}
-				continue
-			}
+		if tracker.observe(line, trimmed, lineNum, &result) {
+			continue
 		}
 
-		if inFunction {
-			braceDepth += strings.Count(line, "{") - strings.Count(line, "}")
-			if braceDepth <= 0 {
-				result.Functions = append(result.Functions, ShellFunction{
-					Name: functionName, Line: functionStartLine, EndLine: lineNum, BodyLines: lineNum - functionStartLine + 1,
-				})
-				inFunction = false
-			}
-		}
-
-		if varName, varValue := matchVariableAssign(trimmed); varName != "" {
-			result.Variables = append(result.Variables, ShellVariable{Name: varName, Line: lineNum, Value: varValue})
-		}
-
-		if source := matchSourceCommand(trimmed); source != "" {
-			if !sourcesSeen[source] {
-				sourcesSeen[source] = true
-				result.Sources = append(result.Sources, source)
-			}
-		}
-
-		if cmd := matchExternalCommand(trimmed); cmd != "" {
-			if !commandsSeen[cmd] {
-				commandsSeen[cmd] = true
-				result.Commands = append(result.Commands, cmd)
-			}
-		}
+		recordLineMatches(trimmed, lineNum, &result, commandsSeen, sourcesSeen)
 	}
 
 	result.SLOC = result.LOC - result.Blanks - result.Comments
@@ -401,28 +360,14 @@ func calculateFunctionComplexity(name string, startLine int, lines []string) Fun
 			continue
 		}
 
-		if strings.HasPrefix(trimmed, "if ") || strings.HasPrefix(trimmed, "elif ") {
-			fc.Cyclomatic++
+		delta, opensNesting := branchDelta(trimmed)
+		fc.Cyclomatic += delta
+		if opensNesting {
 			currentNesting++
 			if currentNesting > maxNesting {
 				maxNesting = currentNesting
 			}
 		}
-
-		if strings.HasPrefix(trimmed, "for ") || strings.HasPrefix(trimmed, "while ") || strings.HasPrefix(trimmed, "until ") {
-			fc.Cyclomatic++
-			currentNesting++
-			if currentNesting > maxNesting {
-				maxNesting = currentNesting
-			}
-		}
-
-		if strings.HasSuffix(trimmed, ";;") {
-			fc.Cyclomatic++
-		}
-
-		fc.Cyclomatic += strings.Count(trimmed, " && ")
-		fc.Cyclomatic += strings.Count(trimmed, " || ")
 
 		if trimmed == "fi" || trimmed == "done" || trimmed == "esac" {
 			currentNesting--
@@ -431,16 +376,142 @@ func calculateFunctionComplexity(name string, startLine int, lines []string) Fun
 			}
 		}
 
-		for i := range 10 {
-			fc.ParameterRefs += strings.Count(line, fmt.Sprintf("$%d", i))
-		}
-		fc.ParameterRefs += strings.Count(line, "$@")
-		fc.ParameterRefs += strings.Count(line, "$*")
-		fc.ParameterRefs += strings.Count(line, "$#")
+		fc.ParameterRefs += countParameterRefs(line)
 	}
 
 	fc.NestingDepth = maxNesting
 	return fc
+}
+
+// functionTracker carries the function-boundary state parseShellFile threads through its line scan.
+type functionTracker struct {
+	inFunction bool
+	name       string
+	startLine  int
+	braceDepth int
+}
+
+// observe consumes one line's function-boundary evidence, appending any completed function to result.
+//
+// Parameters:
+//   - `line`: the raw line (brace counting).
+//   - `trimmed`: the trimmed line (definition matching).
+//   - `lineNum`: the 1-based line number.
+//   - `result`: the parse accumulator receiving completed functions.
+//
+// Returns:
+//   - `bool`: true when the line WAS a function definition (the caller skips match recording).
+func (t *functionTracker) observe(line, trimmed string, lineNum int, result *ParsedFile) bool {
+
+	if !t.inFunction {
+		matched := matchFunctionDef(trimmed)
+		if matched == "" {
+			return false
+		}
+		t.inFunction = true
+		t.name = matched
+		t.startLine = lineNum
+		t.braceDepth = strings.Count(line, "{") - strings.Count(line, "}")
+		if t.braceDepth <= 0 {
+			result.Functions = append(result.Functions, ShellFunction{
+				Name: t.name, Line: t.startLine, EndLine: lineNum, BodyLines: 1,
+			})
+			t.inFunction = false
+		}
+		return true
+	}
+
+	t.braceDepth += strings.Count(line, "{") - strings.Count(line, "}")
+	if t.braceDepth <= 0 {
+		result.Functions = append(result.Functions, ShellFunction{
+			Name: t.name, Line: t.startLine, EndLine: lineNum, BodyLines: lineNum - t.startLine + 1,
+		})
+		t.inFunction = false
+	}
+
+	return false
+}
+
+// recordLineMatches records the line's variable assignment, source, and external-command matches,
+// deduplicating sources and commands via the seen maps.
+//
+// Parameters:
+//   - `trimmed`: the trimmed line.
+//   - `lineNum`: the 1-based line number.
+//   - `result`: the parse accumulator.
+//   - `commandsSeen`: the external-command dedup set.
+//   - `sourcesSeen`: the source dedup set.
+func recordLineMatches(
+	trimmed string, lineNum int, result *ParsedFile, commandsSeen, sourcesSeen map[string]bool,
+) {
+
+	if varName, varValue := matchVariableAssign(trimmed); varName != "" {
+		result.Variables = append(result.Variables, ShellVariable{Name: varName, Line: lineNum, Value: varValue})
+	}
+
+	if source := matchSourceCommand(trimmed); source != "" {
+		if !sourcesSeen[source] {
+			sourcesSeen[source] = true
+			result.Sources = append(result.Sources, source)
+		}
+	}
+
+	if cmd := matchExternalCommand(trimmed); cmd != "" {
+		if !commandsSeen[cmd] {
+			commandsSeen[cmd] = true
+			result.Commands = append(result.Commands, cmd)
+		}
+	}
+}
+
+// branchDelta reports one line's cyclomatic contribution and whether it opens a nesting level.
+//
+// if/elif and the loop keywords both branch and nest; a case arm terminator (";;") and the boolean
+// connectives branch without nesting.
+//
+// Parameters:
+//   - `trimmed`: the trimmed line.
+//
+// Returns:
+//   - `delta`: the cyclomatic increment.
+//   - `opensNesting`: true when the line opens an if/loop nesting level.
+func branchDelta(trimmed string) (delta int, opensNesting bool) {
+
+	if strings.HasPrefix(trimmed, "if ") || strings.HasPrefix(trimmed, "elif ") ||
+		strings.HasPrefix(trimmed, "for ") || strings.HasPrefix(trimmed, "while ") ||
+		strings.HasPrefix(trimmed, "until ") {
+		delta++
+		opensNesting = true
+	}
+
+	if strings.HasSuffix(trimmed, ";;") {
+		delta++
+	}
+
+	delta += strings.Count(trimmed, " && ")
+	delta += strings.Count(trimmed, " || ")
+
+	return delta, opensNesting
+}
+
+// countParameterRefs counts the line's positional and special parameter references ($0..$9, $@, $*, $#).
+//
+// Parameters:
+//   - `line`: the raw line.
+//
+// Returns:
+//   - `int`: the reference count.
+func countParameterRefs(line string) int {
+
+	refs := 0
+	for i := range 10 {
+		refs += strings.Count(line, fmt.Sprintf("$%d", i))
+	}
+	refs += strings.Count(line, "$@")
+	refs += strings.Count(line, "$*")
+	refs += strings.Count(line, "$#")
+
+	return refs
 }
 
 // matchFunctionDef matches shell function definitions and returns the function name.
@@ -471,17 +542,25 @@ func isValidFunctionName(name string) bool {
 		return false
 	}
 	for i, c := range name {
-		if i == 0 {
-			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_' {
-				return false
-			}
-		} else {
-			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' {
-				return false
-			}
+		if i == 0 && !isNameStart(c) {
+			return false
+		}
+		if i > 0 && !isNameRune(c) {
+			return false
 		}
 	}
 	return true
+}
+
+// isNameStart reports whether the rune may start a shell function name (a letter or underscore).
+func isNameStart(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+// isNameRune reports whether the rune may appear after the first position of a shell function name
+// (a name-start rune, a digit, or a dash).
+func isNameRune(c rune) bool {
+	return isNameStart(c) || (c >= '0' && c <= '9') || c == '-'
 }
 
 // matchVariableAssign matches variable assignments.

--- a/cmd/star/star/command.go
+++ b/cmd/star/star/command.go
@@ -56,23 +56,77 @@ func (c *Command) Run(flags map[string]string, positional ...string) error {
 		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
 	}
 
+	argsDict, err := c.buildArgsDict(flags, positional)
+	if err != nil {
+		return err
+	}
+
+	ctx := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+		"args":    argsDict,
+		"dry_run": starlark.Bool(DryRun),
+	})
+
+	c.setCurrentCommand()
+
+	// Do run(command, ctx).
+	_, err = starlark.Call(thread, c.RunFunc, starlark.Tuple{c, ctx}, nil)
+	if err != nil {
+		var evalErr *starlark.EvalError
+		if errors.As(err, &evalErr) {
+			return fmt.Errorf("%s", evalErr.Backtrace())
+		}
+		return err
+	}
+	return nil
+}
+
+// buildArgsDict builds the context dict with native starlark types from the flag values and
+// positional arguments, per the command's specs.
+//
+// Parameters:
+//   - `flags`: flag name to string value, as collected from cobra.
+//   - `positional`: the positional arguments, consumed in arg-spec order.
+//
+// Returns:
+//   - `*starlark.Dict`: the populated args dict.
+//   - `error`: non-nil when a dict entry cannot be set.
+func (c *Command) buildArgsDict(flags map[string]string, positional []string) (*starlark.Dict, error) {
+
 	// Build flag type lookup for native starlark types.
 	flagTypes := make(map[string]string, len(c.Flags))
 	for _, f := range c.Flags {
 		flagTypes[f.Name] = f.Type
 	}
 
-	// Build context dict with native types based on flag spec.
 	argsDict := starlark.NewDict(len(flags) + len(c.Args))
 	for k, v := range flags {
 		sv := flagToStarlark(flagTypes[k], v)
 		if err := argsDict.SetKey(starlark.String(k), sv); err != nil {
-			return fmt.Errorf("setting flag %q: %w", k, err)
+			return nil, fmt.Errorf("setting flag %q: %w", k, err)
 		}
 	}
 
-	// Map positional args to named entries using the arg spec.
-	for _, arg := range c.Args {
+	if err := applyPositionalArgs(argsDict, c.Args, positional); err != nil {
+		return nil, err
+	}
+
+	return argsDict, nil
+}
+
+// applyPositionalArgs maps the positional arguments onto named dict entries per the arg specs: a
+// variadic arg absorbs the remainder as a list (falling back to its default when empty), a plain arg
+// consumes one value, and an unfilled arg takes its default when it has one.
+//
+// Parameters:
+//   - `argsDict`: the args dict receiving the entries.
+//   - `args`: the command's positional arg specs, in declaration order.
+//   - `positional`: the positional arguments, consumed left to right.
+//
+// Returns:
+//   - `error`: non-nil when a dict entry cannot be set.
+func applyPositionalArgs(argsDict *starlark.Dict, args []Arg, positional []string) error {
+
+	for _, arg := range args {
 		switch {
 		case arg.Variadic:
 			vals := make([]starlark.Value, len(positional))
@@ -97,30 +151,23 @@ func (c *Command) Run(flags map[string]string, positional ...string) error {
 		}
 	}
 
-	ctx := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
-		"args":    argsDict,
-		"dry_run": starlark.Bool(DryRun),
-	})
-
-	// Set current_command so the commands provider can read it via Application.Overrides during this
-	// dispatch. Per-dispatch mutation — doesn't fit RegisterParameter's construction-time resolution model.
-	if c.runtime != nil && c.runtime.app != nil {
-		if c.runtime.app.Overrides == nil {
-			c.runtime.app.Overrides = make(map[string]any)
-		}
-		c.runtime.app.Overrides["current_command"] = c.Name
-	}
-
-	// Do run(command, ctx).
-	_, err := starlark.Call(thread, c.RunFunc, starlark.Tuple{c, ctx}, nil)
-	if err != nil {
-		var evalErr *starlark.EvalError
-		if errors.As(err, &evalErr) {
-			return fmt.Errorf("%s", evalErr.Backtrace())
-		}
-		return err
-	}
 	return nil
+}
+
+// setCurrentCommand records this command's name in the application overrides so the commands provider
+// can read it via Application.Overrides during this dispatch.
+//
+// Per-dispatch mutation — doesn't fit RegisterParameter's construction-time resolution model.
+func (c *Command) setCurrentCommand() {
+
+	if c.runtime == nil || c.runtime.app == nil {
+		return
+	}
+
+	if c.runtime.app.Overrides == nil {
+		c.runtime.app.Overrides = make(map[string]any)
+	}
+	c.runtime.app.Overrides["current_command"] = c.Name
 }
 
 // flagToStarlark converts a string value to the appropriate starlark type based on

--- a/cmd/star/star/extension.go
+++ b/cmd/star/star/extension.go
@@ -85,37 +85,84 @@ func (e *Extension) Validate() error {
 		return fmt.Errorf("extension must define at least one command")
 	}
 
-	for i, c := range e.Commands {
-		if c.Name == "" {
-			return fmt.Errorf("command[%d] name is required", i)
+	for i := range e.Commands {
+		if err := validateCommand(i, e.Commands[i]); err != nil {
+			return err
 		}
-		if c.Implementation == "" {
-			return fmt.Errorf("command %q: implementation is required", c.Name)
+	}
+
+	return nil
+}
+
+// validateCommand checks one command spec: identity, implementation placement, args, and flags.
+//
+// Parameters:
+//   - `index`: the command's position, used when it has no name to blame.
+//   - `c`: the command spec.
+//
+// Returns:
+//   - `error`: the first violation, or nil.
+func validateCommand(index int, c *Command) error {
+
+	if c.Name == "" {
+		return fmt.Errorf("command[%d] name is required", index)
+	}
+	if c.Implementation == "" {
+		return fmt.Errorf("command %q: implementation is required", c.Name)
+	}
+	if !strings.HasPrefix(c.Implementation, "commands/") {
+		return fmt.Errorf("command %q: implementation must be in commands/ subdirectory", c.Name)
+	}
+
+	if err := validateCommandArgs(c); err != nil {
+		return err
+	}
+
+	return validateCommandFlags(c)
+}
+
+// validateCommandArgs checks the command's positional arg specs.
+//
+// Parameters:
+//   - `c`: the command spec.
+//
+// Returns:
+//   - `error`: the first violation, or nil.
+func validateCommandArgs(c *Command) error {
+
+	for j, a := range c.Args {
+		if a.Name == "" {
+			return fmt.Errorf("command %q arg[%d]: name is required", c.Name, j)
 		}
-		if !strings.HasPrefix(c.Implementation, "commands/") {
-			return fmt.Errorf("command %q: implementation must be in commands/ subdirectory", c.Name)
+		if a.Variadic && j != len(c.Args)-1 {
+			return fmt.Errorf("command %q arg %q: variadic arg must be last", c.Name, a.Name)
 		}
-		for j, a := range c.Args {
-			if a.Name == "" {
-				return fmt.Errorf("command %q arg[%d]: name is required", c.Name, j)
-			}
-			if a.Variadic && j != len(c.Args)-1 {
-				return fmt.Errorf("command %q arg %q: variadic arg must be last", c.Name, a.Name)
-			}
+	}
+
+	return nil
+}
+
+// validateCommandFlags checks the command's flag specs.
+//
+// Parameters:
+//   - `c`: the command spec.
+//
+// Returns:
+//   - `error`: the first violation, or nil.
+func validateCommandFlags(c *Command) error {
+
+	for j, f := range c.Flags {
+		if f.Name == "" {
+			return fmt.Errorf("command %q flag[%d]: name is required", c.Name, j)
 		}
-		for j, f := range c.Flags {
-			if f.Name == "" {
-				return fmt.Errorf("command %q flag[%d]: name is required", c.Name, j)
-			}
-			if f.Type == "" {
-				return fmt.Errorf("command %q flag %q: type is required", c.Name, f.Name)
-			}
-			switch f.Type {
-			case "bool", "string", "int", "glob":
-				// valid
-			default:
-				return fmt.Errorf("command %q flag %q: unknown type %q", c.Name, f.Name, f.Type)
-			}
+		if f.Type == "" {
+			return fmt.Errorf("command %q flag %q: type is required", c.Name, f.Name)
+		}
+		switch f.Type {
+		case "bool", "string", "int", "glob":
+			// valid
+		default:
+			return fmt.Errorf("command %q flag %q: unknown type %q", c.Name, f.Name, f.Type)
 		}
 	}
 

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -32,7 +32,7 @@ complexity limits. This is the repository's only remaining lint debt.
 | # | Branch | Scope | Findings | Status |
 |---|---|---|---|---|
 | 1 | `refactor/complexity-writ` | writ commands: upgrade `Execute` 30 + `classifyEntry` 21, deploy `Execute` 22 + `buildScopeGraph` 29, decommission `Execute` 23; devlore-test `TestContext.Check` 32 | 6 | **complete** |
-| 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | pending |
+| 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | **complete** |
 | 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | pending |
 | 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | pending |
 | 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | pending |
@@ -52,6 +52,19 @@ split its encrypted-chain arm (`classifyEncryptedChain`) and render arm (`render
 `TestContext.Check` became a uniform per-kind dispatch (`checkExpectation`), extracting
 `checkUnitCount` and `checkEqual` to match the existing check-helper family;
 deploy's plan closure extracted `splitManifests` / `planManifests` / `planChains`.
+
+**Phase 2 (complete):** `registerStarlarkCommand` extracted its four stages
+(`findOrCreateParent`, `useLineFor`, `collectFlagValues`, `defineFlags`);
+`Extension.Validate` became a per-command dispatch (`validateCommand` →
+`validateCommandArgs`/`validateCommandFlags`); `Command.Run` extracted `buildArgsDict`
+(itself split once more when the extraction still scored 23 — `applyPositionalArgs`
+carries the positional switch) and `setCurrentCommand`; `flagValue`'s 24-case switch
+split into three type-family extractors (integer/scalar/collection) with a stated
+fallback chain. shellcheck's scanner state moved into a `functionTracker` with an
+`observe` method, match recording into `recordLineMatches`, per-line cyclomatic
+accounting into `branchDelta` + `countParameterRefs` (preserving the quirk that `case`
+opens no nesting level while `esac` closes one, floored at zero), and
+`isValidFunctionName` now reads through positive rune predicates.
 
 ## Ordering rationale
 

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -139,58 +139,116 @@ func kebabToSnake(name string) string {
 //   - `any`: the typed Go value of the flag, or its string representation when the type is unknown.
 func flagValue(cmd *cobra.Command, f *pflag.Flag) any {
 
+	if v, ok := flagIntegerValue(cmd, f); ok {
+		return v
+	}
+	if v, ok := flagScalarValue(cmd, f); ok {
+		return v
+	}
+	if v, ok := flagCollectionValue(cmd, f); ok {
+		return v
+	}
+
+	return f.Value.String()
+}
+
+// flagIntegerValue extracts a signed or unsigned integer flag value.
+//
+// Parameters:
+//   - `cmd`: the cobra command (provides typed flag accessors).
+//   - `f`: the pflag.Flag whose typed value is being extracted.
+//
+// Returns:
+//   - `any`: the typed integer value.
+//   - `bool`: false when the flag's type is not an integer family member.
+func flagIntegerValue(cmd *cobra.Command, f *pflag.Flag) (any, bool) {
+
+	switch f.Value.Type() {
+	case "int":
+		return assert.Must(cmd.Flags().GetInt(f.Name)), true
+	case "int8":
+		return assert.Must(cmd.Flags().GetInt8(f.Name)), true
+	case "int16":
+		return assert.Must(cmd.Flags().GetInt16(f.Name)), true
+	case "int32":
+		return assert.Must(cmd.Flags().GetInt32(f.Name)), true
+	case "int64":
+		return assert.Must(cmd.Flags().GetInt64(f.Name)), true
+	case "uint":
+		return assert.Must(cmd.Flags().GetUint(f.Name)), true
+	case "uint8":
+		return assert.Must(cmd.Flags().GetUint8(f.Name)), true
+	case "uint16":
+		return assert.Must(cmd.Flags().GetUint16(f.Name)), true
+	case "uint32":
+		return assert.Must(cmd.Flags().GetUint32(f.Name)), true
+	case "uint64":
+		return assert.Must(cmd.Flags().GetUint64(f.Name)), true
+	}
+
+	return nil, false
+}
+
+// flagScalarValue extracts a non-integer scalar flag value.
+//
+// Parameters:
+//   - `cmd`: the cobra command (provides typed flag accessors).
+//   - `f`: the pflag.Flag whose typed value is being extracted.
+//
+// Returns:
+//   - `any`: the typed scalar value.
+//   - `bool`: false when the flag's type is not a non-integer scalar.
+func flagScalarValue(cmd *cobra.Command, f *pflag.Flag) (any, bool) {
+
 	switch f.Value.Type() {
 	case "bool":
-		return assert.Must(cmd.Flags().GetBool(f.Name))
+		return assert.Must(cmd.Flags().GetBool(f.Name)), true
 	case "string":
-		return assert.Must(cmd.Flags().GetString(f.Name))
-	case "int":
-		return assert.Must(cmd.Flags().GetInt(f.Name))
-	case "int8":
-		return assert.Must(cmd.Flags().GetInt8(f.Name))
-	case "int16":
-		return assert.Must(cmd.Flags().GetInt16(f.Name))
-	case "int32":
-		return assert.Must(cmd.Flags().GetInt32(f.Name))
-	case "int64":
-		return assert.Must(cmd.Flags().GetInt64(f.Name))
-	case "uint":
-		return assert.Must(cmd.Flags().GetUint(f.Name))
-	case "uint8":
-		return assert.Must(cmd.Flags().GetUint8(f.Name))
-	case "uint16":
-		return assert.Must(cmd.Flags().GetUint16(f.Name))
-	case "uint32":
-		return assert.Must(cmd.Flags().GetUint32(f.Name))
-	case "uint64":
-		return assert.Must(cmd.Flags().GetUint64(f.Name))
+		return assert.Must(cmd.Flags().GetString(f.Name)), true
 	case "float32":
-		return assert.Must(cmd.Flags().GetFloat32(f.Name))
+		return assert.Must(cmd.Flags().GetFloat32(f.Name)), true
 	case "float64":
-		return assert.Must(cmd.Flags().GetFloat64(f.Name))
+		return assert.Must(cmd.Flags().GetFloat64(f.Name)), true
 	case "duration":
-		return assert.Must(cmd.Flags().GetDuration(f.Name))
-	case "stringSlice":
-		return assert.Must(cmd.Flags().GetStringSlice(f.Name))
-	case "stringArray":
-		return assert.Must(cmd.Flags().GetStringArray(f.Name))
-	case "intSlice":
-		return assert.Must(cmd.Flags().GetIntSlice(f.Name))
-	case "int32Slice":
-		return assert.Must(cmd.Flags().GetInt32Slice(f.Name))
-	case "int64Slice":
-		return assert.Must(cmd.Flags().GetInt64Slice(f.Name))
-	case "stringToString":
-		return assert.Must(cmd.Flags().GetStringToString(f.Name))
-	case "stringToInt":
-		return assert.Must(cmd.Flags().GetStringToInt(f.Name))
-	case "stringToInt64":
-		return assert.Must(cmd.Flags().GetStringToInt64(f.Name))
-	case "boolSlice":
-		return assert.Must(cmd.Flags().GetBoolSlice(f.Name))
+		return assert.Must(cmd.Flags().GetDuration(f.Name)), true
 	case "count":
-		return assert.Must(cmd.Flags().GetCount(f.Name))
-	default:
-		return f.Value.String()
+		return assert.Must(cmd.Flags().GetCount(f.Name)), true
 	}
+
+	return nil, false
+}
+
+// flagCollectionValue extracts a slice or map flag value.
+//
+// Parameters:
+//   - `cmd`: the cobra command (provides typed flag accessors).
+//   - `f`: the pflag.Flag whose typed value is being extracted.
+//
+// Returns:
+//   - `any`: the typed collection value.
+//   - `bool`: false when the flag's type is not a collection.
+func flagCollectionValue(cmd *cobra.Command, f *pflag.Flag) (any, bool) {
+
+	switch f.Value.Type() {
+	case "stringSlice":
+		return assert.Must(cmd.Flags().GetStringSlice(f.Name)), true
+	case "stringArray":
+		return assert.Must(cmd.Flags().GetStringArray(f.Name)), true
+	case "intSlice":
+		return assert.Must(cmd.Flags().GetIntSlice(f.Name)), true
+	case "int32Slice":
+		return assert.Must(cmd.Flags().GetInt32Slice(f.Name)), true
+	case "int64Slice":
+		return assert.Must(cmd.Flags().GetInt64Slice(f.Name)), true
+	case "boolSlice":
+		return assert.Must(cmd.Flags().GetBoolSlice(f.Name)), true
+	case "stringToString":
+		return assert.Must(cmd.Flags().GetStringToString(f.Name)), true
+	case "stringToInt":
+		return assert.Must(cmd.Flags().GetStringToInt(f.Name)), true
+	case "stringToInt64":
+		return assert.Must(cmd.Flags().GetStringToInt64(f.Name)), true
+	}
+
+	return nil, false
 }


### PR DESCRIPTION
Phase 2 of docs/plans/complexity-refactors.md (#312): seven functions decomposed under gocognit 20 / gocyclo 15, behavior-preserving — the suite passes unmodified. Highlights: `flagValue`'s 24-case switch splits by type family; shellcheck's scanner state becomes a `functionTracker` with per-line `branchDelta` accounting (its nesting quirks preserved exactly); `Command.Run`'s extraction was itself over threshold and split again (`applyPositionalArgs`). Plan doc rides along with phase 2 marked complete.