### PR TITLE
refactor(complexity): phase 4 — goast analysis and serialization

### DIFF
--- a/cmd/star/provider/goast/astrewrite.go
+++ b/cmd/star/provider/goast/astrewrite.go
@@ -71,15 +71,11 @@ func schemaFromConfigVal(name string, val interface{}) *doctaxonomy.CommentSchem
 	}
 
 	schema := &doctaxonomy.CommentSchema{Name: name}
-	if f := rv.FieldByName("Format"); f.IsValid() {
-		schema.Format = f.String()
-	}
-	if f := rv.FieldByName("NodeType"); f.IsValid() {
-		schema.NodeType = f.String()
-	}
-	if f := rv.FieldByName("SummaryPrefix"); f.IsValid() {
-		schema.SummaryPrefix = f.String()
-	}
+	reflectStringFields(rv, map[string]*string{
+		"Format":        &schema.Format,
+		"NodeType":      &schema.NodeType,
+		"SummaryPrefix": &schema.SummaryPrefix,
+	})
 
 	elementsField := rv.FieldByName("Elements")
 	if !elementsField.IsValid() || elementsField.Kind() != reflect.Slice {
@@ -87,64 +83,71 @@ func schemaFromConfigVal(name string, val interface{}) *doctaxonomy.CommentSchem
 	}
 
 	for i := 0; i < elementsField.Len(); i++ {
-		ev := elementsField.Index(i)
-		if ev.Kind() == reflect.Interface {
-			ev = ev.Elem()
+		if se, ok := schemaElementFromValue(elementsField.Index(i)); ok {
+			schema.Elements = append(schema.Elements, se)
 		}
-		if ev.Kind() == reflect.Ptr {
-			ev = ev.Elem()
-		}
-		if ev.Kind() != reflect.Struct {
-			continue
-		}
-
-		se := doctaxonomy.SchemaElement{}
-		if f := ev.FieldByName("Name"); f.IsValid() {
-			se.Name = f.String()
-		}
-		if f := ev.FieldByName("Type"); f.IsValid() {
-			se.Type = f.String()
-		}
-		if f := ev.FieldByName("Required"); f.IsValid() {
-			se.Required = f.String()
-		}
-		if f := ev.FieldByName("Cardinality"); f.IsValid() {
-			se.Cardinality = f.String()
-		}
-		if f := ev.FieldByName("Order"); f.IsValid() && f.CanInt() {
-			se.Order = int(f.Int())
-		}
-		if f := ev.FieldByName("Header"); f.IsValid() {
-			se.Header = f.String()
-		}
-		if f := ev.FieldByName("ItemTokens"); f.IsValid() {
-			se.ItemTokens = f.String()
-		}
-		if f := ev.FieldByName("Production"); f.IsValid() {
-			se.Production = f.String()
-		}
-		if f := ev.FieldByName("Consumes"); f.IsValid() {
-			se.Consumes = f.String()
-		}
-		if f := ev.FieldByName("Condition"); f.IsValid() {
-			se.Condition = f.String()
-		}
-		if f := ev.FieldByName("Prefix"); f.IsValid() {
-			se.Prefix = f.String()
-		}
-		if f := ev.FieldByName("Split"); f.IsValid() {
-			se.Split = f.String()
-		}
-		if f := ev.FieldByName("Slots"); f.IsValid() {
-			se.Slots = f.String()
-		}
-		if f := ev.FieldByName("SlotPrefix"); f.IsValid() {
-			se.SlotPrefix = f.String()
-		}
-		schema.Elements = append(schema.Elements, se)
 	}
 
 	return schema
+}
+
+// schemaElementFromValue extracts one schema element from a reflected config value, unwrapping
+// interface and pointer indirection.
+//
+// Parameters:
+//   - `ev`: the reflected element value.
+//
+// Returns:
+//   - `doctaxonomy.SchemaElement`: the populated element.
+//   - `bool`: false when the value does not resolve to a struct.
+func schemaElementFromValue(ev reflect.Value) (doctaxonomy.SchemaElement, bool) {
+
+	if ev.Kind() == reflect.Interface {
+		ev = ev.Elem()
+	}
+	if ev.Kind() == reflect.Ptr {
+		ev = ev.Elem()
+	}
+	if ev.Kind() != reflect.Struct {
+		return doctaxonomy.SchemaElement{}, false
+	}
+
+	se := doctaxonomy.SchemaElement{}
+	reflectStringFields(ev, map[string]*string{
+		"Name":        &se.Name,
+		"Type":        &se.Type,
+		"Required":    &se.Required,
+		"Cardinality": &se.Cardinality,
+		"Header":      &se.Header,
+		"ItemTokens":  &se.ItemTokens,
+		"Production":  &se.Production,
+		"Consumes":    &se.Consumes,
+		"Condition":   &se.Condition,
+		"Prefix":      &se.Prefix,
+		"Split":       &se.Split,
+		"Slots":       &se.Slots,
+		"SlotPrefix":  &se.SlotPrefix,
+	})
+	if f := ev.FieldByName("Order"); f.IsValid() && f.CanInt() {
+		se.Order = int(f.Int())
+	}
+
+	return se, true
+}
+
+// reflectStringFields copies the named string fields from a reflected struct into their targets,
+// skipping absent fields.
+//
+// Parameters:
+//   - `rv`: the reflected struct value.
+//   - `targets`: field name to destination.
+func reflectStringFields(rv reflect.Value, targets map[string]*string) {
+
+	for name, target := range targets {
+		if f := rv.FieldByName(name); f.IsValid() {
+			*target = f.String()
+		}
+	}
 }
 
 // genDeclName returns the primary name for a GenDecl — the first TypeSpec, ValueSpec, or ImportSpec name.

--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -209,35 +209,9 @@ func typeToString(expr ast.Expr) string {
 		}
 		return "interface{...}"
 	case *ast.FuncType:
