### PR TITLE
chore(lint): golangci v2.12.2 — pin aligned, the new analyzers satisfied

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install lint tools
         run: |
           for attempt in 1 2 3; do
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.10.1/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.10.1 && break
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2 && break
             echo "golangci-lint install attempt $attempt failed; retrying in 5s" >&2
             sleep 5
           done

--- a/cmd/star/cli/output.go
+++ b/cmd/star/cli/output.go
@@ -261,7 +261,7 @@ func matchesFilter(item interface{}, filter string) bool {
 func toSlice(data interface{}) []interface{} {
 	v := reflect.ValueOf(data)
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -278,7 +278,7 @@ func toSlice(data interface{}) []interface{} {
 
 func getFieldNames(item interface{}) []string {
 	v := reflect.ValueOf(item)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -314,7 +314,7 @@ func getFieldNames(item interface{}) []string {
 
 func getFieldValue(item interface{}, field string) interface{} {
 	v := reflect.ValueOf(item)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/cmd/star/config/accessor.go
+++ b/cmd/star/config/accessor.go
@@ -17,7 +17,7 @@ type Accessor struct {
 // The value should be a struct or pointer to struct.
 func NewAccessor(v interface{}) *Accessor {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	return &Accessor{v: rv}
@@ -168,7 +168,7 @@ func (a *Accessor) Struct(name string) *Accessor {
 	if !field.IsValid() {
 		return &Accessor{}
 	}
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		field = field.Elem()
 	}
 	if field.Kind() != reflect.Struct {

--- a/cmd/star/config/element.go
+++ b/cmd/star/config/element.go
@@ -121,7 +121,7 @@ func (e *Element) navigateParts(parts []string) interface{} {
 // navigateStructFields traverses struct fields by name.
 func navigateStructFields(obj interface{}, parts []string) interface{} {
 	rv := reflect.ValueOf(obj)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -135,7 +135,7 @@ func navigateStructFields(obj interface{}, parts []string) interface{} {
 			return nil
 		}
 		rv = field
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			rv = rv.Elem()
 		}
 	}
@@ -149,7 +149,7 @@ func navigateStructFields(obj interface{}, parts []string) interface{} {
 // extractConfigElement extracts the embedded Element from a struct.
 func extractConfigElement(obj interface{}) *Element {
 	rv := reflect.ValueOf(obj)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -177,7 +177,7 @@ func setPath(child interface{}, path string) {
 	}
 
 	rv := reflect.ValueOf(child)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Pointer {
 		return
 	}
 	rv = rv.Elem()

--- a/cmd/star/config/starlark.go
+++ b/cmd/star/config/starlark.go
@@ -80,7 +80,7 @@ func (v *Value) Attr(name string) (starlark.Value, error) {
 	}
 
 	rv := reflect.ValueOf(v.elem)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 
@@ -114,7 +114,7 @@ func getConfigElement(v interface{}) *Element {
 
 	// Try to extract via reflection for other types
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -154,7 +154,7 @@ func (v *Value) AttrNames() []string {
 	}
 
 	rv := reflect.ValueOf(v.elem)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -200,7 +200,7 @@ func reflectToStarlark(rv reflect.Value) (starlark.Value, error) {
 	}
 
 	// Handle pointers - wrap pointer to struct as Value to preserve reference
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return starlark.None, nil
 		}

--- a/cmd/star/config/types.go
+++ b/cmd/star/config/types.go
@@ -289,7 +289,7 @@ func setPrimitiveValue(field reflect.Value, val interface{}) {
 
 // setStructFields populates struct fields from a map.
 func setStructFields(structVal reflect.Value, values map[string]interface{}) {
-	if structVal.Kind() == reflect.Ptr {
+	if structVal.Kind() == reflect.Pointer {
 		structVal = structVal.Elem()
 	}
 	if structVal.Kind() != reflect.Struct {

--- a/cmd/star/provider/goast/astrewrite.go
+++ b/cmd/star/provider/goast/astrewrite.go
@@ -19,7 +19,7 @@ type configNavigator interface {
 // schemasFromConfig converts config map data into a SchemaRegistry.
 func schemasFromConfig(val interface{}) *doctaxonomy.SchemaRegistry {
 	rv := reflect.ValueOf(val)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() == reflect.Map {
@@ -38,7 +38,7 @@ func schemasFromMap(val interface{}) *doctaxonomy.SchemaRegistry {
 	if !ok {
 		// Try reflect-based map access for generated config types.
 		rv := reflect.ValueOf(val)
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			rv = rv.Elem()
 		}
 		if rv.Kind() != reflect.Map {
@@ -63,7 +63,7 @@ func schemasFromMap(val interface{}) *doctaxonomy.SchemaRegistry {
 // schemaFromConfigVal converts a single schema config value into a CommentSchema.
 func schemaFromConfigVal(name string, val interface{}) *doctaxonomy.CommentSchema {
 	rv := reflect.ValueOf(val)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -105,7 +105,7 @@ func schemaElementFromValue(ev reflect.Value) (doctaxonomy.SchemaElement, bool) 
 	if ev.Kind() == reflect.Interface {
 		ev = ev.Elem()
 	}
-	if ev.Kind() == reflect.Ptr {
+	if ev.Kind() == reflect.Pointer {
 		ev = ev.Elem()
 	}
 	if ev.Kind() != reflect.Struct {

--- a/cmd/star/provider/goast/provider.go
+++ b/cmd/star/provider/goast/provider.go
@@ -532,7 +532,7 @@ func (p *Provider) spacingRules() SpacingRules {
 // spacingRulesFromConfig extracts SpacingRules from a config value using reflection.
 func spacingRulesFromConfig(val interface{}) SpacingRules {
 	rv := reflect.ValueOf(val)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {

--- a/docs/plans/golangci-bump.md
+++ b/docs/plans/golangci-bump.md
@@ -1,0 +1,33 @@
+---
+title: "Golangci Bump"
+status: complete
+created: 2026-08-07
+updated: 2026-08-07
+---
+
+# Plan: Golangci Bump
+
+## Summary
+
+Item 12: the local golangci-lint auto-updated to v2.12.2 while CI pinned v2.10.1, splitting
+the board — v2.12's new `inline` govet analyzer surfaced 23 deprecated `reflect.Ptr` uses,
+and its gosec pass flagged one new G115 (`hashString`'s rune→uint32). Approved 2026-08-07:
+align the CI pin to v2.12.2 and fix the findings deliberately, restoring the single-board
+contract (local and CI lint the same way, uncapped zero on both GOOS).
+
+## Changes
+
+1. **CI pin** — `.github/workflows/ci.yaml` installs v2.12.2 (both the install.sh URL and
+   the version argument).
+2. **`reflect.Ptr` → `reflect.Pointer`** — 23 sites across 9 files (star cli/config/goast,
+   `pkg/op/helpers.go`, `pkg/op/receiver_type.go`); `reflect.Ptr` is the deprecated alias.
+3. **G115 suppression with reason** — `hashString` (`pkg/op/starlarkbridge/go_receiver.go`)
+   ranges a string, so the rune is a code point (0..0x10FFFF, never negative) and hash
+   wraparound is the algorithm's intent.
+4. **No config change** — the current `.golangci.yaml` runs unchanged under v2.12.2, so the
+   three-copy lockstep (repo config, star seed template, ops canonical) is untouched and
+   the drift guard stays green.
+
+## Verification
+
+Suite green; uncapped board zero on Darwin and `GOOS=linux` under v2.12.2.

--- a/pkg/op/helpers.go
+++ b/pkg/op/helpers.go
@@ -106,7 +106,7 @@ func assignToType(
 		return raw, nil
 	}
 	if raw == nil {
-		if declared.Kind() == reflect.Ptr ||
+		if declared.Kind() == reflect.Pointer ||
 			declared.Kind() == reflect.Interface ||
 			declared.Kind() == reflect.Slice ||
 			declared.Kind() == reflect.Map ||

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -354,7 +354,7 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 
 	// Use the pointer type so pointer-receiver methods are visible to reflect.
 	methodType := providerType
-	if methodType.Kind() != reflect.Ptr {
+	if methodType.Kind() != reflect.Pointer {
 		methodType = reflect.PointerTo(methodType)
 	}
 
@@ -654,7 +654,7 @@ func methodFromReflectedMethod(receiverType reflect.Type, method reflect.Method,
 
 		// Ensure we are searching the pointer type so pointer-receiver methods are visible.
 		searchType := receiverType
-		if searchType.Kind() != reflect.Ptr {
+		if searchType.Kind() != reflect.Pointer {
 			searchType = reflect.PointerTo(searchType)
 		}
 
@@ -719,7 +719,7 @@ func deriveMethodParams(goType reflect.Type) map[string][]Parameter {
 
 func receiverName(providerType reflect.Type) string {
 
-	if providerType.Kind() == reflect.Ptr {
+	if providerType.Kind() == reflect.Pointer {
 		providerType = providerType.Elem()
 	}
 

--- a/pkg/op/starlarkbridge/go_receiver.go
+++ b/pkg/op/starlarkbridge/go_receiver.go
@@ -1120,6 +1120,7 @@ func hashString(s string) uint32 {
 	var hash uint32
 
 	for _, c := range s {
+		//nolint:gosec // G115: c is a code point (0..0x10FFFF) from string range; hash wraparound is intended.
 		hash = hash*31 + uint32(c)
 	}
 


### PR DESCRIPTION
Item 12. CI's golangci pin moves v2.10.1 → v2.12.2, restoring the single-board contract with the local tool. The 24 findings v2.12 introduces are fixed deliberately: 23 deprecated `reflect.Ptr` → `reflect.Pointer` across 9 files, and one reasoned G115 suppression in `hashString` (string range yields code points, never negative; wraparound is the hash's intent). No `.golangci.yaml` change — the three-copy lockstep and the drift guard are untouched. Verified: suite green, uncapped board zero on Darwin and `GOOS=linux` under v2.12.2. Plan: `docs/plans/golangci-bump.md`.