### PR TITLE
refactor(complexity): phase 5 — concrete providers; the reservedKwargs carrier

### DIFF
--- a/cmd/lore/lore/builder.go
+++ b/cmd/lore/lore/builder.go
@@ -331,25 +331,9 @@ func (p *Planner) buildPackage(provider *plan.Provider, sharedEnv *op.RuntimeEnv
 			continue
 		}
 
-		var phaseRetry *op.RetryPolicy
-
-		for _, action := range actions {
-			switch typed := action.(type) {
-			case *lorepackage.ScriptAction:
-				retry, err := executeScriptAction(sharedEnv, release, typed, cfg)
-				if err != nil {
-					return nil, fmt.Errorf("phase %q: %w", phaseName, err)
-				}
-				if retry != nil && phaseRetry == nil {
-					phaseRetry = retry
-				}
-			case *lorepackage.NativePMAction:
-				if err := p.addNativeSoftwarePackages(provider, typed); err != nil {
-					return nil, fmt.Errorf("phase %q: %w", phaseName, err)
-				}
-			default:
-				return nil, fmt.Errorf("phase %q: unknown action type %T", phaseName, action)
-			}
+		phaseRetry, err := p.applyPhaseActions(provider, sharedEnv, release, phaseName, actions, cfg)
+		if err != nil {
+			return nil, err
 		}
 
 		children := parentlessTargets(provider)
@@ -357,24 +341,92 @@ func (p *Planner) buildPackage(provider *plan.Provider, sharedEnv *op.RuntimeEnv
 			continue
 		}
 
-		// lore owns the package output: it names the phase subgraph and stamps its provenance annotations.
-		spec := op.NewSubgraphSpec().
-			WithID(fmt.Sprintf("subgraph.%s.%s", release.Name, phaseName)).
-			WithName(phaseName).
-			WithAction(subgraphAction).
-			WithAnnotations(map[string]any{"package": release.Name, "phase": phaseName}).
-			WithChildren(children...).
-			WithRetryPolicy(phaseRetry)
-
-		subgraph, err := op.NewSubgraph(spec)
+		subgraph, err := phaseSubgraph(subgraphAction, release, phaseName, children, phaseRetry)
 		if err != nil {
-			return nil, fmt.Errorf("phase %q: %w", phaseName, err)
+			return nil, err
 		}
 
 		phases = append(phases, subgraph)
 	}
 
 	return phases, nil
+}
+
+// applyPhaseActions applies one phase's actions to the shared provider, returning the phase's retry
+// policy (the first script-supplied one wins).
+//
+// Parameters:
+//   - `provider`: the shared plan provider.
+//   - `sharedEnv`: the shared planning environment.
+//   - `release`: the release under construction.
+//   - `phaseName`: the phase, for error context.
+//   - `actions`: the phase's actions, in order.
+//   - `cfg`: the build configuration.
+//
+// Returns:
+//   - `*op.RetryPolicy`: the phase retry policy, or nil.
+//   - `error`: non-nil when any action fails or is of unknown type.
+func (p *Planner) applyPhaseActions(
+	provider *plan.Provider, sharedEnv *op.RuntimeEnvironment, release *lorepackage.Release,
+	phaseName string, actions []lorepackage.PhaseAction, cfg BuildConfig,
+) (*op.RetryPolicy, error) {
+
+	var phaseRetry *op.RetryPolicy
+
+	for _, action := range actions {
+		switch typed := action.(type) {
+		case *lorepackage.ScriptAction:
+			retry, err := executeScriptAction(sharedEnv, release, typed, cfg)
+			if err != nil {
+				return nil, fmt.Errorf("phase %q: %w", phaseName, err)
+			}
+			if retry != nil && phaseRetry == nil {
+				phaseRetry = retry
+			}
+		case *lorepackage.NativePMAction:
+			if err := p.addNativeSoftwarePackages(provider, typed); err != nil {
+				return nil, fmt.Errorf("phase %q: %w", phaseName, err)
+			}
+		default:
+			return nil, fmt.Errorf("phase %q: unknown action type %T", phaseName, action)
+		}
+	}
+
+	return phaseRetry, nil
+}
+
+// phaseSubgraph assembles one phase's subgraph: lore owns the package output, so it names the phase
+// subgraph and stamps its package/phase annotations.
+//
+// Parameters:
+//   - `subgraphAction`: the resolved flow.subgraph action.
+//   - `release`: the release under construction.
+//   - `phaseName`: the phase.
+//   - `children`: the phase's planned units.
+//   - `phaseRetry`: the phase retry policy, or nil.
+//
+// Returns:
+//   - `*op.Subgraph`: the sealed phase subgraph.
+//   - `error`: non-nil when assembly fails.
+func phaseSubgraph(
+	subgraphAction op.Action, release *lorepackage.Release, phaseName string,
+	children []op.ExecutableUnit, phaseRetry *op.RetryPolicy,
+) (*op.Subgraph, error) {
+
+	spec := op.NewSubgraphSpec().
+		WithID(fmt.Sprintf("subgraph.%s.%s", release.Name, phaseName)).
+		WithName(phaseName).
+		WithAction(subgraphAction).
+		WithAnnotations(map[string]any{"package": release.Name, "phase": phaseName}).
+		WithChildren(children...).
+		WithRetryPolicy(phaseRetry)
+
+	subgraph, err := op.NewSubgraph(spec)
+	if err != nil {
+		return nil, fmt.Errorf("phase %q: %w", phaseName, err)
+	}
+
+	return subgraph, nil
 }
 
 // addNativeSoftwarePackages registers a native-software-management invocation (install / remove / upgrade) into the

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -35,7 +35,7 @@ complexity limits. This is the repository's only remaining lint debt.
 | 2 | `refactor/complexity-star-app` | star app + shellcheck: `registerStarlarkCommand` 37, `Extension.Validate` 30, `Command.Run` 30, `flagValue` 26 (gocyclo); `parseShellFile` 32, `calculateFunctionComplexity` 26, `isValidFunctionName` 17 | 7 | **complete** |
 | 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | **complete** |
 | 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | **complete** |