-		var params []string
-		if t.Params != nil {
-			for _, p := range t.Params.List {
-				ts := typeToString(p.Type)
-				n := len(p.Names)
-				if n == 0 {
-					n = 1
-				}
-				for range n {
-					params = append(params, ts)
-				}
-			}
-		}
-
-		ret := returnTypeString(t.Results)
-		if ret == "" {
-			return "func(" + strings.Join(params, ", ") + ")"
-		}
-
-		return "func(" + strings.Join(params, ", ") + ") " + ret
+		return funcTypeToString(t)
 	case *ast.ChanType:
-		switch t.Dir {
-		case ast.SEND:
-			return "chan<- " + typeToString(t.Value)
-		case ast.RECV:
-			return "<-chan " + typeToString(t.Value)
-		default:
-			return "chan " + typeToString(t.Value)
-		}
+		return chanTypeToString(t)
 	case *ast.IndexExpr:
 		return typeToString(t.X) + "[" + typeToString(t.Index) + "]"
 	case *ast.IndexListExpr:
@@ -248,6 +222,56 @@ func typeToString(expr ast.Expr) string {
 		return typeToString(t.X) + "[" + strings.Join(indices, ", ") + "]"
 	default:
 		return "unknown"
+	}
+}
+
+// funcTypeToString renders a function type, expanding grouped parameter names.
+//
+// Parameters:
+//   - `t`: the function type.
+//
+// Returns:
+//   - `string`: the rendered type (e.g. "func(string, int) error").
+func funcTypeToString(t *ast.FuncType) string {
+
+	var params []string
+	if t.Params != nil {
+		for _, p := range t.Params.List {
+			ts := typeToString(p.Type)
+			n := len(p.Names)
+			if n == 0 {
+				n = 1
+			}
+			for range n {
+				params = append(params, ts)
+			}
+		}
+	}
+
+	ret := returnTypeString(t.Results)
+	if ret == "" {
+		return "func(" + strings.Join(params, ", ") + ")"
+	}
+
+	return "func(" + strings.Join(params, ", ") + ") " + ret
+}
+
+// chanTypeToString renders a channel type with its direction arrow.
+//
+// Parameters:
+//   - `t`: the channel type.
+//
+// Returns:
+//   - `string`: the rendered type (e.g. "<-chan int").
+func chanTypeToString(t *ast.ChanType) string {
+
+	switch t.Dir {
+	case ast.SEND:
+		return "chan<- " + typeToString(t.Value)
+	case ast.RECV:
+		return "<-chan " + typeToString(t.Value)
+	default:
+		return "chan " + typeToString(t.Value)
 	}
 }
 
