### PR TITLE
ci(scenario): the writ-deploy scenario on ubuntu and macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,20 @@ jobs:
         run: |
           go install github.com/boyter/scc/v3@latest
           scc .
+
+  # The writ-deploy scenario (docs/plans/writ-deploy-scenario.md, #346): the real binaries driven
+  # end-to-end in a pristine sandbox, on both unix platforms. Windows joins via the #91 audit.
+  scenario:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Writ-deploy scenario
+        run: make test-scenario

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -180,7 +180,9 @@ branch's content evolves, the fixture is refreshed deliberately.
       precision.
    Also fixed in passing: the store docs named the run index `index.jsonl`; the file is
    `index.ndjson`.
-3. **CI matrix** — the scenario job on ubuntu + macos.
+3. **CI matrix — done 2026-08-08.** The `scenario` job in `ci.yaml`: ubuntu-latest +
+   macos-latest, checkout + Go + `make test-scenario` only (the full gate stays ubuntu).
+   The landing PR's own checks are the first cross-platform proof.
 4. **Windows** — per Q3's ruling.
 
 ## Acceptance criteria


### PR DESCRIPTION
Phase 3 of #346: the `scenario` matrix job (ubuntu-latest + macos-latest) running `make test-scenario` — the real binaries driven end-to-end in the pristine sandbox on both unix platforms. The full gate stays ubuntu-only; this PR's own checks are the first cross-platform run. Phase 4 (Windows) rides the #91 audit.