### PR TITLE
refactor(complexity): phase 7 — the engine core; the board reads zero

### DIFF
--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -51,15 +51,7 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 		paths = []string{"./..."}
 	}
 
-	modTidyPassed := true
-	modTidyDetails := ""
-	if !skipModTidy {
-		sessionCtx := p.RuntimeEnvironment().Context
-		if sessionCtx == nil {
-			sessionCtx = context.Background()
-		}
-		modTidyPassed, modTidyDetails = checkModTidy(sessionCtx)
-	}
+	modTidyPassed, modTidyDetails := p.modTidyStatus(skipModTidy)
 
 	if checkTool("golangci-lint") == "" {
 		return GoResult{}, fmt.Errorf("golangci-lint not installed\n  Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest")
@@ -74,36 +66,9 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 		}
 	}
 
-	cmdArgs := []string{"run", "--output.json.path", "stdout"}
-	if config != "" {
-		if !filepath.IsAbs(config) {
-			if absConfig, err := filepath.Abs(config); err == nil {
-				config = absConfig
-			}
-		}
-		cmdArgs = append(cmdArgs, "--config="+config)
-	}
-	cmdArgs = append(cmdArgs, paths...)
-
-	cmd := exec.CommandContext(context.Background(), "golangci-lint", cmdArgs...)
-	output, err := cmd.Output()
-
-	var issues []goIssueRaw
-	if len(output) > 0 {
-		var lintOutput goOutputRaw
-		if jsonErr := json.Unmarshal(output, &lintOutput); jsonErr == nil {
-			issues = lintOutput.Issues
-		}
-	}
-
-	if err != nil && len(output) == 0 {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			stderr := string(exitErr.Stderr)
-			if stderr != "" {
-				return GoResult{}, fmt.Errorf("golangci-lint failed: %s", strings.TrimSpace(stderr))
-			}
-		}
+	issues, err := runGolangciLint(golangciArgs(config, paths))
+	if err != nil {
+		return GoResult{}, err
 	}
 
 	result := GoResult{
@@ -111,28 +76,7 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 		ModTidyPassed:  modTidyPassed,
 		ModTidyDetails: modTidyDetails,
 	}
-
-	for _, issue := range issues {
-		severity := issue.Severity
-		if severity == "" {
-			severity = "warning"
-		}
-		switch severity {
-		case "error":
-			result.ErrorCount++
-		default:
-			result.WarningCount++
-		}
-		result.Issues = append(result.Issues, GoIssue{
-			File:        issue.Pos.Filename,
-			Line:        issue.Pos.Line,
-			Column:      issue.Pos.Column,
-			Message:     issue.Text,
-			Linter:      issue.FromLinter,
-			Severity:    severity,
-			SourceLines: issue.SourceLines,
-		})
-	}
+	appendGoIssues(&result, issues)
 
 	result.TotalCount = len(result.Issues)
 	result.LintPassed = result.ErrorCount == 0 && result.WarningCount == 0
@@ -314,6 +258,119 @@ type goPosRaw struct {
 	Filename string `json:"Filename"`
 	Line     int    `json:"Line"`
 	Column   int    `json:"Column"`
+}
+
+// modTidyStatus runs the tidy check under the session context (Background for bare test
+// environments) unless skipped.
+//
+// Parameters:
+//   - `skipModTidy`: when true, the check is skipped and reports passing.
+//
+// Returns:
+//   - `bool`: whether go.mod/go.sum are tidy.
+//   - `string`: the failure detail, or empty.
+func (p *Provider) modTidyStatus(skipModTidy bool) (bool, string) {
+
+	if skipModTidy {
+		return true, ""
+	}
+
+	sessionCtx := p.RuntimeEnvironment().Context
+	if sessionCtx == nil {
+		sessionCtx = context.Background()
+	}
+
+	return checkModTidy(sessionCtx)
+}
+
+// golangciArgs builds the golangci-lint argv: JSON output, the (absolutized) config when one is set,
+// and the package patterns.
+//
+// Parameters:
+//   - `config`: the config path; empty adds no --config flag.
+//   - `paths`: the package patterns.
+//
+// Returns:
+//   - `[]string`: the argv after the binary name.
+func golangciArgs(config string, paths []string) []string {
+
+	cmdArgs := []string{"run", "--output.json.path", "stdout"}
+	if config != "" {
+		if !filepath.IsAbs(config) {
+			if absConfig, err := filepath.Abs(config); err == nil {
+				config = absConfig
+			}
+		}
+		cmdArgs = append(cmdArgs, "--config="+config)
+	}
+
+	return append(cmdArgs, paths...)
+}
+
+// runGolangciLint executes golangci-lint and parses its JSON issue stream; an empty-output failure
+// surfaces the tool's stderr.
+//
+// Parameters:
+//   - `cmdArgs`: the argv after the binary name.
+//
+// Returns:
+//   - `[]goIssueRaw`: the parsed issues; empty when the run was clean.
+//   - `error`: non-nil when the tool failed without producing output.
+func runGolangciLint(cmdArgs []string) ([]goIssueRaw, error) {
+
+	cmd := exec.CommandContext(context.Background(), "golangci-lint", cmdArgs...)
+	output, err := cmd.Output()
+
+	var issues []goIssueRaw
+	if len(output) > 0 {
+		var lintOutput goOutputRaw
+		if jsonErr := json.Unmarshal(output, &lintOutput); jsonErr == nil {
+			issues = lintOutput.Issues
+		}
+	}
+
+	if err != nil && len(output) == 0 {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderr := string(exitErr.Stderr)
+			if stderr != "" {
+				return nil, fmt.Errorf("golangci-lint failed: %s", strings.TrimSpace(stderr))
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+// appendGoIssues folds the raw issues into the result: severities default to warning, counts
+// accumulate per severity.
+//
+// Parameters:
+//   - `result`: the result under construction.
+//   - `issues`: the parsed raw issues.
+func appendGoIssues(result *GoResult, issues []goIssueRaw) {
+
+	for _, issue := range issues {
+		severity := issue.Severity
+		if severity == "" {
+			severity = "warning"
+		}
+		switch severity {
+		case "error":
+			result.ErrorCount++
+		default:
+			result.WarningCount++
+		}
+		result.Issues = append(result.Issues, GoIssue{
+			File:        issue.Pos.Filename,
+			Line:        issue.Pos.Line,
+			Column:      issue.Pos.Column,
+			Message:     issue.Text,
+			Linter:      issue.FromLinter,
+			Severity:    severity,
+			SourceLines: issue.SourceLines,
+		})
+	}
 }
 
 func checkModTidy(ctx context.Context) (tidy bool, detail string) {

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -1,7 +1,7 @@
 ---
 title: "Complexity refactors: 61 functions under the thresholds"
 issue: "#312"
-status: in-progress
+status: complete
 created: 2026-08-02
 updated: 2026-08-02
 ---
@@ -37,7 +37,7 @@ complexity limits. This is the repository's only remaining lint debt.
 | 4 | `refactor/complexity-goast-analysis` | goast analysis/serialization: `LoadSourceFile` 67, `analyzeFileMetrics` 55, `assignSlots` 44, `schemaFromConfigVal` 43, `typeToString` 37, `checkLineWidth` 32, `SaveAs` 29, `itemProduction.Execute` 23 | 8 | **complete** |
 | 5 | `refactor/complexity-providers` | Concrete providers + satellites: archive `extractEntries` 48, plan `splitReservedKwargs` 39 (**also resolves the parked seven-results carrier-struct question**), file `compensateWrite` 25 + `Link` 23 + `Find` 22, lore `buildPackage` 26, devconfig `reflectToStarlark` 23, platform `compositeManager.dispatch` 21 | 8 | **complete** |
 | 6 | `refactor/complexity-conversion` | The conversion surfaces: starlarkbridge `dispatch` 65, `toGoInto` 38, `toStarlarkReflect` 31, `toNaturalGo` 16; op `envValue.ConvertTo` 26, `Convert` 18, `IsTruthy` 19 | 7 | **complete** |
-| 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16 | 15 | pending |
+| 7 | `refactor/complexity-engine` | The op engine core, last and most carefully: `ActionPlanner.Plan` 69, `NewMethod` 59, `newReceiverType` 32, executor `dispatchWithPolicy` 32 + `Run` 26, subgraph `validateGuardedEdges` 32, `checkPromiseTypes` 31, `rearm` 23, `parseParameterToken` 21, `assembleGraph` 17; flow `GatherPlanner.Plan` 34, `Gather` 26, `WaitUntil` 25, `ChoosePlanner.Plan` 16, `WaitUntilPlanner.Plan` 16; **plus lint `Go` 31, a plan-table omission caught and folded in here** | 16 | **complete** |
 
 Total: 60 listed + `TestContext.Check` counted in phase 1 = 61.
 
@@ -122,6 +122,27 @@ its sequence/dict projections. `envValue.ConvertTo` extracted `parseScalarEnv`;
 recovered by restoring the develop copy via the API and re-applying with
 bounds-verified slices — the lesson (assert slice contents and lengths before
 replacing) applied to every later edit.
+
+**Phase 7 (complete):** the engine decomposed with exact order preservation throughout.
+`ActionPlanner.Plan` (69) became `bindParameterSlots` → `bindPresentValue` →
+`bindResourceValue` (the addressing rules' commentary carried into the helpers); `NewMethod`
+(59) its four labeled validators (`validateParameterPositions`, `classifyMethodKind`,
+`validatePlanCompanion`, `buildUndoInvoke`); `newReceiverType` (32) split announced/derived
+method building. The executor's `dispatchWithPolicy` (32) extracted `waitRetryDelay` and
+the three-outcome `gateRetry`; `Run` (26) extracted `prepareResume` and `failAndUnwind`
+(the step-21 terminal selection stated once). The subgraph's guard validation split into
+decision-node and tree-shape passes; `checkPromiseTypes` into a per-slot check; `rearm`
+into per-entry re-arming; `parseParameterToken` into sink/named token parsers. flow gained
+a shared `resolveCombinatorSubgraph` (Gather's nil-Graph compensator nuance preserved by an
+inline pre-check), `classifyGatherRuns` with `gatherRun` promoted from an anonymous type,
+`bindKwargFrame`, a shared `desugarLambdaBody`, and `layoutDecisionTree`. **A plan-table
+omission surfaced and was corrected: lint's `Go` (31) was in the original 61 but assigned
+to no phase; it folded in here** (`modTidyStatus`/`golangciArgs`/`runGolangciLint`/
+`appendGoIssues`).
+
+**Final board: zero.** The repository's full lint output — every linter, uncapped — is
+empty. From 2,486 findings at the start of the lint charter to none, with every
+suppression in the codebase carrying its stated reason.
 
 ## Ordering rationale
 

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -269,6 +269,45 @@ func LoadGraph(env *RuntimeEnvironment, data []byte, format string) (*Graph, err
 	return assembleGraph(env, &p)
 }
 
+// assembleUnits builds the unit symbol table from the flat payload lists. Each unit comes into
+// existence with its action already bound — NewNode / NewSubgraph's assert.NonZero invariant holds.
+//
+// Parameters:
+//   - `p`: the decoded graph payload.
+//
+// Returns:
+//   - `map[string]ExecutableUnit`: the unit table, keyed by ID.
+//   - `error`: the joined per-unit assembly failures, or nil.
+func assembleUnits(p *graphData) (map[string]ExecutableUnit, error) {
+
+	var violations []error
+	unitsByID := make(map[string]ExecutableUnit, len(p.Nodes)+len(p.Subgraphs))
+
+	for i := range p.Nodes {
+		node, err := assembleNode(&p.Nodes[i])
+		if err != nil {
+			violations = append(violations, err)
+			continue
+		}
+		unitsByID[node.ID()] = node
+	}
+
+	for i := range p.Subgraphs {
+		sg, err := assembleSubgraph(&p.Subgraphs[i])
+		if err != nil {
+			violations = append(violations, err)
+			continue
+		}
+		unitsByID[sg.ID()] = sg
+	}
+
+	if len(violations) > 0 {
+		return nil, errors.Join(violations...)
+	}
+
+	return unitsByID, nil
+}
+
 // assembleGraph constructs a [*Graph] from a decoded [graphData] payload — the dual to [Graph.marshalData].
 //
 // It prepares the root the load way: each unit's action is resolved through env.Registry and the concrete
@@ -299,33 +338,12 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 	// recomputed checksum matches the document's; re-deriving here would drop hand-authored, non-slot-producer edges.
 	root.edges = p.Edges
 
+	unitsByID, err := assembleUnits(p)
+	if err != nil {
+		return nil, err
+	}
+
 	var violations []error
-
-	// Build the unit symbol table from the flat payload lists. Each unit comes into existence with its action already
-	// bound — NewNode / NewSubgraph's assert.NonZero invariant holds.
-	unitsByID := make(map[string]ExecutableUnit, len(p.Nodes)+len(p.Subgraphs))
-
-	for i := range p.Nodes {
-		node, err := assembleNode(&p.Nodes[i])
-		if err != nil {
-			violations = append(violations, err)
-			continue
-		}
-		unitsByID[node.ID()] = node
-	}
-
-	for i := range p.Subgraphs {
-		sg, err := assembleSubgraph(&p.Subgraphs[i])
-		if err != nil {
-			violations = append(violations, err)
-			continue
-		}
-		unitsByID[sg.ID()] = sg
-	}
-
-	if len(violations) > 0 {
-		return nil, errors.Join(violations...)
-	}
 
 	// Wire root's children + the per-subgraph child links. Each Subgraph's executableUnitsByID was pre-populated with
 	// placeholder nil entries by assembleSubgraph from its Children list; linkChildren resolves each placeholder against

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -490,29 +490,8 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 	}()
 
 	if resuming {
-		// Resume: [ResumeExecutor] already restored e.stack (the recovery tree) and e.variables (the resolved frame)
-		// from the trace. Re-publish the variables onto the fresh environment; the dispatch re-descends, adopting each
-		// subgraph's restored child stack and replaying units that already carry a successful receipt (pseudo replay).
-		e.environment.variables = e.variables
-
-		// Rehydrate the saved resource ledger so the recovery stack's receipt id references resolve against the same
-		// generations the pre-pause run produced; a fresh clone would lose superseded shadow generations.
-		if e.ledgerSnapshot != nil {
-			restored, rehydrateErr := e.ledgerSnapshot.Rehydrate(e.environment)
-			if rehydrateErr != nil {
-				e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
-					Reason: ReasonPreflightFailed, Message: "resource ledger rehydrate failed"}
-				return nil, fmt.Errorf("Run: rehydrate resource ledger: %w", rehydrateErr)
-			}
-			e.environment.ResourceCatalog = restored
-		}
-
-		// Reconstruct concrete receipts against the rehydrated ledger and re-arm compensation, so a resumed-then-failed
-		// run can roll back the pre-pause work.
-		if rearmErr := e.stack.rearm(e.environment); rearmErr != nil {
-			e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
-				Reason: ReasonPreflightFailed, Message: "recovery stack re-arm failed"}
-			return nil, fmt.Errorf("Run: re-arm recovery stack: %w", rearmErr)
+		if err := e.prepareResume(); err != nil {
+			return nil, err
 		}
 	} else {
 		if err := e.bindVariables(e.graph, variables); err != nil {
@@ -567,38 +546,52 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 			return nil, err
 		}
 
-		// Unwind in LIFO order so every Action that completed before the failure gets its Compensate
-		// companion called; without this, TestCompensation-style rollback never runs.
-		//
-		// The unwind outcome selects between the two failure terminals (phase-8 step 21, the compensation-failure
-		// contract): a clean unwind means the system is back at its pre-run state (stopped × [ConditionExecutionFailed]);
-		// any failed Compensate means the system is dirty (stopped × [ConditionCompensationFailed]) — the joined error
-		// names the forward failure and every compensation that failed.
-		if unwindErr := e.stack.Unwind(e.environment); unwindErr != nil {
-			e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionCompensationFailed,
-				Reason: ReasonCompensationFailed, Message: "unwind failed: compensation error"}
-			e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: unwindErr})
-			return nil, fmt.Errorf("%w; compensation: %w", err, unwindErr)
-		}
-		// Land stopped × the condition the failure implies, honoring a worse condition the run already recorded
-		// (bubbled up from the failing boundary). `conditionForReason` derives the terminal from the reason a
-		// dispatchFailure carries, so a degraded-driven stop lands stopped × degraded, not × execution_failed.
-		reason := failureReason(err)
-		condition := conditionForReason(reason)
-		if e.status.Condition > condition {
-			condition = e.status.Condition
-			reason = e.status.Reason
-		}
-		e.status = RunStatus{Phase: PhaseStopped, Condition: condition, Reason: reason,
-			Message: "unhandled failure; stack unwound cleanly"}
-		e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: err})
-		return nil, err
+		return e.failAndUnwind(err)
 	}
 
 	e.status.Phase = PhaseCompleted
 	e.control.emit(ControlEvent{Kind: EventPhaseChanged, Status: e.status})
 	e.control.emit(ControlEvent{Kind: EventResult, Status: e.status})
 	return result, nil
