### PR TITLE
fix(op): the narrator wired — dead Discard defaults die, one instance on both seams

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 
+	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
 	"go.starlark.net/starlark"
@@ -256,6 +257,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 	}
 
 	spec := op.NewRuntimeEnvironmentSpec("devlore-test").
+		WithStatus(cli.UI()).
 		WithModules(receiverRegistry.Modules()...).
 		WithRoot(root).
 		WithPlatform(hostPlatform).

--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -843,6 +844,7 @@ func (tc *TestContext) buildSpec() (*op.RuntimeEnvironmentSpec, error) {
 	}
 
 	return op.NewRuntimeEnvironmentSpec(programName).
+		WithStatus(cli.UI()).
 		WithRoot(root).
 		WithPlatform(hostPlatform).
 		WithApplication(app), nil

--- a/cmd/lore/lore/builder.go
+++ b/cmd/lore/lore/builder.go
@@ -13,6 +13,7 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 
+	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/internal/lorepackage"
 	"github.com/NobleFactor/devlore-cli/internal/manifest"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
@@ -104,6 +105,7 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 	}
 
 	sharedEnv := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("lore").
+		WithStatus(cli.UI()).
 		WithModules(op.ReceiverRegistry().Modules()...).
 		WithApplication(&application.Application{Name: "lore"}))
 

--- a/cmd/lore/lore/commands.go
+++ b/cmd/lore/lore/commands.go
@@ -247,6 +247,7 @@ func executeDeployments(ctx context.Context, resolved []resolvedPackage, cfg *lo
 	}
 
 	spec := op.NewRuntimeEnvironmentSpec("lore").
