### PR TITLE
refactor(op): SerializeGraphs — the framework owns the graph-stream rendering

### DIFF
--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -18,8 +18,6 @@ import (
 	"os"
 	"sort"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/readback"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
@@ -81,7 +79,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	if cfg.DryRun {
-		return emitGraphs(graphs)
+		return op.SerializeGraphs(os.Stdout, graphs)
 	}
 
 	return runAll(ctx, cfg, graphs)
@@ -116,32 +114,6 @@ func buildScopeGraphs(ctx context.Context, cfg *Config, selected []readback.Entr
 	}
 
 	return graphs, nil
-}
-
-// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
-//
-// Parameters:
-//   - `graphs`: the assembled graphs, in removal order.
-//
-// Returns:
-//   - `err`: a serialization or encoder-close failure.
-func emitGraphs(graphs []*op.Graph) (err error) {
-
-	encoder := yaml.NewEncoder(os.Stdout)
-	defer func() {
-		if closeErr := encoder.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	encoder.SetIndent(2)
-
-	for _, graph := range graphs {
-		if err := graph.Serialize(encoder); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // runAll executes every graph, collecting per-scope failures.

--- a/cmd/writ/writ/deploy/deploy.go
+++ b/cmd/writ/writ/deploy/deploy.go
@@ -20,8 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/NobleFactor/devlore-cli/cmd/lore/lore"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/readback"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/segment"
@@ -118,7 +116,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	if cfg.DryRun {
-		return emitGraphs(build.Graphs)
+		return op.SerializeGraphs(os.Stdout, build.Graphs)
 	}
 
 	sortGraphsByScope(build.Graphs)
@@ -129,32 +127,6 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	return runAll(ctx, cfg, build.Graphs, runPolicy)
-}
-
-// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
-//
-// Parameters:
-//   - `graphs`: the assembled graphs, in run order.
-//
-// Returns:
-//   - `err`: a serialization or encoder-close failure.
-func emitGraphs(graphs []*op.Graph) (err error) {
-
-	encoder := yaml.NewEncoder(os.Stdout)
-	defer func() {
-		if closeErr := encoder.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	encoder.SetIndent(2)
-
-	for _, graph := range graphs {
-		if err := graph.Serialize(encoder); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // runAll executes every graph under the run policy, collecting per-scope failures.

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -31,8 +31,6 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/deploy"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/readback"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/segment"
@@ -109,7 +107,7 @@ func Execute(ctx context.Context, cfg *Config) (err error) {
 	}
 
 	if cfg.DryRun {
-		return emitGraphs(graphs)
+		return op.SerializeGraphs(os.Stdout, graphs)
 	}
 
 	regenerated, err := runAll(ctx, cfg, graphs)
@@ -184,32 +182,6 @@ func buildScopeGraphs(
 	}
 
 	return graphs, nil
-}
-
-// emitGraphs serializes the graphs to stdout as one YAML stream — the dry-run rendering.
-//
-// Parameters:
-//   - `graphs`: the assembled graphs, in run order.
-//
-// Returns:
-//   - `err`: a serialization or encoder-close failure.
-func emitGraphs(graphs []*op.Graph) (err error) {
-
-	encoder := yaml.NewEncoder(os.Stdout)
-	defer func() {
-		if closeErr := encoder.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	encoder.SetIndent(2)
-
-	for _, graph := range graphs {
-		if err := graph.Serialize(encoder); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // runAll executes every graph, collecting per-scope failures; the regenerated count accumulates even

--- a/docs/plans/complexity-refactors.md
+++ b/docs/plans/complexity-refactors.md
@@ -45,9 +45,9 @@ Total: 60 listed + `TestContext.Check` counted in phase 1 = 61.
 
 **Phase 1 (complete):** the three writ `Execute`s decomposed onto the same narrative shape
 — fold/build → group (`buildScopeGraphs`) → dry-run (`emitGraphs`) → run-and-collect
-(`runAll`) — as per-package unexported helpers. The dry-run emitter is now verbatim-
-identical in three packages; deduplicating it into a shared location is a structure
-decision available for a ruling, deliberately not taken unilaterally. `classifyEntry`
+(`runAll`) — as per-package unexported helpers. The dry-run emitter was verbatim-
+identical in three packages; ruled 2026-08-04 (single-codec Requirement 1) and folded into
+`op.SerializeGraphs` beside `op.LoadGraph` — see docs/plans/single-codec.md. `classifyEntry`
 split its encrypted-chain arm (`classifyEncryptedChain`) and render arm (`renderedFresh`);
 `TestContext.Check` became a uniform per-kind dispatch (`checkExpectation`), extracting
 `checkUnitCount` and `checkEqual` to match the existing check-helper family;

--- a/docs/plans/single-codec.md
+++ b/docs/plans/single-codec.md
@@ -1,0 +1,45 @@
+---
+title: "Single Codec"
+status: draft
+created: 2026-08-04
+updated: 2026-08-04
+---
+
+# Plan: Single Codec
+
+> **Authoring status**: this plan is being authored by the project owner. This file currently
+> holds the plan's collected requirements and the current-state inventory feeding that
+> authoring; it is not the design. Referenced by
+> [fix-trace-format-leak.md](fix-trace-format-leak.md), which defers its unlegislated
+> canonical-form corners here.
+
+## Summary
+
+One canonical model for op documents. YAML, JSON, and protobuf are renderings of that model;
+two documents with the same checksum are the same logical document regardless of rendering.
+The raw-bytes canonical from PR #298 is interim until this plan lands.
+
+## Requirements
+
+### Requirement 1 — the framework owns both directions of graph-document handling (ruled 2026-08-04)
+
+`pkg/op` must own graph-document handling completely, in both directions, including all
+aspects of serialization. No serialization decision — encoder selection, indentation,
+document-stream framing, close-error handling — may live in a CLI.
+
+**Current state.** The framework already owns most of this:
+
+| Surface | Location | Direction |
+| --- | --- | --- |
+| `op.LoadGraph` (YAML/JSON decode) | [pkg/op/graph.go:243](../../pkg/op/graph.go) | read |
+| `Graph.Serialize` (via `op.Encoder`) | [pkg/op/graph.go:729](../../pkg/op/graph.go) | write |
+| `yaml.v3` import | [pkg/op/graph.go:28](../../pkg/op/graph.go) | both |
+
+**The gap (closed 2026-08-04).** The dry-run rendering of a graph sequence — one YAML
+stream, indent 2, encoder close-error folded into the return — previously lived outside the
+framework as three byte-identical `emitGraphs` copies (writ deploy, upgrade, decommission).
+`op.SerializeGraphs(w io.Writer, graphs []*op.Graph) error` now owns that rendering beside
+`op.LoadGraph` in [pkg/op/graph.go](../../pkg/op/graph.go); each command reduced to
+`return op.SerializeGraphs(os.Stdout, graphs)`, the destination writer the only caller
+choice. No `pkg/op` sub-package yet: where serialization surfaces consolidate is this
+plan's decision, and a single free function does not preempt it.

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -267,6 +268,37 @@ func LoadGraph(env *RuntimeEnvironment, data []byte, format string) (*Graph, err
 	}
 
 	return assembleGraph(env, &p)
+}
+
+// SerializeGraphs serializes the graphs to w as one YAML document stream.
+//
+// This is the write-side complement of [LoadGraph]: the framework owns every aspect of the rendering — the
+// two-space indentation, the multi-document framing, and the folding of an encoder-close failure into the
+// returned error. Callers choose only the destination writer.
+//
+// Parameters:
+//   - `w`: the destination writer.
+//   - `graphs`: the graphs to serialize, in order.
+//
+// Returns:
+//   - `err`: a serialization or encoder-close failure, or nil on success.
+func SerializeGraphs(w io.Writer, graphs []*Graph) (err error) {
+
+	encoder := yaml.NewEncoder(w)
+	defer func() {
+		if closeErr := encoder.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	encoder.SetIndent(2)
+
+	for _, graph := range graphs {
+		if err := graph.Serialize(encoder); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // assembleUnits builds the unit symbol table from the flat payload lists. Each unit comes into


### PR DESCRIPTION
Implements single-codec Requirement 1 (ruled 2026-08-04): the framework owns both directions of graph-document handling, including all serialization aspects. `op.SerializeGraphs(w io.Writer, graphs []*op.Graph) error` lands beside `op.LoadGraph` as the write-side complement — two-space indentation, multi-document YAML framing, encoder-close error folding — and the three byte-identical `emitGraphs` copies (writ deploy/upgrade/decommission) are deleted; each dry-run path reduces to `return op.SerializeGraphs(os.Stdout, graphs)`. Also lands `docs/plans/single-codec.md` as the plan's requirements ledger and resolves the phase-1 open ruling in the complexity plan. Verified: vet, build, tests, and zero lint findings under both GOOS values.