+}
+
+// failAndUnwind lands an unhandled dispatch failure: unwind in LIFO order so every Action that
+// completed before the failure gets its Compensate companion called, then pick the failure terminal.
+//
+// The unwind outcome selects between the two failure terminals (phase-8 step 21, the
+// compensation-failure contract): a clean unwind means the system is back at its pre-run state
+// (stopped × [ConditionExecutionFailed]); any failed Compensate means the system is dirty
+// (stopped × [ConditionCompensationFailed]) — the joined error names the forward failure and every
+// compensation that failed. A clean unwind lands stopped × the condition the failure implies,
+// honoring a worse condition the run already recorded (bubbled up from the failing boundary):
+// `conditionForReason` derives the terminal from the reason a dispatchFailure carries, so a
+// degraded-driven stop lands stopped × degraded, not × execution_failed.
+//
+// Parameters:
+//   - `err`: the dispatch failure.
+//
+// Returns:
+//   - `any`: always nil.
+//   - `error`: the failure (joined with compensation errors when the unwind fails).
+func (e *GraphExecutor) failAndUnwind(err error) (any, error) {
+
+	if unwindErr := e.stack.Unwind(e.environment); unwindErr != nil {
+		e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionCompensationFailed,
+			Reason: ReasonCompensationFailed, Message: "unwind failed: compensation error"}
+		e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: unwindErr})
+		return nil, fmt.Errorf("%w; compensation: %w", err, unwindErr)
+	}
+
+	reason := failureReason(err)
+	condition := conditionForReason(reason)
+	if e.status.Condition > condition {
+		condition = e.status.Condition
+		reason = e.status.Reason
+	}
+	e.status = RunStatus{Phase: PhaseStopped, Condition: condition, Reason: reason,
+		Message: "unhandled failure; stack unwound cleanly"}
+	e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: err})
+	return nil, err
 }
 
 // dispatchWithPolicy dispatches `unit` through this executor, retrying per the unit's [RetryPolicy].
@@ -649,15 +642,8 @@ func (e *GraphExecutor) dispatchWithPolicy(
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 
-		if attempt > 0 && policy != nil {
-			delay := policy.ComputeDelay(attempt - 1)
-			if delay > 0 {
-				select {
-				case <-time.After(delay):
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				}
-			}
+		if err := waitRetryDelay(ctx, policy, attempt); err != nil {
+			return nil, err
 		}
 
 		result, err := unit.Execute(ctx, e, stack, variables)
@@ -683,20 +669,113 @@ func (e *GraphExecutor) dispatchWithPolicy(
 		// retrying, a falsy verdict vetoes the loop (the failure then falls to OnError with the retry_vetoed base
 		// reason), and a handler that itself fails ends it as handler_failed.
 		if attempt+1 < maxAttempts {
-			if handler := unit.OnRetry(); handler != nil {
-				verdict, handlerErr := e.dispatchHandler(ctx, handler, variables)
-				if handlerErr != nil {
-					return nil, &dispatchFailure{reason: ReasonHandlerFailed, cause: handlerErr}
-				}
-				if !IsTruthy(verdict) {
-					return e.resolveFailure(ctx, unit, variables, ReasonRetryVetoed, lastErr)
-				}
+			retry, gateResult, gateErr := e.gateRetry(ctx, unit, variables, lastErr)
+			if !retry {
+				return gateResult, gateErr
 			}
 		}
 	}
 
 	// The retry budget is exhausted; the failure falls to OnError with the objective action_failed base reason.
 	return e.resolveFailure(ctx, unit, variables, ReasonActionFailed, lastErr)
+}
+
+// waitRetryDelay sleeps the policy's computed backoff before a retry attempt, honoring cancellation.
+//
+// Parameters:
+//   - `ctx`: the cancellation context.
+//   - `policy`: the unit's retry policy; nil (or the first attempt) waits nothing.
+//   - `attempt`: the zero-based attempt about to run.
+//
+// Returns:
+//   - `error`: the context's error when cancelled mid-wait.
+func waitRetryDelay(ctx context.Context, policy *RetryPolicy, attempt int) error {
+
+	if attempt == 0 || policy == nil {
+		return nil
+	}
+
+	delay := policy.ComputeDelay(attempt - 1)
+	if delay <= 0 {
+		return nil
+	}
+
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// gateRetry consults the unit's OnRetry handler between attempts: no handler (or a truthy verdict)
+// keeps retrying; a falsy verdict vetoes the loop and resolves the failure with the retry_vetoed
+// base reason; a handler that itself fails ends the dispatch as handler_failed.
+//
+// Parameters:
+//   - `ctx`: the cancellation context.
+//   - `unit`: the unit under dispatch.
+//   - `variables`: the variable frame in scope.
+//   - `lastErr`: the attempt's failure, resolved on a veto.
+//
+// Returns:
+//   - `bool`: true to keep retrying.
+//   - `any`: the veto resolution's result, when not retrying.
+//   - `error`: the veto resolution's (or handler's) error, when not retrying.
+func (e *GraphExecutor) gateRetry(
+	ctx context.Context, unit ExecutableUnit, variables map[string]Variable, lastErr error,
+) (bool, any, error) {
+
+	handler := unit.OnRetry()
+	if handler == nil {
+		return true, nil, nil
+	}
+
+	verdict, handlerErr := e.dispatchHandler(ctx, handler, variables)
+	if handlerErr != nil {
+		return false, nil, &dispatchFailure{reason: ReasonHandlerFailed, cause: handlerErr}
+	}
+
+	if !IsTruthy(verdict) {
+		result, err := e.resolveFailure(ctx, unit, variables, ReasonRetryVetoed, lastErr)
+		return false, result, err
+	}
+
+	return true, nil, nil
+}
+
+// prepareResume rebuilds the resumed run's state on the fresh environment: [ResumeExecutor] already
+// restored e.stack (the recovery tree) and e.variables (the resolved frame) from the trace.
+//
+// The variables re-publish onto the fresh environment; the saved resource ledger rehydrates so the
+// recovery stack's receipt id references resolve against the same generations the pre-pause run
+// produced (a fresh clone would lose superseded shadow generations); and the stack re-arms concrete
+// receipts against the rehydrated ledger, so a resumed-then-failed run can roll back the pre-pause
+// work. A failure lands the preflight-failed terminal.
+//
+// Returns:
+//   - `error`: non-nil when rehydration or re-arming fails.
+func (e *GraphExecutor) prepareResume() error {
+
+	e.environment.variables = e.variables
+
+	if e.ledgerSnapshot != nil {
+		restored, rehydrateErr := e.ledgerSnapshot.Rehydrate(e.environment)
+		if rehydrateErr != nil {
+			e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
+				Reason: ReasonPreflightFailed, Message: "resource ledger rehydrate failed"}
+			return fmt.Errorf("Run: rehydrate resource ledger: %w", rehydrateErr)
+		}
+		e.environment.ResourceCatalog = restored
+	}
+
+	if rearmErr := e.stack.rearm(e.environment); rearmErr != nil {
+		e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
+			Reason: ReasonPreflightFailed, Message: "recovery stack re-arm failed"}
+		return fmt.Errorf("Run: re-arm recovery stack: %w", rearmErr)
+	}
+
+	return nil
 }
 
 // dispatchHandler runs a failure-handler subgraph ([OnRetry] / [OnError]) on a fresh [RecoveryStack] and returns its

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -135,133 +135,17 @@ func NewMethod(
 			strings.Join(names, ", "))
 	}
 
