### PR TITLE
fix(op): the receipt trust boundary — verified-side asserts, no swallowed stamp

### DIFF
--- a/docs/plans/receipt-trust-boundary.md
+++ b/docs/plans/receipt-trust-boundary.md
@@ -1,0 +1,49 @@
+---
+title: "Receipt Trust Boundary"
+status: complete
+created: 2026-08-07
+updated: 2026-08-07
+---
+
+# Plan: Receipt Trust Boundary
+
+## Summary
+
+Item 9: scrutiny of the resume path's `receipt.Commit` handling and the restore chain's
+compliance with the settled checksum trust boundary (verified-side decode asserts; the load
+boundary errors). Three findings, ruled 2026-08-07; one positive finding needed no change
+(pause/cancel receipts round-trip safely — a zero UUID serializes as the all-zeros string,
+which parses back).
+
+## Findings and dispositions
+
+### 1. Provider Restore split — aligned to assert
+
+`encryption` and `git` receipts error-returned on catalog-lookup, type, and base-restore
+failures where `file`/`service`/`pkg` assert. All five run on verified-trace data. Both now
+assert; the error return survives only for the missing-environment caller contract.
+
+### 2. Recovery-stack reconstruction — moved to the assert side
+
+`fromEntries` (bare-receipt base restore) and `reconstructReceipt` (companion-type
+resolution, shape checks, encoded restore) asserted; both signatures dropped their
+structurally-impossible error returns and callers simplified. `rearmEntry` keeps its error
+(retyping and nested re-arms have live error sources).
+
+### 3. The swallowed audit-stamp Commit — propagated
+
+`pushAuditReceipt` ignored `receipt.Commit`'s error under a mislabeled annotation. The
+analysis that settled the ruling: `Commit` mints the transaction id first and returns on
+failure before recording the result and compensator, so a swallowed failure pushes an empty
+receipt — a claimed success whose side effect has no undo information, a silent hole in the
+recovery chain found only when compensation quietly skips it. The failure itself is
+`uuid.NewV7`'s random read; on Go 1.24+ the default `crypto/rand` reader never returns an
+error, so the path is effectively unreachable — but when it fires, failing honestly beats
+hiding the same orphan. `pushAuditReceipt` now returns the error: failure exits join it
+onto the exit error (`joinAuditStamp`, extracted after the inline joins pushed
+`Subgraph.Execute` past the gocognit gate), success exits fail the unit.
+
+## Verification
+
+Suite green (no test exercised the converted error paths); uncapped board zero on Darwin
+and `GOOS=linux`.

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1122,6 +1122,11 @@ func (e *GraphExecutor) controlPoint() error {
 //   - `action`: the dispatched [Action], or nil for an audit-only exit that never dispatched (cancellation, pause,
 //     or an unbound unit). Nil suppresses the commit — a unit carries an action even when canceled, so this flag,
 //     not `unit.Action()`, signals whether the dispatch ran.
+//
+// Returns:
+//   - `error`: non-nil when [Receipt.Commit] fails (its only failure: minting the transaction id). The receipt is
+//     still pushed for the audit trail, but its result and compensator were never recorded, so the caller must fail
+//     the dispatch rather than report success over an untracked side effect.
 func (e *GraphExecutor) pushAuditReceipt(
 	unit ExecutableUnit,
 	stack *RecoveryStack,
@@ -1130,7 +1135,7 @@ func (e *GraphExecutor) pushAuditReceipt(
 	compensator Compensator,
 	dispatchErr error,
 	action Action,
-) {
+) error {
 
 	// A *RecoveryStack compensator (a combinator or batch action) is stamped with the unit's identity/outcome and
 	// nested directly, so it is a RecoveryStack in the tree — compensated by its own Unwind, needing no wrapping
@@ -1138,7 +1143,7 @@ func (e *GraphExecutor) pushAuditReceipt(
 	if childStack, ok := compensator.(*RecoveryStack); ok {
 		childStack.Stamp(unit.ID(), result, dispatchErr)
 		stack.PushNested(childStack)
-		return
+		return nil
 	}
 
 	var receipt Receipt
@@ -1151,14 +1156,54 @@ func (e *GraphExecutor) pushAuditReceipt(
 
 	receipt.SetSlots(slots)
 
+	var commitErr error
+
 	if action != nil {
 		// A minimal activation carries the caller identity Commit stamps (step 30): the unit's id as the caller,
 		// plus the graph so Commit can resolve the unit object for its action-name stamping.
-		//nolint:errcheck // diagnose-ignored-error: resume stamp; see docs/architecture/2.8-eventing-infrastructure.md
-		_ = receipt.Commit(&ActivationRecord{Graph: e.graph, CallerID: unit.ID()}, result, compensator, dispatchErr)
+		commitErr = receipt.Commit(
+			&ActivationRecord{Graph: e.graph, CallerID: unit.ID()}, result, compensator, dispatchErr)
 	}
 
 	stack.Push(receipt)
+
+	if commitErr != nil {
+		return fmt.Errorf("commit audit receipt for %s: %w", unit.ID(), commitErr)
+	}
+
+	return nil
+}
+
+// joinAuditStamp pushes the dispatch-exit audit receipt for a failing exit and joins any stamp failure onto it.
+//
+// The failure-exit companion of [GraphExecutor.pushAuditReceipt]: the exit already carries `err`, so a commit
+// failure (its only failure: minting the transaction id) rides the same returned error rather than masking the
+// exit's cause. Success exits call [GraphExecutor.pushAuditReceipt] directly and fail the unit on a stamp failure.
+//
+// Parameters:
+//   - `unit`: the dispatching [ExecutableUnit].
+//   - `stack`: the recovery stack the receipt pushes onto.
+//   - `slots`: the resolved slot snapshot, or nil when the exit precedes slot resolution.
+//   - `compensator`: the action's compensator return, or nil when the dispatch never ran.
+//   - `err`: the failing exit's error. Must not be nil.
+//   - `action`: the dispatched [Action], or nil for an exit that never dispatched.
+//
+// Returns:
+//   - `error`: `err`, with any stamp failure joined via [errors.Join].
+func (e *GraphExecutor) joinAuditStamp(
+	unit ExecutableUnit,
+	stack *RecoveryStack,
+	slots map[string]any,
+	compensator Compensator,
+	err error,
+	action Action,
+) error {
+
+	if stampErr := e.pushAuditReceipt(unit, stack, slots, nil, compensator, err, action); stampErr != nil {
+		return errors.Join(err, stampErr)
+	}
+
+	return err
 }
 
 // endregion

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -107,7 +107,8 @@ func NewNode(spec *NodeSpec) (*Node, error) {
 //
 // Returns:
 //   - `any`: the dispatch's terminal result; nil on failure, cancellation, pause, or void return.
-//   - `error`: non-nil on cancellation, pause ([ErrPaused]), missing action, or [Action.Do] error.
+//   - `error`: non-nil on cancellation, pause ([ErrPaused]), missing action, [Action.Do] error, or a failed
+//     audit-receipt commit.
 func (n *Node) Execute(
 	ctx context.Context,
 	executor *GraphExecutor,
@@ -119,7 +120,7 @@ func (n *Node) Execute(
 
 	// Exit 1: context canceled before dispatch begins.
 	if err := ctx.Err(); err != nil {
-		executor.pushAuditReceipt(n, stack, nil, nil, nil, err, nil)
+		err = executor.joinAuditStamp(n, stack, nil, nil, err, nil)
 		return nil, fmt.Errorf("node %s: %w", nodeID, err)
 	}
 
@@ -143,7 +144,7 @@ func (n *Node) Execute(
 	if action == nil && n.ActionName() != "" {
 		resolved, err := runtimeEnvironment.ActionByName(n.ActionName())
 		if err != nil {
-			executor.pushAuditReceipt(n, stack, nil, nil, nil, err, nil)
+			err = executor.joinAuditStamp(n, stack, nil, nil, err, nil)
 			return nil, executor.frameworkFailure(n.ID(),
 				fmt.Errorf("node %s: resolve action %q: %w", nodeID, n.ActionName(), err))
 		}
@@ -152,7 +153,7 @@ func (n *Node) Execute(
 
 	if action == nil {
 		err := fmt.Errorf("node %s: no Action bound", nodeID)
-		executor.pushAuditReceipt(n, stack, nil, nil, nil, err, nil)
+		err = executor.joinAuditStamp(n, stack, nil, nil, err, nil)
 		return nil, executor.frameworkFailure(n.ID(), err)
 	}
 
@@ -170,14 +171,18 @@ func (n *Node) Execute(
 
 	// Exit 3: Do returned an error.
 	if err != nil {
-		executor.pushAuditReceipt(n, stack, slots, nil, compensator, err, action)
+		err = executor.joinAuditStamp(n, stack, slots, compensator, err, action)
 		executor.hooks.FireNodeComplete(runtimeEnvironment, nodeID, nil, err)
 		executor.control.emit(ControlEvent{Kind: EventError, Status: executor.status, UnitID: nodeID, Err: err})
 		return nil, fmt.Errorf("%s: %w", action.Name(), err)
 	}
 
-	// Exit 4: successful dispatch.
-	executor.pushAuditReceipt(n, stack, slots, result, compensator, nil, action)
+	// Exit 4: successful dispatch. A failed audit stamp fails the node: the receipt never recorded the result and
+	// compensator, and success over an untracked side effect would hole the recovery chain.
+	if stampErr := executor.pushAuditReceipt(n, stack, slots, result, compensator, nil, action); stampErr != nil {
+		executor.hooks.FireNodeComplete(runtimeEnvironment, nodeID, nil, stampErr)
+		return nil, executor.frameworkFailure(nodeID, stampErr)
+	}
 	executor.hooks.FireNodeComplete(runtimeEnvironment, nodeID, result, nil)
 
 	return result, nil

--- a/pkg/op/provider/encryption/receipt.go
+++ b/pkg/op/provider/encryption/receipt.go
@@ -6,6 +6,7 @@ package encryption
 import (
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -43,7 +44,8 @@ type Receipt struct {
 //   - `_`: the receipt's id-reference sub-field, unused (no provider-specific fields).
 //
 // Returns:
-//   - `error`: a missing catalog, a resource-resolution failure, or an [op.ReceiptBase.Restore] failure.
+//   - `error`: non-nil only when the runtime environment or its catalog is missing; resolution and restore
+//     failures are verified-side defects and assert.
 func (r *Receipt) RestoreEncoded(
 	runtimeEnvironment *op.RuntimeEnvironment, base op.ReceiptData, _ map[string]any,
 ) error {
@@ -56,20 +58,12 @@ func (r *Receipt) RestoreEncoded(
 	// URI through the catalog's URI->id namespace (a Resource.URI() is a canonical tag URI, not a DiscoverResource input).
 	catalog := runtimeEnvironment.ResourceCatalog
 	got, ok := catalog.Lookup(catalog.Current(base.ResourceURI))
-	if !ok {
-		return fmt.Errorf("encryption.Receipt: RestoreEncoded: resource %q not in catalog", base.ResourceURI)
-	}
+	assert.True("encryption.Receipt: resource "+base.ResourceURI+" in catalog", ok)
 	resource, ok := got.(*file.Regular)
-	if !ok {
-		return fmt.Errorf("encryption.Receipt: RestoreEncoded: catalog entry for %q is %T, want *file.Regular",
-			base.ResourceURI, got)
-	}
+	assert.True("encryption.Receipt: catalog entry is *file.Regular", ok)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
-
-	if err := r.Restore(base); err != nil {
-		return fmt.Errorf("encryption.Receipt: RestoreEncoded restore: %w", err)
-	}
+	assert.NoError("encryption.Receipt: restore base", r.Restore(base))
 
 	return nil
 }

--- a/pkg/op/provider/git/receipt.go
+++ b/pkg/op/provider/git/receipt.go
@@ -6,6 +6,7 @@ package git
 import (
 	"fmt"
 
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -57,7 +58,8 @@ func NewReceipt(resource *Resource) *Receipt {
 //   - `_`: the receipt's id-reference sub-field, unused (no provider-specific fields).
 //
 // Returns:
-//   - `error`: a missing catalog, a [DiscoverResource] failure, or an [op.ReceiptBase.Restore] failure.
+//   - `error`: non-nil only when the runtime environment or its catalog is missing; resolution and restore
+//     failures are verified-side defects and assert.
 func (r *Receipt) RestoreEncoded(
 	runtimeEnvironment *op.RuntimeEnvironment, base op.ReceiptData, _ map[string]any,
 ) error {
@@ -70,20 +72,12 @@ func (r *Receipt) RestoreEncoded(
 	// through the catalog's URI->id namespace (a Resource.URI() is a canonical tag URI, not a DiscoverResource input).
 	catalog := runtimeEnvironment.ResourceCatalog
 	got, ok := catalog.Lookup(catalog.Current(base.ResourceURI))
-	if !ok {
-		return fmt.Errorf("git.Receipt: RestoreEncoded: resource %q not in catalog", base.ResourceURI)
-	}
+	assert.True("git.Receipt: resource "+base.ResourceURI+" in catalog", ok)
 	resource, ok := got.(*Resource)
-	if !ok {
-		return fmt.Errorf("git.Receipt: RestoreEncoded: catalog entry for %q is %T, want *git.Resource",
-			base.ResourceURI, got)
-	}
+	assert.True("git.Receipt: catalog entry is *git.Resource", ok)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
-
-	if err := r.Restore(base); err != nil {
-		return fmt.Errorf("git.Receipt: RestoreEncoded restore: %w", err)
-	}
+	assert.NoError("git.Receipt: restore base", r.Restore(base))
 
 	return nil
 }

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -367,7 +367,9 @@ func (s *RecoveryStack) UnmarshalJSON(data []byte) error {
 	}
 
 	s.restoreStamp(encoded.UnitID, encoded.Result, encoded.ResultType, encoded.Status)
-	return s.fromEntries(encoded.Entries)
+	s.fromEntries(encoded.Entries)
+
+	return nil
 }
 
 // UnmarshalYAML reconstructs the stack tree from the YAML form encoded by [RecoveryStack.MarshalYAML].
@@ -395,7 +397,9 @@ func (s *RecoveryStack) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	s.restoreStamp(encoded.UnitID, encoded.Result, encoded.ResultType, encoded.Status)
-	return s.fromEntries(encoded.Entries)
+	s.fromEntries(encoded.Entries)
+
+	return nil
 }
 
 // Unwind rolls back all stack entries in LIFO order.
@@ -472,9 +476,8 @@ func (s *RecoveryStack) Unwind(runtimeEnvironment *RuntimeEnvironment) error {
 // Parameters:
 //   - `entries`: the decoded entries, in stack order.
 //
-// Returns:
-//   - `error`: non-nil when a bare receipt's base restore fails.
-func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) error {
+// A bare receipt's base restore runs on the verified side of the checksum trust boundary — a failure asserts.
+func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) {
 
 	s.entries = make([]recoveryEntry, 0, len(entries))
 
@@ -489,9 +492,7 @@ func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) error {
 
 		receipt := &ReceiptBase{}
 
-		if err := receipt.RestoreEncoded(nil, e.base, nil); err != nil {
-			return err
-		}
+		assert.NoError("recovery stack: restore bare receipt base", receipt.RestoreEncoded(nil, e.base, nil))
 
 		entry := recoveryEntry{compensator: receipt}
 
@@ -501,8 +502,6 @@ func (s *RecoveryStack) fromEntries(entries []recoveryEntryData) error {
 
 		s.entries = append(s.entries, entry)
 	}
-
-	return nil
 }
 
 // rearm reconstructs concrete receipts after a resume operation rehydrates the ledger.
@@ -546,7 +545,7 @@ func (s *RecoveryStack) rearm(runtimeEnvironment *RuntimeEnvironment) error {
 //   - `entry`: the entry to re-arm.
 //
 // Returns:
-//   - `error`: non-nil when reconstruction, retyping, or a nested re-arm fails.
+//   - `error`: non-nil when retyping or a nested re-arm fails; reconstruction asserts (verified side).
 func rearmEntry(runtimeEnvironment *RuntimeEnvironment, entry *recoveryEntry) error {
 
 	if stack := entry.recoveryStackOrNil(); stack != nil {
@@ -562,13 +561,9 @@ func rearmEntry(runtimeEnvironment *RuntimeEnvironment, entry *recoveryEntry) er
 
 		restore := entry.restore
 
-		concrete, err := reconstructReceipt(
+		concrete := reconstructReceipt(
 			runtimeEnvironment,
 			restore.base.CompensatingAction, restore.base, restore.fields)
-
-		if err != nil {
-			return err
-		}
 
 		if concrete.Compensator() == nil {
 			concrete.receiptBase().compensator = concrete
@@ -894,34 +889,26 @@ func receiptTypeForAction(runtimeEnvironment *RuntimeEnvironment, action string)
 //   - `base`: the codec-decoded base execution state.
 //   - `fields`: the receipt's id-reference sub-field, decoded to a format-neutral map.
 //
+// Reconstruction runs on the verified side of the checksum trust boundary — an unknown action, a non-Receipt
+// companion, or a [Receipt.RestoreEncoded] failure is a defect and asserts.
+//
 // Returns:
 //   - `Receipt`: the reconstructed concrete receipt.
-//   - `error`: an unknown action, a non-Receipt companion parameter, or a [Receipt.RestoreEncoded] failure.
 func reconstructReceipt(
 	runtimeEnvironment *RuntimeEnvironment,
 	action string,
 	base ReceiptData,
-	fields map[string]any) (Receipt, error) {
+	fields map[string]any) Receipt {
 
 	receiptType, err := receiptTypeForAction(runtimeEnvironment, action)
-	if err != nil {
-		return nil, err
-	}
-
-	if receiptType.Kind() != reflect.Pointer {
-		return nil, fmt.Errorf("reconstructReceipt: action %q companion parameter %s is not a pointer", action, receiptType)
-	}
+	assert.NoError("recovery stack: receipt type for action "+action, err)
+	assert.True("recovery stack: companion parameter is a pointer", receiptType.Kind() == reflect.Pointer)
 
 	receipt, ok := reflect.New(receiptType.Elem()).Interface().(Receipt)
-	if !ok {
-		return nil, fmt.Errorf("reconstructReceipt: action %q reconstructs %s, which is not a Receipt", action, receiptType)
-	}
+	assert.True("recovery stack: reconstructed companion is a Receipt", ok)
+	assert.NoError("recovery stack: restore encoded receipt", receipt.RestoreEncoded(runtimeEnvironment, base, fields))
 
-	if err := receipt.RestoreEncoded(runtimeEnvironment, base, fields); err != nil {
-		return nil, err
-	}
-
-	return receipt, nil
+	return receipt
 }
 
 // retypeResult retypes a receipt's reloaded (untyped) result to its produced Go type, restoring full type fidelity.

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -175,7 +175,7 @@ func (s *Subgraph) Execute(
 	// Exit 1: context canceled before dispatch begins.
 
 	if err := ctx.Err(); err != nil {
-		executor.pushAuditReceipt(s, stack, nil, nil, nil, err, nil)
+		err = executor.joinAuditStamp(s, stack, nil, nil, err, nil)
 		return nil, fmt.Errorf("subgraph %s: %w", subgraphID, err)
 	}
 
@@ -212,7 +212,7 @@ func (s *Subgraph) Execute(
 
 		resolved, err := runtimeEnvironment.ActionByName(s.ActionName())
 		if err != nil {
-			executor.pushAuditReceipt(s, stack, nil, nil, nil, err, nil)
+			err = executor.joinAuditStamp(s, stack, nil, nil, err, nil)
 			return nil, executor.frameworkFailure(s.ID(),
 				fmt.Errorf("subgraph %s: resolve action %q: %w", subgraphID, s.ActionName(), err))
 		}
@@ -226,7 +226,7 @@ func (s *Subgraph) Execute(
 
 	if action == nil {
 		err := fmt.Errorf("subgraph %s: no Action bound", subgraphID)
-		executor.pushAuditReceipt(s, stack, nil, nil, nil, err, nil)
+		err = executor.joinAuditStamp(s, stack, nil, nil, err, nil)
 		return nil, executor.frameworkFailure(s.ID(), err)
 	}
 
@@ -268,14 +268,19 @@ func (s *Subgraph) Execute(
 	// Exit 3: Do returned an error.
 
 	if err != nil {
-		executor.pushAuditReceipt(s, stack, slots, nil, compensator, err, action)
+		err = executor.joinAuditStamp(s, stack, slots, compensator, err, action)
 		executor.hooks.FireSubgraphComplete(runtimeEnvironment, subgraphID, err)
 		return nil, fmt.Errorf("subgraph %s: %s: %w", subgraphID, action.Name(), err)
 	}
 
-	// Exit 4: successful dispatch.
+	// Exit 4: successful dispatch. A failed audit stamp fails the subgraph: the receipt never recorded the result
+	// and compensator, and success over an untracked side effect would hole the recovery chain.
 
-	executor.pushAuditReceipt(s, stack, slots, result, compensator, nil, action)
+	if stampErr := executor.pushAuditReceipt(s, stack, slots, result, compensator, nil, action); stampErr != nil {
+		executor.hooks.FireSubgraphComplete(runtimeEnvironment, subgraphID, stampErr)
+		return nil, executor.frameworkFailure(subgraphID, stampErr)
+	}
+
 	executor.hooks.FireSubgraphComplete(runtimeEnvironment, subgraphID, nil)
 
 	return result, nil


### PR DESCRIPTION
Item 9, all three findings ruled 2026-08-07. (1) `encryption`/`git` receipt restores align to the settled strict extent: verified-side decode failures assert, matching file/service/pkg. (2) Recovery-stack reconstruction (`fromEntries`, `reconstructReceipt`) moves to the assert side; structurally-impossible error returns removed. (3) `pushAuditReceipt` no longer swallows `receipt.Commit`'s error — Commit returns before recording result and compensator, so the swallow pushed an empty receipt: a claimed success with no undo information. Failure exits join the stamp error (`joinAuditStamp`, extracted to keep `Subgraph.Execute` under the gocognit gate), success exits fail the unit. Pause/cancel round-trip verified sound (zero UUID ↔ all-zeros string). Verified: suite green, board zero on both GOOS. Plan: `docs/plans/receipt-trust-boundary.md`.