### PR TITLE
fix(lint): the gate's verdict — file-isolated JSON, no silent pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,12 @@ jobs:
       - name: Lint Go
         run: ./build/star lint go ./...
 
+      # Belt-and-suspenders (ruling 2026-08-04, after the silent-pass gate incident): the dogfooded
+      # star path above carries the verdict; this direct run guards against any future regression in
+      # star's own reporting pipeline.
+      - name: Lint Go (direct)
+        run: make lint
+
       - name: Test
         run: make test-race
 

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -160,6 +160,9 @@ func run() (err error) {
 	rootCmd := &cobra.Command{
 		Use:   "star",
 		Short: "Starlark-powered operations tool",
+		// A failing command verdict (a ui.fail in a .star script, a lint gate saying no) is not a
+		// usage mistake — suppress the usage block on RunE errors (ruling 2026-08-04).
+		SilenceUsage: true,
 		Long: `star is the Starlark-powered operations tool for NobleFactor projects.
 
 Commands are defined as extensions in the star/extensions/ directory.

--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -7,7 +7,6 @@ package lint
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -66,7 +65,7 @@ func (p *Provider) Go(paths []string, config string, skipModTidy bool) (GoResult
 		}
 	}
 
-	issues, err := runGolangciLint(golangciArgs(config, paths))
+	issues, err := runGolangciLint(config, paths)
 	if err != nil {
 		return GoResult{}, err
 	}
@@ -283,18 +282,23 @@ func (p *Provider) modTidyStatus(skipModTidy bool) (tidy bool, detail string) {
 	return checkModTidy(sessionCtx)
 }
 
-// golangciArgs builds the golangci-lint argv: JSON output, the (absolutized) config when one is set,
-// and the package patterns.
+// golangciArgs builds the golangci-lint argv: JSON to its own file, the (absolutized) config when
+// one is set, and the package patterns.
+//
+// The JSON goes to a dedicated file — never stdout — because the repo config's own output formats
+// and the stats footer share stdout, and a polluted stream is unparseable (the 2026-08-04 gate
+// incident: the old stdout parse failed silently and every lint run passed).
 //
 // Parameters:
 //   - `config`: the config path; empty adds no --config flag.
+//   - `jsonPath`: the file receiving the JSON issue report.
 //   - `paths`: the package patterns.
 //
 // Returns:
 //   - `[]string`: the argv after the binary name.
-func golangciArgs(config string, paths []string) []string {
+func golangciArgs(config, jsonPath string, paths []string) []string {
 
-	cmdArgs := []string{"run", "--output.json.path", "stdout"}
+	cmdArgs := []string{"run", "--output.json.path", jsonPath}
 	if config != "" {
 		if !filepath.IsAbs(config) {
 			if absConfig, err := filepath.Abs(config); err == nil {
@@ -307,40 +311,57 @@ func golangciArgs(config string, paths []string) []string {
 	return append(cmdArgs, paths...)
 }
 
-// runGolangciLint executes golangci-lint and parses its JSON issue stream; an empty-output failure
-// surfaces the tool's stderr.
+// runGolangciLint executes golangci-lint and parses its JSON issue report from a dedicated file.
+//
+// The verdict is never silently optimistic: a missing or unparseable report is a hard error (naming
+// the tool's stderr), not a pass — the 2026-08-04 gate incident rule. A non-zero tool exit with a
+// parseable report is the normal findings case.
 //
 // Parameters:
-//   - `cmdArgs`: the argv after the binary name.
+//   - `config`: the config path; empty lets the tool self-discover.
+//   - `paths`: the package patterns.
 //
 // Returns:
 //   - `[]goIssueRaw`: the parsed issues; empty when the run was clean.
-//   - `error`: non-nil when the tool failed without producing output.
-func runGolangciLint(cmdArgs []string) ([]goIssueRaw, error) {
+//   - `error`: non-nil when the tool fails without a report or the report does not parse.
+func runGolangciLint(config string, paths []string) ([]goIssueRaw, error) {
+
+	jsonFile, err := os.CreateTemp("", "star-lint-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("golangci-lint: create report file: %w", err)
+	}
+	jsonPath := jsonFile.Name()
+	if err := jsonFile.Close(); err != nil {
+		return nil, fmt.Errorf("golangci-lint: close report file: %w", err)
+	}
+	//nolint:errcheck // diagnose-ignored-error: temp-file cleanup; see docs/architecture/2.8-eventing-infrastructure.md
+	defer func() { _ = os.Remove(jsonPath) }()
 
 	//nolint:gosec // G204: golangci-lint with argv built by golangciArgs from provider-validated config and paths.
-	cmd := exec.CommandContext(context.Background(), "golangci-lint", cmdArgs...)
-	output, err := cmd.Output()
+	cmd := exec.CommandContext(context.Background(), "golangci-lint", golangciArgs(config, jsonPath, paths)...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
 
-	var issues []goIssueRaw
-	if len(output) > 0 {
-		var lintOutput goOutputRaw
-		if jsonErr := json.Unmarshal(output, &lintOutput); jsonErr == nil {
-			issues = lintOutput.Issues
-		}
+	report, readErr := os.ReadFile(jsonPath) //nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
+	if readErr != nil {
+		return nil, fmt.Errorf("golangci-lint: read report: %w", readErr)
 	}
 
-	if err != nil && len(output) == 0 {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			stderr := string(exitErr.Stderr)
-			if stderr != "" {
-				return nil, fmt.Errorf("golangci-lint failed: %s", strings.TrimSpace(stderr))
-			}
+	if len(report) == 0 {
+		if runErr != nil {
+			return nil, fmt.Errorf("golangci-lint failed without a report: %s", strings.TrimSpace(stderr.String()))
 		}
+		return nil, fmt.Errorf("golangci-lint produced no report and no error")
 	}
 
-	return issues, nil
+	var lintOutput goOutputRaw
+	if jsonErr := json.Unmarshal(report, &lintOutput); jsonErr != nil {
+		return nil, fmt.Errorf("golangci-lint report is not parseable JSON: %w (stderr: %s)",
+			jsonErr, strings.TrimSpace(stderr.String()))
+	}
+
+	return lintOutput.Issues, nil
 }
 
 // appendGoIssues folds the raw issues into the result: severities default to warning, counts

--- a/docs/plans/lint-gate-verdict.md
+++ b/docs/plans/lint-gate-verdict.md
@@ -1,0 +1,49 @@
+---
+title: "The lint gate's verdict: file-isolated JSON, no silent pass"
+issue: TBD
+status: complete
+created: 2026-08-04
+updated: 2026-08-04
+---
+
+# Plan: the lint gate's verdict
+
+Next-steps item 1 after the complexity plan closed: CI's quality-gate passed PR #319 while
+eleven findings existed. Investigation (probe package, both lint paths, stream inspection)
+found the gate could not fail at all.
+
+## Root cause, three layers
+
+1. CI's "Lint Go" step runs `./build/star lint go ./...` — the star lint provider, not
+   golangci-lint directly.
+2. The provider asked for JSON on stdout (`--output.json.path stdout`), but stdout is
+   shared: the repo config's own text format and golangci v2's stats footer pollute the
+   stream, so it never parses as JSON.
+3. `runGolangciLint` silently ignored the parse failure (`if jsonErr == nil` with no else)
+   — zero issues, verdict passes. Every lint run since the stream turned dirty has passed
+   unconditionally.
+
+The `.star` command script was correct throughout (it reports and `ui.fail`s properly);
+the exit-code path was also correct — earlier "exit 0" readings were a shell-pipe
+measurement artifact ($? read head's status, not star's).
+
+## The fix
+
+`runGolangciLint(config, paths)` writes the JSON report to a dedicated temp file
+(`--output.json.path <file>`) so no stdout format can pollute it, captures stderr
+separately, and treats a missing or unparseable report as a hard error naming the stderr —
+never a pass. `golangciArgs` gains the report-path parameter. Verified live: a probe
+package with two planted findings fails the gate (`Go lint failed: 2 lint issues`,
+exit 1); a clean package passes (exit 0).
+
+## Noted, not changed (rulings available)
+
+1. quality-gate could additionally run `make lint` as belt-and-suspenders alongside the
+   dogfooded star path.
+2. cobra prints the full usage block under a `ui.fail` verdict (SilenceUsage unset) —
+   cosmetic noise on failures.
+
+## Verification
+
+- Full-config lint: 0 findings uncapped; `make vet` + full `make test` green; gofmt clean.
+- Live probe: dirty → exit 1 with the correct verdict message; clean → exit 0.

--- a/docs/plans/lint-gate-verdict.md
+++ b/docs/plans/lint-gate-verdict.md
@@ -36,12 +36,14 @@ never a pass. `golangciArgs` gains the report-path parameter. Verified live: a p
 package with two planted findings fails the gate (`Go lint failed: 2 lint issues`,
 exit 1); a clean package passes (exit 0).
 
-## Noted, not changed (rulings available)
+## Follow-on rulings (both ruled and done, 2026-08-04)
 
-1. quality-gate could additionally run `make lint` as belt-and-suspenders alongside the
-   dogfooded star path.
-2. cobra prints the full usage block under a `ui.fail` verdict (SilenceUsage unset) —
-   cosmetic noise on failures.
+1. quality-gate now also runs `make lint` directly ("Lint Go (direct)") as
+   belt-and-suspenders alongside the dogfooded star path — a future regression in star's
+   own reporting pipeline cannot silently re-open the gate.
+2. star's root command sets `SilenceUsage`: a failing verdict prints only the error
+   (verified live — `ui.fail` exits 1 with no usage block; unknown subcommands still show
+   help, which is a genuine usage situation).
 
 ## Verification
 


### PR DESCRIPTION
The next-steps item 1 investigation: CI's lint gate could not fail. Three layers — the gate runs `star lint go`; the provider asked for JSON on a stdout it shares with the config's text format and the v2 stats footer; and the unparseable stream was silently ignored into a pass. Fixed by writing the report to a dedicated file and making a missing/unparseable report a hard error. Live-verified both ways (planted findings → exit 1 with the correct verdict; clean → exit 0). Second commit carries the two follow-on rulings: `make lint` joins quality-gate as belt-and-suspenders, and star's root sets `SilenceUsage` so failing verdicts print without the usage block. Plan: `docs/plans/lint-gate-verdict.md`.