### PR TITLE
test(writ): the deploy leg — and the three defects it caught

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/lore/lore"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+
+	// Blank-import the op inventory so every provider's gen package init() runs and registers its
+	// ProviderReceiverType — the plan provider resolves actions through the receiver registry.
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
 )
 
 func main() {

--- a/cmd/writ/main.go
+++ b/cmd/writ/main.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ"
 	"github.com/NobleFactor/devlore-cli/internal/cli"
+
+	// Blank-import the op inventory so every provider's gen package init() runs and registers its
+	// ProviderReceiverType — the plan provider resolves actions through the receiver registry.
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
 )
 
 func main() {

--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -9,12 +9,14 @@ package main_test
 import (
 	"archive/tar"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -39,7 +41,12 @@ func newScenarioSandbox(t *testing.T) *scenarioSandbox {
 		t.Skip("scenario harness runs under make test-scenario (WRIT_SCENARIO_RUN=1)")
 	}
 
-	root := t.TempDir()
+	// Canonicalize the sandbox root: macOS puts temp dirs behind the /var -> /private/var symlink,
+	// and writ's relative-link math is lexical — a symlinked prefix would skew the climb depth.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	home := filepath.Join(root, "home")
 	dataHome := filepath.Join(root, "data")
 	repo := materializePersonalRepo(t, root)
@@ -71,6 +78,7 @@ func newScenarioSandbox(t *testing.T) *scenarioSandbox {
 			"XDG_CONFIG_HOME=" + filepath.Join(root, "config"),
 			"XDG_STATE_HOME=" + filepath.Join(root, "state"),
 			"XDG_DATA_HOME=" + dataHome,
+			"XDG_CACHE_HOME=" + filepath.Join(root, "cache"),
 			"TMPDIR=" + os.TempDir(),
 		},
 	}
@@ -109,11 +117,34 @@ func materializePersonalRepo(t *testing.T, root string) string {
 			branch = "devlore-cli/writ-layer"
 		}
 		extractGitArchive(t, source, branch, dest)
+		initializeRepo(t, dest)
 		return dest
 	}
 
 	copyFixture(t, filepath.Join("testdata", "personal-repo"), dest)
+	initializeRepo(t, dest)
 	return dest
+}
+
+// initializeRepo turns the materialized tree into a committed git repository — deploy pins layer sources to
+// git-worktree snapshots and refuses layers that are not clean repos.
+func initializeRepo(t *testing.T, dest string) {
+
+	t.Helper()
+
+	for _, args := range [][]string{
+		{"init", "--quiet", "--initial-branch=main"},
+		{"add", "-A"},
+		{"-c", "user.name=scenario", "-c", "user.email=scenario@invalid", "commit", "--quiet", "-m", "scenario baseline"},
+	} {
+		cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dest}, args...)...)
+		// The real user's global git config must not reach the sandbox repo (branch-protection
+		// hooks would reject the baseline commit on main).
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
 }
 
 // copyFixture copies the checked-in fixture tree into the sandbox destination.
