### PR TITLE
test(writ): the scenario harness — a pristine user, the real binary, two sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ test: generate ## Run tests (TAGS=all|integration|e2e|"", default: all)
 test-race: generate ## Run tests with race detector (TAGS=all|integration|e2e|"", default: all)
 	go test $(if $(_TAGS),-tags '$(_TAGS)') $$(go list ./... | grep -v '/pkg/op/provider$$') -count=1 -race -timeout 120s
 
+test-scenario: build ## Run the writ-deploy scenario integration test (docs/plans/writ-deploy-scenario.md)
+	WRIT_SCENARIO_RUN=1 go test -run TestWritDeployScenario -v -count=1 -timeout 600s ./cmd/writ
+
 cover: generate ## Report coverage (per-package inline + total); writes coverage.out. Not a gate — use test/check for that.
 	go test $(if $(_TAGS),-tags '$(_TAGS)') $$(go list ./... | grep -v '/pkg/op/provider$$') -coverprofile=coverage.out -timeout 120s || true
 	go tool cover -func=coverage.out | tail -1

--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+// The writ-deploy scenario harness (docs/plans/writ-deploy-scenario.md): a pristine sandbox user drives the
+// real writ binary as a subprocess against a personal-layer repo. Gated behind WRIT_SCENARIO_RUN=1 (the
+// test-scenario make target) so make test stays fast while the file stays compiled and linted.
+package main_test
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scenarioSandbox is the pristine fake-user world: a fresh home, redirected XDG homes, the personal repo, and
+// the environment every writ subprocess runs under.
+type scenarioSandbox struct {
+	Root string   // the sandbox root
+	Home string   // the fake $HOME
+	Repo string   // the personal-layer repo inside the sandbox
+	Env  []string // the controlled subprocess environment
+}
+
+// newScenarioSandbox builds the sandbox: fresh HOME and XDG homes, the personal repo materialized (fixture by
+// default, the real branch via WRIT_SCENARIO_REPO), and the personal layer registered through the settled
+// packaging mechanism — the layers-dir symlink (config plays no part; the config-vs-layers separation).
+func newScenarioSandbox(t *testing.T) *scenarioSandbox {
+
+	t.Helper()
+
+	if os.Getenv("WRIT_SCENARIO_RUN") == "" {
+		t.Skip("scenario harness runs under make test-scenario (WRIT_SCENARIO_RUN=1)")
+	}
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	dataHome := filepath.Join(root, "data")
+	repo := materializePersonalRepo(t, root)
+
+	for _, dir := range []string{home, filepath.Join(root, "config"), filepath.Join(root, "state"), dataHome} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	layers := filepath.Join(dataHome, "devlore", "writ", "layers")
+	if err := os.MkdirAll(layers, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(repo, filepath.Join(layers, "personal")); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Dir(writBinary(t))
+
+	return &scenarioSandbox{
+		Root: root,
+		Home: home,
+		Repo: repo,
+		Env: []string{
+			"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"HOME=" + home,
+			"USERPROFILE=" + home,
+			"XDG_CONFIG_HOME=" + filepath.Join(root, "config"),
+			"XDG_STATE_HOME=" + filepath.Join(root, "state"),
+			"XDG_DATA_HOME=" + dataHome,
+			"TMPDIR=" + os.TempDir(),
+		},
+	}
+}
+
+// writBinary returns the built writ binary's path, failing with the build instruction when it is absent.
+func writBinary(t *testing.T) string {
+
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "..", "build", "writ"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("writ binary missing at %s — run make test-scenario (it builds first): %v", path, err)
+	}
+	return path
+}
+
+// materializePersonalRepo produces the personal-layer repo inside the sandbox: the checked-in fixture by
+// default; with WRIT_SCENARIO_REPO set, the named repo's scenario branch (WRIT_SCENARIO_BRANCH, default
+// devlore-cli/writ-layer) extracted via git archive so the owner's checkout is never disturbed.
+func materializePersonalRepo(t *testing.T, root string) string {
+
+	t.Helper()
+
+	dest := filepath.Join(root, "Workspace", "Personal")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if source := os.Getenv("WRIT_SCENARIO_REPO"); source != "" {
+		branch := os.Getenv("WRIT_SCENARIO_BRANCH")
+		if branch == "" {
+			branch = "devlore-cli/writ-layer"
+		}
+		extractGitArchive(t, source, branch, dest)
+		return dest
+	}
+
+	copyFixture(t, filepath.Join("testdata", "personal-repo"), dest)
+	return dest
+}
+
+// copyFixture copies the checked-in fixture tree into the sandbox destination.
+func copyFixture(t *testing.T, source, dest string) {
+
+	t.Helper()
+
+	err := filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// extractGitArchive materializes `branch` of the repo at `source` into `dest` by streaming git archive
+// through an in-process tar reader — read-only against the repo, no checkout disturbance.
+func extractGitArchive(t *testing.T, source, branch, dest string) {
+
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", "-C", source, "archive", branch)
+	stream, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := tar.NewReader(stream)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		target, err := containedPath(dest, header.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			data, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, data, os.FileMode(header.Mode)&0o777); err != nil {
+				t.Fatal(err)
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(header.Linkname, target); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("git archive %s %s: %v", source, branch, err)
+	}
+}
+
+// containedPath joins an archive entry name onto dest, refusing names that would escape it.
+func containedPath(dest, name string) (string, error) {
+
+	target := filepath.Join(dest, filepath.FromSlash(name))
+	if !strings.HasPrefix(target, filepath.Clean(dest)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry %q escapes the sandbox", name)
+	}
+	return target, nil
+}
+
+// runWrit runs the built writ binary inside the sandbox and returns its combined outcome.
+func runWrit(t *testing.T, sandbox *scenarioSandbox, args ...string) (stdout, stderr string, err error) {
+
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), writBinary(t), args...)
+	cmd.Dir = sandbox.Home
+	cmd.Env = sandbox.Env
+
+	var outBuffer, errBuffer strings.Builder
+	cmd.Stdout = &outBuffer
+	cmd.Stderr = &errBuffer
+	err = cmd.Run()
+	return outBuffer.String(), errBuffer.String(), err
+}
+
+// TestWritDeployScenario_Harness is the phase-1 deliverable: the sandbox stands up — pristine homes, the
+// personal repo materialized, the layer registered — and the real writ binary runs green inside it.
+func TestWritDeployScenario_Harness(t *testing.T) {
+
+	sandbox := newScenarioSandbox(t)
+
+	stdout, stderr, err := runWrit(t, sandbox, "--help")
+	if err != nil {
+		t.Fatalf("writ --help failed: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stdout, "writ") {
+		t.Fatalf("writ --help output does not mention writ:\n%s", stdout)
+	}
+
+	resolved, err := filepath.EvalSymlinks(filepath.Join(sandbox.Root, "data", "devlore", "writ", "layers", "personal"))
+	if err != nil {
+		t.Fatalf("personal layer symlink does not resolve: %v", err)
+	}
+	expected, err := filepath.EvalSymlinks(sandbox.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != expected {
+		t.Fatalf("layer symlink resolves to %s, want %s", resolved, expected)
+	}
+}

--- a/cmd/writ/testdata/personal-repo/Home/all.Darwin/local/share/scenario/darwin.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Darwin/local/share/scenario/darwin.conf
@@ -1,0 +1,1 @@
+project = all.Darwin

--- a/cmd/writ/testdata/personal-repo/Home/all.Debian/local/share/scenario/debian.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Debian/local/share/scenario/debian.conf
@@ -1,0 +1,1 @@
+project = all.Debian

--- a/cmd/writ/testdata/personal-repo/Home/all.Linux/local/share/scenario/linux.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Linux/local/share/scenario/linux.conf
@@ -1,0 +1,1 @@
+project = all.Linux

--- a/cmd/writ/testdata/personal-repo/Home/all.Unix/local/share/scenario/unix.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Unix/local/share/scenario/unix.conf
@@ -1,0 +1,1 @@
+project = all.Unix

--- a/cmd/writ/testdata/personal-repo/Home/all.Windows/local/share/scenario/windows.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Windows/local/share/scenario/windows.conf
@@ -1,0 +1,1 @@
+project = all.Windows

--- a/cmd/writ/testdata/personal-repo/Home/all/local/share/scenario/all.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all/local/share/scenario/all.conf
@@ -1,0 +1,1 @@
+project = all

--- a/cmd/writ/testdata/personal-repo/Home/microsoft.Unix/local/share/scenario/ms-unix.conf
+++ b/cmd/writ/testdata/personal-repo/Home/microsoft.Unix/local/share/scenario/ms-unix.conf
@@ -1,0 +1,1 @@
+project = microsoft.Unix

--- a/cmd/writ/testdata/personal-repo/Home/microsoft.Windows/local/share/scenario/ms-win.conf
+++ b/cmd/writ/testdata/personal-repo/Home/microsoft.Windows/local/share/scenario/ms-win.conf
@@ -1,0 +1,1 @@
+project = microsoft.Windows

--- a/cmd/writ/testdata/personal-repo/Home/microsoft/scenario-note.md
+++ b/cmd/writ/testdata/personal-repo/Home/microsoft/scenario-note.md
@@ -1,0 +1,1 @@
+# Loose project-top note — mirrors the real microsoft project shape.

--- a/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/.config/scenario/writ.conf.template
+++ b/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/.config/scenario/writ.conf.template
@@ -1,0 +1,3 @@
+# Rendered by writ with segment data.
+os = {{ .Segments.OS }}
+arch = {{ .Segments.Arch }}

--- a/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/local/share/scenario/nf-unix.conf
+++ b/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/local/share/scenario/nf-unix.conf
@@ -1,0 +1,1 @@
+project = noblefactor.Unix

--- a/cmd/writ/testdata/personal-repo/Home/noblefactor/.config/scenario/base.conf
+++ b/cmd/writ/testdata/personal-repo/Home/noblefactor/.config/scenario/base.conf
@@ -1,0 +1,1 @@
+project = noblefactor (base dot-content)

--- a/cmd/writ/testdata/personal-repo/Home/thenobles.Darwin/local/share/scenario/tn-darwin.conf
+++ b/cmd/writ/testdata/personal-repo/Home/thenobles.Darwin/local/share/scenario/tn-darwin.conf
@@ -1,0 +1,1 @@
+project = thenobles.Darwin

--- a/cmd/writ/testdata/personal-repo/Home/thenobles/.config/scenario/shared.conf
+++ b/cmd/writ/testdata/personal-repo/Home/thenobles/.config/scenario/shared.conf
@@ -1,0 +1,1 @@
+project = thenobles (base dot-content)

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -1,7 +1,7 @@
 ---
 title: "Writ Deploy Scenario"
 issue: https://github.com/NobleFactor/devlore-cli/issues/346
-status: draft
+status: in-progress
 created: 2026-08-08
 updated: 2026-08-08
 ---
@@ -96,7 +96,7 @@ corrected shape.
 |---|---|
 | Create a new user account | Pristine sandbox: `t.TempDir()` as `HOME` (`USERPROFILE` on Windows) + fresh `XDG_{CONFIG,STATE,DATA}_HOME` — the established house pattern |
 | Install devlore-cli | Real binaries built once, placed on the sandbox `PATH`; the test shells `writ` as a subprocess |
-| Configure writ (personal only) | `writ config set writ.repos.personal <repo>` (or the config file directly) — base and team unset |
+| Configure writ (personal only) | The harness registers the layer at `XDG_DATA_HOME/devlore/writ/layers/personal` (symlink to the repo) — base and team absent |
 | `writ deploy noblefactor thenobles` | Deploy both projects into the sandbox home |
 | Verify | Links/copies land; `writ status` reports all ✓; the store holds the graph (once) + one trace + index entries; a second deploy is idempotent |
 
@@ -127,12 +127,19 @@ branch's content evolves, the fixture is refreshed deliberately.
    package-manager operations — the packaging leg gets its own scenario). The CI
    fixture mirrors the SHAPE with neutral synthetic content — real dotfiles never enter
    the public devlore-cli repo.
-2. **Configuration mechanism in the test.** Drive `writ config set` (exercises the
-   config surface — recommended) vs writing the config file directly (fewer moving
-   parts).
-3. **Windows staging.** (a) darwin+linux first, Windows as a follow-on phase riding the
-   #91 audit (recommended); (b) immediate windows-latest with `continue-on-error` for
-   signal.
+2. **Configuration mechanism — re-ruled 2026-08-08.** The original ruling ("use
+   `writ config set`") was made against the repositories guide, which documents a
+   `writ.repos.*` config key that nothing reads. Investigation showed the settled design:
+   layer registration is **packaging, not configuration** (the config-vs-layers
+   separation; the config plan's ruled-OUT list names `WritLayersDir()` explicitly), and
+   the real mechanism is the `XDG_DATA_HOME/devlore/writ/layers/<layer>` symlink
+   (`getConfiguredRepo`). The harness creates that symlink directly — the settled
+   mechanism, zero new surface, zero config-API migration debt. Chartered follow-ups,
+   deliberately not in this plan: a `writ repo add/remove/list` packaging command for the
+   fresh-user story, and the repositories-guide correction (its `config set` text is
+   fiction).
+3. **Windows staging — ruled 2026-08-08.** darwin+linux first; Windows follows as its
+   own phase riding the #91 audit.
 
 ## Phases
 
@@ -144,9 +151,13 @@ branch's content evolves, the fixture is refreshed deliberately.
    the clean-tree guard. (Owner-run; nothing automated touches the personal repo.)
    **Executed 2026-08-08** — thirteen directories mapped, secrets verified encrypted at
    the new paths.
-1. **Harness + fixture** — sandbox helper (env redirect, binaries on PATH), the
-   `personal-repo` fixture mirroring the branch, `WRIT_SCENARIO_REPO` resolution.
-   Deliverable: `writ --help` runs green in the sandbox.
+1. **Harness + fixture — done 2026-08-08.** `cmd/writ/scenario_integration_test.go`:
+   sandbox (fresh HOME + XDG triplet, binaries on PATH), the layer registered via the
+   layers-dir symlink, the 14-file neutral fixture at `cmd/writ/testdata/personal-repo/`,
+   `WRIT_SCENARIO_REPO`/`WRIT_SCENARIO_BRANCH` materialization via in-process
+   `git archive` extraction (traversal-guarded). `make test-scenario` builds and runs it
+   (env-gated so `make test` skips while the file stays linted). Verified green in both
+   modes — fixture and the real `devlore-cli/writ-layer` branch.
 2. **Deploy leg** — configure, deploy, assert (filesystem, status, store, idempotent
    re-deploy).
 3. **CI matrix** — the scenario job on ubuntu + macos.


### PR DESCRIPTION
Phase 1 of #346. The sandbox harness: fresh HOME + XDG homes, the personal layer registered via the layers-dir symlink (the settled packaging mechanism — Q2 re-ruled after finding the guide's `writ.repos` config key is read by nothing; zero config-API migration debt), the built `writ` driven as a subprocess. Repo sources: the neutral 14-file fixture (CI) or a real repo's `devlore-cli/writ-layer` branch via `WRIT_SCENARIO_REPO` (in-process `git archive` extraction). `make test-scenario` builds + runs; `make test` skips. Verified green in both modes; board zero on both GOOS. Next: the deploy leg (phase 2).