### PR TITLE
refactor(complexity): phase 3 — the goast provider methods

### DIFF
--- a/cmd/star/provider/goast/provider.go
+++ b/cmd/star/provider/goast/provider.go
@@ -69,61 +69,8 @@ func (p *Provider) Callable(path, name string) (CallableResult, error) {
 			continue
 		}
 
-		for _, decl := range node.Decls {
-			genDecl, ok := decl.(*ast.GenDecl)
-			if !ok || genDecl.Tok != token.TYPE {
-				continue
-			}
-
-			for _, spec := range genDecl.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || ts.Name.Name != name {
-					continue
-				}
-
-				ft, ok := ts.Type.(*ast.FuncType)
-				if !ok {
-					continue
-				}
-
-				// Build params list.
-				params := []ParamDetail{}
-				if ft.Params != nil {
-					for _, field := range ft.Params.List {
-						typeStr := typeToString(field.Type)
-						if len(field.Names) == 0 {
-							params = append(params, ParamDetail{
-								Type: typeStr,
-							})
-						} else {
-							for _, ident := range field.Names {
-								params = append(params, ParamDetail{
-									Name: ident.Name,
-									Type: typeStr,
-								})
-							}
-						}
-					}
-				}
-
-				returns := returnTypeString(ft.Results)
-
-				// Doc comment: prefer TypeSpec.Doc, fall back to GenDecl.Doc. Use
-				// commentGroupRaw to preserve directive lines.
-				var cg *ast.CommentGroup
-				if ts.Doc != nil {
-					cg = ts.Doc
-				} else if genDecl.Doc != nil {
-					cg = genDecl.Doc
-				}
-
-				return CallableResult{
-					Name:    name,
-					Doc:     commentGroupRaw(cg),
-					Params:  params,
-					Returns: returns,
-				}, nil
-			}
+		if result, found := callableInFile(node, name); found {
+			return result, nil
 		}
 	}
 
@@ -146,56 +93,9 @@ func (p *Provider) Calls(scope, name string) ([]CallResult, error) {
 			return true
 		}
 
-		var funcName, qualifier, fullName string
-		switch fn := call.Fun.(type) {
-		case *ast.Ident:
-			funcName = fn.Name
-			fullName = fn.Name
-		case *ast.SelectorExpr:
-			funcName = fn.Sel.Name
-			if x, ok := fn.X.(*ast.Ident); ok {
-				qualifier = x.Name
-			}
-			fullName = typeToString(call.Fun)
+		if cr, matched := callResultFromExpr(fileSet, call, name); matched {
+			result = append(result, cr)
 		}
-
-		if funcName == "" {
-			return true
-		}
-
-		if name != "" && funcName != name {
-			return true
-		}
-
-		args := []CallArg{}
-		for i, arg := range call.Args {
-			strVal := ""
-			if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
-				strVal = strings.Trim(lit.Value, `"`)
-			}
-
-			identName := ""
-			switch a := arg.(type) {
-			case *ast.Ident:
-				identName = a.Name
-			case *ast.SelectorExpr:
-				identName = a.Sel.Name
-			}
-
-			args = append(args, CallArg{
-				Position:    i,
-				StringValue: strVal,
-				IdentName:   identName,
-			})
-		}
-
-		result = append(result, CallResult{
-			Name:      funcName,
-			Qualifier: qualifier,
-			FullName:  fullName,
-			Line:      fileSet.Position(call.Pos()).Line,
-			Args:      args,
-		})
 
 		return true
 	})
@@ -236,44 +136,10 @@ func (p *Provider) Composites(scope, typeName string) ([]CompositeResult, error)
 			return true
 		}
 
-		fields := map[string]any{}
-		for _, elt := range comp.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-
-			key, ok := kv.Key.(*ast.Ident)
-			if !ok {
-				continue
-			}
-
-			switch v := kv.Value.(type) {
-			case *ast.BasicLit:
-				if v.Kind == token.STRING {
-					fields[key.Name] = strings.Trim(v.Value, `"`)
-				} else {
-					fields[key.Name] = v.Value
-				}
-			case *ast.CompositeLit:
-				elems := []string{}
-				for _, elem := range v.Elts {
-					if lit, ok := elem.(*ast.BasicLit); ok && lit.Kind == token.STRING {
-						elems = append(elems, strings.Trim(lit.Value, `"`))
-					} else {
-						elems = append(elems, typeToString(elem))
-					}
-				}
-				fields[key.Name] = elems
-			default:
-				fields[key.Name] = typeToString(kv.Value)
-			}
-		}
-
 		result = append(result, CompositeResult{
 			TypeName: tn,
 			Line:     fileSet.Position(comp.Pos()).Line,
-			Fields:   fields,
+			Fields:   compositeFields(comp.Elts),
 		})
 
 		return true
