### PR TITLE
refactor(complexity): phase 6 — the conversion surfaces

### DIFF
--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -36,7 +36,7 @@ complexity limits. This is the repository's only remaining lint debt.
 | 3 | `refactor/complexity-goast-provider` | goast provider methods: `ConstGroups` 70, `Structs` 49, `Callable` 49, `Methods` 38, `Composites` 35, `SortDeclarations` 24, `TypeDoc` 24, `Calls` 22, `spacingRulesFromConfig` 17 | 9 | **complete** |
 | 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | **complete** |
 | 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | **complete** |
-| 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | pending |
+| 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | **complete** |
 | 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16 | 15 | pending |
 
 Total: 60 listed + `TestContext.Check` counted in phase 1 = 61.
@@ -108,6 +108,20 @@ gone. file's `compensateWrite` extracted `pruneTowardBoundary`; `Link` extracted
 per-action application from phase-subgraph assembly (and a banned-vocabulary comment fixed
 in passing); devconfig's slice/map conversion arms and platform's composite grouping
 (`leafGroup`, promoted from an anonymous type) extracted.
+
+**Phase 6 (complete):** `dispatch` (65) decomposed into named dispatch phases over two new
+carrier types — `parameterLayout` (classification) and `routedArgs` (argument routing) —
+with `classifyParameters`, `routeArgs`, `unpackNamed`, `fillNamedSlots`,
+`fillVariadicSlot`, and `fillKwargsSlot`; the activation/invoke tail untouched.
+`toStarlarkReflect` extracted its struct arm (`structToStarlark`); `toGoInto` extracted
+`toGoScalar` (behind an `isScalarKind` predicate) and `toGoSliceTarget`; `toNaturalGo`
+its sequence/dict projections. `envValue.ConvertTo` extracted `parseScalarEnv`;
+`Convert` its steps-1–2 direct paths (`convertDirect`, hot-path comments preserved);
+`IsTruthy` its scalar switch. **Incident, disclosed:** a blind text-slice during
+`toNaturalGo`'s extraction corrupted `converter.go` (self-referential replacement);
+recovered by restoring the develop copy via the API and re-applying with
+bounds-verified slices — the lesson (assert slice contents and lengths before
+replacing) applied to every later edit.
 
 ## Ordering rationale
 

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -66,46 +66,16 @@ func Convert(runtimeEnvironment *RuntimeEnvironment, value any, target reflect.T
 		return reflect.Zero(target).Interface(), nil
 	}
 
-	// Step 1: identity. Pointer-equal reflect.Type means the same underlying `*rtype`, so `==` is a single pointer
-	// comparison and subsumes the assignability identity case without paying for reflect.ValueOf, the deref walk,
-	// or the Interface() round-trip. Hot path for slot-fill from Parameter.Default (already at p.Type) and for any
-	// caller-supplied value whose dynamic type already matches target exactly.
+	// Steps 1-2: identity, the `any` target, and (pointer-dereferenced) assignability/convertibility —
+	// see [convertDirect].
 