@@ -253,5 +284,163 @@ func TestWritDeployScenario_Harness(t *testing.T) {
 	}
 	if resolved != expected {
 		t.Fatalf("layer symlink resolves to %s, want %s", resolved, expected)
+	}
+}
+
+// assertLinked asserts `path` is a symlink that resolves to readable content containing `want`.
+func assertLinked(t *testing.T, path, want string) {
+
+	t.Helper()
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("expected symlink at %s: %v", path, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected %s to be a symlink, mode %v", path, info.Mode())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		destination, _ := os.Readlink(path) //nolint:errcheck // diagnostic best effort
+		t.Fatalf("symlink %s (-> %s) does not resolve: %v", path, destination, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s content %q does not contain %q", path, data, want)
+	}
+}
+
+// assertRendered asserts `path` is a regular file (a rendered copy, not a link) containing every want.
+func assertRendered(t *testing.T, path string, wants ...string) {
+
+	t.Helper()
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("expected rendered file at %s: %v", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected %s to be a rendered copy, found a symlink", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range wants {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("%s content %q does not contain %q", path, data, want)
+		}
+	}
+}
+
+// assertAbsent asserts nothing exists at `path`.
+func assertAbsent(t *testing.T, path string) {
+
+	t.Helper()
+
+	if _, err := os.Lstat(path); err == nil {
+		t.Fatalf("expected nothing at %s", path)
+	}
+}
+
+// segmentOS returns the capitalized OS segment value for the running platform.
+func segmentOS() string {
+
+	switch runtime.GOOS {
+	case "darwin":
+		return "Darwin"
+	case "linux":
+		return "Linux"
+	default:
+		return runtime.GOOS
+	}
+}
+
+// TestWritDeployScenario_Deploy is the phase-2 leg: deploy noblefactor and thenobles into the sandbox, then
+// assert the deployed filesystem, the status report, the execution store, and a clean second deploy.
+func TestWritDeployScenario_Deploy(t *testing.T) {
+
+	sandbox := newScenarioSandbox(t)
+
+	stdout, stderr, err := runWrit(t, sandbox, "deploy", "noblefactor", "thenobles")
+	if err != nil {
+		t.Fatalf("writ deploy failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	// The per-file inventory assertions are fixture-specific; a real repo (WRIT_SCENARIO_REPO) carries
+	// the owner's content, so that mode asserts the generic invariants only (status, store, re-deploy).
+	fixtureMode := os.Getenv("WRIT_SCENARIO_REPO") == ""
+
+	// The deployed inventory: base dot-content on every platform, segment variants by matching, the
+	// template rendered (suffix stripped, copied not linked), undeployed projects absent.
+	scenario := filepath.Join(sandbox.Home, ".config", "scenario")
+	if fixtureMode {
+		assertLinked(t, filepath.Join(scenario, "base.conf"), "noblefactor (base dot-content)")
+		assertLinked(t, filepath.Join(scenario, "shared.conf"), "thenobles (base dot-content)")
+
+		if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+			assertLinked(t, filepath.Join(sandbox.Home, "local", "share", "scenario", "nf-unix.conf"), "noblefactor.Unix")
+			assertRendered(t, filepath.Join(scenario, "writ.conf"), "os = "+segmentOS(), "arch = "+runtime.GOARCH)
+		}
+		tnDarwin := filepath.Join(sandbox.Home, "local", "share", "scenario", "tn-darwin.conf")
+		if runtime.GOOS == "darwin" {
+			assertLinked(t, tnDarwin, "thenobles.Darwin")
+		} else {
+			assertAbsent(t, tnDarwin)
+		}
+		assertAbsent(t, filepath.Join(sandbox.Home, "local", "share", "scenario", "all.conf"))
+		assertAbsent(t, filepath.Join(sandbox.Home, "scenario-note.md"))
+	}
+
+	// The status report, machine-readable: every classified entry is healthy.
+	statusOut, statusErr, err := runWrit(t, sandbox, "status", "--json")
+	if err != nil {
+		t.Fatalf("writ status failed: %v\nstderr: %s", err, statusErr)
+	}
+	var report struct {
+		Entries []struct {
+			State   string `json:"state"`
+			Target  string `json:"target"`
+			Project string `json:"project"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(statusOut), &report); err != nil {
+		t.Fatalf("status --json is not parseable: %v\n%s", err, statusOut)
+	}
+	if len(report.Entries) < 3 {
+		t.Fatalf("status reports %d entries, expected at least 3:\n%s", len(report.Entries), statusOut)
+	}
+	for _, entry := range report.Entries {
+		if entry.State != "linked" && entry.State != "copied" {
+			t.Fatalf("entry %s (%s) has state %q, expected linked or copied", entry.Target, entry.Project, entry.State)
+		}
+	}
+
+	// The execution store: at least one persisted graph, one timestamped trace, and a non-empty run index.
+	stateHome := filepath.Join(sandbox.Root, "state", "devlore")
+	graphs, err := filepath.Glob(filepath.Join(stateHome, "graphs", "*.yaml"))
+	if err != nil || len(graphs) == 0 {
+		t.Fatalf("no persisted graphs under %s (err %v)", stateHome, err)
+	}
+	traces, err := filepath.Glob(filepath.Join(stateHome, "traces", "*", "2*.yaml"))
+	if err != nil || len(traces) == 0 {
+		t.Fatalf("no persisted traces under %s (err %v)", stateHome, err)
+	}
+	index, err := os.ReadFile(filepath.Join(stateHome, "index.ndjson"))
+	if err != nil || len(index) == 0 {
+		t.Fatalf("run index missing or empty (err %v)", err)
+	}
+
+	// A second deploy against the already-deployed home succeeds (the commit-keyed snapshot makes the
+	// existing links already correct) and appends traces rather than conflicting.
+	_, stderr2, err := runWrit(t, sandbox, "deploy", "noblefactor", "thenobles")
+	if err != nil {
+		t.Fatalf("second writ deploy failed: %v\nstderr: %s", err, stderr2)
+	}
+	tracesAfter, err := filepath.Glob(filepath.Join(stateHome, "traces", "*", "2*.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tracesAfter) <= len(traces) {
+		t.Fatalf("second deploy added no trace: %d before, %d after", len(traces), len(tracesAfter))
 	}
 }

--- a/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/.config/scenario/writ.conf.template
+++ b/cmd/writ/testdata/personal-repo/Home/noblefactor.Unix/.config/scenario/writ.conf.template
@@ -1,3 +1,3 @@
 # Rendered by writ with segment data.
 os = {{ .Segments.OS }}
-arch = {{ .Segments.Arch }}
+arch = {{ .Segments.ARCH }}

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -144,8 +144,10 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 	switch pipeline {
 
 	case "file.link":
+		// The link targets the ORIGIN path: the snapshot this entry was read from is removed when the
+		// run ends, so a durable link must point at the layer repo itself (ruled 2026-08-08).
 		invocation, err := provider.Plan(file.Link, nil, map[string]any{
-			"source_path": f.Source,
+			"source_path": f.Origin,
 			"target_path": f.Target,
 		})
 		return invocation, string(file.Link), err
@@ -504,7 +506,7 @@ func planChains(provider *plan.Provider, chains []*tree.FileEntry, data map[stri
 		}
 		fileMetas[finalInvocation.Target.ID()] = map[string]any{
 			"target":  f.Target,
-			"source":  f.Source,
+			"source":  f.Origin,
 			"project": f.Project,
 			"layer":   f.Layer,
 			"action":  action,
@@ -534,6 +536,10 @@ func runRootFor(cfg *Config, targetRoot string, files []*tree.FileEntry) string 
 	}
 	for _, f := range files {
 		root = CommonAncestor(root, filepath.Dir(f.Source))
+		// Links stat and target the origin path, so the root must span it too (ruled 2026-08-08).
+		if f.Origin != "" && f.Origin != f.Source {
+			root = CommonAncestor(root, filepath.Dir(f.Origin))
+		}
 	}
 
 	return root

--- a/cmd/writ/writ/layer.go
+++ b/cmd/writ/writ/layer.go
@@ -55,6 +55,7 @@ func CollectLayerSources() ([]tree.LayerSource, error) {
 				Path:       path,
 				Order:      i,
 				SourceRoot: sourceDir,
+				OriginRoot: sourceDir,
 				TargetRoot: spec.TargetRoot,
 				TargetName: spec.SourceDir,
 			})

--- a/cmd/writ/writ/snapshot/snapshot.go
+++ b/cmd/writ/writ/snapshot/snapshot.go
@@ -175,6 +175,7 @@ func RewriteSources(sources []tree.LayerSource, snapshots []*Snapshot) []tree.La
 	rewritten := make([]tree.LayerSource, len(sources))
 	for i, src := range sources {
 		rewritten[i] = src
+		rewritten[i].OriginRoot = src.SourceRoot
 		worktree, ok := worktreeByRepo[src.Path]
 		if !ok {
 			continue

--- a/cmd/writ/writ/tree/builder.go
+++ b/cmd/writ/writ/tree/builder.go
@@ -20,7 +20,8 @@ type LayerSource struct {
 	Layer      string // "base", "team", or "personal"
 	Path       string // Repo root path
 	Order      int    // 0=base, 1=team, 2=personal (for precedence sorting)
-	SourceRoot string // Full path to source directory (e.g., /path/to/repo/Home)
+	SourceRoot string // Full path to the directory planning reads (a pinned snapshot under layered deploys)
+	OriginRoot string // Full path to the origin-repo directory links target and records name; SourceRoot when unpinned
 	TargetRoot string // Target root (e.g., $HOME or /)
 	TargetName string // "System" or "Home"
 }
@@ -35,8 +36,14 @@ type FileEntry struct {
 	// Examples: ["link"], ["decrypt", "render", "copy"].
 	Operations []string
 
-	// Source is the absolute path to the source file.
+	// Source is the absolute path to the source file planning and execution read — under a layered
+	// deploy, inside the pinned snapshot worktree.
 	Source string
+
+	// Origin is the absolute origin-repo path for the same file. Links target it and records name it:
+	// snapshots are removed when the run ends, so anything durable must point at the origin (ruled
+	// 2026-08-08). Equals Source when planning reads the origin directly.
+	Origin string
 
 	// Target is the absolute path to the target file.
 	Target string
@@ -161,7 +168,8 @@ func buildSingleSource(cfg BuildConfig) (*BuildResult, error) {
 	entriesByTarget := make(map[string]fileEntryWithMeta)
 
 	for _, match := range matches {
-		entries, err := walkDirectory(match, cfg.TargetRoot)
+		// Single-source mode reads the origin directly — one LayerSource with OriginRoot defaulting.
+		entries, err := walkDirectory(match, LayerSource{SourceRoot: cfg.SourceRoot, TargetRoot: cfg.TargetRoot})
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +248,7 @@ func buildMultiSource(cfg BuildConfig) (*BuildResult, error) { //nolint:gocognit
 		result.MatchedDirs = append(result.MatchedDirs, matches...)
 
 		for _, match := range matches {
-			entries, err := walkDirectory(match, source.TargetRoot)
+			entries, err := walkDirectory(match, source)
 			if err != nil {
 				return nil, fmt.Errorf("layer %s: %w", source.Layer, err)
 			}
@@ -316,8 +324,14 @@ func buildMultiSource(cfg BuildConfig) (*BuildResult, error) { //nolint:gocognit
 	return result, nil
 }
 
-// walkDirectory walks a matched directory and returns file entries for all files.
-func walkDirectory(match segment.MatchResult, targetRoot string) ([]*FileEntry, error) {
+// walkDirectory walks a matched directory and returns file entries for all files, each carrying both the
+// read path (Source, the pinned snapshot under layered deploys) and the durable origin path (Origin).
+func walkDirectory(match segment.MatchResult, source LayerSource) ([]*FileEntry, error) {
+
+	originRoot := source.OriginRoot
+	if originRoot == "" {
+		originRoot = source.SourceRoot
+	}
 	var entries []*FileEntry
 
 	err := filepath.WalkDir(match.Path, func(path string, d fs.DirEntry, err error) error {
@@ -328,43 +342,9 @@ func walkDirectory(match segment.MatchResult, targetRoot string) ([]*FileEntry, 
 			return nil
 		}
 
-		relPath, err := filepath.Rel(match.Path, path)
+		entry, err := fileEntryAt(match, source, originRoot, path, d.Name())
 		if err != nil {
 			return err
-		}
-
-		dir := filepath.Dir(relPath)
-		targetName, actions := ProcessingPipeline(d.Name())
-
-		var relTarget string
-		if dir == "." {
-			relTarget = targetName
-		} else {
-			relTarget = filepath.Join(dir, targetName)
-		}
-
-		// Secrets get restricted permissions
-		var mode os.FileMode
-		if hasAction(actions, "encryption.decrypt") {
-			mode = 0o600
-		}
-
-		entry := &FileEntry{
-			ID:         relTarget,
-			Operations: actions,
-			Source:     path,
-			Target:     filepath.Join(targetRoot, relTarget),
-			Project:    match.Project,
-			Mode:       mode,
-		}
-
-		// Validate packages-manifest files
-		if hasAction(actions, "manifest.resolve") {
-			if manifest.IsManifestFile(d.Name()) {
-				if err := manifest.Validate(path); err != nil {
-					return fmt.Errorf("invalid %s: %w", relPath, err)
-				}
-			}
 		}
 
 		entries = append(entries, entry)
@@ -372,6 +352,51 @@ func walkDirectory(match segment.MatchResult, targetRoot string) ([]*FileEntry, 
 	})
 
 	return entries, err
+}
+
+// fileEntryAt builds one walked file's [FileEntry] — target and pipeline from the name, restricted mode for
+// secrets, the Origin mapped onto `originRoot` — validating packages-manifest files as they surface.
+func fileEntryAt(match segment.MatchResult, source LayerSource, originRoot, path, name string) (*FileEntry, error) {
+
+	relPath, err := filepath.Rel(match.Path, path)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(relPath)
+	targetName, actions := ProcessingPipeline(name)
+
+	relTarget := targetName
+	if dir != "." {
+		relTarget = filepath.Join(dir, targetName)
+	}
+
+	// Secrets get restricted permissions
+	var mode os.FileMode
+	if hasAction(actions, "encryption.decrypt") {
+		mode = 0o600
+	}
+
+	sourceRelative, err := filepath.Rel(source.SourceRoot, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasAction(actions, "manifest.resolve") && manifest.IsManifestFile(name) {
+		if err := manifest.Validate(path); err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", relPath, err)
+		}
+	}
+
+	return &FileEntry{
+		ID:         relTarget,
+		Operations: actions,
+		Source:     path,
+		Origin:     filepath.Join(originRoot, sourceRelative),
+		Target:     filepath.Join(source.TargetRoot, relTarget),
+		Project:    match.Project,
+		Mode:       mode,
+	}, nil
 }
 
 // hasAction returns true if the actions slice contains the given name.

--- a/docs/architecture/5-graph-trace-integrity.md
+++ b/docs/architecture/5-graph-trace-integrity.md
@@ -94,7 +94,7 @@ ${XDG_STATE_HOME:-~/.local/state}/devlore/
 │       ├── 20260807T041500Z.yaml      # one trace per execution, UTC-timestamped
 │       ├── 20260807T093012Z.yaml
 │       └── latest.yaml -> 20260807T093012Z.yaml
-└── index.jsonl                        # the run index: one line per graph/trace event
+└── index.ndjson                        # the run index: one line per graph/trace event
 ```
 
 - A graph persists once (`cli.WriteGraph` is idempotent by checksum); distinct runs of the same plan

--- a/docs/guides/writ/graphs-and-traces.md
+++ b/docs/guides/writ/graphs-and-traces.md
@@ -35,7 +35,7 @@ ${XDG_STATE_HOME:-~/.local/state}/devlore/
 │   └── sha256-<hex>/                  # one subdirectory per graph
 │       ├── 20260807T163000Z.yaml      # one trace per execution, UTC-timestamped
 │       └── latest.yaml -> 20260807T163000Z.yaml
-└── index.jsonl                        # the run index: one line per persisted document
+└── index.ndjson                        # the run index: one line per persisted document
 ```
 
 A graph persists once — re-running the same plan reuses it. Each run appends a timestamped

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -158,8 +158,28 @@ branch's content evolves, the fixture is refreshed deliberately.
    `git archive` extraction (traversal-guarded). `make test-scenario` builds and runs it
    (env-gated so `make test` skips while the file stays linted). Verified green in both
    modes — fixture and the real `devlore-cli/writ-layer` branch.
-2. **Deploy leg** — configure, deploy, assert (filesystem, status, store, idempotent
-   re-deploy).
+2. **Deploy leg — done 2026-08-08.** `TestWritDeployScenario_Deploy`: deploy both
+   projects, assert the filesystem (links resolve, template rendered with segment data,
+   undeployed projects absent — fixture mode), `writ status --json` all-healthy, the
+   store (graph, timestamped trace, `index.ndjson`), and a clean second deploy appending
+   a trace. Green in fixture mode and against the real `devlore-cli/writ-layer` branch.
+   **Three real defects caught and fixed** — the scenario's charter proven on its first
+   full run:
+   1. The writ and lore binaries shipped without provider registration (no
+      `pkg/op/inventory` import in their mains) — every real-binary layered deploy died
+      planning `file.mkdir`. The in-process tests import the inventory themselves, which
+      is why it went unseen.
+   2. Every deployed symlink dangled at command exit: multi-source deploy pinned layers
+      to cache-home git-worktree snapshots, planned link sources inside them, then
+      removed them (`defer cleanup()`). Ruled: links and recorded metadata carry the
+      **origin** path (`FileEntry.Origin`, `LayerSource.OriginRoot`), planning and
+      execution keep reading the snapshot, and the confinement root spans both. This
+      also made re-deploy idempotence real (`occupantIsOurs` compares origin to origin).
+   3. Trace filenames had one-second resolution — two runs in the same second silently
+      overwrote a trace (audit-trail loss). Store filenames now carry nanosecond
+      precision.
+   Also fixed in passing: the store docs named the run index `index.jsonl`; the file is
+   `index.ndjson`.
 3. **CI matrix** — the scenario job on ubuntu + macos.
 4. **Windows** — per Q3's ruling.
 

--- a/internal/cli/store.go
+++ b/internal/cli/store.go
@@ -94,7 +94,9 @@ func WriteGraph(graph *op.Graph) (string, error) {
 func WriteTrace(trace *op.Trace) (string, error) {
 
 	directory := filepath.Join(TracesDir(), safeChecksum(trace.GraphChecksum))
-	filename := time.Now().UTC().Format("20060102T150405Z") + ".yaml"
+	// Nanosecond precision: two runs inside the same second must never overwrite a trace — the store is
+	// the audit trail (caught by the deploy scenario, 2026-08-08).
+	filename := time.Now().UTC().Format("20060102T150405.000000000Z") + ".yaml"
 	path := filepath.Join(directory, filename)
 
 	if err := trace.StampChecksum(); err != nil {


### PR DESCRIPTION
Phase 2 of #346, the scenario's charter proven on its first full run. The deploy leg (fixture + real-branch modes, both green) caught three real defects, all fixed here: (1) writ and lore binaries had no provider registration (missing `pkg/op/inventory` import — only the in-process tests imported it), so every real-binary layered deploy failed at planning; (2) deployed symlinks dangled the moment deploy exited — planned into snapshot worktrees the deferred cleanup removes; ruled: links + recorded metadata carry the origin path (`FileEntry.Origin`/`LayerSource.OriginRoot`), reads keep the pinned snapshot, the confinement root spans both, and `occupantIsOurs` now makes re-deploy idempotence real; (3) trace filenames were second-resolution — same-second runs silently overwrote the audit trail; now nanosecond. Passing doc fix: the run index is `index.ndjson`, not `index.jsonl`. Verified: suite green, three consecutive scenario runs green, board zero both GOOS.