@@ -291,18 +157,7 @@ func (p *Provider) ConstGroups(path, typeName string) ([]ConstGroupResult, error
 		return nil, fmt.Errorf("goast.const_groups: %w", err)
 	}
 
-	type constEntry struct {
-		name  string
-		value string
-		line  int
-	}
-	type group struct {
-		typeName string
-		file     string
-		consts   []constEntry
-	}
-
-	var groups []group
+	var groups []constGroup
 	for _, file := range files {
 		fileSet, node, err := p.parseFile(file)
 		if err != nil {
@@ -314,77 +169,12 @@ func (p *Provider) ConstGroups(path, typeName string) ([]ConstGroupResult, error
 			if !ok || genDecl.Tok != token.CONST {
 				return true
 			}
-
-			var currentType string
-			var currentConsts []constEntry
-
-			for _, spec := range genDecl.Specs {
-				vs, ok := spec.(*ast.ValueSpec)
-				if !ok {
-					continue
-				}
-
-				if vs.Type != nil {
-					if ident, ok := vs.Type.(*ast.Ident); ok {
-						if currentType != "" && currentType != ident.Name && len(currentConsts) > 0 {
-							if typeName == "" || typeName == currentType {
-								groups = append(groups, group{typeName: currentType, file: filepath.Base(file), consts: currentConsts})
-							}
-							currentConsts = nil
-						}
-						currentType = ident.Name
-					}
-				}
-
-				if currentType == "" {
-					continue
-				}
-
-				for i, n := range vs.Names {
-					var value string
-					if i < len(vs.Values) {
-						if lit, ok := vs.Values[i].(*ast.BasicLit); ok {
-							value = strings.Trim(lit.Value, `"`)
-						}
-					}
-
-					currentConsts = append(currentConsts, constEntry{
-						name:  n.Name,
-						value: value,
-						line:  fileSet.Position(n.Pos()).Line,
-					})
-				}
-			}
-
-			if currentType != "" && len(currentConsts) > 0 {
-				if typeName == "" || typeName == currentType {
-					groups = append(groups, group{typeName: currentType, file: filepath.Base(file), consts: currentConsts})
-				}
-			}
-
+			groups = append(groups, constGroupsFromDecl(fileSet, genDecl, filepath.Base(file), typeName)...)
 			return true
 		})
 	}
 
-	result := []ConstGroupResult{}
-	for _, g := range groups {
-		consts := []ConstDetail{}
-		for _, c := range g.consts {
-			consts = append(consts, ConstDetail{
-				Name:  c.name,
-				Value: c.value,
-				Line:  c.line,
-			})
-		}
-
-		result = append(result, ConstGroupResult{
-			TypeName:  g.typeName,
-			File:      g.file,
-			Constants: consts,
-		})
-	}
-
-	return result, nil
+	return constGroupResults(groups), nil
 }
 
 // Deps analyzes import dependencies for Go source files at the given path.
@@ -525,46 +315,13 @@ func (p *Provider) Methods(path, name, receiverType, returns string) ([]MethodRe
 				continue
 			}
 
-			if name != "" && fn.Name.Name != name {
-				continue
-			}
-
 			typeName := receiverTypeName(fn.Recv.List[0].Type)
-			if receiverType != "" {
-				if strings.HasPrefix(receiverType, "*") {
-					if typeName != receiverType {
-						continue
-					}
-				} else {
-					if strings.TrimPrefix(typeName, "*") != receiverType {
-						continue
-					}
-				}
-			}
-
 			retStr := returnTypeString(fn.Type.Results)
-			if returns != "" && retStr != returns {
+			if !methodMatches(fn.Name.Name, typeName, retStr, name, receiverType, returns) {
 				continue
 			}
 
-			rawDoc := ""
-			if fn.Doc != nil {
-				rawDoc = commentGroupRaw(fn.Doc)
-			}
-
-			scope := src.name + "::" + typeName + "." + fn.Name.Name
-
-			result = append(result, MethodResult{
-				Name:         fn.Name.Name,
-				ReceiverType: typeName,
-				Returns:      retStr,
-				Params:       extractParams(fn.Type.Params, nil),
-				TypeParams:   extractTypeParams(fn.Type.TypeParams),
-				File:         src.name,
-				Line:         fileSet.Position(fn.Pos()).Line,
-				Doc:          rawDoc,
-				Scope:        scope,
-			})
+			result = append(result, methodResultFor(src.name, fileSet, fn, typeName, retStr))
 		}
 	}
 