-	// Validate variadic / kwargs position. Each flag implies the parameter sits in the last (or last-before- kwargs)
-	// slot. The wire grammar already enforces that variadic / kwargs cannot also carry ?/=; here we only validate
-	// cross-parameter position.
-
-	for i, p := range parameters {
-
-		if p.Kwargs && i != len(parameters)-1 {
-			return nil, fmt.Errorf("keyword catch-all %q must be the last parameter of method %s",
-				p.Name,
-				do.Name)
-		}
-
-		if p.Variadic && i != len(parameters)-1 && (i != len(parameters)-2 || !parameters[i+1].Kwargs) {
-			return nil, fmt.Errorf("variadic parameter %q must be the last or second-to-last (before **kwargs) parameter of method %s",
-				p.Name,
-				do.Name)
-		}
+	if err := validateParameterPositions(do, parameters); err != nil {
+		return nil, err
 	}
 
-	// Classify by return signature
-
-	numOut := methodType.NumOut()
-
-	var kind MethodKind
-	var err error
-
-	switch numOut {
-	default:
-		err = errorInvalidResultParameters(do)
-
-	case 0:
-
-		kind = MethodAction
-		err = nil
-
-	case 1:
-
-		if methodType.Out(0).Implements(errorType) {
-			kind = MethodFallibleAction
-		} else {
-			kind = MethodFunction
-		}
-
-	case 2:
-
-		kind = MethodFallibleFunction
-
-		if !methodType.Out(1).Implements(errorType) {
-			err = errorInvalidResultParameters(do)
-		}
-
-	case 3:
-
-		kind = MethodCompensableFunction
-
-		if !methodType.Out(2).Implements(errorType) {
-
-			err = errorInvalidResultParameters(do)
-		} else if !isLegalCompensator(methodType.Out(1)) {
-
-			// The compensator must be a concrete *Receipt or a *RecoveryStack if it's to join a saga — no slices, no bare
-			// interface. A batch producer returns one *RecoveryStack of per-item receipts. We enforce this only for
-			// providers where we expect compensation.
-
-			if enforceCompanions {
-				err = fmt.Errorf("compensable method %s: compensator type %s must be a *Receipt or a *RecoveryStack",
-					do.Name,
-					methodType.Out(1))
-			}
-		}
-	}
-
+	kind, err := classifyMethodKind(do, enforceCompanions)
 	if err != nil {
 		return nil, err
 	}
 
-	// Cross-validate plan
-
-	if plan != nil {
-
-		if kind == MethodAction || kind == MethodFallibleAction {
-			return nil, fmt.Errorf("plan companion %s provided for method %s which produces no result",
-				plan.Name,
-				do.Name)
-		}
-
-		planType := plan.Type
-
-		if planType.NumIn() != methodType.NumIn() {
-			return nil, fmt.Errorf("plan companion %s for method %s must accept %d parameters, got %d",
-				plan.Name,
-				do.Name,
-				methodType.NumIn()-1,
-				planType.NumIn()-1)
-		}
-
-		for i := 1; i < methodType.NumIn(); i++ {
-			if planType.In(i) != methodType.In(i) {
-				return nil, fmt.Errorf("plan companion %s for method %s: parameter %d type mismatch: got %s, want %s",
-					plan.Name,
-					do.Name,
-					i-1,
-					planType.In(i),
-					methodType.In(i))
-			}
-		}
-
-		if planType.NumOut() != 2 {
-			return nil, fmt.Errorf("plan companion %s for method %s must return exactly 2 values (result, error), got %d",
-				plan.Name,
-				do.Name,
-				planType.NumOut())
-		}
-
-		if planType.Out(0) != methodType.Out(0) {
-			return nil, fmt.Errorf("plan companion %s for method %s: result type mismatch: got %s, want %s",
-				plan.Name,
-				do.Name,
-				planType.Out(0),
-				methodType.Out(0))
-		}
-
-		if !planType.Out(1).Implements(errorType) {
-			return nil, fmt.Errorf("plan companion %s for method %s: second return value must implement error",
-				plan.Name,
-				do.Name)
-		}
+	if err := validatePlanCompanion(do, plan, kind); err != nil {
+		return nil, err
 	}
 
 	// A compensable forward (three returns) MAY declare a Compensate<Name> companion, attached below as undo, but no
@@ -278,51 +162,9 @@ func NewMethod(
 			do.Name)
 	}
 
-	var undoInvoke func(receiver any, activation *ActivationRecord, compensator any) error
-
-	if undo != nil {
-
-		if kind != MethodCompensableFunction {
-			return nil, fmt.Errorf("compensation companion %s provided, but method %s is %v, not compensable",
-				undo.Name,
-				do.Name,
-				kind)
-		}
-
-		undoType := undo.Type
-
-		// The required floor (step 27): a compensation companion is dispatched by the recovery machinery with
-		// an activation in hand, and its shape is mandated as (receiver, *ActivationRecord, compensator).
-		switch undoType.NumIn() {
-		case 3:
-			if undoType.In(1) != activationRecordType {
-				return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: first parameter must be *ActivationRecord, got %s",
-					undo.Name,
-					do.Name,
-					undoType.In(1))
-			}
-			undoFn := undo.Func
-			undoInvoke = func(receiver any, activation *ActivationRecord, compensator any) error {
-				results := undoFn.Call([]reflect.Value{
-					reflect.ValueOf(receiver),
-					reflect.ValueOf(activation),
-					reflect.ValueOf(compensator),
-				})
-				return errorFromValue(results[0])
-			}
-		default:
-			return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: expected (*ActivationRecord, compensator), got %d parameter(s) (step 27: the required floor)",
-				undo.Name,
-				do.Name,
-				undoType.NumIn()-1)
-		}
-
-		if undoType.NumOut() != 1 || !undoType.Out(0).Implements(errorType) {
-			return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: must return exactly one parameter (error), got %d",
-				undo.Name,
-				do.Name,
-				undoType.NumOut())
-		}
+	undoInvoke, err := buildUndoInvoke(do, undo, kind)
+	if err != nil {
+		return nil, err
 	}
 
 	// The input parameters carry Name, Type, Optional, Variadic, Kwargs, and Default already; Type was set upstream by
@@ -890,3 +732,216 @@ func methodSignature(m *reflect.Method) string {
 }
 
 // endregion