-	if reflect.TypeOf(value) == target {
-		return value, nil
+	if converted, ok := convertDirect(value, target); ok {
+		return converted, nil
 	}
-
-	// Step 1.5: empty interface (`any`) target. Any non-nil value satisfies `any` — return as-is. Crucially,
-	// SKIP the pointer-deref of step 2: a *T value passed to an `any`-typed target must preserve its pointer
-	// shape, because callers downstream (e.g., a method whose signature is `[]*T`) need the pointer back. The
-	// bridge's early-projection path uses this when goReceiver.Project(reflect.TypeFor[any]()) asks for the
-	// natural Go form of a wrapped instance — *op.Invocation must come back as *op.Invocation, not op.Invocation.
-
-	if target.Kind() == reflect.Interface && target.NumMethod() == 0 {
-		return value, nil
-	}
-
-	// Step 2: assignability with pointer-deref. Dereference pointers so a *T value reaches a T target through the
-	// underlying assignability rule.
 
 	elem := reflect.ValueOf(value)
-
 	for elem.Kind() == reflect.Pointer {
 		elem = elem.Elem()
-	}
-
-	if elem.IsValid() {
-		if elem.Type().AssignableTo(target) {
-			return elem.Interface(), nil
-		}
-
-		if elem.Type().ConvertibleTo(target) {
-			return elem.Convert(target).Interface(), nil
-		}
-	}
-
-	if reflect.TypeOf(value).AssignableTo(target) {
-		return value, nil
 	}
 
 	// Step 3: slice element conversion.
@@ -153,6 +123,60 @@ func Convert(runtimeEnvironment *RuntimeEnvironment, value any, target reflect.T
 	// Step 10: not convertible.
 
 	return nil, fmt.Errorf("%T value is neither assignable nor convertible to %s", value, target)
+}
+
+// convertDirect handles [Convert]'s direct paths — steps 1 through 2.
+//
+// Step 1: identity. Pointer-equal reflect.Type means the same underlying `*rtype`, so `==` is a single pointer
+// comparison and subsumes the assignability identity case without paying for reflect.ValueOf, the deref walk,
+// or the Interface() round-trip. Hot path for slot-fill from Parameter.Default (already at p.Type) and for any
+// caller-supplied value whose dynamic type already matches target exactly.
+//
+// Step 1.5: empty interface (`any`) target. Any non-nil value satisfies `any` — return as-is. Crucially,
+// SKIP the pointer-deref of step 2: a *T value passed to an `any`-typed target must preserve its pointer
+// shape, because callers downstream (e.g., a method whose signature is `[]*T`) need the pointer back. The
+// bridge's early-projection path uses this when goReceiver.Project(reflect.TypeFor[any]()) asks for the
+// natural Go form of a wrapped instance — *op.Invocation must come back as *op.Invocation, not op.Invocation.
+//
+// Step 2: assignability with pointer-deref. Dereference pointers so a *T value reaches a T target through the
+// underlying assignability rule.
+//
+// Parameters:
+//   - `value`: the non-nil value under conversion.
+//   - `target`: the destination type.
+//
+// Returns:
+//   - `any`: the converted value when a direct path applied.
+//   - `bool`: true when a direct path applied.
+func convertDirect(value any, target reflect.Type) (any, bool) {
+
+	if reflect.TypeOf(value) == target {
+		return value, true
+	}
+
+	if target.Kind() == reflect.Interface && target.NumMethod() == 0 {
+		return value, true
+	}
+
+	elem := reflect.ValueOf(value)
+	for elem.Kind() == reflect.Pointer {
+		elem = elem.Elem()
+	}
+
+	if elem.IsValid() {
+		if elem.Type().AssignableTo(target) {
+			return elem.Interface(), true
+		}
+		if elem.Type().ConvertibleTo(target) {
+			return elem.Convert(target).Interface(), true
+		}
+	}
+
+	if reflect.TypeOf(value).AssignableTo(target) {
+		return value, true
+	}
+
+	return nil, false
 }
 
 // tryConvertSlice handles [Convert]'s step 3: slice → slice element-wise recursion.

--- a/pkg/op/env_value.go
+++ b/pkg/op/env_value.go
@@ -111,6 +111,21 @@ func (e envValue) ConvertTo(target reflect.Type) (any, error) {
 		return os.FileMode(v), nil
 	}
 
+	return parseScalarEnv(raw, target)
+}
+
+// parseScalarEnv parses an environment string into a scalar-kinded target, falling back to
+// encoding.TextUnmarshaler and finally JSON for everything else.
+//
+// Parameters:
+//   - `raw`: the environment string.
+//   - `target`: the destination type.
+//
+// Returns:
+//   - `any`: the parsed value, converted to the target type.
+//   - `error`: non-nil when parsing fails.
+func parseScalarEnv(raw string, target reflect.Type) (any, error) {
+
 	switch target.Kind() {
 
 	case reflect.Bool:

--- a/pkg/op/starlarkbridge/converter.go
+++ b/pkg/op/starlarkbridge/converter.go
@@ -104,62 +104,13 @@ func (c converter) toGoInto(sv starlark.Value, rv reflect.Value) error {
 
 	// 4. Concrete Type Logic.
 
+	if isScalarKind(rv.Kind()) {
+		return toGoScalar(sv, rv)
+	}
+
 	switch rv.Kind() {
-	case reflect.String:
-		s, ok := starlark.AsString(sv)
-		if !ok {
-			return fmt.Errorf("expected string, got %s", sv.Type())
-		}
-		rv.SetString(s)
-
-	case reflect.Bool:
-		if b, ok := sv.(starlark.Bool); ok {
-			rv.SetBool(bool(b))
-		} else {
-			return fmt.Errorf("expected bool, got %s", sv.Type())
-		}
-
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if si, ok := sv.(starlark.Int); ok {
-			i, ok := si.Int64()
-			if !ok {
-				return fmt.Errorf("int out of range")
-			}
-			rv.SetInt(i)
-		} else {
-			return fmt.Errorf("expected int, got %s", sv.Type())
-		}
-
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if si, ok := sv.(starlark.Int); ok {
-			u, ok := si.Uint64()
-			if !ok {
-				return fmt.Errorf("uint out of range")
-			}
-			rv.SetUint(u)
-		} else {
-			return fmt.Errorf("expected int, got %s", sv.Type())
-		}
-
-	case reflect.Float32, reflect.Float64:
-		f, ok := starlark.AsFloat(sv)
-		if !ok {
-			return fmt.Errorf("expected float or int, got %s", sv.Type())
-		}
-		rv.SetFloat(f)
-
 	case reflect.Slice:
-		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			if b, ok := sv.(starlark.Bytes); ok {
-				rv.SetBytes([]byte(b))
-				return nil
-			}
-			return fmt.Errorf("expected bytes, got %s", sv.Type())
-		}
-		if iter, ok := sv.(starlark.Iterable); ok {
-			return c.toGoSlice(iter, rv)
-		}
-		return fmt.Errorf("expected list, got %s", sv.Type())
+		return c.toGoSliceTarget(sv, rv)
 
 	case reflect.Map:
 		if dict, ok := sv.(*starlark.Dict); ok {
@@ -173,7 +124,167 @@ func (c converter) toGoInto(sv starlark.Value, rv reflect.Value) error {
 	default:
 		return fmt.Errorf("unsupported conversion: %s to %s", sv.Type(), rv.Type())
 	}
+}
+
+// toGoSliceTarget fills a slice-kinded target: byte slices from starlark bytes, everything else
+// element-wise from an iterable.
+//
+// Parameters:
+//   - `sv`: the starlark value.
+//   - `rv`: the slice-kinded target.
+//
+// Returns:
+//   - `error`: non-nil on a shape mismatch or element conversion failure.
+func (c converter) toGoSliceTarget(sv starlark.Value, rv reflect.Value) error {
+
+	if rv.Type().Elem().Kind() == reflect.Uint8 {
+		if b, ok := sv.(starlark.Bytes); ok {
+			rv.SetBytes([]byte(b))
+			return nil
+		}
+		return fmt.Errorf("expected bytes, got %s", sv.Type())
+	}
+
+	if iter, ok := sv.(starlark.Iterable); ok {
+		return c.toGoSlice(iter, rv)
+	}
+
+	return fmt.Errorf("expected list, got %s", sv.Type())
+}
+
+// isScalarKind reports whether the kind is one toGoScalar handles.
+func isScalarKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	}
+	return false
+}
+
+// toGoScalar sets a scalar-kinded target from its starlark counterpart, range-checked for the sized
+// integer kinds.
+//
+// Parameters:
+//   - `sv`: the starlark value.
+//   - `rv`: the scalar-kinded target.
+//
+// Returns:
+//   - `error`: non-nil on a type mismatch or out-of-range integer.
+func toGoScalar(sv starlark.Value, rv reflect.Value) error {
+
+	switch rv.Kind() {
+	case reflect.String:
+		s, ok := starlark.AsString(sv)
+		if !ok {
+			return fmt.Errorf("expected string, got %s", sv.Type())
+		}
+		rv.SetString(s)
+
+	case reflect.Bool:
+		b, ok := sv.(starlark.Bool)
+		if !ok {
+			return fmt.Errorf("expected bool, got %s", sv.Type())
+		}
+		rv.SetBool(bool(b))
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		si, ok := sv.(starlark.Int)
+		if !ok {
+			return fmt.Errorf("expected int, got %s", sv.Type())
+		}
+		i, ok := si.Int64()
+		if !ok {
+			return fmt.Errorf("int out of range")
+		}
+		rv.SetInt(i)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		si, ok := sv.(starlark.Int)
+		if !ok {
+			return fmt.Errorf("expected int, got %s", sv.Type())
+		}
+		u, ok := si.Uint64()
+		if !ok {
+			return fmt.Errorf("uint out of range")
+		}
+		rv.SetUint(u)
+
+	case reflect.Float32, reflect.Float64:
+		f, ok := starlark.AsFloat(sv)
+		if !ok {
+			return fmt.Errorf("expected float or int, got %s", sv.Type())
+		}
+		rv.SetFloat(f)
+	}
+
 	return nil
+}
+
+// naturalSequence projects a starlark sequence (list, tuple, or set) to []any, element by element.
+//
+// Parameters:
+//   - `v`: the sequence value.
+//
+// Returns:
+//   - `any`: the projected []any.
+//   - `error`: non-nil when any element fails projection.
+func (c converter) naturalSequence(v starlark.Value) (any, error) {
+
+	n := max(starlark.Len(v), 0)
+
+	res := make([]any, 0, n) // Optimized: Allocates capacity but stays empty for append.
+	iter := assert.Type[starlark.Iterable]("sequence value", v).Iterate()
+	defer iter.Done()
+
+	var x starlark.Value
+
+	for iter.Next(&x) {
+		nat, err := c.toNaturalGo(x)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, nat)
+	}
+
+	return res, nil
+}
+
+// naturalDict projects a starlark dict to map[string]any.
+//
+// JSON objects are string-keyed and Go's encoding/json rejects any map whose key type is not
+// string/integer/TextMarshaler — so a starlark dict projects to map[string]any, requiring string
+// keys. AsString accepts only starlark.String; any other key type is a hard error here rather than a
+// cryptic encode failure downstream.
+//
+// Parameters:
+//   - `v`: the dict value.
+//
+// Returns:
+//   - `any`: the projected map[string]any.
+//   - `error`: non-nil on a non-string key or a value projection failure.
+func (c converter) naturalDict(v *starlark.Dict) (any, error) {
+
+	res := make(map[string]any, v.Len()) // Optimized: Pre-allocates map buckets.
+
+	for _, item := range v.Items() {
+
+		key, ok := starlark.AsString(item[0])
+		if !ok {
+			return nil, fmt.Errorf("dict key: expected string, got %s", item[0].Type())
+		}
+
+		val, err := c.toNaturalGo(item[1])
+		if err != nil {
+			return nil, err
+		}
+
+		res[key] = val
+	}
+
+	return res, nil
 }
 
 // toGoMap converts a [starlark.Dict] into a typed Go map via reflection.