@@ -793,26 +550,18 @@ func spacingRulesFromConfig(val interface{}) SpacingRules {
 	}
 
 	rules := DefaultSpacingRules()
-	if f := rv.FieldByName("AfterPackage"); f.IsValid() && f.CanInt() {
-		rules.AfterPackage = int(f.Int())
-	}
-	if f := rv.FieldByName("AfterImports"); f.IsValid() && f.CanInt() {
-		rules.AfterImports = int(f.Int())
-	}
-	if f := rv.FieldByName("BetweenFunctions"); f.IsValid() && f.CanInt() {
-		rules.BetweenFunctions = int(f.Int())
-	}
-	if f := rv.FieldByName("BetweenMethods"); f.IsValid() && f.CanInt() {
-		rules.BetweenMethods = int(f.Int())
-	}
-	if f := rv.FieldByName("BeforeTypeMethods"); f.IsValid() && f.CanInt() {
-		rules.BeforeTypeMethods = int(f.Int())
-	}
-	if f := rv.FieldByName("AroundRegionMarkers"); f.IsValid() && f.CanInt() {
-		rules.AroundRegionMarkers = int(f.Int())
-	}
-	if f := rv.FieldByName("AroundDelineators"); f.IsValid() && f.CanInt() {
-		rules.AroundDelineators = int(f.Int())
+	for name, target := range map[string]*int{
+		"AfterPackage":        &rules.AfterPackage,
+		"AfterImports":        &rules.AfterImports,
+		"BetweenFunctions":    &rules.BetweenFunctions,
+		"BetweenMethods":      &rules.BetweenMethods,
+		"BeforeTypeMethods":   &rules.BeforeTypeMethods,
+		"AroundRegionMarkers": &rules.AroundRegionMarkers,
+		"AroundDelineators":   &rules.AroundDelineators,
+	} {
+		if f := rv.FieldByName(name); f.IsValid() && f.CanInt() {
+			*target = int(f.Int())
+		}
 	}
 	return rules
 }
@@ -861,67 +610,11 @@ func (p *Provider) SortDeclarations(path, scope, order string) (string, error) {
 
 	lines := strings.Split(string(content), "\n")
 
-	// Collect function declarations within the scope.
-	type declBlock struct {
-		name      string
-		startLine int // 1-indexed, inclusive
-		endLine   int // 1-indexed, inclusive
-	}
-
-	var blocks []declBlock
-	for _, decl := range node.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name == nil {
-			continue
-		}
-
-		dStart := fileSet.Position(fn.Pos()).Line
-		dEnd := fileSet.Position(fn.End()).Line
-
-		// Include doc comment.
-		if fn.Doc != nil {
-			docStart := fileSet.Position(fn.Doc.Pos()).Line
-			if docStart < dStart {
-				dStart = docStart
-			}
-		}
-
-		// Skip declarations outside the scope.
-		if dStart < startLine || dEnd > endLine {
-			continue
-		}
-
-		blocks = append(blocks, declBlock{
-			name:      fn.Name.Name,
-			startLine: dStart,
-			endLine:   dEnd,
-		})
-	}
-
+	blocks := declBlocksInScope(fileSet, node, startLine, endLine)
 	if len(blocks) <= 1 {
 		return string(content), nil
 	}
 
