### PR TITLE
chore(lint): the seed template synced — ladder-hardened defaults, drift-guarded

### DIFF
--- a/cmd/star/provider/lint/provider.go
+++ b/cmd/star/provider/lint/provider.go
@@ -454,6 +454,14 @@ func runShellcheckForLint(path, severity string) ([]shellcheckprov.LintIssue, er
 
 const defaultGolangciConfig = `# SPDX-License-Identifier: MIT
 # golangci-lint v2 configuration for NobleFactor Go projects
+#
+# Objectives:
+#   - Low complexity (gocyclo <= 15, gocognit <= 20)
+#   - No dead or unused code
+#   - No redundant code
+#   - Clean formatting
+#
+# Copy this file to any Go repo root.
 
 version: "2"
 
@@ -469,15 +477,22 @@ formatters:
 linters:
   default: none
   enable:
+    # Essential
     - errcheck
     - govet
     - staticcheck
     - ineffassign
     - unused
+
+    # Complexity
     - gocyclo
     - gocognit
+
+    # Dead/redundant code
     - unparam
     - unconvert
+
+    # Code quality
     - gocritic
     - gosec
     - misspell
@@ -486,14 +501,25 @@ linters:
     - durationcheck
     - errorlint
     - noctx
+
+    # Style
     - revive
     - whitespace
 
   settings:
     gocyclo:
       min-complexity: 15
+
     gocognit:
       min-complexity: 20
+
+    # multi-func: true requires a newline after every MULTI-LINE function
+    # signature. It does NOT exempt the NobleFactor-mandated blank line after
+    # a function signature from the linter's "unnecessary leading newline"
+    # check — that check is suppressed under exclusions below.
+    whitespace:
+      multi-func: true
+
     gocritic:
       enabled-tags:
         - diagnostic
@@ -502,6 +528,7 @@ linters:
       disabled-checks:
         - whyNoLint
         - hugeParam
+
     revive:
       rules:
         - name: blank-imports
@@ -521,12 +548,15 @@ linters:
         - name: unexported-return
         - name: var-declaration
         - name: var-naming
+
     gosec:
       excludes:
         - G104
         - G304
+
     misspell:
       locale: US
+
     errcheck:
       check-type-assertions: true
       check-blank: true
@@ -538,15 +568,27 @@ linters:
   exclusions:
     generated: lax
     rules:
+      # NobleFactor style requires a blank line after every function signature;
+      # the whitespace linter's leading-newline check flags exactly that blank
+      # line. Suppress it; the trailing-newline and multi-line-statement checks
+      # stay active.
+      - linters:
+          - whitespace
+        text: "unnecessary leading newline"
+
+      # Test files can have higher complexity
       - path: _test\.go
         linters:
           - gocyclo
           - gocognit
           - errcheck
           - gosec
+
+      # Generated files
       - path: \.pb\.go$
         linters:
           - all
+
     paths:
       - vendor
       - testdata
@@ -556,9 +598,8 @@ output:
   formats:
     text:
       path: stdout
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
+      print-linter-name: true
+      print-issued-lines: true
 `
 
 func ensureGolangciConfig() (path string, created bool, err error) {

--- a/cmd/star/provider/lint/provider_test.go
+++ b/cmd/star/provider/lint/provider_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package lint
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestDefaultGolangciConfigTracksRepoConfig asserts the embedded seed template stays in lockstep with the
+// repository's own .golangci.yaml.
+//
+// The repository config is the canonical, hardened through the lint ladder; the embedded template seeds
+// new repos ("NobleFactor defaults") and must match it semantically, minus the exclusions declared
+// repo-specific below. A failure means a config change did not flow into the template, or a new
+// repo-specific exclusion is missing from the declaration.
+func TestDefaultGolangciConfigTracksRepoConfig(t *testing.T) {
+
+	// Exclusion rules whose `path` names devlore-cli-only packages; they never ship in the template.
+	repoSpecificRulePaths := map[string]bool{
+		"pkg/op/provider/(json|yaml)/": true,
+	}
+
+	repoBytes, err := os.ReadFile("../../../../.golangci.yaml")
+	if err != nil {
+		t.Fatalf("reading repository config: %v", err)
+	}
+
+	var repoConfig, templateConfig map[string]any
+	if err := yaml.Unmarshal(repoBytes, &repoConfig); err != nil {
+		t.Fatalf("parsing repository config: %v", err)
+	}
+	if err := yaml.Unmarshal([]byte(defaultGolangciConfig), &templateConfig); err != nil {
+		t.Fatalf("parsing embedded template: %v", err)
+	}
+
+	linters, ok := repoConfig["linters"].(map[string]any)
+	if !ok {
+		t.Fatal("repository config has no linters mapping")
+	}
+	exclusions, ok := linters["exclusions"].(map[string]any)
+	if !ok {
+		t.Fatal("repository config has no linters.exclusions mapping")
+	}
+	rules, ok := exclusions["rules"].([]any)
+	if !ok {
+		t.Fatal("repository config has no linters.exclusions.rules sequence")
+	}
+
+	var shared []any
+	for _, rule := range rules {
+		mapping, ok := rule.(map[string]any)
+		if !ok {
+			t.Fatalf("exclusion rule is not a mapping: %v", rule)
+		}
+		if path, _ := mapping["path"].(string); repoSpecificRulePaths[path] {
+			continue
+		}
+		shared = append(shared, rule)
+	}
+	exclusions["rules"] = shared
+
+	if !reflect.DeepEqual(repoConfig, templateConfig) {
+		t.Fatal("defaultGolangciConfig has drifted from .golangci.yaml: " +
+			"sync the embedded template with the repository config (minus the declared repo-specific exclusions)")
+	}
+}

--- a/docs/plans/golangci-template-sync.md
+++ b/docs/plans/golangci-template-sync.md
@@ -1,0 +1,43 @@
+---
+title: "Golangci Template Sync"
+status: in-progress
+created: 2026-08-06
+updated: 2026-08-06
+---
+
+# Plan: Golangci Template Sync
+
+## Summary
+
+Three divergent copies of the NobleFactor `.golangci` configuration exist: this repository's
+root `.golangci.yaml` (the canonical — hardened by the lint ladder, 2,486 findings → 0), the
+`defaultGolangciConfig` template embedded in star's lint provider (a stale pre-ladder
+snapshot that seeds new repos), and `noblefactor-ops/.golangci.yaml` (older and looser — it
+suppresses G204/G301/G302/G306 wholesale, the policy the ladder rejected in favor of
+per-site suppressions with stated reasons). Approved 2026-08-06: sync all three from the
+canonical.
+
+## Steps
+
+### 1. Upstream the canonical to noblefactor-ops — BLOCKED
+
+Replace `noblefactor-ops/.golangci.yaml` with the canonical template (repo config minus the
+repo-specific exclusion below). **Blocked**: the ops working tree sits on another session's
+active branch (`chore/refine-coding-standards`, plausibly related standards work) — awaiting
+a ruling on whether to branch there or fold into that work.
+
+### 2. Refresh star's embedded template — done
+
+`defaultGolangciConfig` (cmd/star/provider/lint/provider.go) now carries the canonical:
+the repository config minus the one repo-specific exclusion (revive var-naming for
+`pkg/op/provider/(json|yaml)/`, whose package names deliberately mirror the stdlib).
+107 → 148 lines; new repos seeded by `ensureGolangciConfig` get the current standard,
+including `whitespace.multi-func`, the ladder's shared exclusions, and the v2-correct
+`output` block.
+
+### 3. Drift guard — done
+
+`cmd/star/provider/lint/provider_test.go` — `TestDefaultGolangciConfigTracksRepoConfig`
+parses both configs and requires semantic equality after removing the declared
+repo-specific exclusion rules from the repository side. Any future ladder tweak must flow
+into the template or be declared repo-specific in the test.


### PR DESCRIPTION
Item 7, devlore half. star's embedded `defaultGolangciConfig` (the "NobleFactor defaults" seeded into repos lacking a config) was a stale pre-ladder snapshot. It now mirrors the repository's hardened `.golangci.yaml` minus the one repo-specific exclusion (revive var-naming for `pkg/op/provider/(json|yaml)/`), and `TestDefaultGolangciConfigTracksRepoConfig` locks the two together semantically — future ladder tweaks must flow into the template or be declared repo-specific. The noblefactor-ops upstream half is chartered in `docs/plans/golangci-template-sync.md`, blocked pending a ruling on its active branch. Verified: suite green (including the new guard), dual-GOOS lint at zero.