@@ -333,50 +444,10 @@ func (c converter) toNaturalGo(sv starlark.Value) (any, error) {
 		return []byte(v), nil
 
 	case *starlark.List, starlark.Tuple, *starlark.Set:
-
-		n := max(starlark.Len(v), 0)
-
-		res := make([]any, 0, n) // Optimized: Allocates capacity but stays empty for append.
-		iter := assert.Type[starlark.Iterable]("sequence value", v).Iterate()
-		defer iter.Done()
-
-		var x starlark.Value
-
-		for iter.Next(&x) {
-			nat, err := c.toNaturalGo(x)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, nat)
-		}
-
-		return res, nil
+		return c.naturalSequence(v)
 
 	case *starlark.Dict:
-
-		res := make(map[string]any, v.Len()) // Optimized: Pre-allocates map buckets.
-
-		for _, item := range v.Items() {
-
-			// JSON objects are string-keyed and Go's encoding/json rejects any map whose key type is not
-			// string/integer/TextMarshaler — so a starlark dict projects to map[string]any, requiring string keys.
-			// AsString accepts only starlark.String; any other key type is a hard error here rather than a cryptic
-			// encode failure downstream.
-
-			key, ok := starlark.AsString(item[0])
-			if !ok {
-				return nil, fmt.Errorf("dict key: expected string, got %s", item[0].Type())
-			}
-
-			val, err := c.toNaturalGo(item[1])
-			if err != nil {
-				return nil, err
-			}
-
-			res[key] = val
-		}
-
-		return res, nil
+		return c.naturalDict(v)
 
 	case Projector:
 		return v.Project(reflect.TypeFor[any]())