@@ -551,7 +575,32 @@ func analyzeFileMetrics(path string) (FileMetric, error) {
 
 	fm := FileMetric{Path: path}
 
-	lines := strings.Split(string(content), "\n")
+	countLineMetrics(&fm, string(content), node)
+	fm.Imports = len(node.Imports)
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncDecl:
+			countFuncDecl(&fm, x)
+		case *ast.GenDecl:
+			countGenDecl(&fm, x)
+		}
+		return true
+	})
+
+	return fm, nil
+}
+
+// countLineMetrics fills the line-level counters: LOC, blanks, comment lines, and the derived SLOC
+// (floored at zero).
+//
+// Parameters:
+//   - `fm`: the metric under construction.
+//   - `content`: the file content.
+//   - `node`: the parsed file, for its comment groups.
+func countLineMetrics(fm *FileMetric, content string, node *ast.File) {
+
+	lines := strings.Split(content, "\n")
 	fm.LOC = len(lines)
 
 	for _, line := range lines {
@@ -570,55 +619,61 @@ func analyzeFileMetrics(path string) (FileMetric, error) {
 	if fm.SLOC < 0 {
 		fm.SLOC = 0
 	}
+}
 
-	fm.Imports = len(node.Imports)
+// countFuncDecl counts one function declaration: method vs function, plus Test/Benchmark naming.
+//
+// Parameters:
+//   - `fm`: the metric under construction.
+//   - `x`: the function declaration.
+func countFuncDecl(fm *FileMetric, x *ast.FuncDecl) {
 
-	ast.Inspect(node, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.FuncDecl:
-			if x.Recv != nil {
-				fm.Methods++
-			} else {
-				fm.Functions++
-			}
+	if x.Recv != nil {
+		fm.Methods++
+	} else {
+		fm.Functions++
+	}
 
-			if strings.HasPrefix(x.Name.Name, "Test") || strings.HasPrefix(x.Name.Name, "Benchmark") {
-				fm.TestFunctions++
-			}
-		case *ast.GenDecl:
-			switch x.Tok {
-			case token.TYPE:
-				for _, spec := range x.Specs {
-					if ts, ok := spec.(*ast.TypeSpec); ok {
-						fm.Types++
+	if strings.HasPrefix(x.Name.Name, "Test") || strings.HasPrefix(x.Name.Name, "Benchmark") {
+		fm.TestFunctions++
+	}
+}
 
-						switch ts.Type.(type) {
-						case *ast.StructType:
-							fm.Structs++
-						case *ast.InterfaceType:
-							fm.Interfaces++
-						}
-					}
-				}
-			case token.CONST:
-				for _, spec := range x.Specs {
-					if vs, ok := spec.(*ast.ValueSpec); ok {
-						fm.Constants += len(vs.Names)
-					}
-				}
-			case token.VAR:
-				for _, spec := range x.Specs {
-					if vs, ok := spec.(*ast.ValueSpec); ok {
-						fm.Variables += len(vs.Names)
-					}
+// countGenDecl counts one general declaration's types (with struct/interface splits), constants, and
+// variables.
+//
+// Parameters:
+//   - `fm`: the metric under construction.
+//   - `x`: the general declaration.
+func countGenDecl(fm *FileMetric, x *ast.GenDecl) {
+
+	switch x.Tok {
+	case token.TYPE:
+		for _, spec := range x.Specs {
+			if ts, ok := spec.(*ast.TypeSpec); ok {
+				fm.Types++
+
+				switch ts.Type.(type) {
+				case *ast.StructType:
+					fm.Structs++
+				case *ast.InterfaceType:
+					fm.Interfaces++
 				}
 			}
 		}
-
-		return true
-	})
-
-	return fm, nil
+	case token.CONST:
+		for _, spec := range x.Specs {
+			if vs, ok := spec.(*ast.ValueSpec); ok {
+				fm.Constants += len(vs.Names)
+			}
+		}
+	case token.VAR:
+		for _, spec := range x.Specs {
+			if vs, ok := spec.(*ast.ValueSpec); ok {
+				fm.Variables += len(vs.Names)
+			}
+		}
+	}
 }
 
 // =============================================================================
@@ -808,66 +863,92 @@ func checkLineWidth(content string, width int) []LineViolation {
 
 	// Under-filled comment lines.
 	for i := 0; i < len(lines)-1; i++ {
-		curr := lines[i]
-		next := lines[i+1]
-
-		currBody, currOK := commentBodyText(curr)
-		nextBody, nextOK := commentBodyText(next)
-		if !currOK || !nextOK {
-			continue
-		}
-
-		// Skip blank separator lines.
-		if strings.TrimSpace(currBody) == "" || strings.TrimSpace(nextBody) == "" {
-			continue
-		}
-
-		// Skip delineators.
-		if isDelineatorLine(currBody) || isDelineatorLine(nextBody) {
-			continue
-		}
-
-		// Skip SPDX/copyright.
-		if strings.HasPrefix(currBody, "SPDX-") || strings.HasPrefix(currBody, "Copyright") {
-			continue
-		}
-
-		// Skip indented code blocks (4+ spaces after //).
-		if strings.HasPrefix(currBody, "    ") || strings.HasPrefix(nextBody, "    ") {
-			continue
-		}
-
-		// Skip bullet items.
-		ct := strings.TrimSpace(currBody)
-		nt := strings.TrimSpace(nextBody)
-		if strings.HasPrefix(ct, "- ") || strings.HasPrefix(nt, "- ") {
-			continue
-		}
-
-		// Skip section headers and directives.
-		if strings.HasSuffix(ct, ":") || strings.HasPrefix(ct, "+") {
-			continue
-		}
-		if strings.HasSuffix(nt, ":") || strings.HasPrefix(nt, "+") || strings.HasPrefix(nt, "- ") {
-			continue
-		}
-
-		// Check if first word of next line fits on current line.
-		words := strings.Fields(nt)
-		if len(words) == 0 {
-			continue
-		}
-		firstWord := words[0]
-		if len(curr)+1+len(firstWord) <= width {
-			violations = append(violations, LineViolation{
-				Line: i + 1,
-				Message: fmt.Sprintf("under-filled comment ('%s' fits on previous line, %d columns available)",
-					firstWord, width-len(curr)),
-			})
+		if v := underFilledViolation(lines[i], lines[i+1], i+1, width); v != nil {
+			violations = append(violations, *v)
 		}
 	}
 
 	return violations
+}
+
+// underFilledViolation reports an under-filled comment line: a comment pair where the next line's
+// first word would fit on the current line without exceeding width.
+//
+// Blank separators, delineators, SPDX/copyright headers, indented code blocks, bullet items, section
+// headers, and directive lines are exempt.
+//
+// Parameters:
+//   - `curr`: the current line.
+//   - `next`: the following line.
+//   - `line`: the current line's 1-based number.
+//   - `width`: the maximum width.
+//
+// Returns:
+//   - `*LineViolation`: the violation, or nil.
+func underFilledViolation(curr, next string, line, width int) *LineViolation {
+
+	currBody, currOK := commentBodyText(curr)
+	nextBody, nextOK := commentBodyText(next)
+	if !currOK || !nextOK {
+		return nil
+	}
+
+	if commentPairExempt(currBody, nextBody) {
+		return nil
+	}
+
+	words := strings.Fields(strings.TrimSpace(nextBody))
+	if len(words) == 0 {
+		return nil
+	}
+
+	firstWord := words[0]
+	if len(curr)+1+len(firstWord) > width {
+		return nil
+	}
+
+	return &LineViolation{
+		Line: line,
+		Message: fmt.Sprintf("under-filled comment ('%s' fits on previous line, %d columns available)",
+			firstWord, width-len(curr)),
+	}
+}
+
+// commentPairExempt reports whether a comment pair is exempt from under-fill analysis: blank
+// separators, delineators, SPDX/copyright headers, indented code blocks, bullet items, section
+// headers, and directive lines.
+//
+// Parameters:
+//   - `currBody`: the current line's comment body.
+//   - `nextBody`: the next line's comment body.
+//
+// Returns:
+//   - `bool`: true when the pair is exempt.
+func commentPairExempt(currBody, nextBody string) bool {
+
+	if strings.TrimSpace(currBody) == "" || strings.TrimSpace(nextBody) == "" {
+		return true
+	}
+	if isDelineatorLine(currBody) || isDelineatorLine(nextBody) {
+		return true
+	}
+	if strings.HasPrefix(currBody, "SPDX-") || strings.HasPrefix(currBody, "Copyright") {
+		return true
+	}
+	if strings.HasPrefix(currBody, "    ") || strings.HasPrefix(nextBody, "    ") {
+		return true
+	}
+
+	ct := strings.TrimSpace(currBody)
+	nt := strings.TrimSpace(nextBody)
+	if strings.HasPrefix(ct, "- ") || strings.HasPrefix(nt, "- ") {
+		return true
+	}
+	if strings.HasSuffix(ct, ":") || strings.HasPrefix(ct, "+") {
+		return true
+	}
+
+	return strings.HasSuffix(nt, ":") || strings.HasPrefix(nt, "+") || strings.HasPrefix(nt, "- ")
 }
 
 // commentBodyText extracts the text after // from a comment line.

--- a/cmd/star/provider/goast/production.go
+++ b/cmd/star/provider/goast/production.go
@@ -49,38 +49,17 @@ func (p *itemProduction) Execute(
 	count := 0
 
 	for pos < len(blocks) {
-		if p.consumes.Max >= 0 && count >= p.consumes.Max {
-			break
-		}
-
 		b := blocks[pos]
-		if !p.consumes.Matches(blockTypeName(b)) {
+		if !p.canConsume(b, count, elem, ctx) {
 			break
-		}
-
-		// Prefix check: for single-match (Max=1), only check the first block.
-		// For multi-match (Max=-1), check every block.
-		if elem.Prefix != "" {
-			if !blockMatchesPrefix(b, elem.Prefix, ctx) {
-				break
-			}
 		}
 
 		// Sentence splitting: extract first sentence, replace block with remainder.
 		if count == 0 && elem.Split == "sentence" {
-			text := blockText(b)
-			if text != "" {
-				summaryText, remainderText := splitSentence(text)
-				if remainderText != "" {
-					output = append(output, &comment.Paragraph{
-						Text: []comment.Text{comment.Plain(summaryText)},
-					})
-					blocks[pos] = &comment.Paragraph{
-						Text: []comment.Text{comment.Plain(remainderText)},
-					}
-					count++
-					continue
-				}
+			if summary, ok := splitFirstSentence(blocks, pos); ok {
+				output = append(output, summary)
+				count++
+				continue
 			}
 		}
 
@@ -96,6 +75,61 @@ func (p *itemProduction) Execute(
 	}
 
 	return output, pos
+}
+
+// canConsume reports whether the block at the cursor may join this production: under the Max cap,
+// type-matched, and prefix-matched when the element declares a prefix (the first block for
+// single-match, every block for multi-match).
+//
+// Parameters:
+//   - `b`: the candidate block.
+//   - `count`: the number of blocks already consumed.
+//   - `elem`: the schema element driving the production.
+//   - `ctx`: the style context for prefix matching.
+//
+// Returns:
+//   - `bool`: true when the block may be consumed.
+func (p *itemProduction) canConsume(b comment.Block, count int, elem doctaxonomy.SchemaElement, ctx styleContext) bool {
+
+	if p.consumes.Max >= 0 && count >= p.consumes.Max {
+		return false
+	}
+	if !p.consumes.Matches(blockTypeName(b)) {
+		return false
+	}
+
+	return elem.Prefix == "" || blockMatchesPrefix(b, elem.Prefix, ctx)
+}
+
+// splitFirstSentence splits the block at the cursor at its first sentence boundary: the summary
+// paragraph is returned and the block is replaced in place by the remainder.
+//
+// Parameters:
+//   - `blocks`: the block list; `blocks[pos]` is replaced on a successful split.
+//   - `pos`: the cursor.
+//
+// Returns:
+//   - `comment.Block`: the first-sentence summary paragraph.
+//   - `bool`: false when the block has no text or no remainder to split off.
+func splitFirstSentence(blocks []comment.Block, pos int) (comment.Block, bool) {
+
+	text := blockText(blocks[pos])
+	if text == "" {
+		return nil, false
+	}
+
+	summaryText, remainderText := splitSentence(text)
+	if remainderText == "" {
+		return nil, false
+	}
+
+	blocks[pos] = &comment.Paragraph{
+		Text: []comment.Text{comment.Plain(remainderText)},
+	}
+
+	return &comment.Paragraph{
+		Text: []comment.Text{comment.Plain(summaryText)},
+	}, true
 }
 
 // listProduction consumes an optional heading paragraph followed by a list block.

--- a/cmd/star/provider/goast/slotassign.go
+++ b/cmd/star/provider/goast/slotassign.go
@@ -24,40 +24,14 @@ func assignSlots(slots, items []string) (matched []Match, unmatchedSlots, unmatc
 		return nil, nil, nil
 	}
 
-	// Build score matrix.
-	scores := make([][]float64, m)
-	for i, item := range items {
-		scores[i] = make([]float64, n)
-		normItem := normalize(firstToken(item))
-		for j, slot := range slots {
-			normSlot := normalize(slot)
-			scores[i][j] = fuzzyScore(normItem, normSlot)
-		}
-	}
+	scores := buildScoreMatrix(slots, items)
 
 	slotTaken := make([]bool, n)
 	itemTaken := make([]bool, m)
 
 	// Greedy rounds: pick best pair above threshold.
 	for round := 0; round < min2(n, m); round++ {
-		bestScore := 0.0
-		bestI, bestJ := -1, -1
-
-		for i := 0; i < m; i++ {
-			if itemTaken[i] {
-				continue
-			}
-			for j := 0; j < n; j++ {
-				if slotTaken[j] {
-					continue
-				}
-				if scores[i][j] > bestScore {
-					bestScore = scores[i][j]
-					bestI = i
-					bestJ = j
-				}
-			}
-		}
+		bestI, bestJ, bestScore := bestFreePair(scores, slotTaken, itemTaken)
 
 		if bestScore < 0.3 {
 			break
@@ -73,42 +47,118 @@ func assignSlots(slots, items []string) (matched []Match, unmatchedSlots, unmatc
 	}
 
 	// Forced assignment: one unmatched slot + one unmatched item.
-	freeSlots := countFree(slotTaken)
-	freeItems := countFree(itemTaken)
-	if freeSlots == 1 && freeItems == 1 {
-		for j := 0; j < n; j++ {
+	if countFree(slotTaken) == 1 && countFree(itemTaken) == 1 {
+		matched = append(matched, forcedMatch(slots, items, slotTaken, itemTaken))
+	}
+
+	return matched, freeStrings(slots, slotTaken), freeStrings(items, itemTaken)
+}
+
+// buildScoreMatrix scores every item against every slot via the normalized fuzzy comparison.
+//
+// Parameters:
+//   - `slots`: the slot names.
+//   - `items`: the item names.
+//
+// Returns:
+//   - `[][]float64`: scores indexed [item][slot].
+func buildScoreMatrix(slots, items []string) [][]float64 {
+
+	scores := make([][]float64, len(items))
+	for i, item := range items {
+		scores[i] = make([]float64, len(slots))
+		normItem := normalize(firstToken(item))
+		for j, slot := range slots {
+			scores[i][j] = fuzzyScore(normItem, normalize(slot))
+		}
+	}
+
+	return scores
+}
+
+// bestFreePair finds the highest-scoring pair among the untaken items and slots.
+//
+// Parameters:
+//   - `scores`: the score matrix, indexed [item][slot].
+//   - `slotTaken`: the taken flags per slot.
+//   - `itemTaken`: the taken flags per item.
+//
+// Returns:
+//   - `bestI`: the best item index, or -1 when no free pair exists.
+//   - `bestJ`: the best slot index, or -1 when no free pair exists.
+//   - `bestScore`: the pair's score; 0.0 when no free pair beats it.
+func bestFreePair(scores [][]float64, slotTaken, itemTaken []bool) (bestI, bestJ int, bestScore float64) {
+
+	bestI, bestJ = -1, -1
+	for i := range itemTaken {
+		if itemTaken[i] {
+			continue
+		}
+		for j := range slotTaken {
 			if slotTaken[j] {
 				continue
 			}
-			for i := 0; i < m; i++ {
-				if itemTaken[i] {
-					continue
-				}
-				matched = append(matched, Match{
-					Slot:   slots[j],
-					Item:   items[i],
-					Score:  0.1,
-					Forced: true,
-				})
-				slotTaken[j] = true
-				itemTaken[i] = true
+			if scores[i][j] > bestScore {
+				bestScore = scores[i][j]
+				bestI = i
+				bestJ = j
 			}
 		}
 	}
 
-	// Collect unmatched.
-	for j := 0; j < n; j++ {
+	return bestI, bestJ, bestScore
+}
+
+// forcedMatch pairs the single remaining free slot with the single remaining free item, marking both
+// taken.
+//
+// Parameters:
+//   - `slots`: the slot names.
+//   - `items`: the item names.
+//   - `slotTaken`: the taken flags per slot; exactly one must be free.
+//   - `itemTaken`: the taken flags per item; exactly one must be free.
+//
+// Returns:
+//   - `Match`: the forced pair, scored 0.1.
+func forcedMatch(slots, items []string, slotTaken, itemTaken []bool) Match {
+
+	match := Match{Score: 0.1, Forced: true}
+	for j := range slotTaken {
 		if !slotTaken[j] {
-			unmatchedSlots = append(unmatchedSlots, slots[j])
+			match.Slot = slots[j]
+			slotTaken[j] = true
+			break
 		}
 	}
-	for i := 0; i < m; i++ {
+	for i := range itemTaken {
 		if !itemTaken[i] {
-			unmatchedItems = append(unmatchedItems, items[i])
+			match.Item = items[i]
+			itemTaken[i] = true
+			break
 		}
 	}
 
-	return
+	return match
+}
+
+// freeStrings collects the entries whose taken flag is unset, in order.
+//
+// Parameters:
+//   - `list`: the entries.
+//   - `taken`: the taken flags, parallel to `list`.
+//
+// Returns:
+//   - `[]string`: the untaken entries.
+func freeStrings(list []string, taken []bool) []string {
+
+	var free []string
+	for i := range list {
+		if !taken[i] {
+			free = append(free, list[i])
+		}
+	}
+
+	return free
 }
 
 func countFree(taken []bool) int {

--- a/cmd/star/provider/goast/source_file.go
+++ b/cmd/star/provider/goast/source_file.go
@@ -73,62 +73,15 @@ func LoadSourceFile(content string) (*SourceFile, error) {
 		funcIndex: make(map[string]*FuncDecl),
 	}
 
-	// Classify comment groups: doc comments are attached to declarations, body comments are inside declaration bodies,
-	// everything else is floating.
+	docCGs := docCommentGroups(file)
+	bodyCGs := bodyCommentGroups(file, docCGs)
 
-	docCGs := map[*ast.CommentGroup]bool{}
+	// Collect all positioned items for source-order interleaving; the package doc leads as a
+	// CommentDecl with StylePackageDoc.
 
-	for _, decl := range file.Decls {
-		switch d := decl.(type) {
-		case *ast.FuncDecl:
-			if d.Doc != nil {
-				docCGs[d.Doc] = true
-			}
-		case *ast.GenDecl:
-			if d.Doc != nil {
-				docCGs[d.Doc] = true
-			}
-			for _, spec := range d.Specs {
-				switch s := spec.(type) {
-				case *ast.TypeSpec:
-					if s.Doc != nil {
-						docCGs[s.Doc] = true
-					}
-				case *ast.ValueSpec:
-					if s.Doc != nil {
-						docCGs[s.Doc] = true
-					}
-				}
-			}
-		}
-	}
-
+	var items []positionedDecl
 	if file.Doc != nil {
-		docCGs[file.Doc] = true
-	}
-
-	bodyCGs := map[*ast.CommentGroup]bool{}
-
-	for _, decl := range file.Decls {
-		for _, cg := range file.Comments {
-			if !docCGs[cg] && cg.Pos() >= decl.Pos() && cg.End() <= decl.End() {
-				bodyCGs[cg] = true
-			}
-		}
-	}
-
-	// Collect all positioned items for source-order interleaving.
-
-	type positioned struct {
-		pos  token.Pos
-		decl Decl
-	}
-	var items []positioned
-
-	// Package doc as a CommentDecl with StylePackageDoc.
-
-	if file.Doc != nil {
-		items = append(items, positioned{
+		items = append(items, positionedDecl{
 			pos: file.Doc.Pos(),
 			decl: &CommentDecl{
 				cg:    file.Doc,
@@ -138,114 +91,33 @@ func LoadSourceFile(content string) (*SourceFile, error) {
 		})
 	}
 
-	type pendingMethod struct {
-		typeName string
-		decl     *FuncDecl
-	}
-
 	var pending []pendingMethod
 
-	// Declarations.
-
 	for _, decl := range file.Decls {
-
 		switch d := decl.(type) {
-
 		case *ast.FuncDecl:
-
-			fd := &FuncDecl{
-				Name:    d.Name.Name,
-				Params:  extractParams(d.Type.Params, nil),
-				Returns: returnTypeString(d.Type.Results),
-				node:    d,
-				comment: docFromCommentGroup(d.Doc, StyleFuncDoc),
-				code:    extractCodeDecl(content, fileSet, d),
+			fd, methodType := loadFuncDecl(sf, content, fileSet, d)
+			if methodType != "" {
+				pending = append(pending, pendingMethod{typeName: methodType, decl: fd})
 			}
-
-			if d.Recv != nil && len(d.Recv.List) > 0 {
-				typeName := strings.TrimPrefix(receiverTypeName(d.Recv.List[0].Type), "*")
-				pending = append(pending, pendingMethod{typeName: typeName, decl: fd})
-			} else {
-				sf.Funcs = append(sf.Funcs, fd)
-				sf.funcIndex[d.Name.Name] = fd
-			}
-
-			items = append(items, positioned{pos: d.Pos(), decl: fd})
-
+			items = append(items, positionedDecl{pos: d.Pos(), decl: fd})
 		case *ast.GenDecl:
-
-			style := StyleGenDeclDoc
-
-			if d.Tok == token.IMPORT {
-				style = StyleImportDoc
-			}
-
-			gd := &GenDeclNode{
-				Name:        genDeclName(d),
-				Entries:     constEntries(d),
-				genDecl:     d,
-				comment:     docFromGenDecl(d, style),
-				code:        extractCodeDecl(content, fileSet, d),
-				methodIndex: make(map[string]*FuncDecl),
-			}
-
-			sf.genDecls = append(sf.genDecls, gd)
-
-			// Index type names for method association and GetType lookup.
-
-			if d.Tok == token.TYPE {
-				for _, spec := range d.Specs {
-					if ts, ok := spec.(*ast.TypeSpec); ok {
-						sf.typeIndex[ts.Name.Name] = gd
-					}
-				}
-			}
-
-			items = append(items, positioned{pos: d.Pos(), decl: gd})
+			items = append(items, positionedDecl{pos: d.Pos(), decl: loadGenDecl(sf, content, fileSet, d)})
 		}
 	}
 
-	// Floating comments — classify each one.
+	items = append(items, floatingCommentDecls(file, docCGs, bodyCGs)...)
 
-	for _, cg := range file.Comments {
-
-		if docCGs[cg] || bodyCGs[cg] {
-			continue
-		}
-
-		rawText := cg.Text()
-		style := classifyFloatingComment(rawText)
-
-		items = append(items, positioned{
-			pos: cg.Pos(),
-			decl: &CommentDecl{
-				cg:    cg,
-				doc:   textToDoc(rawText),
-				style: style,
-			},
-		})
-	}
-
-	// Sort by source position.
+	// Sort by source position and build allDecls in source order.
 
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].pos < items[j].pos
 	})
-
-	// Build allDecls in source order.
-
 	for _, item := range items {
 		sf.Decls = append(sf.Decls, item.decl)
 	}
 
-	// Associate methods with their types.
-
-	for _, pm := range pending {
-		if gd, ok := sf.typeIndex[pm.typeName]; ok {
-			gd.Methods = append(gd.Methods, pm.decl)
-			gd.methodIndex[pm.decl.Name] = pm.decl
-		}
-	}
+	associateMethods(sf, pending)
 
 	// Precompute the exported view fields (immutable after load) — the bridge projects them as read-only properties.
 	// Funcs and Decls were accumulated above; filter the rest from genDecls here.
@@ -405,28 +277,18 @@ func (sf *SourceFile) SaveAs(path string) error {
 
 		// Preamble: copyright and package doc come before package clause.
 		if !packageEmitted {
-			if cd, ok := decl.(*CommentDecl); ok {
-				if cd.style == StyleCopyright || cd.style == StylePackageDoc {
-					if prevKind != "" {
-						b.WriteString("\n\n")
-					}
-					b.WriteString(renderDoc(cd.doc, width))
-					if cd.style == StylePackageDoc {
-						hasPackageDoc = true
-					}
-					prevKind = kind
-					continue
+			if cd, ok := preambleCommentDecl(decl); ok {
+				if prevKind != "" {
+					b.WriteString("\n\n")
 				}
+				b.WriteString(renderDoc(cd.doc, width))
+				if cd.style == StylePackageDoc {
+					hasPackageDoc = true
+				}
+				prevKind = kind
+				continue
 			}
-			// Package doc comment must be directly above the package keyword
-			// (no blank line). Copyright gets a blank line separator.
-			if hasPackageDoc {
-				b.WriteString("\n")
-			} else if prevKind != "" {
-				b.WriteString("\n\n")
-			}
-			b.WriteString("package ")
-			b.WriteString(sf.file.Name.Name)
+			writePackageClause(&b, sf.file.Name.Name, hasPackageDoc, prevKind)
 			packageEmitted = true
 			prevKind = "package"
 		}
@@ -435,15 +297,7 @@ func (sf *SourceFile) SaveAs(path string) error {
 		lines := sf.spacingBetween(prevKind, kind)
 		b.WriteString(strings.Repeat("\n", lines+1))
 
-		// Emit the declaration.
-		switch d := decl.(type) {
-		case *FuncDecl:
-			sf.emitDecl(&b, d.comment, d.code, width)
-		case *GenDeclNode:
-			sf.emitDecl(&b, d.comment, d.code, width)
-		case *CommentDecl:
-			b.WriteString(renderDoc(d.doc, width))
-		}
+		sf.emitDeclNode(&b, decl, width)
 
 		prevKind = kind
 	}
@@ -469,6 +323,25 @@ func (sf *SourceFile) SaveAs(path string) error {
 // region UNEXPORTED METHODS
 
 // region State management
+
+// emitDeclNode writes one declaration: comment-and-code for functions and general declarations,
+// rendered doc for standalone comments.
+//
+// Parameters:
+//   - `b`: the output builder.
+//   - `decl`: the declaration to emit.
+//   - `width`: the render width.
+func (sf *SourceFile) emitDeclNode(b *strings.Builder, decl Decl, width int) {
+
+	switch d := decl.(type) {
+	case *FuncDecl:
+		sf.emitDecl(b, d.comment, d.code, width)
+	case *GenDeclNode:
+		sf.emitDecl(b, d.comment, d.code, width)
+	case *CommentDecl:
+		b.WriteString(renderDoc(d.doc, width))
+	}
+}
 
 // lineWidth returns the line-width budget stamped on this file at LoadSourceFile time.
 //
@@ -1176,3 +1049,265 @@ func textToDoc(text string) *comment.Doc {
 }
 
 // endregion
+
+// positionedDecl pairs a declaration with its source position for source-order interleaving.
+type positionedDecl struct {
+	pos  token.Pos
+	decl Decl
+}
+
+// pendingMethod defers a method's type association until the type index is fully built.
+type pendingMethod struct {
+	typeName string
+	decl     *FuncDecl
+}
+
+// docCommentGroups classifies the comment groups attached to declarations (and the package doc) as
+// doc comments.
+//
+// Parameters:
+//   - `file`: the parsed file.
+//
+// Returns:
+//   - `map[*ast.CommentGroup]bool`: the doc-attached comment groups.
+func docCommentGroups(file *ast.File) map[*ast.CommentGroup]bool {
+
+	docCGs := map[*ast.CommentGroup]bool{}
+
+	for _, decl := range file.Decls {
+		markDeclDocs(decl, docCGs)
+	}
+
+	if file.Doc != nil {
+		docCGs[file.Doc] = true
+	}
+
+	return docCGs
+}
+
+// markDeclDocs marks one declaration's doc comment (and its specs' doc comments) as doc-attached.
+//
+// Parameters:
+//   - `decl`: the declaration.
+//   - `docCGs`: the doc-attached set under construction.
+func markDeclDocs(decl ast.Decl, docCGs map[*ast.CommentGroup]bool) {
+
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		if d.Doc != nil {
+			docCGs[d.Doc] = true
+		}
+	case *ast.GenDecl:
+		if d.Doc != nil {
+			docCGs[d.Doc] = true
+		}
+		for _, spec := range d.Specs {
+			markSpecDoc(spec, docCGs)
+		}
+	}
+}
+
+// markSpecDoc marks one spec's doc comment as doc-attached.
+//
+// Parameters:
+//   - `spec`: the type or value spec.
+//   - `docCGs`: the doc-attached set under construction.
+func markSpecDoc(spec ast.Spec, docCGs map[*ast.CommentGroup]bool) {
+
+	switch s := spec.(type) {
+	case *ast.TypeSpec:
+		if s.Doc != nil {
+			docCGs[s.Doc] = true
+		}
+	case *ast.ValueSpec:
+		if s.Doc != nil {
+			docCGs[s.Doc] = true
+		}
+	}
+}
+
+// bodyCommentGroups classifies the comment groups lying inside declaration bodies.
+//
+// Parameters:
+//   - `file`: the parsed file.
+//   - `docCGs`: the doc-attached groups, excluded from body classification.
+//
+// Returns:
+//   - `map[*ast.CommentGroup]bool`: the body comment groups.
+func bodyCommentGroups(file *ast.File, docCGs map[*ast.CommentGroup]bool) map[*ast.CommentGroup]bool {
+
+	bodyCGs := map[*ast.CommentGroup]bool{}
+
+	for _, decl := range file.Decls {
+		for _, cg := range file.Comments {
+			if !docCGs[cg] && cg.Pos() >= decl.Pos() && cg.End() <= decl.End() {
+				bodyCGs[cg] = true
+			}
+		}
+	}
+
+	return bodyCGs
+}
+
+// loadFuncDecl builds a FuncDecl, registering free functions on the source file directly and
+// reporting methods for deferred association.
+//
+// Parameters:
+//   - `sf`: the source file under construction.
+//   - `content`: the raw source, for code extraction.
+//   - `fileSet`: the file set.
+//   - `d`: the function declaration.
+//
+// Returns:
+//   - `*FuncDecl`: the built declaration node.
+//   - `string`: the receiver type name for methods; empty for free functions.
+func loadFuncDecl(sf *SourceFile, content string, fileSet *token.FileSet, d *ast.FuncDecl) (*FuncDecl, string) {
+
+	fd := &FuncDecl{
+		Name:    d.Name.Name,
+		Params:  extractParams(d.Type.Params, nil),
+		Returns: returnTypeString(d.Type.Results),
+		node:    d,
+		comment: docFromCommentGroup(d.Doc, StyleFuncDoc),
+		code:    extractCodeDecl(content, fileSet, d),
+	}
+
+	if d.Recv != nil && len(d.Recv.List) > 0 {
+		return fd, strings.TrimPrefix(receiverTypeName(d.Recv.List[0].Type), "*")
+	}
+
+	sf.Funcs = append(sf.Funcs, fd)
+	sf.funcIndex[d.Name.Name] = fd
+
+	return fd, ""
+}
+
+// loadGenDecl builds a GenDeclNode, registering it on the source file and indexing its type names for
+// method association and GetType lookup.
+//
+// Parameters:
+//   - `sf`: the source file under construction.
+//   - `content`: the raw source, for code extraction.
+//   - `fileSet`: the file set.
+//   - `d`: the general declaration.
+//
+// Returns:
+//   - `*GenDeclNode`: the built declaration node.
+func loadGenDecl(sf *SourceFile, content string, fileSet *token.FileSet, d *ast.GenDecl) *GenDeclNode {
+
+	style := StyleGenDeclDoc
+	if d.Tok == token.IMPORT {
+		style = StyleImportDoc
+	}
+
+	gd := &GenDeclNode{
+		Name:        genDeclName(d),
+		Entries:     constEntries(d),
+		genDecl:     d,
+		comment:     docFromGenDecl(d, style),
+		code:        extractCodeDecl(content, fileSet, d),
+		methodIndex: make(map[string]*FuncDecl),
+	}
+
+	sf.genDecls = append(sf.genDecls, gd)
+
+	if d.Tok == token.TYPE {
+		for _, spec := range d.Specs {
+			if ts, ok := spec.(*ast.TypeSpec); ok {
+				sf.typeIndex[ts.Name.Name] = gd
+			}
+		}
+	}
+
+	return gd
+}
+
+// floatingCommentDecls builds CommentDecls for the comment groups attached to nothing, each
+// classified by style.
+//
+// Parameters:
+//   - `file`: the parsed file.
+//   - `docCGs`: the doc-attached groups.
+//   - `bodyCGs`: the body groups.
+//
+// Returns:
+//   - `[]positionedDecl`: the floating comments as positioned declarations.
+func floatingCommentDecls(
+	file *ast.File, docCGs, bodyCGs map[*ast.CommentGroup]bool,
+) []positionedDecl {
+
+	var items []positionedDecl
+	for _, cg := range file.Comments {
+		if docCGs[cg] || bodyCGs[cg] {
+			continue
+		}
+
+		rawText := cg.Text()
+		items = append(items, positionedDecl{
+			pos: cg.Pos(),
+			decl: &CommentDecl{
+				cg:    cg,
+				doc:   textToDoc(rawText),
+				style: classifyFloatingComment(rawText),
+			},
+		})
+	}
+
+	return items
+}
+
+// associateMethods attaches the deferred methods to their types via the type index.
+//
+// Parameters:
+//   - `sf`: the source file under construction.
+//   - `pending`: the deferred method associations.
+func associateMethods(sf *SourceFile, pending []pendingMethod) {
+
+	for _, pm := range pending {
+		if gd, ok := sf.typeIndex[pm.typeName]; ok {
+			gd.Methods = append(gd.Methods, pm.decl)
+			gd.methodIndex[pm.decl.Name] = pm.decl
+		}
+	}
+}
+
+// preambleCommentDecl reports whether the declaration is preamble commentary (copyright or package
+// doc) that renders before the package clause.
+//
+// Parameters:
+//   - `decl`: the declaration under consideration.
+//
+// Returns:
+//   - `*CommentDecl`: the comment declaration when it is preamble commentary.
+//   - `bool`: true for preamble commentary.
+func preambleCommentDecl(decl Decl) (*CommentDecl, bool) {
+
+	cd, ok := decl.(*CommentDecl)
+	if !ok {
+		return nil, false
+	}
+	if cd.style != StyleCopyright && cd.style != StylePackageDoc {
+		return nil, false
+	}
+
+	return cd, true
+}
+
+// writePackageClause writes the package clause with its leading separation: the package doc sits
+// directly above the keyword (no blank line); copyright gets a blank-line separator.
+//
+// Parameters:
+//   - `b`: the output builder.
+//   - `packageName`: the package name.
+//   - `hasPackageDoc`: whether a package doc was just emitted.
+//   - `prevKind`: the previous declaration kind; empty at file start.
+func writePackageClause(b *strings.Builder, packageName string, hasPackageDoc bool, prevKind string) {
+
+	if hasPackageDoc {
+		b.WriteString("\n")
+	} else if prevKind != "" {
+		b.WriteString("\n\n")
+	}
+	b.WriteString("package ")
+	b.WriteString(packageName)
+}

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -34,7 +34,7 @@ complexity limits. This is the repository's only remaining lint debt.
 | 1 | `refactor/complexity-writ` | writ commands: upgrade `Execute` 30 + `classifyEntry` 21, deploy `Execute` 22 + `buildScopeGraph` 29, decommission `Execute` 23; devlore-test `TestContext.Check` 32 | 6 | **complete** |
 | 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | **complete** |
 | 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | **complete** |
-| 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | pending |
+| 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | **complete** |
 | 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | pending |
 | 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | pending |
 | 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16 | 15 | pending |
@@ -80,6 +80,20 @@ question is now concrete:** the `collectGoFiles` + `parseFile` iteration remains
 repeated in five methods (`Callable`, `ConstGroups`, `Structs`, `TypeDoc`, `Deps`) — a
 shared per-file walker (e.g. `forEachParsedFile`) would retire the repetition; available
 for a ruling, not adopted unilaterally.
+
+**Phase 4 (complete):** `LoadSourceFile` (67) decomposed along its own commented phases —
+`docCommentGroups` (itself split once more via `markDeclDocs`/`markSpecDoc` when the
+extraction scored 27), `bodyCommentGroups`, `loadFuncDecl`/`loadGenDecl`,
+`floatingCommentDecls`, `associateMethods` — with its anonymous types promoted to
+`positionedDecl`/`pendingMethod`. `SaveAs` extracted the preamble rule
+(`preambleCommentDecl` + `writePackageClause`, the package-doc-adjacency comment kept) and
+`emitDeclNode`. `analyzeFileMetrics` split into line counters and per-declaration
+counters. `assignSlots` became the algorithm's named parts — `buildScoreMatrix`,
+`bestFreePair`, `forcedMatch`, `freeStrings` — retiring the two inline G602 proofs
+naturally. `schemaFromConfigVal` went table-driven over a shared `reflectStringFields`.
+`typeToString` extracted its func/chan arms; `checkLineWidth` its under-fill analysis
+(`underFilledViolation` over a single `commentPairExempt` predicate);
+`itemProduction.Execute` its consume predicate and in-place sentence split.
 
 ## Ordering rationale
 


### PR DESCRIPTION
Phase 4 of docs/plans/complexity-refactors.md (#312): eight functions decomposed under the thresholds — `LoadSourceFile` (67) along its own commented phases, `analyzeFileMetrics` (55) into line/declaration counters, `assignSlots` (44) into the algorithm's named parts (naturally retiring its two inline G602 proofs), `schemaFromConfigVal` (43) table-driven. Behavior-preserving; the suite passes unmodified. goast is now complexity-clean. Plan doc rides along with phase 4 marked complete.