-	// Record the overall range of all blocks.
-	overallStart := blocks[0].startLine
-	overallEnd := blocks[0].endLine
-	for _, b := range blocks {
-		if b.startLine < overallStart {
-			overallStart = b.startLine
-		}
-		if b.endLine > overallEnd {
-			overallEnd = b.endLine
-		}
-	}
-
-	// Extract text for each block before sorting.
-	blockTexts := make(map[string]string, len(blocks))
-	for _, b := range blocks {
-		text := strings.Join(lines[b.startLine-1:b.endLine], "\n")
-		blockTexts[b.name] = strings.TrimRight(text, " \t\n")
-	}
-
-	// Sort blocks.
 	switch order {
 	case "alphabetical", "":
 		sort.Slice(blocks, func(i, j int) bool {
@@ -931,23 +624,7 @@ func (p *Provider) SortDeclarations(path, scope, order string) (string, error) {
 		return "", fmt.Errorf("goast.sort_declarations: unknown order: %s", order)
 	}
 
-	// Build sorted content.
-	var sortedParts []string
-	for _, b := range blocks {
-		sortedParts = append(sortedParts, blockTexts[b.name])
-	}
-	replacement := strings.Join(sortedParts, "\n\n")
-
-	// Replace the overall range in the file.
-	before := lines[:overallStart-1]
-	after := lines[overallEnd:]
-
-	var resultLines []string
-	resultLines = append(resultLines, before...)
-	resultLines = append(resultLines, strings.Split(replacement, "\n")...)
-	resultLines = append(resultLines, after...)
-
-	return strings.Join(resultLines, "\n"), nil
+	return spliceSortedBlocks(lines, blocks), nil
 }
 
 // Structs returns struct definitions from Go source files.
@@ -981,55 +658,11 @@ func (p *Provider) Structs(path string) ([]StructResult, error) {
 					continue
 				}
 
-				fields := []FieldDetail{}
-				for _, field := range st.Fields.List {
-					if len(field.Names) == 0 {
-						// Embedded field.
-						fieldType := typeToString(field.Type)
-						fields = append(fields, FieldDetail{
-							Name:     fieldType,
-							Type:     fieldType,
-							Embedded: true,
-						})
-						continue
-					}
-
-					jsonName := ""
-					required := false
-					if field.Tag != nil {
-						tag := strings.Trim(field.Tag.Value, "`")
-						jsonName, required = parseJSONTag(tag)
-					}
-
-					if jsonName == "-" {
-						continue
-					}
-
-					desc := ""
-					if field.Comment != nil {
-						desc = strings.TrimSpace(field.Comment.Text())
-					} else if field.Doc != nil {
-						desc = strings.TrimSpace(field.Doc.Text())
-					}
-
-					fieldType := typeToString(field.Type)
-					for _, ident := range field.Names {
-						fields = append(fields, FieldDetail{
-							Name:        ident.Name,
-							JSONName:    jsonName,
-							Type:        fieldType,
-							Required:    required,
-							Description: desc,
-						})
-					}
-				}
-
-				// Parse type doc with taxonomy.
 				result = append(result, StructResult{
 					Name:   ts.Name.Name,
 					File:   filepath.Base(file),
 					Line:   fileSet.Position(ts.Pos()).Line,
-					Fields: fields,
+					Fields: structFields(st),
 				})
 			}
 
@@ -1059,27 +692,8 @@ func (p *Provider) TypeDoc(path, name string) (string, error) {
 			continue
 		}
 
-		for _, decl := range node.Decls {
-			genDecl, ok := decl.(*ast.GenDecl)
-			if !ok || genDecl.Tok != token.TYPE {
-				continue
-			}
-
-			for _, spec := range genDecl.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || ts.Name.Name != name {
-					continue
-				}
-
-				var cg *ast.CommentGroup
-				if ts.Doc != nil {
-					cg = ts.Doc
-				} else if genDecl.Doc != nil {
-					cg = genDecl.Doc
-				}
-
-				return commentGroupRaw(cg), nil
-			}
+		if doc, found := typeDocInFile(node, name); found {
+			return doc, nil
 		}
 	}
 