--- a/pkg/op/starlarkbridge/go_receiver.go
+++ b/pkg/op/starlarkbridge/go_receiver.go
@@ -414,52 +414,332 @@ func (c converter) toStarlarkReflect(rv reflect.Value) (starlark.Value, error) {
 		return c.toStarlarkMap(rv)
 
 	case reflect.Struct:
-
-		if rv.CanInterface() {
-			if sv, ok := rv.Interface().(starlark.Value); ok {
-				return sv, nil
-			}
-		}
-
-		if rv.CanAddr() {
-			if sv, ok := rv.Addr().Interface().(starlark.Value); ok {
-				return sv, nil
-			}
-		}
-
-		var ptr reflect.Value
-
-		if rv.CanAddr() {
-			ptr = rv.Addr()
-		} else {
-			ptr = reflect.New(rv.Type())
-			ptr.Elem().Set(rv)
-		}
-
-		// Resolve the receiver type from the process-global registry, not the RuntimeEnvironment: type metadata is
-		// global declaration data, and a value type projecting another value type has no Provider (hence no env) in
-		// its chain. See docs/architecture/3.2 "Type resolution is environment-free".
-
-		receiverType := op.ReceiverRegistry().TypeByReflectionOrDerive(ptr.Type())
-
-		if receiverType == nil {
-
-			// Not registered (e.g. a framework type like *op.RecoveryStack handed to a reducer): derive a receiver
-			// type from the Go type by reflection — the "otherwise derived fresh" path. A derived type's methods take
-			// no parameters (tested elsewhere), which fits passing the value through as an opaque receiver.
-			derived, err := op.NewReceiverType(ptr.Type(), nil)
-			if err != nil {
-				return nil, fmt.Errorf("cannot derive receiver type for %s: %w", ptr.Type(), err)
-			}
-
-			receiverType = derived
-		}
-
-		return newGoReceiver(c, receiverType, ptr.Interface()), nil
+		return c.structToStarlark(rv)
 
 	default:
 		return nil, fmt.Errorf("cannot represent %s as a starlark value", rv.Type())
 	}