+
+// validateParameterPositions checks the variadic / kwargs position rules: each flag implies the
+// parameter sits in the last (or last-before-kwargs) slot. The wire grammar already enforces that
+// variadic / kwargs cannot also carry ?/=; only cross-parameter position is validated here.
+//
+// Parameters:
+//   - `do`: the forward method, for error context.
+//   - `parameters`: the declared parameters.
+//
+// Returns:
+//   - `error`: the first position violation, or nil.
+func validateParameterPositions(do *reflect.Method, parameters []Parameter) error {
+
+	for i, p := range parameters {
+
+		if p.Kwargs && i != len(parameters)-1 {
+			return fmt.Errorf("keyword catch-all %q must be the last parameter of method %s",
+				p.Name,
+				do.Name)
+		}
+
+		if p.Variadic && i != len(parameters)-1 && (i != len(parameters)-2 || !parameters[i+1].Kwargs) {
+			return fmt.Errorf("variadic parameter %q must be the last or second-to-last (before **kwargs) parameter of method %s",
+				p.Name,
+				do.Name)
+		}
+	}
+
+	return nil
+}
+
+// classifyMethodKind classifies the forward method by its return signature.
+//
+// The compensator of a three-return (compensable) method must be a concrete *Receipt or a
+// *RecoveryStack if it's to join a saga — no slices, no bare interface. A batch producer returns one
+// *RecoveryStack of per-item receipts. That shape is enforced only for providers where compensation
+// is expected (`enforceCompanions`).
+//
+// Parameters:
+//   - `do`: the forward method.
+//   - `enforceCompanions`: whether provider companion rules apply.
+//
+// Returns:
+//   - `MethodKind`: the classification.
+//   - `error`: non-nil for an unsupported return signature.
+func classifyMethodKind(do *reflect.Method, enforceCompanions bool) (MethodKind, error) {
+
+	methodType := do.Type
+
+	switch methodType.NumOut() {
+	default:
+		return 0, errorInvalidResultParameters(do)
+
+	case 0:
+		return MethodAction, nil
+
+	case 1:
+		if methodType.Out(0).Implements(errorType) {
+			return MethodFallibleAction, nil
+		}
+		return MethodFunction, nil
+
+	case 2:
+		if !methodType.Out(1).Implements(errorType) {
+			return 0, errorInvalidResultParameters(do)
+		}
+		return MethodFallibleFunction, nil
+
+	case 3:
+		if !methodType.Out(2).Implements(errorType) {
+			return 0, errorInvalidResultParameters(do)
+		}
+		if !isLegalCompensator(methodType.Out(1)) && enforceCompanions {
+			return 0, fmt.Errorf("compensable method %s: compensator type %s must be a *Receipt or a *RecoveryStack",
+				do.Name,
+				methodType.Out(1))
+		}
+		return MethodCompensableFunction, nil
+	}
+}
+
+// validatePlanCompanion cross-validates a Plan<Name> companion against the forward method: same
+// parameters, exactly (result, error) returns with the forward's result type.
+//
+// Parameters:
+//   - `do`: the forward method.
+//   - `plan`: the plan companion; nil validates trivially.
+//   - `kind`: the forward's classification.
+//
+// Returns:
+//   - `error`: the first mismatch, or nil.
+func validatePlanCompanion(do, plan *reflect.Method, kind MethodKind) error {
+
+	if plan == nil {
+		return nil
+	}
+
+	methodType := do.Type
+
+	if kind == MethodAction || kind == MethodFallibleAction {
+		return fmt.Errorf("plan companion %s provided for method %s which produces no result",
+			plan.Name,
+			do.Name)
+	}
+
+	planType := plan.Type
+
+	if planType.NumIn() != methodType.NumIn() {
+		return fmt.Errorf("plan companion %s for method %s must accept %d parameters, got %d",
+			plan.Name,
+			do.Name,
+			methodType.NumIn()-1,
+			planType.NumIn()-1)
+	}
+
+	for i := 1; i < methodType.NumIn(); i++ {
+		if planType.In(i) != methodType.In(i) {
+			return fmt.Errorf("plan companion %s for method %s: parameter %d type mismatch: got %s, want %s",
+				plan.Name,
+				do.Name,
+				i-1,
+				planType.In(i),
+				methodType.In(i))
+		}
+	}
+
+	if planType.NumOut() != 2 {
+		return fmt.Errorf("plan companion %s for method %s must return exactly 2 values (result, error), got %d",
+			plan.Name,
+			do.Name,
+			planType.NumOut())
+	}
+
+	if planType.Out(0) != methodType.Out(0) {
+		return fmt.Errorf("plan companion %s for method %s: result type mismatch: got %s, want %s",
+			plan.Name,
+			do.Name,
+			planType.Out(0),
+			methodType.Out(0))
+	}
+
+	if !planType.Out(1).Implements(errorType) {
+		return fmt.Errorf("plan companion %s for method %s: second return value must implement error",
+			plan.Name,
+			do.Name)
+	}
+
+	return nil
+}
+
+// buildUndoInvoke validates a Compensate<Name> companion and builds its invoker.
+//
+// The required floor (step 27): a compensation companion is dispatched by the recovery machinery with
+// an activation in hand, and its shape is mandated as (receiver, *ActivationRecord, compensator)
+// returning exactly one error.
+//
+// Parameters:
+//   - `do`: the forward method, for error context.
+//   - `undo`: the compensation companion; nil builds a nil invoker.
+//   - `kind`: the forward's classification; a companion demands a compensable forward.
+//
+// Returns:
+//   - `func(any, *ActivationRecord, any) error`: the invoker, or nil without a companion.
+//   - `error`: the first signature violation, or nil.
+func buildUndoInvoke(
+	do, undo *reflect.Method, kind MethodKind,
+) (func(receiver any, activation *ActivationRecord, compensator any) error, error) {
+
+	if undo == nil {
+		return nil, nil
+	}
+
+	if kind != MethodCompensableFunction {
+		return nil, fmt.Errorf("compensation companion %s provided, but method %s is %v, not compensable",
+			undo.Name,
+			do.Name,
+			kind)
+	}
+
+	undoType := undo.Type
+
+	if undoType.NumIn() != 3 {
+		return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: expected (*ActivationRecord, compensator), got %d parameter(s) (step 27: the required floor)",
+			undo.Name,
+			do.Name,
+			undoType.NumIn()-1)
+	}
+
+	if undoType.In(1) != activationRecordType {
+		return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: first parameter must be *ActivationRecord, got %s",
+			undo.Name,
+			do.Name,
+			undoType.In(1))
+	}
+
+	if undoType.NumOut() != 1 || !undoType.Out(0).Implements(errorType) {
+		return nil, fmt.Errorf("compensation companion %s for method %s has an invalid signature: must return exactly one parameter (error), got %d",
+			undo.Name,
+			do.Name,
+			undoType.NumOut())
+	}
+
+	undoFn := undo.Func
+
+	return func(receiver any, activation *ActivationRecord, compensator any) error {
+		results := undoFn.Call([]reflect.Value{
+			reflect.ValueOf(receiver),
+			reflect.ValueOf(activation),
+			reflect.ValueOf(compensator),
+		})
+		return errorFromValue(results[0])
+	}, nil
+}

--- a/pkg/op/parameter.go
+++ b/pkg/op/parameter.go
@@ -48,46 +48,66 @@ func parseParameterToken(raw string, paramType reflect.Type) (Parameter, error) 
 		return Parameter{}, fmt.Errorf("empty parameter token")
 	}
 
-	// Step 1: kwargs prefix takes priority over variadic — "**" must be checked before "*".
+	// Kwargs prefix takes priority over variadic — "**" must be checked before "*".
 
 	if strings.HasPrefix(raw, "**") {
-
-		name := raw[2:]
-
-		if name == "" {
-			return Parameter{}, fmt.Errorf("kwargs marker %q requires a name", raw)
-		}
-
-		if strings.ContainsAny(name, "?=") {
-			return Parameter{}, fmt.Errorf("kwargs token %q cannot carry '?' or '=value'", raw)
-		}
-
-		// Kwargs are inherently optional — the caller may always omit extra kwargs. Optional is set so consumers
-		// that ask "may caller omit this slot?" get a single-source-of-truth answer without special-casing the
-		// Variadic / Kwargs flags.
-		return Parameter{Name: name, Type: paramType, Optional: true, Kwargs: true}, nil
+		return parseSinkToken(raw, raw[2:], paramType, true)
 	}
 
 	if strings.HasPrefix(raw, "*") {
-
-		name := raw[1:]
-
-		if name == "" {
-			return Parameter{}, fmt.Errorf("variadic marker %q requires a name", raw)
-		}
-
-		if strings.ContainsAny(name, "?=") {
-			return Parameter{}, fmt.Errorf("variadic token %q cannot carry '?' or '=value'", raw)
-		}
-
-		// Variadic params are inherently optional — the caller may always omit positional overflow. Optional is
-		// set so consumers that ask "may caller omit this slot?" get a single-source-of-truth answer without
-		// special-casing the Variadic / Kwargs flags.
-		return Parameter{Name: name, Type: paramType, Optional: true, Variadic: true}, nil
+		return parseSinkToken(raw, raw[1:], paramType, false)
 	}
 