-| 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | pending |
+| 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | **complete** |
 | 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | pending |
 | 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16 | 15 | pending |
 
@@ -94,6 +94,20 @@ naturally. `schemaFromConfigVal` went table-driven over a shared `reflectStringF
 `typeToString` extracted its func/chan arms; `checkLineWidth` its under-fill analysis
 (`underFilledViolation` over a single `commentPairExempt` predicate);
 `itemProduction.Execute` its consume predicate and in-place sentence split.
+
+**Phase 5 (complete):** archive's `extractEntries` split per-entry materialization
+(`extractEntry` with the hard-link arm in `copyHardlinkEntry`) from the loop's
+guard/commit/push bookkeeping, plus `resolveExtractPrefix`. **The parked seven-results
+question resolved:** `splitReservedKwargs` now returns `(filtered, reservedKwargs, error)`
+— the carrier struct holds label, retry/transition policies, and error/retry handlers;
+per-key parsing lives in `reservedKwargs.apply` over a generic `policyKwarg[T]` (the two
+policy arms were identical modulo type), and the tooManyResultsChecker suppression is
+gone. file's `compensateWrite` extracted `pruneTowardBoundary`; `Link` extracted
+`existingLinkMatches`/`archiveOccupant` around the untouched conflict-policy switch;
+`Find` extracted `resolveFindRoot` and its walk closure. lore's `buildPackage` split
+per-action application from phase-subgraph assembly (and a banned-vocabulary comment fixed
+in passing); devconfig's slice/map conversion arms and platform's composite grouping
+(`leafGroup`, promoted from an anonymous type) extracted.
 
 ## Ordering rationale
 

--- a/pkg/devconfig/config.go
+++ b/pkg/devconfig/config.go
@@ -521,6 +521,57 @@ func toStarlark(value any) (starlark.Value, error) {
 	return reflectToStarlark(reflect.ValueOf(value))
 }
 
+// sliceToStarlark converts a reflected slice or array into a starlark list, element by element.
+//
+// Parameters:
+//   - `value`: the reflected slice or array.
+//
+// Returns:
+//   - `starlark.Value`: the converted list.
+//   - `error`: non-nil when any element fails conversion.
+func sliceToStarlark(value reflect.Value) (starlark.Value, error) {
+
+	items := make([]starlark.Value, value.Len())
+	for index := range items {
+		item, err := reflectToStarlark(value.Index(index))
+		if err != nil {
+			return nil, err
+		}
+		items[index] = item
+	}
+
+	return starlark.NewList(items), nil
+}
+
+// mapToStarlark converts a reflected map into a starlark dict, keys and values alike.
+//
+// Parameters:
+//   - `value`: the reflected map.
+//
+// Returns:
+//   - `starlark.Value`: the converted dict.
+//   - `error`: non-nil when any key or value fails conversion or insertion.
+func mapToStarlark(value reflect.Value) (starlark.Value, error) {
+
+	dict := starlark.NewDict(value.Len())
+	iterator := value.MapRange()
+	for iterator.Next() {
+		key, err := reflectToStarlark(iterator.Key())
+		if err != nil {
+			return nil, err
+		}
+		mapped, err := reflectToStarlark(iterator.Value())
+		if err != nil {
+			return nil, err
+		}
+		if err := dict.SetKey(key, mapped); err != nil {
+			return nil, err
+		}
+	}
+
+	return dict, nil
+}
+
 // reflectToStarlark projects a value of a type not handled by [toStarlark]'s switch — homogeneous sequences and
 // string-keyed maps — using reflection.
 //
@@ -556,33 +607,10 @@ func reflectToStarlark(value reflect.Value) (starlark.Value, error) {
 		return reflectToStarlark(value.Elem())
 
 	case reflect.Slice, reflect.Array:
-		items := make([]starlark.Value, value.Len())
-		for index := range items {
-			item, err := reflectToStarlark(value.Index(index))
-			if err != nil {
-				return nil, err
-			}
-			items[index] = item
-		}
-		return starlark.NewList(items), nil
+		return sliceToStarlark(value)
 
 	case reflect.Map:
-		dict := starlark.NewDict(value.Len())
-		iterator := value.MapRange()
-		for iterator.Next() {
-			key, err := reflectToStarlark(iterator.Key())
-			if err != nil {
-				return nil, err
-			}
-			mapped, err := reflectToStarlark(iterator.Value())
-			if err != nil {
-				return nil, err
-			}
-			if err := dict.SetKey(key, mapped); err != nil {
-				return nil, err
-			}
-		}
-		return dict, nil
+		return mapToStarlark(value)
 
 	default:
 		return nil, fmt.Errorf("devconfig: cannot project %s to a starlark value", value.Type())

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -160,27 +160,10 @@ func (p *Provider) extractEntries(
 		return nil, nil, err
 	}
 
-	// Destination is discovery — the prefix directory must already exist (we error below if not), so archive isn't
-	// producing it. DiscoverDirectory registers without claiming production (step 23, ruling 6a).
-
-	destination, err := file.DiscoverDirectory(runtimeEnvironment, prefixPath)
+	prefix, err := resolveExtractPrefix(runtimeEnvironment, prefixPath)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if err := destination.Resolve(); err != nil {
-		return nil, nil, err
-	}
-
-	if !destination.Exists() {
-		return nil, nil, fmt.Errorf("prefix directory does not exist: %s", prefixPath)
-	}
-
-	if !destination.IsDir() {
-		return nil, nil, fmt.Errorf("prefix path is not a directory: %s", prefixPath)
-	}
-
-	prefix := destination.SourcePath.Abs()
 
 	for {
 		entry, readErr := reader.Next()
@@ -198,49 +181,9 @@ func (p *Provider) extractEntries(
 			return products, stack, guardErr
 		}
 
-		var (
-			product file.Entry
-			receipt *file.Receipt
-		)
-
-		switch entry.Kind {
-		case entryDir:
-			if product, receipt, err = fileProvider.Mkdir(activationRecord, target, entry.Mode, ""); err != nil {
-				return products, stack, fmt.Errorf("archive: mkdir %q: %w", target, err)
-			}
-		case entryFile:
-			if product, receipt, err = fileProvider.WriteFile(activationRecord, target, entry.Reader, entry.Mode); err != nil {
-				return products, stack, fmt.Errorf("archive: write %q: %w", target, err)
-			}
-		case entrySymlink:
-			// §10 ruling 1a: contained targets only; the link lands verbatim so the on-disk content — and the
-			// SymbolicLink digest, which hashes the literal target — stays faithful to the archive.
-			if guardErr := containedLinkTarget(entry.Name, entry.Linkname); guardErr != nil {
-				return products, stack, guardErr
-			}
-			if product, receipt, err = fileProvider.Link(activationRecord, entry.Linkname, target, true); err != nil {
-				return products, stack, fmt.Errorf("archive: link %q: %w", target, err)
-			}
-		case entryHardlink:
-			// §10 ruling 1b: a hard link is an aliasing property, not a kind — materialize the entry as a
-			// content copy of the already-extracted referent (archive-root-relative by tar convention).
-			referent, refErr := containedTarget(prefix, entry.Linkname)
-			if refErr != nil {
-				return products, stack, refErr
-			}
-			root := runtimeEnvironment.Root
-			referentFile, openErr := root.Open(root.NewPath(referent))
-			if openErr != nil {
-				return products, stack, fmt.Errorf(
-					"archive: entry %q: hardlink referent %q is not extracted: %w", entry.Name, entry.Linkname, openErr)
-			}
-			product, receipt, err = fileProvider.WriteFile(activationRecord, target, referentFile, entry.Mode)
-			if closeErr := referentFile.Close(); err == nil && closeErr != nil {
-				err = closeErr
-			}
-			if err != nil {
-				return products, stack, fmt.Errorf("archive: hardlink copy %q: %w", target, err)
-			}
+		product, receipt, extractErr := extractEntry(activationRecord, fileProvider, prefix, entry, target)
+		if extractErr != nil {
+			return products, stack, extractErr
 		}
 
 		// A nil product+receipt pair is a policy no-op (an already-correct link, an existing directory, or a
@@ -387,6 +330,130 @@ func openArchiveStream(src io.Reader) (archiveReader, error) {
 	default:
 		return nil, fmt.Errorf("unsupported archive format on stream")
 	}
+}
+
+// resolveExtractPrefix discovers and validates the extraction prefix directory.
+//
+// Destination is discovery — the prefix directory must already exist, so archive isn't producing it.
+// DiscoverDirectory registers without claiming production (step 23, ruling 6a).
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session environment.
+//   - `prefixPath`: the requested prefix directory.
+//
+// Returns:
+//   - `string`: the prefix's absolute path.
+//   - `error`: non-nil when the prefix is missing or not a directory.
+func resolveExtractPrefix(runtimeEnvironment *op.RuntimeEnvironment, prefixPath string) (string, error) {
+
+	destination, err := file.DiscoverDirectory(runtimeEnvironment, prefixPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := destination.Resolve(); err != nil {
+		return "", err
+	}
+
+	if !destination.Exists() {
+		return "", fmt.Errorf("prefix directory does not exist: %s", prefixPath)
+	}
+
+	if !destination.IsDir() {
+		return "", fmt.Errorf("prefix path is not a directory: %s", prefixPath)
+	}
+
+	return destination.SourcePath.Abs(), nil
+}
+
+// extractEntry materializes one archive entry through the file provider, per its kind.
+//
+// Parameters:
+//   - `activationRecord`: the dispatch activation.
+//   - `fileProvider`: the file provider performing the mutations.
+//   - `prefix`: the extraction prefix's absolute path.
+//   - `entry`: the archive entry.
+//   - `target`: the entry's contained target path.
+//
+// Returns:
+//   - `file.Entry`: the produced entry; nil for a policy no-op.
+//   - `*file.Receipt`: the mutation receipt; nil for a no-change outcome.
+//   - `error`: non-nil on any guard or mutation failure.
+func extractEntry(
+	activationRecord *op.ActivationRecord, fileProvider *file.Provider, prefix string, entry archiveEntry, target string,
+) (file.Entry, *file.Receipt, error) {
+
+	switch entry.Kind {
+	case entryDir:
+		product, receipt, err := fileProvider.Mkdir(activationRecord, target, entry.Mode, "")
+		if err != nil {
+			return nil, nil, fmt.Errorf("archive: mkdir %q: %w", target, err)
+		}
+		return product, receipt, nil
+	case entryFile:
+		product, receipt, err := fileProvider.WriteFile(activationRecord, target, entry.Reader, entry.Mode)
+		if err != nil {
+			return nil, nil, fmt.Errorf("archive: write %q: %w", target, err)
+		}
+		return product, receipt, nil
+	case entrySymlink:
+		// §10 ruling 1a: contained targets only; the link lands verbatim so the on-disk content — and the
+		// SymbolicLink digest, which hashes the literal target — stays faithful to the archive.
+		if guardErr := containedLinkTarget(entry.Name, entry.Linkname); guardErr != nil {
+			return nil, nil, guardErr
+		}
+		product, receipt, err := fileProvider.Link(activationRecord, entry.Linkname, target, true)
+		if err != nil {
+			return nil, nil, fmt.Errorf("archive: link %q: %w", target, err)
+		}
+		return product, receipt, nil
+	case entryHardlink:
+		return copyHardlinkEntry(activationRecord, fileProvider, prefix, entry, target)
+	}
+
+	return nil, nil, nil
+}
+
+// copyHardlinkEntry materializes a hard-link entry as a content copy of its already-extracted
+// referent (archive-root-relative by tar convention) — §10 ruling 1b: a hard link is an aliasing
+// property, not a kind.
+//
+// Parameters:
+//   - `activationRecord`: the dispatch activation.
+//   - `fileProvider`: the file provider performing the write.
+//   - `prefix`: the extraction prefix's absolute path.
+//   - `entry`: the hard-link entry.
+//   - `target`: the entry's contained target path.
+//
+// Returns:
+//   - `file.Entry`: the produced entry; nil for a policy no-op.
+//   - `*file.Receipt`: the mutation receipt; nil for a no-change outcome.
+//   - `error`: non-nil on a guard, open, write, or close failure.
+func copyHardlinkEntry(
+	activationRecord *op.ActivationRecord, fileProvider *file.Provider, prefix string, entry archiveEntry, target string,
+) (file.Entry, *file.Receipt, error) {
+
+	referent, refErr := containedTarget(prefix, entry.Linkname)
+	if refErr != nil {
+		return nil, nil, refErr
+	}
+
+	root := activationRecord.RuntimeEnvironment.Root
+	referentFile, openErr := root.Open(root.NewPath(referent))
+	if openErr != nil {
+		return nil, nil, fmt.Errorf(
+			"archive: entry %q: hardlink referent %q is not extracted: %w", entry.Name, entry.Linkname, openErr)
+	}
+
+	product, receipt, err := fileProvider.WriteFile(activationRecord, target, referentFile, entry.Mode)
+	if closeErr := referentFile.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("archive: hardlink copy %q: %w", target, err)
+	}
+
+	return product, receipt, nil
 }
 
 // spoolZipStream drains `stream` to a temporary file and opens it as a zip, removing the file on close.

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -214,16 +214,8 @@ func (p *Provider) Link(
 
 	if info, err := p.lstat(product.SourcePath.Abs()); err == nil {
 
-		if info.Mode()&os.ModeSymlink != 0 {
-			existing, readErr := p.rawReadLink(product.SourcePath.Abs())
-			if !verbatim {
-				// The default path stores a relativized target (see [Provider.symlink]); the absolutized read
-				// is what matches the canonical stored name.
-				existing, readErr = p.readLink(product.SourcePath.Abs())
-			}
-			if readErr == nil && existing == storedName {
-				return product, nil, nil // Already correct — no change
-			}
+		if info.Mode()&os.ModeSymlink != 0 && p.existingLinkMatches(product.SourcePath.Abs(), storedName, verbatim) {
+			return product, nil, nil // Already correct — no change
 		}
 
 		// Something exists at the target — the write-seam conflict policy governs (phase-8 step 49).
@@ -237,15 +229,10 @@ func (p *Provider) Link(
 		case op.ConflictReplace:
 		}
 
-		// Archive the occupant before creating the symlink.
-		preDigest := preArchiveDigest(p.RuntimeEnvironment().Root, product.SourcePath.Abs())
-
-		recoveryID, archiveErr := p.RuntimeEnvironment().RecoverySite.ArchiveFile(product.SourcePath)
-		if archiveErr != nil {
-			return nil, nil, archiveErr
+		receipt, err = p.archiveOccupant(product)
+		if err != nil {
+			return nil, nil, err
 		}
-
-		receipt = NewReceipt(NewReceiptSpec(product, MutationUpdateFile).WithRecovery(recoveryID, preDigest))
 	} else {
 
 		// Does not exist — standard parent directory creation.
@@ -277,6 +264,49 @@ func (p *Provider) Link(
 	}
 
 	return product, receipt, nil
+}
+
+// existingLinkMatches reports whether the symlink at `linkPath` already stores the canonical name.
+//
+// The default path stores a relativized target (see [Provider.symlink]); the absolutized read is what
+// matches the canonical stored name. Verbatim links compare the raw stored target.
+//
+// Parameters:
+//   - `linkPath`: the symlink's absolute path.
+//   - `storedName`: the canonical stored name to match.
+//   - `verbatim`: whether the link was stored verbatim.
+//
+// Returns:
+//   - `bool`: true when the existing link already matches.
+func (p *Provider) existingLinkMatches(linkPath, storedName string, verbatim bool) bool {
+
+	existing, readErr := p.rawReadLink(linkPath)
+	if !verbatim {
+		existing, readErr = p.readLink(linkPath)
+	}
+
+	return readErr == nil && existing == storedName
+}
+
+// archiveOccupant archives whatever occupies the product's path ahead of a replace, minting the
+// update receipt that restores it on compensation.
+//
+// Parameters:
+//   - `product`: the symbolic link whose path is occupied.
+//
+// Returns:
+//   - `*Receipt`: the update receipt carrying the recovery ID and pre-archive digest.
+//   - `error`: non-nil when archiving fails.
+func (p *Provider) archiveOccupant(product *SymbolicLink) (*Receipt, error) {
+
+	preDigest := preArchiveDigest(p.RuntimeEnvironment().Root, product.SourcePath.Abs())
+
+	recoveryID, archiveErr := p.RuntimeEnvironment().RecoverySite.ArchiveFile(product.SourcePath)
+	if archiveErr != nil {
+		return nil, archiveErr
+	}
+
+	return NewReceipt(NewReceiptSpec(product, MutationUpdateFile).WithRecovery(recoveryID, preDigest)), nil
 }
 
 // Mkdir creates a directory (and any missing parents) at `path` with the given mode and ownership.
@@ -1030,18 +1060,8 @@ func (p *Provider) Find(pattern string, includeGitignored bool) (product []Entry
 		root = "."
 	}
 
-	var absoluteRoot string
-
-	if filepath.IsAbs(root) {
-		absoluteRoot = filepath.Clean(root)
-	} else {
-		absoluteRoot = filepath.Clean(filepath.Join(scopedRoot, root))
-	}
-
-	var relativePath string
-	relativePath, err = filepath.Rel(scopedRoot, absoluteRoot)
-
-	if err != nil || strings.HasPrefix(relativePath, "..") {
+	absoluteRoot, err := resolveFindRoot(scopedRoot, root)
+	if err != nil {
 		return nil, fmt.Errorf("find: pattern %q resolves to %s, which lies outside scoped root %s",
 			pattern,
 			absoluteRoot,
@@ -1054,8 +1074,58 @@ func (p *Provider) Find(pattern string, includeGitignored bool) (product []Entry
 	}
 
 	matches := make([]string, 0, 8192)
+	walk := p.findWalkFunc(absoluteRoot, matchPattern, tracker, &matches)
 
-	walk := func(absolutePath string, dirEntry fs.DirEntry, err error) error {
+	err = p.walkDir(p.RuntimeEnvironment().Root, absoluteRoot, walk)
+	if err != nil {
+		return nil, fmt.Errorf("find: walk %q: %w", absoluteRoot, err)
+	}
+
+	return p.discoverEntries(matches)
+}
+
+// resolveFindRoot resolves a find pattern's root against the scoped root, confining the result.
+//
+// Parameters:
+//   - `scopedRoot`: the provider's scoped root.
+//   - `root`: the pattern's root segment (absolute or scoped-relative).
+//
+// Returns:
+//   - `string`: the cleaned absolute root.
+//   - `error`: non-nil when the root escapes the scoped root.
+func resolveFindRoot(scopedRoot, root string) (string, error) {
+
+	var absoluteRoot string
+	if filepath.IsAbs(root) {
+		absoluteRoot = filepath.Clean(root)
+	} else {
+		absoluteRoot = filepath.Clean(filepath.Join(scopedRoot, root))
+	}
+
+	relativePath, err := filepath.Rel(scopedRoot, absoluteRoot)
+	if err != nil || strings.HasPrefix(relativePath, "..") {
+		return absoluteRoot, fmt.Errorf("outside scoped root")
+	}
+
+	return absoluteRoot, nil
+}
+
+// findWalkFunc builds the Find walk callback: gitignore-filtered, directory-skipping, double-star
+// matched, accumulating absolute paths into `matches`.
+//
+// Parameters:
+//   - `absoluteRoot`: the walk root.
+//   - `matchPattern`: the double-star pattern, root-relative.
+//   - `tracker`: the gitignore tracker; nil disables filtering.
+//   - `matches`: the accumulator for matched absolute paths.
+//
+// Returns:
+//   - `fs.WalkDirFunc`: the walk callback.
+func (p *Provider) findWalkFunc(
+	absoluteRoot, matchPattern string, tracker *gitignore.Tracker, matches *[]string,
+) fs.WalkDirFunc {
+
+	return func(absolutePath string, dirEntry fs.DirEntry, err error) error {
 
 		if err != nil {
 			return err
@@ -1082,18 +1152,11 @@ func (p *Provider) Find(pattern string, includeGitignored bool) (product []Entry
 		}
 
 		if matchDoubleStar(matchPattern, relativePath) {
-			matches = append(matches, absolutePath)
+			*matches = append(*matches, absolutePath)
 		}
 
 		return nil
 	}
-
-	err = p.walkDir(p.RuntimeEnvironment().Root, absoluteRoot, walk)
-	if err != nil {
-		return nil, fmt.Errorf("find: walk %q: %w", absoluteRoot, err)
-	}
-
-	return p.discoverEntries(matches)
 }
 
 // Glob returns the [Resource] entries for filesystem paths matching `pattern` via [filepath.Glob].
@@ -1421,8 +1484,19 @@ func (p *Provider) compensateWrite(receipt *Receipt) error {
 		return nil
 	}
 
-	boundaryPath := boundary.Path().Abs()
-	current := filepath.Dir(resource.Path().Abs())
+	return p.pruneTowardBoundary(filepath.Dir(resource.Path().Abs()), boundary.Path().Abs())
+}
+
+// pruneTowardBoundary removes the now-empty directories from `current` up to (excluding) the
+// boundary, stopping at the first non-empty directory.
+//
+// Parameters:
+//   - `current`: the deepest directory to prune.
+//   - `boundaryPath`: the boundary's absolute path; never removed.
+//
+// Returns:
+//   - `error`: non-nil when `current` lies outside the boundary or a removal genuinely fails.
+func (p *Provider) pruneTowardBoundary(current, boundaryPath string) error {
 
 	relativePath, err := filepath.Rel(boundaryPath, current)
 	if err != nil || strings.HasPrefix(relativePath, "..") {

--- a/pkg/op/provider/plan/helpers.go
+++ b/pkg/op/provider/plan/helpers.go
@@ -51,7 +51,7 @@ func dispatchBuiltinBody(
 
 		env := provider.RuntimeEnvironment()
 
-		filtered, label, retryPolicy, onError, onRetry, transitionPolicy, err := splitReservedKwargs(env, kwargs)
+		filtered, reserved, err := splitReservedKwargs(env, kwargs)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", actionName, err)
 		}
@@ -82,11 +82,11 @@ func dispatchBuiltinBody(
 			methodName,
 			goArgs,
 			goKwargs,
-			retryPolicy,
-			onError,
-			onRetry,
-			transitionPolicy,
-			label,
+			reserved.retryPolicy,
+			reserved.onError,
+			reserved.onRetry,
+			reserved.transitionPolicy,
+			reserved.label,
 		)
 		if err != nil {
 			return nil, err
@@ -244,115 +244,162 @@ func projectToBinding(value any) op.Binding {
 //   - `kwargs`: the input kwarg tuple list.
 //
 // Returns:
-//   - []starlark.Tuple: kwargs with the five reserved entries removed. The input slice is returned as-is when no
-//     reserved entry was present.
-//   - `string`: the supplied label, or empty.
-//   - *op.RetryPolicy: the supplied retry policy, or nil.
-//   - *op.Subgraph: the materialized error-handler subgraph, or nil.
-//   - *op.Subgraph: the materialized retry-handler subgraph, or nil.
-//   - *op.TransitionPolicy: the supplied transition policy, or nil.
+//   - `[]starlark.Tuple`: kwargs with the five reserved entries removed. The input slice is returned as-is when
+//     no reserved entry was present.
+//   - `reservedKwargs`: the split reserved values (label, retry/transition policies, error/retry handlers).
 //   - `error`: non-nil when any reserved entry has an invalid shape or fails conversion.
 //
 // struct is a structure decision awaiting a ruling (see docs/plans/lint-signatures.md).
-//
-//nolint:gocritic // tooManyResultsChecker: the reserved kwargs are one splice; folding them into a carrier
 func splitReservedKwargs(
 	env *op.RuntimeEnvironment,
 	kwargs []starlark.Tuple,
-) ([]starlark.Tuple, string, *op.RetryPolicy, *op.Subgraph, *op.Subgraph, *op.TransitionPolicy, error) {
+) ([]starlark.Tuple, reservedKwargs, error) {
 
-	var label string
-	var retryPolicy *op.RetryPolicy
-	var onError *op.Subgraph
-	var onRetry *op.Subgraph
-	var transitionPolicy *op.TransitionPolicy
+	var reserved reservedKwargs
 	sawReserved := false
 
 	for _, kv := range kwargs {
 
 		if len(kv) != 2 {
-			return nil, "", nil, nil, nil, nil, fmt.Errorf("kwarg tuple must have length 2, got %d", len(kv))
+			return nil, reservedKwargs{}, fmt.Errorf("kwarg tuple must have length 2, got %d", len(kv))
 		}
 
 		keyStr, ok := kv[0].(starlark.String)
 		if !ok {
-			return nil, "", nil, nil, nil, nil, fmt.Errorf("kwarg key must be a string, got %s", kv[0].Type())
+			return nil, reservedKwargs{}, fmt.Errorf("kwarg key must be a string, got %s", kv[0].Type())
 		}
-		key := string(keyStr)
 
-		switch key {
-
-		case "label":
-			sawReserved = true
-			s, ok := kv[1].(starlark.String)
-			if !ok {
-				return nil, "", nil, nil, nil, nil, fmt.Errorf("label= must be a string, got %s", kv[1].Type())
-			}
-			label = string(s)
-
-		case "retry_policy":
-			sawReserved = true
-			value, err := starlarkbridge.StarlarkToGoTyped(env, kv[1], reflect.TypeFor[*op.RetryPolicy]())
-			if err != nil {
-				return nil, "", nil, nil, nil, nil, fmt.Errorf("retry_policy=: %w", err)
-			}
-			if value == nil {
-				continue
-			}
-			policy, ok := value.(*op.RetryPolicy)
-			if !ok {
-				return nil, "", nil, nil, nil, nil, fmt.Errorf("retry_policy= must be *op.RetryPolicy or None, got %T", value)
-			}
-			retryPolicy = policy
-
-		case "transition_policy":
-			sawReserved = true
-			value, err := starlarkbridge.StarlarkToGoTyped(env, kv[1], reflect.TypeFor[*op.TransitionPolicy]())
-			if err != nil {
-				return nil, "", nil, nil, nil, nil, fmt.Errorf("transition_policy=: %w", err)
-			}
-			if value == nil {
-				continue
-			}
-			policy, ok := value.(*op.TransitionPolicy)
-			if !ok {
-				return nil, "", nil, nil, nil, nil, fmt.Errorf("transition_policy= must be *op.TransitionPolicy or None, got %T", value)
-			}
-			transitionPolicy = policy
-
-		case "on_error":
-			sawReserved = true
-			subgraph, err := onErrorSubgraph(env, kv[1])
-			if err != nil {
-				return nil, "", nil, nil, nil, nil, err
-			}
-			onError = subgraph
-
-		case "on_retry":
-			sawReserved = true
-			subgraph, err := onRetrySubgraph(env, kv[1])
-			if err != nil {
-				return nil, "", nil, nil, nil, nil, err
-			}
-			onRetry = subgraph
+		matched, err := reserved.apply(env, string(keyStr), kv[1])
+		if err != nil {
+			return nil, reservedKwargs{}, err
 		}
+		sawReserved = sawReserved || matched
 	}
 
 	if !sawReserved {
-		return kwargs, label, retryPolicy, onError, onRetry, transitionPolicy, nil
+		return kwargs, reserved, nil
 	}
+
+	return filterReservedKwargs(kwargs), reserved, nil
+}
+
+// reservedKwargs carries the reserved plan-mode kwargs split from one dispatch call.
+type reservedKwargs struct {
+	label            string
+	retryPolicy      *op.RetryPolicy
+	onError          *op.Subgraph
+	onRetry          *op.Subgraph
+	transitionPolicy *op.TransitionPolicy
+}
+
+// apply consumes one kwarg when its key is reserved, populating the matching field.
+//
+// Parameters:
+//   - `env`: the runtime environment used by the conversion cascade.
+//   - `key`: the kwarg key.
+//   - `value`: the kwarg value.
+//
+// Returns:
+//   - `bool`: true when the key was reserved (and consumed).
+//   - `error`: non-nil when a reserved value has an invalid shape or fails conversion.
+func (r *reservedKwargs) apply(env *op.RuntimeEnvironment, key string, value starlark.Value) (bool, error) {
+
+	switch key {
+
+	case "label":
+		s, ok := value.(starlark.String)
+		if !ok {
+			return true, fmt.Errorf("label= must be a string, got %s", value.Type())
+		}
+		r.label = string(s)
+
+	case "retry_policy":
+		policy, err := policyKwarg[op.RetryPolicy](env, "retry_policy", value)
+		if err != nil {
+			return true, err
+		}
+		if policy != nil {
+			r.retryPolicy = policy
+		}
+
+	case "transition_policy":
+		policy, err := policyKwarg[op.TransitionPolicy](env, "transition_policy", value)
+		if err != nil {
+			return true, err
+		}
+		if policy != nil {
+			r.transitionPolicy = policy
+		}
+
+	case "on_error":
+		subgraph, err := onErrorSubgraph(env, value)
+		if err != nil {
+			return true, err
+		}
+		r.onError = subgraph
+
+	case "on_retry":
+		subgraph, err := onRetrySubgraph(env, value)
+		if err != nil {
+			return true, err
+		}
+		r.onRetry = subgraph
+
+	default:
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// policyKwarg converts a reserved policy kwarg through the conversion cascade, admitting None as nil.
+//
+// Parameters:
+//   - `env`: the runtime environment used by the conversion cascade.
+//   - `name`: the kwarg name, for error messages.
+//   - `value`: the kwarg value.
+//
+// Returns:
+//   - `*T`: the converted policy, or nil for None.
+//   - `error`: non-nil when conversion fails or the shape is wrong.
+func policyKwarg[T any](env *op.RuntimeEnvironment, name string, value starlark.Value) (*T, error) {
+
+	converted, err := starlarkbridge.StarlarkToGoTyped(env, value, reflect.TypeFor[*T]())
+	if err != nil {
+		return nil, fmt.Errorf("%s=: %w", name, err)
+	}
+	if converted == nil {
+		return nil, nil
+	}
+
+	policy, ok := converted.(*T)
+	if !ok {
+		return nil, fmt.Errorf("%s= must be %T or None, got %T", name, (*T)(nil), converted)
+	}
+
+	return policy, nil
+}
+
+// filterReservedKwargs returns the kwargs with the five reserved entries removed.
+//
+// Parameters:
+//   - `kwargs`: the input kwarg tuple list, already key-validated.
+//
+// Returns:
+//   - `[]starlark.Tuple`: the non-reserved kwargs, in order.
+func filterReservedKwargs(kwargs []starlark.Tuple) []starlark.Tuple {
 
 	filtered := make([]starlark.Tuple, 0, len(kwargs))
 	for _, kv := range kwargs {
 		keyStr := assert.Type[starlark.String]("kwarg key", kv[0])
-		key := string(keyStr)
-		if key == "label" || key == "retry_policy" || key == "on_error" || key == "on_retry" || key == "transition_policy" {
+		switch string(keyStr) {
+		case "label", "retry_policy", "on_error", "on_retry", "transition_policy":
 			continue
 		}
 		filtered = append(filtered, kv)
 	}
 
-	return filtered, label, retryPolicy, onError, onRetry, transitionPolicy, nil
+	return filtered
 }
 
 // subgraphFromInvocations materializes a *op.Subgraph from a list of invocations, bound to flow.subgraph.

--- a/pkg/platform/composite.go
+++ b/pkg/platform/composite.go
@@ -220,37 +220,8 @@ func (c *compositeManager) Version(p PURL) string {
 //   - `error`: the first failing receipt's error, or nil when every package succeeded.
 func (c *compositeManager) dispatch(packages []PURL, kwargs map[string]any, verb func(leaf, []PURL, map[string]any) ([]Receipt, error)) ([]Receipt, error) {
 
-	type group struct {
-		owner   leaf
-		indices []int
-		purls   []PURL
-	}
-
-	groups := make(map[string]*group)
 	receipts := make([]Receipt, len(packages))
-
-	var firstErr error
-
-	for i, p := range packages {
-
-		owner, ok := c.byType[p.Type]
-		if !ok {
-			receipts[i] = Receipt{Purl: p, Err: fmt.Errorf("platform: no package manager for purl type %q (package %q)", p.Type, p.Name)}
-			if firstErr == nil {
-				firstErr = receipts[i].Err
-			}
-			continue
-		}
-
-		g := groups[p.Type]
-		if g == nil {
-			g = &group{owner: owner}
-			groups[p.Type] = g
-		}
-
-		g.indices = append(g.indices, i)
-		g.purls = append(g.purls, p)
-	}
+	groups, firstErr := c.groupByOwner(packages, receipts)
 
 	var (
 		wg    sync.WaitGroup
@@ -261,7 +232,7 @@ func (c *compositeManager) dispatch(packages []PURL, kwargs map[string]any, verb
 
 		wg.Add(1)
 
-		go func(g *group) {
+		go func(g *leafGroup) {
 
 			defer wg.Done()
 
@@ -287,6 +258,54 @@ func (c *compositeManager) dispatch(packages []PURL, kwargs map[string]any, verb
 	wg.Wait()
 
 	return receipts, firstErr
+}
+
+// leafGroup is one leaf's slice of a composite dispatch: the packages it owns and their positions in
+// the caller's receipt slice.
+type leafGroup struct {
+	owner   leaf
+	indices []int
+	purls   []PURL
+}
+
+// groupByOwner partitions the packages by owning leaf, stamping an error receipt for any purl type no
+// manager owns.
+//
+// Parameters:
+//   - `packages`: the packages to dispatch.
+//   - `receipts`: the caller's receipt slice, receiving error receipts for unowned types.
+//
+// Returns:
+//   - `map[string]*leafGroup`: the per-type groups.
+//   - `error`: the first unowned-type error, or nil.
+func (c *compositeManager) groupByOwner(packages []PURL, receipts []Receipt) (map[string]*leafGroup, error) {
+
+	groups := make(map[string]*leafGroup)
+
+	var firstErr error
+
+	for i, p := range packages {
+
+		owner, ok := c.byType[p.Type]
+		if !ok {
+			receipts[i] = Receipt{Purl: p, Err: fmt.Errorf("platform: no package manager for purl type %q (package %q)", p.Type, p.Name)}
+			if firstErr == nil {
+				firstErr = receipts[i].Err
+			}
+			continue
+		}
+
+		g := groups[p.Type]
+		if g == nil {
+			g = &leafGroup{owner: owner}
+			groups[p.Type] = g
+		}
+
+		g.indices = append(g.indices, i)
+		g.purls = append(g.purls, p)
+	}
+
+	return groups, firstErr
 }
 
 // resolveType maps a caller-supplied prefix — a manager name or a purl type — to the canonical purl type.


### PR DESCRIPTION
Phase 5 of docs/plans/complexity-refactors.md (#312): eight functions decomposed under the thresholds. The parked structure question resolves here: `splitReservedKwargs` returns `(filtered, reservedKwargs, error)` with per-key parsing in `reservedKwargs.apply` over a generic `policyKwarg[T]`; the seven-results suppression is gone. Archive extraction, the file provider's compensation pruning and link/find paths, lore's phase building, devconfig conversion, and platform's composite grouping all decomposed behavior-preserving — the suite passes unmodified. Plan doc rides along with phase 5 marked complete.