+}
+
+// parameterLayout is a dispatch call's parameter classification: the plain named parameters (with
+// their optionality, defaults, and types) and the positions of the variadic and kwargs sinks.
+type parameterLayout struct {
+	namedParams   []string
+	namedOptional []bool
+	namedDefaults []any
+	namedTypes    []reflect.Type
+	variadicName  string
+	variadicIdx   int
+	kwargsName    string
+	kwargsIdx     int
+}
+
+// routedArgs is a dispatch call's argument routing: what goes to starlark.UnpackArgs, the positional
+// overflow bound for the variadic sink, a keyword-supplied variadic value, and the unknown keywords
+// bound for the kwargs sink.
+type routedArgs struct {
+	unpackArgs         starlark.Tuple
+	unpackKwargs       []starlark.Tuple
+	positionalVariadic starlark.Tuple
+	kwVariadic         starlark.Value
+	extraKwargs        []starlark.Tuple
+}
+
+// classifyParameters splits a method's parameters into the layout dispatch works from.
+//
+// Parameters:
+//   - `params`: the method's declared parameters.
+//
+// Returns:
+//   - `parameterLayout`: the classification.
+func classifyParameters(params []op.Parameter) parameterLayout {
+
+	var layout parameterLayout
+	for i, p := range params {
+		switch {
+		case p.Kwargs:
+			layout.kwargsName = p.Name
+			layout.kwargsIdx = i
+		case p.Variadic:
+			layout.variadicName = p.Name
+			layout.variadicIdx = i
+		default:
+			layout.namedParams = append(layout.namedParams, p.Name)
+			layout.namedOptional = append(layout.namedOptional, p.Optional)
+			layout.namedDefaults = append(layout.namedDefaults, p.Default)
+			layout.namedTypes = append(layout.namedTypes, p.Type)
+		}
+	}
+
+	return layout
+}
+
+// routeArgs routes the call's arguments per the layout: with no variadic or kwargs sink everything
+// goes straight to UnpackArgs; otherwise keywords split into known, variadic-named, and extra, and
+// positional overflow beyond the named count binds for the variadic sink. Unknown keywords without a
+// kwargs sink are an error.
+//
+// Parameters:
+//   - `actionName`: the dispatch name, for error messages.
+//   - `args`: the positional arguments.
+//   - `kwargs`: the keyword arguments.
+//
+// Returns:
+//   - `routedArgs`: the routing.
+//   - `error`: non-nil for an unexpected keyword argument.
+func (l parameterLayout) routeArgs(actionName string, args starlark.Tuple, kwargs []starlark.Tuple) (routedArgs, error) {
+
+	routed := routedArgs{unpackArgs: args, unpackKwargs: kwargs}
+
+	if l.variadicName == "" && l.kwargsName == "" {
+		return routed, nil
+	}
+
+	knownKwargs := make(map[string]bool, len(l.namedParams)+1)
+	for _, n := range l.namedParams {
+		knownKwargs[n] = true
+	}
+	if l.variadicName != "" {
+		knownKwargs[l.variadicName] = true
+	}
+
+	routed.unpackKwargs = nil
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		switch {
+		case key == l.variadicName:
+			routed.kwVariadic = kv[1]
+		case knownKwargs[key]:
+			routed.unpackKwargs = append(routed.unpackKwargs, kv)
+		default:
+			routed.extraKwargs = append(routed.extraKwargs, kv)
+		}
+	}
+
+	if l.kwargsName == "" && len(routed.extraKwargs) > 0 {
+		key, _ := starlark.AsString(routed.extraKwargs[0][0])
+		return routedArgs{}, fmt.Errorf("%s() got an unexpected keyword argument %q", actionName, key)
+	}
+
+	if len(args) > len(l.namedParams) {
+		routed.unpackArgs = args[:len(l.namedParams)]
+		routed.positionalVariadic = args[len(l.namedParams):]
+	}
+
+	return routed, nil
+}
+
+// unpackNamed unpacks the named parameters via starlark.UnpackArgs.
+//
+// starlark.UnpackArgs uses a trailing "?" on the pair name to mark a kwarg optional; the layout
+// carries clean names, so the suffix is reconstructed here.
+//
+// Parameters:
+//   - `actionName`: the dispatch name, for error messages.
+//   - `unpackArgs`: the routed positional arguments.
+//   - `unpackKwargs`: the routed known keywords.
+//
+// Returns:
+//   - `[]starlark.Value`: the unpacked values, parallel to the named parameters; nil for absent
+//     optionals.
+//   - `error`: the unpack failure, if any.
+func (l parameterLayout) unpackNamed(
+	actionName string, unpackArgs starlark.Tuple, unpackKwargs []starlark.Tuple,
+) ([]starlark.Value, error) {
+
+	vals := make([]starlark.Value, len(l.namedParams))
+	pairs := make([]any, 0, len(l.namedParams)*2)
+
+	for i, n := range l.namedParams {
+		unpackName := n
+		if l.namedOptional[i] {
+			unpackName += "?"
+		}
+		pairs = append(pairs, unpackName, &vals[i])
+	}
+
+	if err := starlark.UnpackArgs(actionName, unpackArgs, unpackKwargs, pairs...); err != nil {
+		return nil, err
+	}
+
+	return vals, nil
+}
+
+// fillNamedSlots converts the unpacked named values into the slot map, filling truly absent kwargs
+// from their declared defaults.
+//
+// Literal-form defaults arrive already typed (parseDefaultExpression widens via
+// reflect.Value.Convert at announcement time); deferred-default forms (op.DeferredDefault) resolve
+// here against the live runtime environment and the already-filled sibling slots.
+//
+// Parameters:
+//   - `actionName`: the dispatch name, for error messages.
+//   - `layout`: the parameter layout.
+//   - `vals`: the unpacked values, parallel to the named parameters.
+//
+// Returns:
+//   - `map[string]any`: the slot map.
+//   - `error`: non-nil on a default resolution or conversion failure.
+func (g *goReceiver) fillNamedSlots(
+	actionName string, layout parameterLayout, vals []starlark.Value,
+) (map[string]any, error) {
+
+	slots := make(map[string]any, len(layout.namedParams)+2)
+
+	for i, sv := range vals {
+
+		if sv == nil {
+			if layout.namedDefaults[i] != nil {
+				value := layout.namedDefaults[i]
+				if d, ok := value.(op.DeferredDefault); ok {
+					resolved, err := d.Resolve(g.runtimeEnvironment(), slots, layout.namedTypes[i])
+					if err != nil {
+						return nil, fmt.Errorf("%s(): %s: default: %w", actionName, layout.namedParams[i], err)
+					}
+					value = resolved
+				}
+				slots[layout.namedParams[i]] = value
+			}
+			continue
+		}
+
+		var val any
+		if err := g.converter.toGoInto(sv, reflect.ValueOf(&val).Elem()); err != nil {
+			return nil, fmt.Errorf("%s(): %s: %w", actionName, layout.namedParams[i], err)
+		}
+
+		slots[layout.namedParams[i]] = val
+	}
+
+	return slots, nil
+}
+
+// fillVariadicSlot fills the variadic sink from the positional overflow or the keyword-supplied
+// list — supplying both is an error, matching starlark's multiple-values diagnosis.
+//
+// Parameters:
+//   - `actionName`: the dispatch name, for error messages.
+//   - `layout`: the parameter layout.
+//   - `params`: the method's declared parameters.
+//   - `routed`: the argument routing.
+//   - `slots`: the slot map receiving the variadic value.
+//
+// Returns:
+//   - `error`: non-nil on double supply, a non-list keyword value, or a conversion failure.
+func (g *goReceiver) fillVariadicSlot(
+	actionName string, layout parameterLayout, params []op.Parameter, routed routedArgs, slots map[string]any,
+) error {
+
+	if len(routed.positionalVariadic) > 0 && routed.kwVariadic != nil {
+		return fmt.Errorf("%s() got multiple values for argument %q", actionName, layout.variadicName)
+	}
+
+	var variadicList *starlark.List
+
+	if len(routed.positionalVariadic) > 0 {
+		elems := make([]starlark.Value, len(routed.positionalVariadic))
+		copy(elems, routed.positionalVariadic)
+		variadicList = starlark.NewList(elems)
+	} else if routed.kwVariadic != nil {
+		list, ok := routed.kwVariadic.(*starlark.List)
+		if !ok {
+			return fmt.Errorf("%s(): keyword %s must be a list, got %s", actionName, layout.variadicName, routed.kwVariadic.Type())
+		}
+		variadicList = list
+	}
+
+	if variadicList == nil || variadicList.Len() == 0 {
+		return nil
+	}
+
+	var val any
+	if err := g.converter.toGoInto(variadicList, reflect.ValueOf(&val).Elem()); err != nil {
+		return fmt.Errorf("%s(): %s: %w", actionName, layout.variadicName, err)
+	}
+	slots[params[layout.variadicIdx].Name] = val
+
+	return nil
+}
+
+// fillKwargsSlot converts the unknown keywords into the kwargs sink's map slot.
+//
+// Parameters:
+//   - `actionName`: the dispatch name, for error messages.
+//   - `layout`: the parameter layout.
+//   - `params`: the method's declared parameters.
+//   - `extraKwargs`: the routed unknown keywords.
+//   - `slots`: the slot map receiving the kwargs map.
+//
+// Returns:
+//   - `error`: non-nil on a conversion failure.
+func (g *goReceiver) fillKwargsSlot(
+	actionName string, layout parameterLayout, params []op.Parameter, extraKwargs []starlark.Tuple, slots map[string]any,
+) error {
+
+	kwargsMap := make(map[string]any, len(extraKwargs))
+
+	for _, kv := range extraKwargs {
+		key, _ := starlark.AsString(kv[0])
+		var val any
+		if err := g.converter.toGoInto(kv[1], reflect.ValueOf(&val).Elem()); err != nil {
+			return fmt.Errorf("%s(): keyword %s: %w", actionName, key, err)
+		}
+		kwargsMap[key] = val
+	}
+
+	slots[params[layout.kwargsIdx].Name] = kwargsMap
+
+	return nil
+}
+
+// structToStarlark projects a struct value: a starlark.Value implementation passes through (value or
+// pointer receiver), and everything else wraps as a goReceiver over its addressable pointer.
+//
+// The receiver type resolves from the process-global registry, not the RuntimeEnvironment: type
+// metadata is global declaration data, and a value type projecting another value type has no Provider
+// (hence no env) in its chain. See docs/architecture/3.2 "Type resolution is environment-free". An
+// unregistered type (e.g. a framework type like *op.RecoveryStack handed to a reducer) derives a
+// receiver type from the Go type by reflection — a derived type's methods take no parameters, which
+// fits passing the value through as an opaque receiver.
+//
+// Parameters:
+//   - `rv`: the struct value.
+//
+// Returns:
+//   - `starlark.Value`: the projection.
+//   - `error`: non-nil when a receiver type cannot be derived.
+func (c converter) structToStarlark(rv reflect.Value) (starlark.Value, error) {
+
+	if rv.CanInterface() {
+		if sv, ok := rv.Interface().(starlark.Value); ok {
+			return sv, nil
+		}
+	}
+
+	if rv.CanAddr() {
+		if sv, ok := rv.Addr().Interface().(starlark.Value); ok {
+			return sv, nil
+		}
+	}
+
+	var ptr reflect.Value
+	if rv.CanAddr() {
+		ptr = rv.Addr()
+	} else {
+		ptr = reflect.New(rv.Type())
+		ptr.Elem().Set(rv)
+	}
+
+	receiverType := op.ReceiverRegistry().TypeByReflectionOrDerive(ptr.Type())
+	if receiverType == nil {
+		derived, err := op.NewReceiverType(ptr.Type(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("cannot derive receiver type for %s: %w", ptr.Type(), err)
+		}
+		receiverType = derived
+	}
+
+	return newGoReceiver(c, receiverType, ptr.Interface()), nil
 }
 
 // scalarToStarlark projects a scalar-kinded [reflect.Value] to its starlark scalar form.
@@ -572,179 +852,33 @@ func (g *goReceiver) dispatch(
 	method := g.methods[name]
 	params := method.Parameters()
 
-	var namedParams []string
-	var namedOptional []bool
-	var namedDefaults []any
-	var namedTypes []reflect.Type
-	var variadicName string
-	var variadicIdx int
-	var kwargsName string
-	var kwargsIdx int
+	layout := classifyParameters(params)
 
-	for i, p := range params {
-		switch {
-		case p.Kwargs:
-			kwargsName = p.Name
-			kwargsIdx = i
-		case p.Variadic:
-			variadicName = p.Name
-			variadicIdx = i
-		default:
-			namedParams = append(namedParams, p.Name)
-			namedOptional = append(namedOptional, p.Optional)
-			namedDefaults = append(namedDefaults, p.Default)
-			namedTypes = append(namedTypes, p.Type)
-		}
-	}
-
-	numNamed := len(namedParams)
-	numParams := len(params)
-
-	unpackArgs := args
-	unpackKwargs := kwargs
-
-	var positionalVariadic starlark.Tuple
-	var kwVariadic starlark.Value
-	var extraKwargs []starlark.Tuple
-
-	if variadicName != "" || kwargsName != "" {
-
-		knownKwargs := make(map[string]bool, numNamed+1)
-
-		for _, n := range namedParams {
-			knownKwargs[n] = true
-		}
-
-		if variadicName != "" {
-			knownKwargs[variadicName] = true
-		}
-
-		unpackKwargs = nil
-
-		for _, kv := range kwargs {
-
-			key, _ := starlark.AsString(kv[0])
-
-			switch {
-			case key == variadicName:
-				kwVariadic = kv[1]
-			case knownKwargs[key]:
-				unpackKwargs = append(unpackKwargs, kv)
-			default:
-				extraKwargs = append(extraKwargs, kv)
-			}
-		}
-
-		if kwargsName == "" && len(extraKwargs) > 0 {
-			key, _ := starlark.AsString(extraKwargs[0][0])
-			return nil, fmt.Errorf("%s() got an unexpected keyword argument %q", actionName, key)
-		}
-
-		if len(args) > numNamed {
-			unpackArgs = args[:numNamed]
-			positionalVariadic = args[numNamed:]
-		}
-	}
-
-	vals := make([]starlark.Value, numNamed)
-	pairs := make([]any, 0, numNamed*2)
-
-	for i, n := range namedParams {
-
-		// starlark.UnpackArgs uses a trailing "?" on the pair name to mark a kwarg optional. namedParams carries clean
-		// names. Here we reconstruct the "?" suffix so UnpackArgs sees the optional convention.
-
-		unpackName := n
-
-		if namedOptional[i] {
-			unpackName += "?"
-		}
-
-		pairs = append(pairs, unpackName, &vals[i])
-	}
-
-	if err := starlark.UnpackArgs(actionName, unpackArgs, unpackKwargs, pairs...); err != nil {
+	routed, err := layout.routeArgs(actionName, args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 
-	slots := make(map[string]any, numParams)
-
-	for i, sv := range vals {
-
-		if sv == nil {
-
-			// Truly absent kwarg — fill from the parameter's declared default if one exists. Literal-form defaults
-			// arrive already typed (parseDefaultExpression widens via reflect.Value.Convert at announcement time);
-			// deferred-default forms (op.DeferredDefault) resolve here against the live runtime environment and the
-			// already-filled sibling slots in the slot map.
-
-			if namedDefaults[i] != nil {
-				value := namedDefaults[i]
-				if d, ok := value.(op.DeferredDefault); ok {
-					resolved, err := d.Resolve(g.runtimeEnvironment(), slots, namedTypes[i])
-					if err != nil {
-						return nil, fmt.Errorf("%s(): %s: default: %w", actionName, namedParams[i], err)
-					}
-					value = resolved
-				}
-				slots[namedParams[i]] = value
-			}
-
-			continue
-		}
-
-		var val any
-
-		if err := g.converter.toGoInto(sv, reflect.ValueOf(&val).Elem()); err != nil {
-			return nil, fmt.Errorf("%s(): %s: %w", actionName, namedParams[i], err)
-		}
-
-		slots[namedParams[i]] = val
+	vals, err := layout.unpackNamed(actionName, routed.unpackArgs, routed.unpackKwargs)
+	if err != nil {
+		return nil, err
 	}
 
-	if variadicName != "" {
+	slots, err := g.fillNamedSlots(actionName, layout, vals)
+	if err != nil {
+		return nil, err
+	}
 
-		if len(positionalVariadic) > 0 && kwVariadic != nil {
-			return nil, fmt.Errorf("%s() got multiple values for argument %q", actionName, variadicName)
-		}
-
-		var variadicList *starlark.List
-
-		if len(positionalVariadic) > 0 {
-			elems := make([]starlark.Value, len(positionalVariadic))
-			copy(elems, positionalVariadic)
-			variadicList = starlark.NewList(elems)
-		} else if kwVariadic != nil {
-			list, ok := kwVariadic.(*starlark.List)
-			if !ok {
-				return nil, fmt.Errorf("%s(): keyword %s must be a list, got %s", actionName, variadicName, kwVariadic.Type())
-			}
-			variadicList = list
-		}
-
-		if variadicList != nil && variadicList.Len() > 0 {
-			var val any
-			if err := g.converter.toGoInto(variadicList, reflect.ValueOf(&val).Elem()); err != nil {
-				return nil, fmt.Errorf("%s(): %s: %w", actionName, variadicName, err)
-			}
-			slots[params[variadicIdx].Name] = val
+	if layout.variadicName != "" {
+		if err := g.fillVariadicSlot(actionName, layout, params, routed, slots); err != nil {
+			return nil, err
 		}
 	}
 
-	if kwargsName != "" {
-
-		kwargsMap := make(map[string]any, len(extraKwargs))
-
-		for _, kv := range extraKwargs {
-			key, _ := starlark.AsString(kv[0])
-			var val any
-			if err := g.converter.toGoInto(kv[1], reflect.ValueOf(&val).Elem()); err != nil {
-				return nil, fmt.Errorf("%s(): keyword %s: %w", actionName, key, err)
-			}
-			kwargsMap[key] = val
+	if layout.kwargsName != "" {
+		if err := g.fillKwargsSlot(actionName, layout, params, routed.extraKwargs, slots); err != nil {
+			return nil, err
 		}
-
-		slots[params[kwargsIdx].Name] = kwargsMap
 	}
 
 	// Immediate-mode starlark dispatch (codegen, REPL, ad-hoc calls) has no graph in scope: there is no

--- a/pkg/op/truthiness.go
+++ b/pkg/op/truthiness.go
@@ -30,35 +30,8 @@ func IsTruthy(value any) bool {
 		return false
 	}
 
-	switch v := value.(type) {
-	case bool:
-		return v
-	case int:
-		return v != 0
-	case int8:
-		return v != 0
-	case int16:
-		return v != 0
-	case int32:
-		return v != 0
-	case int64:
-		return v != 0
-	case uint:
-		return v != 0
-	case uint8:
-		return v != 0
-	case uint16:
-		return v != 0
-	case uint32:
-		return v != 0
-	case uint64:
-		return v != 0
-	case float32:
-		return v != 0
-	case float64:
-		return v != 0
-	case string:
-		return v != ""
+	if truthy, ok := scalarTruthy(value); ok {
+		return truthy
 	}
 
 	switch reflected := reflect.ValueOf(value); reflected.Kind() {
@@ -71,4 +44,49 @@ func IsTruthy(value any) bool {
 	default:
 		return true
 	}
+}
+
+// scalarTruthy reports a built-in scalar's truthiness: false for zero numbers, empty strings, and
+// false itself.
+//
+// Parameters:
+//   - `value`: the value under test.
+//
+// Returns:
+//   - `bool`: the truthiness, when `value` is a built-in scalar.
+//   - `bool`: true when `value` was a built-in scalar.
+func scalarTruthy(value any) (bool, bool) {
+
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case int:
+		return v != 0, true
+	case int8:
+		return v != 0, true
+	case int16:
+		return v != 0, true
+	case int32:
+		return v != 0, true
+	case int64:
+		return v != 0, true
+	case uint:
+		return v != 0, true
+	case uint8:
+		return v != 0, true
+	case uint16:
+		return v != 0, true
+	case uint32:
+		return v != 0, true
+	case uint64:
+		return v != 0, true
+	case float32:
+		return v != 0, true
+	case float64:
+		return v != 0, true
+	case string:
+		return v != "", true
+	}
+
+	return false, false
 }


### PR DESCRIPTION
Phase 6 of docs/plans/complexity-refactors.md (#312): the conversion stack decomposed under the thresholds — `dispatch` (65) into named phases over `parameterLayout`/`routedArgs` carriers, the converter's scalar/slice/struct/sequence arms extracted, `Convert`'s direct paths named (`convertDirect`). Behavior-preserving; the suite passes unmodified. One incident disclosed in the plan notes: a blind slice corrupted `converter.go` mid-phase, recovered from the develop copy and re-applied with bounds-verified slices. Plan doc rides along with phase 6 marked complete.