-	// Step 2: named token. Split on the optional marker; everything before is the name, everything after is the
-	// optional+default segment.
+	return parseNamedToken(raw, paramType)
+}
+
+// parseSinkToken parses a variadic ("*name") or kwargs ("**name") token.
+//
+// Both sinks are inherently optional — the caller may always omit positional overflow or extra
+// kwargs. Optional is set so consumers that ask "may caller omit this slot?" get a
+// single-source-of-truth answer without special-casing the Variadic / Kwargs flags.
+//
+// Parameters:
+//   - `raw`: the full token, for error messages.
+//   - `name`: the token with its marker stripped.
+//   - `paramType`: the parameter's Go type.
+//   - `kwargs`: true for the kwargs sink, false for the variadic sink.
+//
+// Returns:
+//   - `Parameter`: the parsed parameter.
+//   - `error`: non-nil for a missing name or a stray '?'/'=' marker.
+func parseSinkToken(raw, name string, paramType reflect.Type, kwargs bool) (Parameter, error) {
+
+	label := "variadic"
+	if kwargs {
+		label = "kwargs"
+	}
+
+	if name == "" {
+		return Parameter{}, fmt.Errorf("%s marker %q requires a name", label, raw)
+	}
+
+	if strings.ContainsAny(name, "?=") {
+		return Parameter{}, fmt.Errorf("%s token %q cannot carry '?' or '=value'", label, raw)
+	}
+
+	return Parameter{Name: name, Type: paramType, Optional: true, Variadic: !kwargs, Kwargs: kwargs}, nil
+}
+
+// parseNamedToken parses a plain named token, with its optional marker and default expression.
+//
+// `rest` is what follows the '?'. Three cases: empty (just optional, no default), "=value" (optional
+// with default), or anything else (malformed).
+//
+// Parameters:
+//   - `raw`: the full token.
+//   - `paramType`: the parameter's Go type.
+//
+// Returns:
+//   - `Parameter`: the parsed parameter.
+//   - `error`: non-nil for a malformed marker, an unsupported Resource default, or a default
+//     expression that fails to parse.
+func parseNamedToken(raw string, paramType reflect.Type) (Parameter, error) {
 
 	name, rest, hasMarker := strings.Cut(raw, "?")
 
@@ -107,9 +127,6 @@ func parseParameterToken(raw string, paramType reflect.Type) (Parameter, error) 
 	if name == "" {
 		return Parameter{}, fmt.Errorf("token %q is missing a parameter name before '?'", raw)
 	}
-
-	// `rest` is what follows the '?'. Three cases: empty (just optional, no default), "=value" (optional with default),
-	// or anything else (malformed).
 
 	if rest == "" {
 		return Parameter{Name: name, Type: paramType, Optional: true}, nil

--- a/pkg/op/planner.go
+++ b/pkg/op/planner.go
@@ -230,29 +230,46 @@ func (ActionPlanner) Plan(
 		WithRetryPolicy(retryPolicy).
 		WithTransitionPolicy(transitionPolicy)
 
-	params := method.Parameters()
+	if err := bindParameterSlots(invocator, spec, actionName, method.Parameters(), args, kwargs); err != nil {
+		return nil, err
+	}
+
+	return NewNode(spec)
+}
+
+// bindParameterSlots binds the call's positional and keyword arguments to the method's parameters:
+// the variadic sink absorbs positional overflow, the kwargs sink the unconsumed keywords, defaults
+// fill absences, a missing required parameter is a plan error, and every supplied value routes
+// through [bindPresentValue].
+//
+// Parameters:
+//   - `invocator`: the planning invocator, for the runtime environment.
+//   - `spec`: the node spec under construction.
+//   - `actionName`: the action name, for error messages.
+//   - `params`: the method's declared parameters.
+//   - `args`: the positional arguments.
+//   - `kwargs`: the keyword arguments.
+//
+// Returns:
+//   - `error`: non-nil for a missing required parameter or a binding failure.
+func bindParameterSlots(
+	invocator PlanInvocator, spec *NodeSpec, actionName string, params []Parameter, args []any, kwargs map[string]any,
+) error {
+
 	consumed := make(map[string]bool, len(kwargs))
 	positional := 0
 
 	for _, param := range params {
 
 		if param.Variadic {
-			rest := make([]any, 0, max(0, len(args)-positional))
-			for ; positional < len(args); positional++ {
-				rest = append(rest, args[positional])
-			}
+			var rest []any
+			rest, positional = positionalRest(args, positional)
 			spec.WithSlot(param.Name, NewImmediateBinding(rest))
 			continue
 		}
 
 		if param.Kwargs {
-			remaining := make(map[string]any, len(kwargs))
-			for k, v := range kwargs {
-				if !consumed[k] {
-					remaining[k] = v
-				}
-			}
-			spec.WithSlot(param.Name, NewImmediateBinding(remaining))
+			spec.WithSlot(param.Name, NewImmediateBinding(remainingKwargs(kwargs, consumed)))
 			continue
 		}
 
@@ -275,92 +292,168 @@ func (ActionPlanner) Plan(
 				continue
 			}
 			if !param.Optional {
-				return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: missing required parameter %q", actionName, param.Name)
+				return fmt.Errorf("op.ActionPlanner.Plan: %s: missing required parameter %q", actionName, param.Name)
 			}
 			continue
 		}
 
-		switch v := value.(type) {
-		case *Invocation:
-
-			if param.Type != nil && executableUnitType.AssignableTo(param.Type) {
-				spec.WithSlot(param.Name, NewImmediateBinding(v.Target))
-			} else {
-				spec.WithSlot(param.Name, v.Binding())
-			}
-
-		case *Variable:
-
-			spec.WithSlot(param.Name, NewVariableBindingWithField(v.Name, v.Field))
-
-		default:
-
-			// A builtin value may be the Go form of a content resource (e.g. a *starlark.Function). The provider
-			// keys its constructor by the source type; if the registry has one, build the resource here so the
-			// addressing switch below takes over — naming only op + reflect, never the provider.
-			if _, isResource := value.(Resource); !isResource {
-				if construct, ok := ReceiverRegistry().ConstructorForSource(reflect.TypeOf(value)); ok {
-					built, err := construct(invocator.RuntimeEnvironment(), value)
-					if err != nil {
-						return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
-					}
-					value = built
-				}
-			}
-
-			if r, ok := value.(Resource); ok {
-
-				switch r.Addressing() {
-
-				case AddressingContent:
-
-					// Content-based conversion to a native Go type. Validate now, defer the conversion to runtime.
-					// Example: function.Resource -> Go function pointer is deferred because pointers are ephemeral.
-
-					sc, ok := r.(SourceConverter)
-					if !ok || !sc.CanConvertTo(param.Type) {
-						return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %T has no conversion to %s",
-							actionName, param.Name, r, param.Type)
-					}
-
-					spec.WithSlot(param.Name, NewImmediateBinding(r))
-
-				case AddressingLocation:
-
-					// Location-based conversion. Serializable and stable, so convert now.
-					// Example: file.Resource -> string is immediate because path strings are serializable and stable.
-
-					converted, err := Convert(invocator.RuntimeEnvironment(), r, param.Type)
-					if err != nil {
-						return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
-					}
-
-					spec.WithSlot(param.Name, NewImmediateBinding(converted))
-
-				default:
-					assert.Unreachablef(
-						"op.ActionPlanner.Plan: %s: param %q: resource %T has addressing %v; "+
-							"want AddressingContent or AddressingLocation",
-						actionName,
-						param.Name,
-						r,
-						r.Addressing())
-				}
-			} else {
-
-				// A plain value: convert toward the parameter type now.
-
-				converted, err := Convert(invocator.RuntimeEnvironment(), value, param.Type)
-				if err != nil {
-					return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
-				}
-
-				spec.WithSlot(param.Name, NewImmediateBinding(converted))
-			}
+		if err := bindPresentValue(invocator, spec, actionName, param, value); err != nil {
+			return err
 		}
 	}
 
-	return NewNode(spec)
+	return nil
+}
+
+// positionalRest collects the positional overflow from `positional` onward.
+//
+// Parameters:
+//   - `args`: the positional arguments.
+//   - `positional`: the first unconsumed index.
+//
+// Returns:
+//   - `[]any`: the overflow, in order.
+//   - `int`: the advanced positional index (len(args)).
+func positionalRest(args []any, positional int) ([]any, int) {
+
+	rest := make([]any, 0, max(0, len(args)-positional))
+	for ; positional < len(args); positional++ {
+		rest = append(rest, args[positional])
+	}
+
+	return rest, positional
+}
+
+// remainingKwargs collects the keywords not yet consumed by named parameters.
+//
+// Parameters:
+//   - `kwargs`: the keyword arguments.
+//   - `consumed`: the consumed-key set.
+//
+// Returns:
+//   - `map[string]any`: the remaining keywords.
+func remainingKwargs(kwargs map[string]any, consumed map[string]bool) map[string]any {
+
+	remaining := make(map[string]any, len(kwargs))
+	for k, v := range kwargs {
+		if !consumed[k] {
+			remaining[k] = v
+		}
+	}
+
+	return remaining
+}
+
+// bindPresentValue binds one supplied argument value into the parameter's slot: an Invocation binds
+// its promise (or its target unit for ExecutableUnit-typed parameters), a Variable binds by name, and
+// everything else routes through resource construction and the addressing rules.
+//
+// Parameters:
+//   - `invocator`: the planning invocator, for the runtime environment.
+//   - `spec`: the node spec under construction.
+//   - `actionName`: the action name, for error messages.
+//   - `param`: the parameter being bound.
+//   - `value`: the supplied value.
+//
+// Returns:
+//   - `error`: non-nil on a construction or conversion failure.
+func bindPresentValue(invocator PlanInvocator, spec *NodeSpec, actionName string, param Parameter, value any) error {
+
+	switch v := value.(type) {
+	case *Invocation:
+
+		if param.Type != nil && executableUnitType.AssignableTo(param.Type) {
+			spec.WithSlot(param.Name, NewImmediateBinding(v.Target))
+		} else {
+			spec.WithSlot(param.Name, v.Binding())
+		}
+
+	case *Variable:
+
+		spec.WithSlot(param.Name, NewVariableBindingWithField(v.Name, v.Field))
+
+	default:
+
+		// A builtin value may be the Go form of a content resource (e.g. a *starlark.Function). The provider
+		// keys its constructor by the source type; if the registry has one, build the resource here so the
+		// addressing switch below takes over — naming only op + reflect, never the provider.
+		if _, isResource := value.(Resource); !isResource {
+			if construct, ok := ReceiverRegistry().ConstructorForSource(reflect.TypeOf(value)); ok {
+				built, err := construct(invocator.RuntimeEnvironment(), value)
+				if err != nil {
+					return fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
+				}
+				value = built
+			}
+		}
+
+		if r, ok := value.(Resource); ok {
+			return bindResourceValue(invocator, spec, actionName, param, r)
+		}
+
+		// A plain value: convert toward the parameter type now.
+
+		converted, err := Convert(invocator.RuntimeEnvironment(), value, param.Type)
+		if err != nil {
+			return fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
+		}
+
+		spec.WithSlot(param.Name, NewImmediateBinding(converted))
+	}
+
+	return nil
+}
+
+// bindResourceValue binds a resource-valued argument per its addressing.
+//
+// Content addressing validates the conversion now and defers it to runtime (e.g. function.Resource →
+// Go function pointer, deferred because pointers are ephemeral); location addressing converts
+// immediately (e.g. file.Resource → string, immediate because path strings are serializable and
+// stable).
+//
+// Parameters:
+//   - `invocator`: the planning invocator, for the runtime environment.
+//   - `spec`: the node spec under construction.
+//   - `actionName`: the action name, for error messages.
+//   - `param`: the parameter being bound.
+//   - `r`: the resource value.
+//
+// Returns:
+//   - `error`: non-nil when the resource cannot reach the parameter type.
+func bindResourceValue(invocator PlanInvocator, spec *NodeSpec, actionName string, param Parameter, r Resource) error {
+
+	switch r.Addressing() {
+
+	case AddressingContent:
+
+		sc, ok := r.(SourceConverter)
+		if !ok || !sc.CanConvertTo(param.Type) {
+			return fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %T has no conversion to %s",
+				actionName, param.Name, r, param.Type)
+		}
+
+		spec.WithSlot(param.Name, NewImmediateBinding(r))
+
+	case AddressingLocation:
+
+		converted, err := Convert(invocator.RuntimeEnvironment(), r, param.Type)
+		if err != nil {
+			return fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
+		}
+
+		spec.WithSlot(param.Name, NewImmediateBinding(converted))
+
+	default:
+		assert.Unreachablef(
+			"op.ActionPlanner.Plan: %s: param %q: resource %T has addressing %v; "+
+				"want AddressingContent or AddressingLocation",
+			actionName,
+			param.Name,
+			r,
+			r.Addressing())
+	}
+
+	return nil
 }
 
 // endregion

--- a/pkg/op/provider/flow/planners.go
+++ b/pkg/op/provider/flow/planners.go
@@ -99,19 +99,9 @@ func (ChoosePlanner) Plan(
 		return nil, fmt.Errorf("flow.ChoosePlanner.Plan: %s: missing required kwarg %q", actionName, "default")
 	}
 
