### PR TITLE
fix(archive): opens route through Root — the reported bypass and the hidden one

### DIFF
--- a/docs/plans/archive-root-confinement.md
+++ b/docs/plans/archive-root-confinement.md
@@ -1,0 +1,46 @@
+---
+title: "Archive Root Confinement"
+status: complete
+created: 2026-08-07
+updated: 2026-08-07
+---
+
+# Plan: Archive Root Confinement
+
+## Summary
+
+Issue #225: the archive provider opened archives with `os.Open`, bypassing the
+`fsroot.Root` confinement boundary. The sweep found the reported site plus a second,
+subtler one in the same flow: the zip branch closed the file and re-opened it by path via
+`zip.OpenReader`, which performs its own unconfined `os.Open` internally.
+
+## Fix
+
+`openArchive` opens through the environment's root (`root.Open(root.NewPath(source))` —
+the file provider's idiom), and `newZipArchiveReader` now takes the already-open handle:
+`file.Stat` for size, `zip.NewReader` over the handle, the handle owned and closed by the
+reader. The zip branch hands the same confined handle over instead of re-opening; the
+spool path passes its temp-file handle directly, dropping a close-and-reopen. The
+`zipArchiveReader` struct holds `*zip.Reader` + `io.Closer` in place of `*zip.ReadCloser`.
+
+## Sweep: remaining os-level file I/O in providers
+
+The broadened search (all `os.*` filesystem calls under `pkg/op/provider/`) found four
+judgment groups, none a confinement hole of the #225 kind. Ruled 2026-08-07: all four are
+deliberate keeps, each site now carrying a one-line confinement-reason comment:
+
+1. **archive spool** — `os.CreateTemp`/`os.Remove` in the system temp dir. Process
+   scratch mandated by §10 ruling 5 (stream-shaped zips spool to disk); not target-tree
+   I/O.
+2. **plan Save/LoadDefinition** — `os.Create`/`os.ReadFile` on caller-named plan-document
+   paths. Plan documents are store/CLI documents, not confined-tree resources;
+   Root-routing would confine them to the run root (a behavior change).
+3. **function synthesize** — `os.ReadFile` of the Starlark source at the interpreter
+   position. Script sources live outside the target root by definition.
+4. **git provider** — `os.RemoveAll` in CompensateClone and three `os.Stat` repo probes.
+   Git trees are managed by the external git subprocess, which confinement never binds;
+   `fsroot.Root` has no `RemoveAll`.
+
+## Verification
+
+Suite green, board zero on both GOOS, zero `os.Open` remaining in the archive provider.

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -261,9 +261,9 @@ func (p *Provider) CompensateExtractStream(activation *op.ActivationRecord, stac
 // Detection sniffs up to `headerSniffLen` bytes and matches compression and container magic numbers — never the file
 // name. A compression match (gzip, bzip2, xz, zstd) wraps the rewound file in the matching decompressor feeding one
 // tar reader — the design's Layer-A table (§2 of docs/architecture/3.5.1-archive-provider.md); a ustar magic at
-// offset 257 selects the plain-tar (identity) path; a zip match reopens the path via [zip.OpenReader] (zip needs
-// random access to its central directory). Pre-POSIX V7 tar carries no magic, is not content-detectable, and
-// resolves to unsupported.
+// offset 257 selects the plain-tar (identity) path; a zip match hands the same open handle to [zip.NewReader]
+// (zip needs random access to its central directory). Pre-POSIX V7 tar carries no magic, is not
+// content-detectable, and resolves to unsupported. Every open routes through [fsroot.Root] (#225).
 // The returned [archiveReader] yields entries in storage order and must be closed by the caller.
 //
 // Parameters:
@@ -274,7 +274,9 @@ func (p *Provider) CompensateExtractStream(activation *op.ActivationRecord, stac
 //   - `error`: an unsupported or undetectable format, or any open/sniff/decompress failure.
 func (p *Provider) openArchive(source string) (archiveReader, error) {
 
-	archiveFile, err := os.Open(source)
+	root := p.RuntimeEnvironment().Root
+
+	archiveFile, err := root.Open(root.NewPath(source))
 	if err != nil {
 		return nil, err
 	}
@@ -288,10 +290,7 @@ func (p *Provider) openArchive(source string) (archiveReader, error) {
 	case formatGzip, formatBzip2, formatXz, formatZstd, formatTar:
 		return tarReaderFor(format, archiveFile, archiveFile)
 	case formatZip:
-		if err := archiveFile.Close(); err != nil {
-			return nil, err
-		}
-		return newZipArchiveReader(source)
+		return newZipArchiveReader(archiveFile)
 	default:
 		return nil, errors.Join(fmt.Errorf("unsupported archive format: %s", source), archiveFile.Close())
 	}
@@ -466,6 +465,7 @@ func copyHardlinkEntry(
 //   - `error`: any spool or zip-open failure (the temporary file is removed on failure).
 func spoolZipStream(stream io.Reader) (archiveReader, error) {
 
+	// Confinement: the spool is process scratch in the system temp dir, not target-tree I/O (§10 ruling 5).
 	spool, err := os.CreateTemp("", "devlore-archive-*.zip")
 	if err != nil {
 		return nil, fmt.Errorf("archive: spool zip stream: %w", err)
@@ -475,12 +475,7 @@ func spoolZipStream(stream io.Reader) (archiveReader, error) {
 		//nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
 		return nil, errors.Join(fmt.Errorf("archive: spool zip stream: %w", err), spool.Close(), os.Remove(spool.Name()))
 	}
-	if err = spool.Close(); err != nil {
-		//nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
-		return nil, errors.Join(fmt.Errorf("archive: spool zip stream: %w", err), os.Remove(spool.Name()))
-	}
-
-	inner, err := newZipArchiveReader(spool.Name())
+	inner, err := newZipArchiveReader(spool)
 	if err != nil {
 		//nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
 		return nil, errors.Join(err, os.Remove(spool.Name()))
@@ -804,27 +799,36 @@ func (r *tarArchiveReader) Close() error {
 // zipArchiveReader iterates a zip archive's central directory, opening each file entry's body on demand and closing it
 // when the iteration advances.
 type zipArchiveReader struct {
-	rc      *zip.ReadCloser
+	zr      *zip.Reader
+	closer  io.Closer
 	index   int
 	current io.ReadCloser
 }
 
-// newZipArchiveReader opens `source` as a zip archive.
+// newZipArchiveReader wraps the already-open zip archive `file` as an entry iterator.
+//
+// Taking the open handle rather than a path keeps every archive open on the caller's [fsroot.Root] route
+// (#225); the handle is owned by the returned reader, which closes it — including on its own error paths.
 //
 // Parameters:
-//   - `source`: absolute path to the zip archive on disk.
+//   - `archive`: the open zip archive; zip needs its random access for the central directory.
 //
 // Returns:
 //   - `*zipArchiveReader`: the entry iterator; the caller closes it.
-//   - `error`: any open failure.
-func newZipArchiveReader(source string) (*zipArchiveReader, error) {
+//   - `error`: a stat or central-directory failure.
+func newZipArchiveReader(archive *os.File) (*zipArchiveReader, error) {
 
-	rc, err := zip.OpenReader(source)
+	info, err := archive.Stat()
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, archive.Close())
 	}
 
-	return &zipArchiveReader{rc: rc}, nil
+	zr, err := zip.NewReader(archive, info.Size())
+	if err != nil {
+		return nil, errors.Join(err, archive.Close())
+	}
+
+	return &zipArchiveReader{zr: zr, closer: archive}, nil
 }
 
 // Next advances to the next entry, closing the previous entry's body reader first.
@@ -839,11 +843,11 @@ func (r *zipArchiveReader) Next() (archiveEntry, error) {
 		r.current = nil
 	}
 
-	if r.index >= len(r.rc.File) {
+	if r.index >= len(r.zr.File) {
 		return archiveEntry{}, io.EOF
 	}
 
-	entry := r.rc.File[r.index]
+	entry := r.zr.File[r.index]
 	r.index++
 
 	if entry.FileInfo().IsDir() {
@@ -883,9 +887,9 @@ func (r *zipArchiveReader) Next() (archiveEntry, error) {
 func (r *zipArchiveReader) Close() error {
 
 	if r.current != nil {
-		return errors.Join(r.current.Close(), r.rc.Close())
+		return errors.Join(r.current.Close(), r.closer.Close())
 	}
-	return r.rc.Close()
+	return r.closer.Close()
 }
 
 // endregion

--- a/pkg/op/provider/function/synthesize.go
+++ b/pkg/op/provider/function/synthesize.go
@@ -171,6 +171,7 @@ func extractNodeAt[T syntax.Node](pos syntax.Position) (source []byte, node T, e
 
 	var result T
 
+	// Confinement: reads the Starlark source at the interpreter position — scripts live outside the target root.
 	data, err := os.ReadFile(pos.Filename())
 	if err != nil {
 		return nil, result, fmt.Errorf("read source %s: %w", pos.Filename(), err)

--- a/pkg/op/provider/git/helpers.go
+++ b/pkg/op/provider/git/helpers.go
@@ -335,6 +335,7 @@ func isDirtyRepo(path string) bool {
 //   - `bare`: true when the repository is bare; meaningful only when repo is true.
 func isGitRepo(path string) (repo, bare bool) {
 
+	// Confinement: read-only probes of a git tree outside the target root — external git is never Root-bound.
 	if info, err := os.Stat(filepath.Join(path, ".git")); err == nil && info.IsDir() {
 		return true, false
 	}

--- a/pkg/op/provider/git/provider.go
+++ b/pkg/op/provider/git/provider.go
@@ -157,6 +157,7 @@ func (p *Provider) CompensateClone(activationRecord *op.ActivationRecord, receip
 		return nil
 	}
 
+	// Confinement: the clone tree belongs to the external git subprocess, which Root never binds.
 	return os.RemoveAll(resource.SourcePath.Abs())
 }
 

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -343,6 +343,7 @@ func (p *Provider) Clear() error {
 //   - `error`: non-nil when the file cannot be read, the format is unsupported, or decoding fails.
 func (p *Provider) LoadDefinition(path string) (*op.Graph, error) {
 
+	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree resources.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("plan.Provider.LoadDefinition: %w", err)
@@ -385,6 +386,7 @@ func (p *Provider) SaveDefinition(graph *op.Graph, path string) (err error) {
 
 	var file *os.File
 
+	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree resources.
 	file, err = os.Create(path)
 	if err != nil {
 		return fmt.Errorf("plan.Provider.SaveDefinition: %w", err)


### PR DESCRIPTION
Closes #225. `openArchive` bypassed `fsroot.Root` with `os.Open` — and the zip branch hid a second bypass, re-opening by path through `zip.OpenReader`. Opens now route through `root.Open(root.NewPath(source))`; `newZipArchiveReader` takes the open handle (`Stat` + `zip.NewReader`, handle owned by the reader), so zip reads the confined handle and the spool path drops a close-and-reopen. The broadened sweep of all provider os-level file I/O found four judgment groups — none a hole of this kind — ruled deliberate keeps, each site annotated with a one-line confinement reason (`docs/plans/archive-root-confinement.md`). Verified: suite green, board zero both GOOS, zero `os.Open` left in the archive provider.