@@ -1093,6 +707,582 @@ func (p *Provider) TypeDoc(path, name string) (string, error) {
 // =============================================================================
 // UNEXPORTED HELPERS
 // =============================================================================
+
+// callableInFile finds the named function-type declaration in one parsed file.
+//
+// Parameters:
+//   - `node`: the parsed file.
+//   - `name`: the function-type name to find.
+//
+// Returns:
+//   - `CallableResult`: the populated result when found.
+//   - `bool`: true when the named function type was found.
+func callableInFile(node *ast.File, name string) (CallableResult, bool) {
+
+	for _, decl := range node.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != name {
+				continue
+			}
+
+			ft, ok := ts.Type.(*ast.FuncType)
+			if !ok {
+				continue
+			}
+
+			return CallableResult{
+				Name:    name,
+				Doc:     commentGroupRaw(typeSpecDoc(ts, genDecl)),
+				Params:  funcTypeParams(ft),
+				Returns: returnTypeString(ft.Results),
+			}, true
+		}
+	}
+
+	return CallableResult{}, false
+}
+
+// funcTypeParams builds the params list for a function type, expanding grouped names.
+//
+// Parameters:
+//   - `ft`: the function type.
+//
+// Returns:
+//   - `[]ParamDetail`: one entry per declared name (or per unnamed param).
+func funcTypeParams(ft *ast.FuncType) []ParamDetail {
+
+	params := []ParamDetail{}
+	if ft.Params == nil {
+		return params
+	}
+
+	for _, field := range ft.Params.List {
+		typeStr := typeToString(field.Type)
+		if len(field.Names) == 0 {
+			params = append(params, ParamDetail{Type: typeStr})
+			continue
+		}
+		for _, ident := range field.Names {
+			params = append(params, ParamDetail{Name: ident.Name, Type: typeStr})
+		}
+	}
+
+	return params
+}
+
+// typeSpecDoc picks a type spec's doc comment: TypeSpec.Doc preferred, GenDecl.Doc as the fallback.
+//
+// Callers render it via commentGroupRaw to preserve directive lines.
+//
+// Parameters:
+//   - `ts`: the type spec.
+//   - `genDecl`: the enclosing declaration.
+//
+// Returns:
+//   - `*ast.CommentGroup`: the chosen doc comment, or nil when neither carries one.
+func typeSpecDoc(ts *ast.TypeSpec, genDecl *ast.GenDecl) *ast.CommentGroup {
+
+	if ts.Doc != nil {
+		return ts.Doc
+	}
+	if genDecl.Doc != nil {
+		return genDecl.Doc
+	}
+
+	return nil
+}
+
+// typeDocInFile finds the named type declaration's doc comment in one parsed file.
+//
+// Parameters:
+//   - `node`: the parsed file.
+//   - `name`: the type name to find.
+//
+// Returns:
+//   - `string`: the raw doc comment when found.
+//   - `bool`: true when the named type was found.
+func typeDocInFile(node *ast.File, name string) (string, bool) {
+
+	for _, decl := range node.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != name {
+				continue
+			}
+
+			return commentGroupRaw(typeSpecDoc(ts, genDecl)), true
+		}
+	}
+
+	return "", false
+}
+
+// callResultFromExpr builds a CallResult from one call expression, applying the name filter.
+//
+// Parameters:
+//   - `fileSet`: the file set for line positions.
+//   - `call`: the call expression.
+//   - `nameFilter`: when non-empty, only calls to this function name match.
+//
+// Returns:
+//   - `CallResult`: the populated result.
+//   - `bool`: true when the call names a function and passes the filter.
+func callResultFromExpr(fileSet *token.FileSet, call *ast.CallExpr, nameFilter string) (CallResult, bool) {
+
+	var funcName, qualifier, fullName string
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		funcName = fn.Name
+		fullName = fn.Name
+	case *ast.SelectorExpr:
+		funcName = fn.Sel.Name
+		if x, ok := fn.X.(*ast.Ident); ok {
+			qualifier = x.Name
+		}
+		fullName = typeToString(call.Fun)
+	}
+
+	if funcName == "" || (nameFilter != "" && funcName != nameFilter) {
+		return CallResult{}, false
+	}
+
+	return CallResult{
+		Name:      funcName,
+		Qualifier: qualifier,
+		FullName:  fullName,
+		Line:      fileSet.Position(call.Pos()).Line,
+		Args:      callArgsFrom(call.Args),
+	}, true
+}
+
+// callArgsFrom builds the CallArg list for a call's arguments, capturing string literals and
+// identifier names.
+//
+// Parameters:
+//   - `exprs`: the call's argument expressions.
+//
+// Returns:
+//   - `[]CallArg`: one entry per argument, in position order.
+func callArgsFrom(exprs []ast.Expr) []CallArg {
+
+	args := []CallArg{}
+	for i, arg := range exprs {
+		strVal := ""
+		if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			strVal = strings.Trim(lit.Value, `"`)
+		}
+
+		identName := ""
+		switch a := arg.(type) {
+		case *ast.Ident:
+			identName = a.Name
+		case *ast.SelectorExpr:
+			identName = a.Sel.Name
+		}
+
+		args = append(args, CallArg{
+			Position:    i,
+			StringValue: strVal,
+			IdentName:   identName,
+		})
+	}
+
+	return args
+}
+
+// compositeFields extracts a composite literal's keyed fields: string literals unquoted, nested
+// composites flattened to element strings, everything else rendered as its type string.
+//
+// Parameters:
+//   - `elts`: the composite literal's elements.
+//
+// Returns:
+//   - `map[string]any`: field name to extracted value.
+func compositeFields(elts []ast.Expr) map[string]any {
+
+	fields := map[string]any{}
+	for _, elt := range elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+
+		fields[key.Name] = compositeFieldValue(kv.Value)
+	}
+
+	return fields
+}
+
+// compositeFieldValue extracts one composite field's value per the compositeFields rules.
+//
+// Parameters:
+//   - `value`: the field's value expression.
+//
+// Returns:
+//   - `any`: the extracted value.
+func compositeFieldValue(value ast.Expr) any {
+
+	switch v := value.(type) {
+	case *ast.BasicLit:
+		if v.Kind == token.STRING {
+			return strings.Trim(v.Value, `"`)
+		}
+		return v.Value
+	case *ast.CompositeLit:
+		elems := []string{}
+		for _, elem := range v.Elts {
+			if lit, ok := elem.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				elems = append(elems, strings.Trim(lit.Value, `"`))
+			} else {
+				elems = append(elems, typeToString(elem))
+			}
+		}
+		return elems
+	default:
+		return typeToString(value)
+	}
+}
+
+// constEntry is one named constant within a typed const group.
+type constEntry struct {
+	name  string
+	value string
+	line  int
+}
+
+// constGroup is one contiguous run of constants sharing a declared type within a const block.
+type constGroup struct {
+	typeName string
+	file     string
+	consts   []constEntry
+}
+
+// constGroupsFromDecl walks one const declaration, splitting it into typed groups: a run of specs
+// sharing a declared type forms a group, flushed when the type changes or the declaration ends;
+// untyped leading specs belong to no group.
+//
+// Parameters:
+//   - `fileSet`: the file set for line positions.
+//   - `genDecl`: the const declaration.
+//   - `file`: the file's base name, stamped onto each group.
+//   - `typeName`: when non-empty, only groups of this type are kept.
+//
+// Returns:
+//   - `[]constGroup`: the declaration's typed groups, in order.
+func constGroupsFromDecl(fileSet *token.FileSet, genDecl *ast.GenDecl, file, typeName string) []constGroup {
+
+	var groups []constGroup
+	var currentType string
+	var currentConsts []constEntry
+
+	flush := func() {
+		if currentType != "" && len(currentConsts) > 0 && (typeName == "" || typeName == currentType) {
+			groups = append(groups, constGroup{typeName: currentType, file: file, consts: currentConsts})
+		}
+		currentConsts = nil
+	}
+
+	for _, spec := range genDecl.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+
+		if vs.Type != nil {
+			if ident, ok := vs.Type.(*ast.Ident); ok {
+				if currentType != "" && currentType != ident.Name {
+					flush()
+				}
+				currentType = ident.Name
+			}
+		}
+
+		if currentType == "" {
+			continue
+		}
+
+		currentConsts = append(currentConsts, constEntriesFromSpec(fileSet, vs)...)
+	}
+
+	flush()
+
+	return groups
+}
+
+// constEntriesFromSpec extracts the named constants of one value spec, capturing basic-literal values
+// unquoted.
+//
+// Parameters:
+//   - `fileSet`: the file set for line positions.
+//   - `vs`: the value spec.
+//
+// Returns:
+//   - `[]constEntry`: one entry per declared name.
+func constEntriesFromSpec(fileSet *token.FileSet, vs *ast.ValueSpec) []constEntry {
+
+	var entries []constEntry
+	for i, n := range vs.Names {
+		var value string
+		if i < len(vs.Values) {
+			if lit, ok := vs.Values[i].(*ast.BasicLit); ok {
+				value = strings.Trim(lit.Value, `"`)
+			}
+		}
+
+		entries = append(entries, constEntry{
+			name:  n.Name,
+			value: value,
+			line:  fileSet.Position(n.Pos()).Line,
+		})
+	}
+
+	return entries
+}
+
+// constGroupResults maps the internal groups to the provider's result shape.
+//
+// Parameters:
+//   - `groups`: the collected typed groups.
+//
+// Returns:
+//   - `[]ConstGroupResult`: the result list, in group order.
+func constGroupResults(groups []constGroup) []ConstGroupResult {
+
+	result := []ConstGroupResult{}
+	for _, g := range groups {
+		consts := []ConstDetail{}
+		for _, c := range g.consts {
+			consts = append(consts, ConstDetail{Name: c.name, Value: c.value, Line: c.line})
+		}
+		result = append(result, ConstGroupResult{TypeName: g.typeName, File: g.file, Constants: consts})
+	}
+
+	return result
+}
+
+// methodMatches applies the Methods filters: name, receiver type (pointer-exact when the filter has
+// one, pointer-insensitive otherwise), and returns signature.
+//
+// Parameters:
+//   - `methodName`: the declaration's method name.
+//   - `typeName`: the declaration's receiver type name (pointer-prefixed when so declared).
+//   - `retStr`: the declaration's rendered returns.
+//   - `name`: the name filter; empty matches all.
+//   - `receiverType`: the receiver filter; empty matches all.
+//   - `returns`: the returns filter; empty matches all.
+//
+// Returns:
+//   - `bool`: true when every supplied filter matches.
+func methodMatches(methodName, typeName, retStr, name, receiverType, returns string) bool {
+
+	if name != "" && methodName != name {
+		return false
+	}
+
+	if receiverType != "" {
+		if strings.HasPrefix(receiverType, "*") {
+			if typeName != receiverType {
+				return false
+			}
+		} else if strings.TrimPrefix(typeName, "*") != receiverType {
+			return false
+		}
+	}
+
+	return returns == "" || retStr == returns
+}
+
+// methodResultFor builds one MethodResult from a matched method declaration.
+//
+// Parameters:
+//   - `file`: the source name the method was parsed from.
+//   - `fileSet`: the file set for line positions.
+//   - `fn`: the matched method declaration.
+//   - `typeName`: the receiver type name.
+//   - `retStr`: the rendered returns.
+//
+// Returns:
+//   - `MethodResult`: the populated result.
+func methodResultFor(file string, fileSet *token.FileSet, fn *ast.FuncDecl, typeName, retStr string) MethodResult {
+
+	rawDoc := ""
+	if fn.Doc != nil {
+		rawDoc = commentGroupRaw(fn.Doc)
+	}
+
+	return MethodResult{
+		Name:         fn.Name.Name,
+		ReceiverType: typeName,
+		Returns:      retStr,
+		Params:       extractParams(fn.Type.Params, nil),
+		TypeParams:   extractTypeParams(fn.Type.TypeParams),
+		File:         file,
+		Line:         fileSet.Position(fn.Pos()).Line,
+		Doc:          rawDoc,
+		Scope:        file + "::" + typeName + "." + fn.Name.Name,
+	}
+}
+
+// declBlock is one function declaration's line extent (doc comment included) within a sort scope.
+type declBlock struct {
+	name      string
+	startLine int // 1-indexed, inclusive
+	endLine   int // 1-indexed, inclusive
+}
+
+// declBlocksInScope collects the function declarations lying wholly within the line range, each
+// extended to include its doc comment.
+//
+// Parameters:
+//   - `fileSet`: the file set for line positions.
+//   - `node`: the parsed file.
+//   - `startLine`: the scope's first line (1-indexed, inclusive).
+//   - `endLine`: the scope's last line (1-indexed, inclusive).
+//
+// Returns:
+//   - `[]declBlock`: the in-scope declaration blocks, in source order.
+func declBlocksInScope(fileSet *token.FileSet, node *ast.File, startLine, endLine int) []declBlock {
+
+	var blocks []declBlock
+	for _, decl := range node.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil {
+			continue
+		}
+
+		dStart := fileSet.Position(fn.Pos()).Line
+		dEnd := fileSet.Position(fn.End()).Line
+
+		if fn.Doc != nil {
+			if docStart := fileSet.Position(fn.Doc.Pos()).Line; docStart < dStart {
+				dStart = docStart
+			}
+		}
+
+		if dStart < startLine || dEnd > endLine {
+			continue
+		}
+
+		blocks = append(blocks, declBlock{name: fn.Name.Name, startLine: dStart, endLine: dEnd})
+	}
+
+	return blocks
+}
+
+// spliceSortedBlocks rebuilds the file content with the blocks' overall range replaced by their
+// sorted texts, blank-line separated.
+//
+// Parameters:
+//   - `lines`: the file's lines.
+//   - `blocks`: the declaration blocks, already in the desired order.
+//
+// Returns:
+//   - `string`: the rebuilt file content.
+func spliceSortedBlocks(lines []string, blocks []declBlock) string {
+
+	overallStart := blocks[0].startLine
+	overallEnd := blocks[0].endLine
+	var sortedParts []string
+
+	for _, b := range blocks {
+		if b.startLine < overallStart {
+			overallStart = b.startLine
+		}
+		if b.endLine > overallEnd {
+			overallEnd = b.endLine
+		}
+		text := strings.Join(lines[b.startLine-1:b.endLine], "\n")
+		sortedParts = append(sortedParts, strings.TrimRight(text, " \t\n"))
+	}
+
+	var resultLines []string
+	resultLines = append(resultLines, lines[:overallStart-1]...)
+	resultLines = append(resultLines, strings.Split(strings.Join(sortedParts, "\n\n"), "\n")...)
+	resultLines = append(resultLines, lines[overallEnd:]...)
+
+	return strings.Join(resultLines, "\n")
+}
+
+// structFields extracts a struct type's field details: embedded fields flagged, json-omitted fields
+// skipped, grouped names expanded, and descriptions taken from trailing then leading comments.
+//
+// Parameters:
+//   - `st`: the struct type.
+//
+// Returns:
+//   - `[]FieldDetail`: the field details, in declaration order.
+func structFields(st *ast.StructType) []FieldDetail {
+
+	fields := []FieldDetail{}
+	for _, field := range st.Fields.List {
+		fields = append(fields, fieldDetailsFrom(field)...)
+	}
+
+	return fields
+}
+
+// fieldDetailsFrom extracts one field declaration's details per the structFields rules.
+//
+// Parameters:
+//   - `field`: the field declaration.
+//
+// Returns:
+//   - `[]FieldDetail`: one entry per declared name (or one embedded entry); empty when json-omitted.
+func fieldDetailsFrom(field *ast.Field) []FieldDetail {
+
+	if len(field.Names) == 0 {
+		fieldType := typeToString(field.Type)
+		return []FieldDetail{{Name: fieldType, Type: fieldType, Embedded: true}}
+	}
+
+	jsonName := ""
+	required := false
+	if field.Tag != nil {
+		tag := strings.Trim(field.Tag.Value, "`")
+		jsonName, required = parseJSONTag(tag)
+	}
+
+	if jsonName == "-" {
+		return nil
+	}
+
+	desc := ""
+	if field.Comment != nil {
+		desc = strings.TrimSpace(field.Comment.Text())
+	} else if field.Doc != nil {
+		desc = strings.TrimSpace(field.Doc.Text())
+	}
+
+	fieldType := typeToString(field.Type)
+	details := make([]FieldDetail, 0, len(field.Names))
+	for _, ident := range field.Names {
+		details = append(details, FieldDetail{
+			Name:        ident.Name,
+			JSONName:    jsonName,
+			Type:        fieldType,
+			Required:    required,
+			Description: desc,
+		})
+	}
+
+	return details
+}
 
 // mapKeys returns the keys of a map as a string slice.
 func mapKeys(m map[string]bool) []string {

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -33,7 +33,7 @@ complexity limits. This is the repository's only remaining lint debt.
 |---|---|---|---|---|
 | 1 | `refactor/complexity-writ` | writ commands: upgrade `Execute` 30 + `classifyEntry` 21, deploy `Execute` 22 + `buildScopeGraph` 29, decommission `Execute` 23; devlore-test `TestContext.Check` 32 | 6 | **complete** |
 | 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | **complete** |
-| 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | pending |
+| 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | **complete** |
 | 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | pending |
 | 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | pending |
 | 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | pending |
@@ -65,6 +65,21 @@ fallback chain. shellcheck's scanner state moved into a `functionTracker` with a
 accounting into `branchDelta` + `countParameterRefs` (preserving the quirk that `case`
 opens no nesting level while `esac` closes one, floored at zero), and
 `isValidFunctionName` now reads through positive rune predicates.
+
+**Phase 3 (complete):** the repo's worst function, `ConstGroups` (70), decomposed into a
+named state machine — `constGroupsFromDecl` with an explicit `flush` closure, entries via
+`constEntriesFromSpec`, mapping via `constGroupResults`, the anonymous local types
+promoted to file-level `constEntry`/`constGroup`. `Structs` extracted
+`structFields`/`fieldDetailsFrom`; `Callable` and `TypeDoc` now share `typeSpecDoc` (the
+Doc-preference rule stated once) via per-file finders; `Methods` split filter
+(`methodMatches`) from construction (`methodResultFor`); `SortDeclarations` split
+collection (`declBlocksInScope`) from splicing (`spliceSortedBlocks`); `Calls` and
+`Composites` extracted their closure bodies; `spacingRulesFromConfig` went table-driven
+(order-independent fields, so map iteration is safe). **The pre-declared structure
+question is now concrete:** the `collectGoFiles` + `parseFile` iteration remains
+repeated in five methods (`Callable`, `ConstGroups`, `Structs`, `TypeDoc`, `Deps`) — a
+shared per-file walker (e.g. `forEachParsedFile`) would retire the repetition; available
+for a ruling, not adopted unilaterally.
 
 ## Ordering rationale
 


### PR DESCRIPTION
Phase 3 of docs/plans/complexity-refactors.md (#312): nine functions decomposed under the thresholds, including the repo's worst (`ConstGroups`, 70 → a named state machine with an explicit flush). Behavior-preserving throughout — the suite passes unmodified. The pre-declared structure question is now concrete in the phase notes: five methods still repeat the per-file parse walk; a shared walker awaits a ruling. Plan doc rides along with phase 3 marked complete.