-	// A lambda default is sugar for a one-invocation body evaluating it via function.call, mirroring plan.case's
-	// desugaring (settled 2026-07-02).
-	if lambda, ok := defaultBody.(*starlark.Function); ok {
-		planner, capable := invocator.(actionInvocationPlanner)
-		if !capable {
-			return nil, fmt.Errorf(
-				"flow.ChoosePlanner.Plan: %s: a lambda default requires a planning session host", actionName)
-		}
-		invocation, planErr := planner.Plan(function.Call, []any{lambda}, nil)
-		if planErr != nil {
-			return nil, fmt.Errorf("flow.ChoosePlanner.Plan: default: %w", planErr)
-		}
-		defaultBody = invocation
+	defaultBody, err := desugarLambdaBody(invocator, "flow.ChoosePlanner.Plan", actionName, "default", defaultBody)
+	if err != nil {
+		return nil, err
 	}
 
 	defaultSubgraph, err := bodySubgraph("default", defaultBody)
@@ -130,25 +120,7 @@ func (ChoosePlanner) Plan(
 		cases = append(cases, caseValue)
 	}
 
-	// Lay out the decision tree: when₀, then₀, …, default as children; whenᵢ —truthy→ thenᵢ and whenᵢ —falsy→ the
-	// next when (the last falsy edge lands on the default leaf).
-	children := make([]op.ExecutableUnit, 0, 2*len(cases)+1)
-	edges := make([]op.Edge, 0, 2*len(cases))
-
-	for i, caseValue := range cases {
-		when, then := &caseValue.When, &caseValue.Then
-		children = append(children, when, then)
-
-		falsyTarget := defaultSubgraph.ID()
-		if i+1 < len(cases) {
-			falsyTarget = cases[i+1].When.ID()
-		}
-
-		edges = append(edges,
-			op.Edge{From: when.ID(), To: then.ID(), Guard: op.GuardTruthy},
-			op.Edge{From: when.ID(), To: falsyTarget, Guard: op.GuardFalsy})
-	}
-	children = append(children, defaultSubgraph)
+	children, edges := layoutDecisionTree(cases, defaultSubgraph)
 
 	slots := make(map[string]op.Binding)
 	for key, value := range kwargs {
@@ -259,59 +231,9 @@ func (GatherPlanner) Plan(
 		}
 	}
 
-	// Gather slot bindings from positional/kwargs against the method's parameter list.
-	slots := make(map[string]op.Binding)
-	params := method.Parameters()
-	consumed := map[string]bool{"body": true}
-	positional := 0
-
-	for _, param := range params {
-
-		if param.Variadic {
-			rest := make([]any, 0, max(0, len(args)-positional))
-			for ; positional < len(args); positional++ {
-				rest = append(rest, args[positional])
-			}
-			slots[param.Name] = op.NewImmediateBinding(rest)
-			continue
-		}
-
-		if param.Kwargs {
-			remaining := make(map[string]any, len(kwargs))
-			for k, v := range kwargs {
-				if !consumed[k] {
-					remaining[k] = v
-				}
-			}
-			slots[param.Name] = op.NewImmediateBinding(remaining)
-			continue
-		}
-
-		var value any
-		var present bool
-
-		if positional < len(args) {
-			value = args[positional]
-			positional++
-			present = true
-		} else if v, ok := kwargs[param.Name]; ok {
-			value = v
-			consumed[param.Name] = true
-			present = true
-		}
-
-		if !present {
-			if param.Default != nil {
-				slots[param.Name] = op.NewImmediateBinding(param.Default)
-				continue
-			}
-			if !param.Optional {
-				return nil, fmt.Errorf("flow.GatherPlanner.Plan: %s: missing required parameter %q", actionName, param.Name)
-			}
-			continue
-		}
-
-		slots[param.Name] = projectKwargValue(value)
+	slots, err := bindGatherSlots(actionName, method.Parameters(), args, kwargs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate item-field projections against the immediate items' record shape (phase-8 step 45): a missing
@@ -524,19 +446,9 @@ func (WaitUntilPlanner) Plan(
 		return nil, fmt.Errorf("flow.WaitUntilPlanner.Plan: %s: missing required kwarg %q", actionName, "body")
 	}
 
-	// A lambda body is sugar for a one-invocation body evaluating it via function.call, mirroring plan.case's
-	// desugaring (settled 2026-07-02).
-	if lambda, ok := body.(*starlark.Function); ok {
-		planner, capable := invocator.(actionInvocationPlanner)
-		if !capable {
-			return nil, fmt.Errorf(
-				"flow.WaitUntilPlanner.Plan: %s: a lambda body requires a planning session host", actionName)
-		}
-		invocation, planErr := planner.Plan(function.Call, []any{lambda}, nil)
-		if planErr != nil {
-			return nil, fmt.Errorf("flow.WaitUntilPlanner.Plan: body: %w", planErr)
-		}
-		body = invocation
+	body, err := desugarLambdaBody(invocator, "flow.WaitUntilPlanner.Plan", actionName, "body", body)
+	if err != nil {
+		return nil, err
 	}
 
 	children, err := resolveBodyChildren(body)
@@ -740,4 +652,179 @@ func validateItemProjections(children []op.ExecutableUnit, items op.Binding) err
 	}
 
 	return nil
+}
+
+// bindGatherSlots binds the gather call's positional and keyword arguments to the method's
+// parameters as immediate bindings: the variadic sink absorbs positional overflow, the kwargs sink
+// the unconsumed keywords (body is pre-consumed), defaults fill absences, and a missing required
+// parameter is a plan error.
+//
+// Parameters:
+//   - `actionName`: the action name, for error messages.
+//   - `params`: the method's declared parameters.
+//   - `args`: the positional arguments.
+//   - `kwargs`: the keyword arguments.
+//
+// Returns:
+//   - `map[string]op.Binding`: the slot bindings.
+//   - `error`: non-nil for a missing required parameter.
+func bindGatherSlots(
+	actionName string, params []op.Parameter, args []any, kwargs map[string]any,
+) (map[string]op.Binding, error) {
+
+	slots := make(map[string]op.Binding)
+	consumed := map[string]bool{"body": true}
+	positional := 0
+
+	for _, param := range params {
+
+		if param.Variadic {
+			var rest []any
+			rest, positional = variadicRest(args, positional)
+			slots[param.Name] = op.NewImmediateBinding(rest)
+			continue
+		}
+
+		if param.Kwargs {
+			slots[param.Name] = op.NewImmediateBinding(unconsumedKwargs(kwargs, consumed))
+			continue
+		}
+
+		var value any
+		var present bool
+
+		if positional < len(args) {
+			value = args[positional]
+			positional++
+			present = true
+		} else if v, ok := kwargs[param.Name]; ok {
+			value = v
+			consumed[param.Name] = true
+			present = true
+		}
+
+		if !present {
+			if param.Default != nil {
+				slots[param.Name] = op.NewImmediateBinding(param.Default)
+				continue
+			}
+			if !param.Optional {
+				return nil, fmt.Errorf("flow.GatherPlanner.Plan: %s: missing required parameter %q", actionName, param.Name)
+			}
+			continue
+		}
+
+		slots[param.Name] = projectKwargValue(value)
+	}
+
+	return slots, nil
+}
+
+// desugarLambdaBody desugars a lambda-valued body/default kwarg into a one-invocation body
+// evaluating it via function.call, mirroring plan.case's desugaring (settled 2026-07-02). A
+// non-lambda value passes through unchanged.
+//
+// Parameters:
+//   - `invocator`: the planning invocator; must host a planning session to desugar.
+//   - `prefix`: the planner's error prefix (e.g. "flow.ChoosePlanner.Plan").
+//   - `actionName`: the action name, for error messages.
+//   - `role`: the kwarg role ("default" or "body"), for error messages.
+//   - `value`: the kwarg value.
+//
+// Returns:
+//   - `any`: the invocation, or the value unchanged.
+//   - `error`: non-nil without a session host or when planning the call fails.
+func desugarLambdaBody(
+	invocator op.PlanInvocator, prefix, actionName, role string, value any,
+) (any, error) {
+
+	lambda, ok := value.(*starlark.Function)
+	if !ok {
+		return value, nil
+	}
+
+	planner, capable := invocator.(actionInvocationPlanner)
+	if !capable {
+		return nil, fmt.Errorf("%s: %s: a lambda %s requires a planning session host", prefix, actionName, role)
+	}
+
+	invocation, planErr := planner.Plan(function.Call, []any{lambda}, nil)
+	if planErr != nil {
+		return nil, fmt.Errorf("%s: %s: %w", prefix, role, planErr)
+	}
+
+	return invocation, nil
+}
+
+// layoutDecisionTree lays out choose's decision tree: when₀, then₀, …, default as children;
+// whenᵢ —truthy→ thenᵢ and whenᵢ —falsy→ the next when (the last falsy edge lands on the default
+// leaf).
+//
+// Parameters:
+//   - `cases`: the ordered cases.
+//   - `defaultSubgraph`: the default leaf.
+//
+// Returns:
+//   - `[]op.ExecutableUnit`: the children, in layout order.
+//   - `[]op.Edge`: the guarded edges.
+func layoutDecisionTree(cases []*Case, defaultSubgraph *op.Subgraph) ([]op.ExecutableUnit, []op.Edge) {
+
+	children := make([]op.ExecutableUnit, 0, 2*len(cases)+1)
+	edges := make([]op.Edge, 0, 2*len(cases))
+
+	for i, caseValue := range cases {
+		when, then := &caseValue.When, &caseValue.Then
+		children = append(children, when, then)
+
+		falsyTarget := defaultSubgraph.ID()
+		if i+1 < len(cases) {
+			falsyTarget = cases[i+1].When.ID()
+		}
+
+		edges = append(edges,
+			op.Edge{From: when.ID(), To: then.ID(), Guard: op.GuardTruthy},
+			op.Edge{From: when.ID(), To: falsyTarget, Guard: op.GuardFalsy})
+	}
+	children = append(children, defaultSubgraph)
+
+	return children, edges
+}
+
+// variadicRest collects the positional overflow from `positional` onward.
+//
+// Parameters:
+//   - `args`: the positional arguments.
+//   - `positional`: the first unconsumed index.
+//
+// Returns:
+//   - `[]any`: the overflow, in order.
+//   - `int`: the advanced positional index (len(args)).
+func variadicRest(args []any, positional int) ([]any, int) {
+
+	rest := make([]any, 0, max(0, len(args)-positional))
+	for ; positional < len(args); positional++ {
+		rest = append(rest, args[positional])
+	}
+
+	return rest, positional
+}
+
+// unconsumedKwargs collects the keywords not yet consumed by named parameters.
+//
+// Parameters:
+//   - `kwargs`: the keyword arguments.
+//   - `consumed`: the consumed-key set.
+//
+// Returns:
+//   - `map[string]any`: the remaining keywords.
+func unconsumedKwargs(kwargs map[string]any, consumed map[string]bool) map[string]any {
+
+	remaining := make(map[string]any, len(kwargs))
+	for k, v := range kwargs {
+		if !consumed[k] {
+			remaining[k] = v
+		}
+	}
+
+	return remaining
 }

--- a/pkg/op/provider/flow/provider.go
+++ b/pkg/op/provider/flow/provider.go
@@ -208,54 +208,18 @@ func (p *Provider) Gather(
 		return []any{}, stack, nil
 	}
 
-	limit := 0
-	if raw, ok := kwargs["limit"]; ok {
-		switch v := raw.(type) {
-		case int:
-			limit = v
-		case int64:
-			limit = int(v)
-		}
-	}
-	if limit <= 0 {
-		limit = p.RuntimeEnvironment().Platform.DefaultConcurrency()
-	}
+	limit := p.gatherLimit(kwargs)
 
 	if activation.Graph == nil {
 		return nil, nil, fmt.Errorf("flow: combinator dispatched without a graph (caller %q)", activation.CallerID)
 	}
-	caller, resolveErr := activation.Graph.ResolveExecutable(activation.CallerID)
+	subgraph, resolveErr := resolveCombinatorSubgraph(activation, "flow.Gather")
 	if resolveErr != nil {
-		return nil, stack, fmt.Errorf("flow.Gather: resolve caller %q: %w", activation.CallerID, resolveErr)
-	}
-	subgraph, ok := caller.(*op.Subgraph)
-	if !ok {
-		return nil, stack, fmt.Errorf("flow.Gather: caller %q is %T, want *op.Subgraph", activation.CallerID, caller)
+		return nil, stack, resolveErr
 	}
 
 	results := make([]any, len(items))
-
-	// Classify each iteration against the (possibly resume-adopted) stack, mirroring Subgraph.Execute's adopt-guard: a
-	// completed run replays its stamped result and is skipped; a paused run adopts its partial substack and re-enters
-	// (its own child skip-guards finish it); a never-run iteration gets a fresh child stack.
-	type run struct {
-		index      int
-		childStack *op.RecoveryStack
-		fresh      bool
-	}
-	var pending []run
-
-	for i := range items {
-		if prior, found := stack.NestedStackByUnitID(gatherIterationID(subgraph, i)); found {
-			if prior.Err() == nil {
-				results[i] = prior.Result()
-				continue
-			}
-			pending = append(pending, run{index: i, childStack: prior, fresh: false})
-			continue
-		}
-		pending = append(pending, run{index: i, childStack: op.NewChildRecoveryStack(stack), fresh: true})
-	}
+	pending := classifyGatherRuns(stack, subgraph, items, results)
 
 	if len(pending) == 0 {
 		return results, stack, nil
@@ -265,7 +229,7 @@ func (p *Provider) Gather(
 	defer gatherCancel()
 
 	type completion struct {
-		run    run
+		run    gatherRun
 		result any
 		err    error
 	}
@@ -280,7 +244,7 @@ func (p *Provider) Gather(
 		wg.Add(1)
 		sem <- struct{}{}
 
-		go func(r run) {
+		go func(r gatherRun) {
 
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -500,16 +464,9 @@ func (p *Provider) WaitUntil(
 	kwargs map[string]any,
 ) (any, *op.RecoveryStack, error) {
 
-	if activation.Graph == nil {
-		return nil, nil, fmt.Errorf("flow: combinator dispatched without a graph (caller %q)", activation.CallerID)
-	}
-	caller, resolveErr := activation.Graph.ResolveExecutable(activation.CallerID)
+	subgraph, resolveErr := resolveCombinatorSubgraph(activation, "flow.WaitUntil")
 	if resolveErr != nil {
-		return nil, nil, fmt.Errorf("flow.WaitUntil: resolve caller %q: %w", activation.CallerID, resolveErr)
-	}
-	subgraph, ok := caller.(*op.Subgraph)
-	if !ok {
-		return nil, nil, fmt.Errorf("flow.WaitUntil: caller %q is %T, want *op.Subgraph", activation.CallerID, caller)
+		return nil, nil, resolveErr
 	}
 	if timeout <= 0 {
 		return nil, nil, fmt.Errorf("flow.WaitUntil: timeout is required")
@@ -519,18 +476,9 @@ func (p *Provider) WaitUntil(
 	}
 
 	// Bind kwargs to the subgraph's parameters, layered onto the inherited variable frame, like Subgraph.
-	parameters, err := subgraph.Parameters()
+	frame, err := bindKwargFrame(activation, subgraph, kwargs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("flow.WaitUntil: %w", err)
-	}
-	frame := make(map[string]op.Variable, len(activation.Variables)+len(parameters))
-	for name, variable := range activation.Variables {
-		frame[name] = variable
-	}
-	for _, parameter := range parameters {
-		if value, present := kwargs[parameter.Name]; present {
-			frame[parameter.Name] = op.Variable{Name: parameter.Name, Value: value}
-		}
 	}
 
 	stack := activation.Stack
@@ -688,3 +636,130 @@ func (p *Provider) Failed(activationRecord *op.ActivationRecord, format string, 
 // endregion
 
 // endregion
+
+// gatherLimit reads the limit= kwarg (int or int64), defaulting to the platform's concurrency for
+// absent or non-positive values.
+//
+// Parameters:
+//   - `kwargs`: the gather call's keyword arguments.
+//
+// Returns:
+//   - `int`: the effective concurrency limit.
+func (p *Provider) gatherLimit(kwargs map[string]any) int {
+
+	limit := 0
+	if raw, ok := kwargs["limit"]; ok {
+		switch v := raw.(type) {
+		case int:
+			limit = v
+		case int64:
+			limit = int(v)
+		}
+	}
+	if limit <= 0 {
+		limit = p.RuntimeEnvironment().Platform.DefaultConcurrency()
+	}
+
+	return limit
+}
+
+// resolveCombinatorSubgraph resolves the dispatching combinator's own subgraph from the activation's
+// caller ID.
+//
+// Parameters:
+//   - `activation`: the dispatch activation; its Graph must be present.
+//   - `combinator`: the combinator name (e.g. "flow.Gather"), for error messages.
+//
+// Returns:
+//   - `*op.Subgraph`: the caller subgraph.
+//   - `error`: non-nil when there is no graph, the caller does not resolve, or it is not a subgraph.
+func resolveCombinatorSubgraph(activation *op.ActivationRecord, combinator string) (*op.Subgraph, error) {
+
+	if activation.Graph == nil {
+		return nil, fmt.Errorf("flow: combinator dispatched without a graph (caller %q)", activation.CallerID)
+	}
+
+	caller, resolveErr := activation.Graph.ResolveExecutable(activation.CallerID)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("%s: resolve caller %q: %w", combinator, activation.CallerID, resolveErr)
+	}
+
+	subgraph, ok := caller.(*op.Subgraph)
+	if !ok {
+		return nil, fmt.Errorf("%s: caller %q is %T, want *op.Subgraph", combinator, activation.CallerID, caller)
+	}
+
+	return subgraph, nil
+}
+
+// gatherRun is one gather iteration awaiting dispatch: its item index, the child stack it runs on,
+// and whether that stack is fresh (as opposed to resume-adopted).
+type gatherRun struct {
+	index      int
+	childStack *op.RecoveryStack
+	fresh      bool
+}
+
+// classifyGatherRuns classifies each iteration against the (possibly resume-adopted) stack, mirroring
+// Subgraph.Execute's adopt-guard: a completed run replays its stamped result (written into `results`)
+// and is skipped; a paused run adopts its partial substack and re-enters (its own child skip-guards
+// finish it); a never-run iteration gets a fresh child stack.
+//
+// Parameters:
+//   - `stack`: the gather's recovery stack.
+//   - `subgraph`: the gather's own subgraph.
+//   - `items`: the iteration items.
+//   - `results`: the results slice; completed iterations' stamped results land here.
+//
+// Returns:
+//   - `[]gatherRun`: the iterations still needing dispatch, in index order.
+func classifyGatherRuns(stack *op.RecoveryStack, subgraph *op.Subgraph, items []any, results []any) []gatherRun {
+
+	var pending []gatherRun
+	for i := range items {
+		if prior, found := stack.NestedStackByUnitID(gatherIterationID(subgraph, i)); found {
+			if prior.Err() == nil {
+				results[i] = prior.Result()
+				continue
+			}
+			pending = append(pending, gatherRun{index: i, childStack: prior, fresh: false})
+			continue
+		}
+		pending = append(pending, gatherRun{index: i, childStack: op.NewChildRecoveryStack(stack), fresh: true})
+	}
+
+	return pending
+}
+
+// bindKwargFrame binds the call's kwargs to the subgraph's parameters, layered onto the inherited
+// variable frame, like Subgraph.
+//
+// Parameters:
+//   - `activation`: the dispatch activation carrying the inherited frame.
+//   - `subgraph`: the combinator's subgraph.
+//   - `kwargs`: the call's keyword arguments.
+//
+// Returns:
+//   - `map[string]op.Variable`: the layered frame.
+//   - `error`: non-nil when the subgraph's parameters cannot be resolved.
+func bindKwargFrame(
+	activation *op.ActivationRecord, subgraph *op.Subgraph, kwargs map[string]any,
+) (map[string]op.Variable, error) {
+
+	parameters, err := subgraph.Parameters()
+	if err != nil {
+		return nil, err
+	}
+
+	frame := make(map[string]op.Variable, len(activation.Variables)+len(parameters))
+	for name, variable := range activation.Variables {
+		frame[name] = variable
+	}
+	for _, parameter := range parameters {
+		if value, present := kwargs[parameter.Name]; present {
+			frame[parameter.Name] = op.Variable{Name: parameter.Name, Value: value}
+		}
+	}
+
+	return frame, nil
+}

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -348,19 +348,9 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 
 	name := receiverName(providerType)
 
-	// Reject reserved parameter names before building the method set. The planner uses "options", "args", and
-	// "kwargs" for cross-cutting concerns and for the variadic markers; provider methods cannot claim any of
-	// them as plain parameter names.
-	for methodName, params := range methodParameters {
-		for _, p := range params {
-			if err := reservedParameterError(p); err != nil {
-				return receiverType{}, fmt.Errorf("provider %s method %s: %w", name, methodName, err)
-			}
-		}
+	if err := validateReservedParameterNames(name, methodParameters); err != nil {
+		return receiverType{}, err
 	}
-
-	methods := make([]*Method, 0, len(methodParameters))
-	methodMap := make(map[string]*Method, len(methodParameters))
 
 	// Use the pointer type so pointer-receiver methods are visible to reflect.
 	methodType := providerType
@@ -368,64 +358,17 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 		methodType = reflect.PointerTo(methodType)
 	}
 
+	var methods []*Method
+	var methodMap map[string]*Method
+
 	if methodParameters != nil {
-
-		for reflectedMethod := range methodType.Methods() {
-
-			parameters, ok := methodParameters[reflectedMethod.Name]
-			if !ok {
-				continue
-			}
-
-			method, err := methodFromReflectedMethod(methodType, reflectedMethod, parameters, isProvider)
-
-			if err != nil {
-				return receiverType{}, err
-			}
-
-			if planners != nil {
-				planner := planners[reflectedMethod.Name]
-				if planner == nil {
-					planner = ActionPlanner{}
-				}
-				method.setPlanner(planner)
-			}
-
-			methodMap[method.Name()] = method
-			methods = append(methods, method)
+		var err error
+		methods, methodMap, err = announcedMethods(methodType, methodParameters, planners, isProvider)
+		if err != nil {
+			return receiverType{}, err
 		}
 	} else {
-
-		for reflectedMethod := range methodType.Methods() {
-
-			// Skip the receiver (index 0) and any framework-injected first parameter (*ActivationRecord at index 1)
-			// when synthesizing auto-positional names. Mirrors the detection rule in [Method.NewMethod]
-			// (firstParamIsActivation).
-			startIdx := 1
-			if reflectedMethod.Type.NumIn() >= 2 && reflectedMethod.Type.In(1) == activationRecordType {
-				startIdx = 2
-			}
-			numParams := reflectedMethod.Type.NumIn() - startIdx
-			parameters := make([]Parameter, numParams)
-
-			for i := range numParams {
-				parameters[i] = Parameter{Name: strconv.Itoa(i), Type: reflectedMethod.Type.In(startIdx + i)}
-			}
-
-			method, err := methodFromReflectedMethod(providerType, reflectedMethod, parameters, isProvider)
-
-			if err != nil {
-				// Derive-fresh mode (no announced parameter metadata) builds an opaque pass-through receiver: a
-				// method whose return signature has no [MethodKind] classification (e.g. a (T, bool) lookup like
-				// [RecoveryStack.ResultByUnitID]) is skipped rather than fatal — it is not projectable to starlark,
-				// and the value must still cross the bridge. Announced types validate strictly through the non-nil
-				// methodParameters branch above.
-				continue
-			}
-
-			methodMap[method.Name()] = method
-			methods = append(methods, method)
-		}
+		methods, methodMap = derivedMethods(providerType, methodType, isProvider)
 	}
 
 	return receiverType{
@@ -435,6 +378,127 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 		methodMap:     methodMap,
 		dispatchTable: &sync.Map{},
 	}, nil
+}
+
+// validateReservedParameterNames rejects reserved parameter names before the method set is built. The
+// planner uses "options", "args", and "kwargs" for cross-cutting concerns and for the variadic
+// markers; provider methods cannot claim any of them as plain parameter names.
+//
+// Parameters:
+//   - `name`: the receiver name, for error context.
+//   - `methodParameters`: the announced parameters per method; nil validates trivially.
+//
+// Returns:
+//   - `error`: the first reserved-name violation, or nil.
+func validateReservedParameterNames(name string, methodParameters map[string][]Parameter) error {
+
+	for methodName, params := range methodParameters {
+		for _, p := range params {
+			if err := reservedParameterError(p); err != nil {
+				return fmt.Errorf("provider %s method %s: %w", name, methodName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// announcedMethods builds the method set from announced parameter metadata, wiring each method's
+// planner when one is declared. Methods absent from the announcement are skipped.
+//
+// Parameters:
+//   - `methodType`: the pointer type whose method set is walked.
+//   - `methodParameters`: the announced parameters per method.
+//   - `planners`: the per-method planners; nil wires none.
+//   - `isProvider`: whether provider companion rules apply.
+//
+// Returns:
+//   - `[]*Method`: the built methods, in walk order.
+//   - `map[string]*Method`: the methods keyed by projected name.
+//   - `error`: non-nil when any announced method fails to build.
+func announcedMethods(
+	methodType reflect.Type, methodParameters map[string][]Parameter, planners map[string]Planner, isProvider bool,
+) ([]*Method, map[string]*Method, error) {
+
+	methods := make([]*Method, 0, len(methodParameters))
+	methodMap := make(map[string]*Method, len(methodParameters))
+
+	for reflectedMethod := range methodType.Methods() {
+
+		parameters, ok := methodParameters[reflectedMethod.Name]
+		if !ok {
+			continue
+		}
+
+		method, err := methodFromReflectedMethod(methodType, reflectedMethod, parameters, isProvider)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if planners != nil {
+			planner := planners[reflectedMethod.Name]
+			if planner == nil {
+				planner = ActionPlanner{}
+			}
+			method.setPlanner(planner)
+		}
+
+		methodMap[method.Name()] = method
+		methods = append(methods, method)
+	}
+
+	return methods, methodMap, nil
+}
+
+// derivedMethods builds the method set for a derive-fresh receiver (no announced parameter metadata),
+// synthesizing auto-positional parameter names.
+//
+// The receiver (index 0) and any framework-injected first parameter (*ActivationRecord at index 1)
+// are skipped when synthesizing names, mirroring the detection rule in [NewMethod]
+// (firstParamIsActivation). Derive-fresh mode builds an opaque pass-through receiver: a method whose
+// return signature has no [MethodKind] classification (e.g. a (T, bool) lookup like
+// [RecoveryStack.ResultByUnitID]) is skipped rather than fatal — it is not projectable to starlark,
+// and the value must still cross the bridge. Announced types validate strictly through
+// [announcedMethods].
+//
+// Parameters:
+//   - `providerType`: the receiver's declared type, passed to method construction.
+//   - `methodType`: the pointer type whose method set is walked.
+//   - `isProvider`: whether provider companion rules apply.
+//
+// Returns:
+//   - `[]*Method`: the built methods, in walk order.
+//   - `map[string]*Method`: the methods keyed by projected name.
+func derivedMethods(providerType, methodType reflect.Type, isProvider bool) ([]*Method, map[string]*Method) {
+
+	var methods []*Method
+	methodMap := make(map[string]*Method)
+
+	for reflectedMethod := range methodType.Methods() {
+
+		startIdx := 1
+		if reflectedMethod.Type.NumIn() >= 2 && reflectedMethod.Type.In(1) == activationRecordType {
+			startIdx = 2
+		}
+		numParams := reflectedMethod.Type.NumIn() - startIdx
+		parameters := make([]Parameter, numParams)
+
+		for i := range numParams {
+			parameters[i] = Parameter{Name: strconv.Itoa(i), Type: reflectedMethod.Type.In(startIdx + i)}
+		}
+
+		method, err := methodFromReflectedMethod(providerType, reflectedMethod, parameters, isProvider)
+
+		if err != nil {
+			continue
+		}
+
+		methodMap[method.Name()] = method
+		methods = append(methods, method)
+	}
+
+	return methods, methodMap
 }
 
 // region HELPER FUNCTIONS

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -521,55 +521,8 @@ func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) error {
 func (s *RecoveryStack) rearm(runtimeEnvironment *RuntimeEnvironment) error {
 
 	for i := range s.entries {
-
-		entry := &s.entries[i]
-
-		if stack := entry.recoveryStackOrNil(); stack != nil {
-			if err := stack.rearm(runtimeEnvironment); err != nil {
-				return err
-			}
-			continue
-		}
-
-		receipt := entry.receiptOrNil()
-
-		if receipt == nil {
-			continue
-		}
-
-		if entry.restore != nil {
-
-			restore := entry.restore
-
-			concrete, err := reconstructReceipt(
-				runtimeEnvironment,
-				restore.base.CompensatingAction, restore.base, restore.fields)
-
-			if err != nil {
-				return err
-			}
-
-			// A resource receipt is its own compensator: the compensable forward method returns (result, compensator,
-			// error) with the receipt as the compensator, and Commit stores that self-reference. Reconstruction has no
-			// forward call, so reinstate the identity here unless the receipt restored a compensator of its own.
-
-			if concrete.Compensator() == nil {
-				concrete.receiptBase().compensator = concrete
-			}
-
-			entry.compensator = concrete
-			entry.restore = nil
-			receipt = concrete
-		}
-
-		if err := retypeResult(runtimeEnvironment, receipt); err != nil {
+		if err := rearmEntry(runtimeEnvironment, &s.entries[i]); err != nil {
 			return err
-		}
-
-		if childStack, ok := receipt.Compensator().(*RecoveryStack); ok {
-			if err := childStack.rearm(runtimeEnvironment); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -577,6 +530,63 @@ func (s *RecoveryStack) rearm(runtimeEnvironment *RuntimeEnvironment) error {
 	// the stamp returns the produced Go type, not the codec's untyped reload — mirroring [retypeResult] for receipts.
 
 	s.retypeStampedResult(runtimeEnvironment)
+	return nil
+}
+
+// rearmEntry re-arms one recovery entry: nested stacks recurse, bare receipts reconstruct from their
+// restore payload when one is pending, results retype, and a receipt-carried child stack recurses.
+//
+// A resource receipt is its own compensator: the compensable forward method returns (result,
+// compensator, error) with the receipt as the compensator, and Commit stores that self-reference.
+// Reconstruction has no forward call, so the identity is reinstated here unless the receipt restored
+// a compensator of its own.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the resumed run's environment.
+//   - `entry`: the entry to re-arm.
+//
+// Returns:
+//   - `error`: non-nil when reconstruction, retyping, or a nested re-arm fails.
+func rearmEntry(runtimeEnvironment *RuntimeEnvironment, entry *recoveryEntry) error {
+
+	if stack := entry.recoveryStackOrNil(); stack != nil {
+		return stack.rearm(runtimeEnvironment)
+	}
+
+	receipt := entry.receiptOrNil()
+	if receipt == nil {
+		return nil
+	}
+
+	if entry.restore != nil {
+
+		restore := entry.restore
+
+		concrete, err := reconstructReceipt(
+			runtimeEnvironment,
+			restore.base.CompensatingAction, restore.base, restore.fields)
+
+		if err != nil {
+			return err
+		}
+
+		if concrete.Compensator() == nil {
+			concrete.receiptBase().compensator = concrete
+		}
+
+		entry.compensator = concrete
+		entry.restore = nil
+		receipt = concrete
+	}
+
+	if err := retypeResult(runtimeEnvironment, receipt); err != nil {
+		return err
+	}
+
+	if childStack, ok := receipt.Compensator().(*RecoveryStack); ok {
+		return childStack.rearm(runtimeEnvironment)
+	}
+
 	return nil
 }
 

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -988,12 +988,27 @@ func (s *Subgraph) validateGuardedEdges() []error {
 		inDegree[edge.To]++
 	}
 
+	errs = append(errs, s.validateDecisionNodes(outByFrom)...)
+
+	return append(errs, s.validateDecisionTreeShape(outByFrom, inDegree)...)
+}
+
+// validateDecisionNodes checks every decision node's out-edges: exactly one truthy and one falsy.
+//
+// Parameters:
+//   - `outByFrom`: the guarded out-edges keyed by source unit.
+//
+// Returns:
+//   - `[]error`: the violations, in sorted decision-node order.
+func (s *Subgraph) validateDecisionNodes(outByFrom map[string][]Edge) []error {
+
 	decisionNodes := make([]string, 0, len(outByFrom))
 	for from := range outByFrom {
 		decisionNodes = append(decisionNodes, from)
 	}
 	sort.Strings(decisionNodes)
 
+	var errs []error
 	for _, from := range decisionNodes {
 		truthy, falsy := 0, 0
 		for _, edge := range outByFrom[from] {
@@ -1010,6 +1025,23 @@ func (s *Subgraph) validateGuardedEdges() []error {
 				s.ID(), from, truthy, falsy))
 		}
 	}
+
+	return errs
+}
+
+// validateDecisionTreeShape checks the tree's structural rules: at most one incoming guarded edge per
+// child, exactly one root, and every child reachable from it.
+//
+// Parameters:
+//   - `outByFrom`: the guarded out-edges keyed by source unit.
+//   - `inDegree`: the guarded in-degree per target unit.
+//
+// Returns:
+//   - `[]error`: the violations; a multi-root tree short-circuits reachability (it needs the single
+//     root).
+func (s *Subgraph) validateDecisionTreeShape(outByFrom map[string][]Edge, inDegree map[string]int) []error {
+
+	var errs []error
 
 	var roots []string
 	for _, child := range s.executableUnits {

--- a/pkg/op/validate.go
+++ b/pkg/op/validate.go
@@ -270,49 +270,71 @@ func checkPromiseTypes(violations []error, g *Graph) []error {
 				continue
 			}
 
-			edge := promise.Edge(id)
-			producer, present := units[edge.From]
-			if !present {
-				violations = append(violations, fmt.Errorf(
-					"op.ValidateGraph: unit %q slot %q: producer %q not found in graph",
-					id, slotName, edge.From))
-				continue
+			if violation := checkPromiseSlot(units, id, slotName, promise, consumerMethod); violation != nil {
+				violations = append(violations, violation)
 			}
-
-			producerAction := producer.Action()
-			if producerAction == nil {
-				continue
-			}
-			producerMethod := producerAction.Method()
-			if producerMethod == nil {
-				continue
-			}
-
-			sourceType := producerMethod.ResultType()
-			if sourceType == nil {
-				continue
-			}
-
-			param, paramPresent := consumerMethod.ParameterByName(slotName)
-			if !paramPresent {
-				continue
-			}
-			targetType := param.Type
-			if targetType == nil {
-				continue
-			}
-
-			if typesAreInterconvertible(sourceType, targetType) {
-				continue
-			}
-
-			violations = append(violations, fmt.Errorf(
-				"op.ValidateGraph: unit %q slot %q: cannot bind %q output (%s) to declared type %s",
-				id, slotName, edge.From, sourceType, targetType))
 		}
 	}
 
 	return violations
+}
+
+// checkPromiseSlot type-checks one promise-bound slot against its producer's declared result type.
+//
+// A producer absent from the unit table is itself a violation; missing type metadata on either side
+// (an unbound action, an untyped parameter) passes — the required-params pass owns those complaints.
+//
+// Parameters:
+//   - `units`: the graph's unit table.
+//   - `id`: the consuming unit's ID.
+//   - `slotName`: the slot under check.
+//   - `promise`: the slot's promise binding.
+//   - `consumerMethod`: the consuming unit's method.
+//
+// Returns:
+//   - `error`: the violation, or nil.
+func checkPromiseSlot(
+	units map[string]ExecutableUnit, id, slotName string, promise PromiseBinding, consumerMethod *Method,
+) error {
+
+	edge := promise.Edge(id)
+	producer, present := units[edge.From]
+	if !present {
+		return fmt.Errorf(
+			"op.ValidateGraph: unit %q slot %q: producer %q not found in graph",
+			id, slotName, edge.From)
+	}
+
+	producerAction := producer.Action()
+	if producerAction == nil {
+		return nil
+	}
+	producerMethod := producerAction.Method()
+	if producerMethod == nil {
+		return nil
+	}
+
+	sourceType := producerMethod.ResultType()
+	if sourceType == nil {
+		return nil
+	}
+
+	param, paramPresent := consumerMethod.ParameterByName(slotName)
+	if !paramPresent {
+		return nil
+	}
+	targetType := param.Type
+	if targetType == nil {
+		return nil
+	}
+
+	if typesAreInterconvertible(sourceType, targetType) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"op.ValidateGraph: unit %q slot %q: cannot bind %q output (%s) to declared type %s",
+		id, slotName, edge.From, sourceType, targetType)
 }
 
 // indexUnitsByID flattens the graph's nodes and resolved-action subgraphs into a single ID → unit map for


### PR DESCRIPTION
Final phase of docs/plans/complexity-refactors.md (#312): sixteen engine functions decomposed with exact order preservation — the planner's binding cascade, NewMethod's validators, the executor's retry gate and failure terminals, the recovery re-arm, and the flow combinators (including a shared subgraph resolver that preserves Gather's nil-Graph compensator nuance via an inline pre-check). One plan-table omission (`lint.Go` 31) surfaced and folded in. **The repository's full lint output is now empty** — from 2,486 findings at the charter's start to zero, every remaining suppression carrying its stated reason. The unmodified suite passes. Plan doc rides along marked complete.