### PR TITLE
refactor(goast): the shared walker — parsedSources over an extended parsedFile

### DIFF
--- a/cmd/star/provider/goast/helpers.go
+++ b/cmd/star/provider/goast/helpers.go
@@ -8,6 +8,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"iter"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -23,28 +24,77 @@ import (
 // PARSED FILE CACHE
 // =============================================================================
 
-// parsedFile holds a cached parsed Go file.
+// parsedFile holds a cached parsed Go file: its file set, its syntax tree, and the path it was
+// parsed from.
 type parsedFile struct {
 	fset *token.FileSet
 	node *ast.File
+	path string
 }
 
-// parseFile parses a Go file with caching.
-func (p *Provider) parseFile(path string) (*token.FileSet, *ast.File, error) {
+// parsedEntry returns the cached parse of a Go file, parsing (with comments) and caching on a miss.
+//
+// Parameters:
+//   - `path`: the Go file to parse.
+//
+// Returns:
+//   - `*parsedFile`: the cached entry.
+//   - `error`: the parse failure, if any.
+func (p *Provider) parsedEntry(path string) (*parsedFile, error) {
 	if cached, ok := p.fileCache.Load(path); ok {
-		pf := assert.Type[*parsedFile]("file cache entry", cached)
-		return pf.fset, pf.node, nil
+		return assert.Type[*parsedFile]("file cache entry", cached), nil
 	}
 
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	p.fileCache.Store(path, &parsedFile{fset: fset, node: node})
+	entry := &parsedFile{fset: fset, node: node, path: path}
+	p.fileCache.Store(path, entry)
 
-	return fset, node, nil
+	return entry, nil
+}
+
+// parseFile parses a Go file with caching.
+func (p *Provider) parseFile(path string) (*token.FileSet, *ast.File, error) {
+	entry, err := p.parsedEntry(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return entry.fset, entry.node, nil
+}
+
+// parsedSources returns an iterator over the parsed Go files under path (walker ruling 2026-08-04).
+//
+// Collection failures surface immediately; files that fail to parse are skipped mid-iteration,
+// matching every walker client's existing behavior. Parsing goes through the provider's cache, and
+// breaking out of the range stops the walk — the early-exit shape Callable and TypeDoc use.
+//
+// Parameters:
+//   - `path`: the file or directory to walk (per [collectGoFiles]).
+//
+// Returns:
+//   - `iter.Seq[*parsedFile]`: the parsed files, in collection order.
+//   - `error`: the collection failure, if any.
+func (p *Provider) parsedSources(path string) (iter.Seq[*parsedFile], error) {
+	files, err := collectGoFiles(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(yield func(*parsedFile) bool) {
+		for _, file := range files {
+			entry, err := p.parsedEntry(file)
+			if err != nil {
+				continue
+			}
+			if !yield(entry) {
+				return
+			}
+		}
+	}, nil
 }
 
 // =============================================================================

--- a/cmd/star/provider/goast/provider.go
+++ b/cmd/star/provider/goast/provider.go
@@ -58,18 +58,13 @@ func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 // Callable introspects a named function type declaration and returns its parameter list, return type, and doc comment
 // (including directives).
 func (p *Provider) Callable(path, name string) (CallableResult, error) {
-	files, err := collectGoFiles(path)
+	sources, err := p.parsedSources(path)
 	if err != nil {
 		return CallableResult{}, fmt.Errorf("goast.callable: %w", err)
 	}
 
-	for _, file := range files {
-		_, node, err := p.parseFile(file)
-		if err != nil {
-			continue
-		}
-
-		if result, found := callableInFile(node, name); found {
+	for src := range sources {
+		if result, found := callableInFile(src.node, name); found {
 			return result, nil
 		}
 	}
@@ -152,24 +147,19 @@ func (p *Provider) Composites(scope, typeName string) ([]CompositeResult, error)
 //
 // +devlore:defaults typeName=
 func (p *Provider) ConstGroups(path, typeName string) ([]ConstGroupResult, error) {
-	files, err := collectGoFiles(path)
+	sources, err := p.parsedSources(path)
 	if err != nil {
 		return nil, fmt.Errorf("goast.const_groups: %w", err)
 	}
 
 	var groups []constGroup
-	for _, file := range files {
-		fileSet, node, err := p.parseFile(file)
-		if err != nil {
-			continue
-		}
-
-		ast.Inspect(node, func(n ast.Node) bool {
+	for src := range sources {
+		ast.Inspect(src.node, func(n ast.Node) bool {
 			genDecl, ok := n.(*ast.GenDecl)
 			if !ok || genDecl.Tok != token.CONST {
 				return true
 			}
-			groups = append(groups, constGroupsFromDecl(fileSet, genDecl, filepath.Base(file), typeName)...)
+			groups = append(groups, constGroupsFromDecl(src.fset, genDecl, filepath.Base(src.path), typeName)...)
 			return true
 		})
 	}
@@ -629,19 +619,14 @@ func (p *Provider) SortDeclarations(path, scope, order string) (string, error) {
 
 // Structs returns struct definitions from Go source files.
 func (p *Provider) Structs(path string) ([]StructResult, error) {
-	files, err := collectGoFiles(path)
+	sources, err := p.parsedSources(path)
 	if err != nil {
 		return nil, fmt.Errorf("goast.structs: %w", err)
 	}
 
 	result := []StructResult{}
-	for _, file := range files {
-		fileSet, node, err := p.parseFile(file)
-		if err != nil {
-			continue
-		}
-
-		ast.Inspect(node, func(n ast.Node) bool {
+	for src := range sources {
+		ast.Inspect(src.node, func(n ast.Node) bool {
 			genDecl, ok := n.(*ast.GenDecl)
 			if !ok || genDecl.Tok != token.TYPE {
 				return true
@@ -660,8 +645,8 @@ func (p *Provider) Structs(path string) ([]StructResult, error) {
 
 				result = append(result, StructResult{
 					Name:   ts.Name.Name,
-					File:   filepath.Base(file),
-					Line:   fileSet.Position(ts.Pos()).Line,
+					File:   filepath.Base(src.path),
+					Line:   src.fset.Position(ts.Pos()).Line,
 					Fields: structFields(st),
 				})
 			}
@@ -681,18 +666,13 @@ func (p *Provider) TypeDoc(path, name string) (string, error) {
 		name = "Provider"
 	}
 
-	files, err := collectGoFiles(path)
+	sources, err := p.parsedSources(path)
 	if err != nil {
 		return "", fmt.Errorf("goast.type_doc: %w", err)
 	}
 
-	for _, file := range files {
-		_, node, err := p.parseFile(file)
-		if err != nil {
-			continue
-		}
-
-		if doc, found := typeDocInFile(node, name); found {
+	for src := range sources {
+		if doc, found := typeDocInFile(src.node, name); found {
 			return doc, nil
 		}
 	}

--- a/cmd/star/provider/goast/source_file.go
+++ b/cmd/star/provider/goast/source_file.go
@@ -1161,9 +1161,9 @@ func bodyCommentGroups(file *ast.File, docCGs map[*ast.CommentGroup]bool) map[*a
 // Returns:
 //   - `*FuncDecl`: the built declaration node.
 //   - `string`: the receiver type name for methods; empty for free functions.
-func loadFuncDecl(sf *SourceFile, content string, fileSet *token.FileSet, d *ast.FuncDecl) (*FuncDecl, string) {
+func loadFuncDecl(sf *SourceFile, content string, fileSet *token.FileSet, d *ast.FuncDecl) (fd *FuncDecl, methodType string) {
 
-	fd := &FuncDecl{
+	fd = &FuncDecl{
 		Name:    d.Name.Name,
 		Params:  extractParams(d.Type.Params, nil),
 		Returns: returnTypeString(d.Type.Results),

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -269,7 +269,7 @@ type goPosRaw struct {
 // Returns:
 //   - `bool`: whether go.mod/go.sum are tidy.
 //   - `string`: the failure detail, or empty.
-func (p *Provider) modTidyStatus(skipModTidy bool) (bool, string) {
+func (p *Provider) modTidyStatus(skipModTidy bool) (tidy bool, detail string) {
 
 	if skipModTidy {
 		return true, ""
@@ -318,6 +318,7 @@ func golangciArgs(config string, paths []string) []string {
 //   - `error`: non-nil when the tool failed without producing output.
 func runGolangciLint(cmdArgs []string) ([]goIssueRaw, error) {
 
+	//nolint:gosec // G204: golangci-lint with argv built by golangciArgs from provider-validated config and paths.
 	cmd := exec.CommandContext(context.Background(), "golangci-lint", cmdArgs...)
 	output, err := cmd.Output()
 

--- a/docs/plans/goast-walker.md
+++ b/docs/plans/goast-walker.md
@@ -1,0 +1,40 @@
+---
+title: "goast shared walker: parsedSources over an extended parsedFile"
+issue: "#312 follow-on"
+status: complete
+created: 2026-08-04
+updated: 2026-08-04
+---
+
+# Plan: goast shared walker
+
+The structure ruling pre-declared in the complexity plan's phase-3 notes, ruled 2026-08-04:
+option 1 (iterator) with the extended `parsedFile`.
+
+## Changes
+
+1. **`parsedFile` gains `path`** — one concept, one type: the parse-cache entry now carries
+   the path it was parsed from. `parsedEntry` becomes the single cache-or-parse primitive;
+   `parseFile` layers over it unchanged for its existing callers.
+2. **`parsedSources(path)`** — an `iter.Seq[*parsedFile]` over the collected Go files:
+   collection failures surface at the call (each client keeps its own `goast.<op>:` error
+   wrap, text unchanged), parse failures skip mid-iteration (the existing semantics stated
+   once), and breaking the range stops the walk — the early-exit shape `Callable` and
+   `TypeDoc` use naturally.
+3. **Four clients converted** — `Callable`, `ConstGroups`, `Structs`, `TypeDoc`. `Deps` and
+   `Metrics` stay as they are: they share only the file collection, parsing per-file with
+   different modes through their analyze helpers.
+
+## Ownership rider: eleven findings from phase 7's final squeeze
+
+The phase-7 squeeze batch skipped the full-config lint recount (complexity-only was
+checked), shipping eleven style debts in my own helpers: seven unnamedResult, one
+paramTypeCombine, one G204 (extraction moved the argv behind a parameter, changing gosec's
+taint view — suppressed with provenance), one misspell, and one unparam (failAndUnwind's
+always-nil result dropped; the caller supplies the nil). All fixed here; the lesson is the
+standing one — every batch ends with the full-config recount, no exceptions.
+
+## Verification
+
+- Full-config lint: **0** findings, uncapped. `make vet` + full `make test` green; gofmt
+  clean.

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -546,7 +546,7 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 			return nil, err
 		}
 
-		return e.failAndUnwind(err)
+		return nil, e.failAndUnwind(err)
 	}
 
 	e.status.Phase = PhaseCompleted
@@ -571,15 +571,14 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 //   - `err`: the dispatch failure.
 //
 // Returns:
-//   - `any`: always nil.
 //   - `error`: the failure (joined with compensation errors when the unwind fails).
-func (e *GraphExecutor) failAndUnwind(err error) (any, error) {
+func (e *GraphExecutor) failAndUnwind(err error) error {
 
 	if unwindErr := e.stack.Unwind(e.environment); unwindErr != nil {
 		e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionCompensationFailed,
 			Reason: ReasonCompensationFailed, Message: "unwind failed: compensation error"}
 		e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: unwindErr})
-		return nil, fmt.Errorf("%w; compensation: %w", err, unwindErr)
+		return fmt.Errorf("%w; compensation: %w", err, unwindErr)
 	}
 
 	reason := failureReason(err)
@@ -591,7 +590,7 @@ func (e *GraphExecutor) failAndUnwind(err error) (any, error) {
 	e.status = RunStatus{Phase: PhaseStopped, Condition: condition, Reason: reason,
 		Message: "unhandled failure; stack unwound cleanly"}
 	e.control.emit(ControlEvent{Kind: EventError, Status: e.status, Err: err})
-	return nil, err
+	return err
 }
 
 // dispatchWithPolicy dispatches `unit` through this executor, retrying per the unit's [RetryPolicy].
@@ -688,7 +687,7 @@ func (e *GraphExecutor) dispatchWithPolicy(
 //   - `attempt`: the zero-based attempt about to run.
 //
 // Returns:
-//   - `error`: the context's error when cancelled mid-wait.
+//   - `error`: the context's error when canceled mid-wait.
 func waitRetryDelay(ctx context.Context, policy *RetryPolicy, attempt int) error {
 
 	if attempt == 0 || policy == nil {
@@ -724,7 +723,7 @@ func waitRetryDelay(ctx context.Context, policy *RetryPolicy, attempt int) error
 //   - `error`: the veto resolution's (or handler's) error, when not retrying.
 func (e *GraphExecutor) gateRetry(
 	ctx context.Context, unit ExecutableUnit, variables map[string]Variable, lastErr error,
-) (bool, any, error) {
+) (retry bool, result any, err error) {
 
 	handler := unit.OnRetry()
 	if handler == nil {

--- a/pkg/op/planner.go
+++ b/pkg/op/planner.go
@@ -314,9 +314,9 @@ func bindParameterSlots(
 // Returns:
 //   - `[]any`: the overflow, in order.
 //   - `int`: the advanced positional index (len(args)).
-func positionalRest(args []any, positional int) ([]any, int) {
+func positionalRest(args []any, positional int) (rest []any, next int) {
 
-	rest := make([]any, 0, max(0, len(args)-positional))
+	rest = make([]any, 0, max(0, len(args)-positional))
 	for ; positional < len(args); positional++ {
 		rest = append(rest, args[positional])
 	}

--- a/pkg/op/provider/flow/planners.go
+++ b/pkg/op/provider/flow/planners.go
@@ -799,9 +799,9 @@ func layoutDecisionTree(cases []*Case, defaultSubgraph *op.Subgraph) ([]op.Execu
 // Returns:
 //   - `[]any`: the overflow, in order.
 //   - `int`: the advanced positional index (len(args)).
-func variadicRest(args []any, positional int) ([]any, int) {
+func variadicRest(args []any, positional int) (rest []any, next int) {
 
-	rest := make([]any, 0, max(0, len(args)-positional))
+	rest = make([]any, 0, max(0, len(args)-positional))
 	for ; positional < len(args); positional++ {
 		rest = append(rest, args[positional])
 	}

--- a/pkg/op/provider/flow/provider.go
+++ b/pkg/op/provider/flow/provider.go
@@ -713,7 +713,7 @@ type gatherRun struct {
 //
 // Returns:
 //   - `[]gatherRun`: the iterations still needing dispatch, in index order.
-func classifyGatherRuns(stack *op.RecoveryStack, subgraph *op.Subgraph, items []any, results []any) []gatherRun {
+func classifyGatherRuns(stack *op.RecoveryStack, subgraph *op.Subgraph, items, results []any) []gatherRun {
 
 	var pending []gatherRun
 	for i := range items {

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -470,10 +470,9 @@ func announcedMethods(
 // Returns:
 //   - `[]*Method`: the built methods, in walk order.
 //   - `map[string]*Method`: the methods keyed by projected name.
-func derivedMethods(providerType, methodType reflect.Type, isProvider bool) ([]*Method, map[string]*Method) {
+func derivedMethods(providerType, methodType reflect.Type, isProvider bool) (methods []*Method, methodMap map[string]*Method) {
 
-	var methods []*Method
-	methodMap := make(map[string]*Method)
+	methodMap = make(map[string]*Method)
 
 	for reflectedMethod := range methodType.Methods() {
 

--- a/pkg/op/truthiness.go
+++ b/pkg/op/truthiness.go
@@ -55,7 +55,7 @@ func IsTruthy(value any) bool {
 // Returns:
 //   - `bool`: the truthiness, when `value` is a built-in scalar.
 //   - `bool`: true when `value` was a built-in scalar.
-func scalarTruthy(value any) (bool, bool) {
+func scalarTruthy(value any) (truthy, isScalar bool) {
 
 	switch v := value.(type) {
 	case bool:


### PR DESCRIPTION
The pre-declared phase-3 structure ruling, executed as ruled: `iter.Seq[*parsedFile]` with the cache entry extended to carry its path. Four true walker clients converted; `Deps`/`Metrics` deliberately untouched (different parse modes). Rider owned in the plan doc: eleven style findings my phase-7 squeeze helpers shipped (the batch skipped the full-config recount) are fixed here — the board reads zero again, uncapped. Vet + full suite green.