+		WithStatus(cli.UI()).
 		WithRoot(root).
 		WithApplication(&application.Application{
 			Name:  "lore",

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -198,12 +198,18 @@ Generate shell completions with:
 
 	cobra.OnInitialize(func() {
 
-		// Construct the canonical status.UI from the parsed --silent flag and install it on the shared cli
-		// package-global. The same instance backs cmd/star/cli's Note/Warn/etc. forwarding wrappers (output.go) and
-		// lore/writ/devlore-test via cli.NewRootCmd, and the starlark ui.note() / ui.print() paths through
-		// pkg/op/provider/ui.Provider's passthrough to env.Status. One instance, one silent gate, every emission
-		// consistent on stderr.
-		cli.SetUI(status.NewNarrator("star", sink.Stderr()))
+		// Construct the canonical status.UI from the parsed --silent flag and install the single instance on
+		// both narration seams: the shared cli package-global backing cmd/star/cli's Note/Warn/etc. forwarding
+		// wrappers (output.go), and the runtime environment's Status backing the starlark ui.note() / ui.warn()
+		// paths through pkg/op/provider/ui.Provider's passthrough. One instance, one silent gate, every
+		// emission consistent on stderr.
+		narratorSink := sink.Stderr()
+		if silent {
+			narratorSink = sink.Discard()
+		}
+		narrator := status.NewNarrator("star", narratorSink)
+		cli.SetUI(narrator)
+		runtime.Environment().Status = narrator
 	})
 
 	// Version command
@@ -316,7 +322,7 @@ Install them to your man path (e.g., /usr/local/share/man/man1/).`,
 
 	rootCmd.AddCommand(docsCmd)
 
-	// CLI status output is wired in cobra.OnInitialize above via cli.SetUI(status.NewConsole(...)). cmd/star/cli's
+	// CLI status output is wired in cobra.OnInitialize above via cli.SetUI(status.NewNarrator(...)). cmd/star/cli's
 	// local Note/Warn/Error/Success/Failure functions forward to that shared UI.
 
 	// Self commands (install, upgrade, etc.)

--- a/cmd/star/star/application.go
+++ b/cmd/star/star/application.go
@@ -123,6 +123,14 @@ func (r *Application) Config() *config.Config {
 	return r.config
 }
 
+// Environment returns the runtime environment owned by the application's starlarkbridge runtime.
+//
+// Returns:
+//   - *op.RuntimeEnvironment: the application's runtime environment.
+func (r *Application) Environment() *op.RuntimeEnvironment {
+	return r.env
+}
+
 // Registry returns the extension registry.
 //
 // Returns:

--- a/cmd/writ/writ/adopt/batch.go
+++ b/cmd/writ/writ/adopt/batch.go
@@ -277,6 +277,7 @@ func buildSpec(root string) (*op.RuntimeEnvironmentSpec, error) {
 	}
 
 	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{Name: "writ"}), nil
 }

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -298,6 +298,7 @@ func removalSpec(root string, dryRun bool) (*op.RuntimeEnvironmentSpec, error) {
 	}
 
 	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{
 			Name:  "writ",

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -388,6 +388,7 @@ func deploySpec(root string, dryRun bool, conflict op.ConflictPolicy) (*op.Runti
 	}
 
 	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{
 			Name:  "writ",

--- a/cmd/writ/writ/migrate/execute.go
+++ b/cmd/writ/writ/migrate/execute.go
@@ -76,7 +76,7 @@ func Execute(ctx context.Context, graph *op.Graph, analysis *MigrationAnalysis) 
 		return nil, fmt.Errorf("open root %s: %w", analysis.SourceRoot, err)
 	}
 
-	executor := op.NewGraphExecutor(graph, op.NewRuntimeEnvironmentSpec("writ").WithRoot(root))
+	executor := op.NewGraphExecutor(graph, op.NewRuntimeEnvironmentSpec("writ").WithStatus(cli.UI()).WithRoot(root))
 
 	if _, err := executor.Run(ctx, nil); err != nil {
 		return executor.Trace(), fmt.Errorf("migration run: %w", err)

--- a/cmd/writ/writ/migrate/helpers.go
+++ b/cmd/writ/writ/migrate/helpers.go
@@ -6,6 +6,7 @@ package migrate
 import (
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -92,6 +93,7 @@ func migrateSpec(root string) (*op.RuntimeEnvironmentSpec, error) {
 	}
 
 	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{Name: "writ"}), nil
 }

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -569,6 +569,7 @@ func upgradeSpec(root string, dryRun bool) (*op.RuntimeEnvironmentSpec, error) {
 	}
 
 	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{
 			Name: "writ",

--- a/cmd/writ/writ/verify/verify.go
+++ b/cmd/writ/writ/verify/verify.go
@@ -258,6 +258,7 @@ func loadGraph(ctx context.Context, data []byte) (*op.Graph, error) {
 	}
 
 	env := op.NewRuntimeEnvironment(ctx, op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
 		WithRoot(confined).
 		WithApplication(&application.Application{Name: "writ"}))
 

--- a/docs/plans/fix-narrator-wiring.md
+++ b/docs/plans/fix-narrator-wiring.md
@@ -1,0 +1,103 @@
+---
+title: "Fix Narrator Wiring"
+status: complete
+created: 2026-08-05
+updated: 2026-08-05
+---
+
+# Plan: Fix Narrator Wiring
+
+## Summary
+
+Every tool's runtime environment silently discards narration. `op.NewRuntimeEnvironmentSpec`
+pre-fills `Status` with a narrator over `sink.Discard` (pkg/op/runtime_environment.go:788),
+which makes `NewRuntimeEnvironment`'s documented nil→`sink.Stderr` default (lines 162–166)
+unreachable — the spec constructor violates its own documented contract. No caller anywhere
+passes `WithStatus`, so the starlark `ui.note` / `ui.warn` / `ui.error` path (a passthrough
+to `RuntimeEnvironment().Status`) writes to `io.Discard` in every tool, everywhere — the
+reason CI's failing lint gate reports "1 lint issues" without naming the finding, and why
+`star lint go` runs mute even interactively. Meanwhile the `internal/cli` package-global
+narrator (the second seam) is correctly wired in lore/writ/devlore-test bootstraps but the
+comment claiming "the same instance flows into RuntimeEnvironmentSpec.Status"
+(internal/cli/output.go:120) describes a flow that does not exist, and star's bootstrap
+ignores its own `--silent` flag.
+
+## Current State
+
+| Piece | State |
+| --- | --- |
+| `NewRuntimeEnvironmentSpec` Status pre-fill | ❌ Discard narrator (runtime_environment.go:788) — dead-contract |
+| `NewRuntimeEnvironment` nil→Stderr default | ❌ Unreachable for spec-built environments |
+| `WithStatus` callers | ❌ Zero repo-wide |
+| lore/writ bootstrap (`internal/cli/root.go:56`) | ✅ `--silent` fork → `SetUI` |
+| devlore-test bootstrap (`root.go:55`) | ✅ `--silent` fork → `SetUI` |
+| star bootstrap (`cmd/star/main.go:206`) | ❌ unconditional `sink.Stderr`; `--silent` (line 184) parsed but ignored |
+| star environment ↔ cli narrator | ❌ two instances; starlark path discards |
+
+## Changes
+
+### 1. Framework: make the documented default real
+
+Delete the `Status` AND `Result` Discard pre-fills from `NewRuntimeEnvironmentSpec` (both
+ruled in, 2026-08-05).
+`spec.Status` is nil until a caller sets it; `NewRuntimeEnvironment`'s existing defaulting
+(nil → narrator over `sink.Stderr`) becomes live, matching both its doc comment (line 152)
+and the field's (line 772: "pass a Narrator wrapping [sink.Discard] to suppress").
+Suppression becomes an explicit caller choice, never a silent default.
+
+### 2. star: honor --silent, one instance on both seams
+
+In `cobra.OnInitialize` (cmd/star/main.go:199–207): fork on the parsed `silent` var
+(Discard vs Stderr), construct ONE narrator, install it via `cli.SetUI` AND onto the star
+application's runtime environment — making the "one instance, one silent gate" comment
+true. Requires environment access on `star.Application` (field is unexported): add an
+`Environment() *op.RuntimeEnvironment` accessor (recommended — smallest general API), then
+`runtime.Environment().Status = narrator`. Fix the stale comments (main.go:201–205, 319).
+
+### 3. Tools: flow the bootstrap narrator into every spec
+
+Add `.WithStatus(cli.UI())` at each spec construction (all run at RunE time, after the
+bootstrap has installed the forked narrator):
+
+1. cmd/lore/lore/builder.go:106
+2. cmd/lore/lore/commands.go:249
+3. cmd/devlore-test/devloretest/runner.go:258
+4. cmd/devlore-test/devloretest/test_context.go:845
+5. cmd/writ/writ/upgrade/upgrade.go:599
+6. cmd/writ/writ/decommission/decommission.go:328
+7. cmd/writ/writ/adopt/batch.go:279
+8. cmd/writ/writ/verify/verify.go:260
+9. cmd/writ/writ/deploy/plan.go:390
+10. cmd/writ/writ/migrate/execute.go:79
+11. cmd/writ/writ/migrate/helpers.go:94
+
+(Unit-test spec constructions that rely on today's silence get an explicit
+`WithStatus(status.NewNarrator(name, sink.Discard()))` — suppression stated, never
+inherited.)
+
+### 4. Documentation corrections
+
+- internal/cli/output.go:114–128 — re-verify every claim against the new wiring.
+- docs/plans/lint-gate-verdict.md fallout addendum — correct the "narrator-suppressed in
+  CI's non-TTY" misattribution to the real mechanism (Discard pre-fill + unwired seam);
+  the narrator never gated on TTY (that selects color only).
+
+## Verification
+
+- `make vet`, `make build`, `make test`; dual-GOOS lint recount at zero.
+- Empirical: `./build/star lint go ./pkg/sink` narrates (notes + per-issue lines);
+  `./build/star --silent lint go ./pkg/sink` is mute; a planted finding's line is named in
+  the failure output (the original item-6 motivation).
+
+## Open questions
+
+None — `Result` (the identical dead-contract pattern) was ruled into this change on
+2026-08-05: same fix, its documented nil→stdout-JSON default becomes live.
+
+## Outcome (2026-08-05)
+
+All changes landed as planned, Result included. Verified: vet, build, full suite green (no
+test relied on the old silence); dual-GOOS recount clean; `star lint go` narrates with the
+`[star]` prefix and `--silent` is fully mute; a planted finding printed as
+`[star] [△] pkg/lintprobe/probe.go:6:6 unused: func probeUnused is unused` before the
+failing verdict — the failing CI gate now names its findings.

--- a/docs/plans/lint-gate-verdict.md
+++ b/docs/plans/lint-gate-verdict.md
@@ -66,5 +66,8 @@ failures compounded it into a red develop:
 Fix-forward: the suppression gains `unconvert` with the platform reason (removal would break
 the Darwin build). Verified zero findings under both `GOOS` values.
 
-Also noted for charter: the per-issue `ui.warn` lines are narrator-suppressed in CI's
-non-TTY, so the failing step reports a count without naming the findings.
+Also noted for charter, since root-caused (correcting this paragraph's original non-TTY
+attribution — the narrator keys only color off TTY, never suppression): the per-issue
+`ui.warn` lines were invisible everywhere because every tool's runtime environment kept
+`NewRuntimeEnvironmentSpec`'s Discard pre-fill, so the failing step reported a count
+without naming the findings. Fixed by docs/plans/fix-narrator-wiring.md.

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -116,10 +116,11 @@ func BuildPipeline(opts SinkOptions, w io.Writer) (*result.Pipeline, error) {
 // =============================================================================
 //
 // The package-global narrator is the canonical [*status.Narrator] for cli.Note / cli.Warn /
-// cli.Error / cli.Failure / cli.Success / cli.Print facades. The same instance flows into
-// RuntimeEnvironmentSpec.Status, so --silent and the program-name prefix apply uniformly across
-// the cli facades, the runtime environment, providers that emit via env.Status, and starlark
-// print().
+// cli.Error / cli.Failure / cli.Success / cli.Print facades. The same instance flows into every
+// runtime environment — WithStatus(cli.UI()) at each RuntimeEnvironmentSpec construction; star
+// installs it on its long-lived environment at bootstrap — so --silent and the program-name
+// prefix apply uniformly across the cli facades, the runtime environment, providers that emit
+// via env.Status, and starlark print().
 //
 // Bootstrap (cobra PersistentPreRun) reads --silent and forks: silent → wrap [sink.Discard],
 // otherwise → wrap [sink.Stderr]. Both forks call [SetUI] with the constructed Narrator.

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -776,8 +776,13 @@ type RuntimeEnvironmentSpec struct {
 
 // NewRuntimeEnvironmentSpec creates a RuntimeEnvironmentSpec with the given program name.
 //
+// Status and Result stay nil so [NewRuntimeEnvironment]'s documented defaulting applies (a [status.Narrator]
+// over [sink.Stderr]; a [result.Pipeline] writing JSON to [sink.Stdout]). Suppression is an explicit caller
+// choice: pass [RuntimeEnvironmentSpec.WithStatus] / [RuntimeEnvironmentSpec.WithResult] wrapping
+// [sink.Discard].
+//
 // Parameters:
-//   - `programName`: the name of the running tool (e.g., "lore", "wri	t").
+//   - `programName`: the name of the running tool (e.g., "lore", "writ").
 //
 // Returns:
 //   - *RuntimeEnvironmentSpec: the initialized config.
@@ -785,8 +790,6 @@ func NewRuntimeEnvironmentSpec(programName string) *RuntimeEnvironmentSpec {
 
 	return &RuntimeEnvironmentSpec{
 		ProgramName: programName,
-		Status:      status.NewNarrator(programName, sink.Discard()),
-		Result:      result.NewPipeline(nil, result.JSONFormatter{}, sink.Discard()),
 	}
 }
 


### PR DESCRIPTION
Item 6, plus the Result ruling. `NewRuntimeEnvironmentSpec` pre-filled Status and Result with `sink.Discard`, making the constructor's documented nil defaults unreachable — every tool's starlark `ui.*` narration was discarded everywhere (the reason the CI lint gate said "1 lint issues" without naming it). The pre-fills are deleted so the documented defaults become real; suppression is an explicit `WithStatus`/`WithResult` choice. star's bootstrap now honors `--silent` and installs one narrator instance on both seams; the other ten spec constructions flow the bootstrap narrator via `WithStatus(cli.UI())`. Stale wiring comments and the earlier fallout addendum's non-TTY misattribution corrected. Verified: suite green, dual-GOOS recount clean, `star lint go` narrates, `--silent` mute, planted finding named in the failing verdict. Plan: `docs/plans/fix-narrator-wiring.md`.