### PR TITLE
feat(writ): the repo command — first-class layer registration, guide corrected

### DIFF
--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -57,17 +57,9 @@ func newScenarioSandbox(t *testing.T) *scenarioSandbox {
 		}
 	}
 
-	layers := filepath.Join(dataHome, "devlore", "writ", "layers")
-	if err := os.MkdirAll(layers, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(repo, filepath.Join(layers, "personal")); err != nil {
-		t.Fatal(err)
-	}
-
 	binDir := filepath.Dir(writBinary(t))
 
-	return &scenarioSandbox{
+	sandbox := &scenarioSandbox{
 		Root: root,
 		Home: home,
 		Repo: repo,
@@ -82,6 +74,14 @@ func newScenarioSandbox(t *testing.T) *scenarioSandbox {
 			"TMPDIR=" + os.TempDir(),
 		},
 	}
+
+	// Register the personal layer through the real command — the fresh-user path, dogfooded on every
+	// platform the scenario runs on.
+	if stdout, stderr, err := runWrit(t, sandbox, "repo", "add", "personal", repo); err != nil {
+		t.Fatalf("writ repo add failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	return sandbox
 }
 
 // writBinary returns the built writ binary's path, failing with the build instruction when it is absent.

--- a/cmd/writ/writ/repo_cmd.go
+++ b/cmd/writ/writ/repo_cmd.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package writ
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NobleFactor/devlore-cli/internal/cli"
+)
+
+// newRepoCmd builds the repo command family: layer-repository registration through the layers directory.
+//
+// Registration is packaging, not configuration (the settled config-vs-layers separation): a layer is a
+// symlink under [cli.WritLayersDir], never a config.yaml key. Bare `writ repo` lists, matching git-remote's
+// idiom; `rm` and `ls` alias `remove` and `list`, matching docker's.
+//
+// Returns:
+//   - `*cobra.Command`: the assembled repo command.
+func newRepoCmd() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "repo [command]",
+		Short: "Manage layer repository registrations",
+		Long: `Manage layer repository registrations.
+
+A layer (base, team, or personal) is registered by a symlink in the writ layers
+directory (XDG_DATA_HOME/devlore/writ/layers) pointing at the repository. This is
+packaging, not configuration: registrations never appear in config.yaml.
+
+With no subcommand, repo lists the registrations.`,
+		Example: `  writ repo add personal ~/Workspace/Personal
+  writ repo                       # list registrations
+  writ repo remove team`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error { return runRepoList(cmd) },
+	}
+
+	cmd.AddCommand(newRepoAddCmd())
+	cmd.AddCommand(newRepoRemoveCmd())
+	cmd.AddCommand(newRepoListCmd())
+
+	return cmd
+}
+
+// newRepoAddCmd builds `repo add <layer> <path>`.
+func newRepoAddCmd() *cobra.Command {
+
+	return &cobra.Command{
+		Use:   "add <layer> <path>",
+		Short: "Register a repository as a layer",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRepoAdd(cmd, args[0], args[1])
+		},
+	}
+}
+
+// newRepoRemoveCmd builds `repo remove <layer>` (alias `rm`).
+func newRepoRemoveCmd() *cobra.Command {
+
+	return &cobra.Command{
+		Use:     "remove <layer>",
+		Aliases: []string{"rm"},
+		Short:   "Unregister a layer (does not delete files)",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRepoRemove(cmd, args[0])
+		},
+	}
+}
+
+// newRepoListCmd builds `repo list` (alias `ls`).
+func newRepoListCmd() *cobra.Command {
+
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List layer registrations",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRepoList(cmd)
+		},
+	}
+}
+
+// runRepoAdd registers `layer` as a symlink to `path` in the layers directory.
+//
+// Parameters:
+//   - `cmd`: the invoking command; supplies the output stream.
+//   - `layer`: the layer name; must be one of [LayerOrder].
+//   - `path`: the repository path; `~` expands, the path must exist and be a directory.
+//
+// Returns:
+//   - `error`: an unknown layer, a missing or non-directory path, an existing registration, or a
+//     filesystem failure.
+func runRepoAdd(cmd *cobra.Command, layer, path string) error {
+
+	if !slices.Contains(LayerOrder, layer) {
+		return fmt.Errorf("unknown layer %q (layers: base, team, personal)", layer)
+	}
+
+	absolute, err := filepath.Abs(expandPath(path))
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return fmt.Errorf("repository path: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("repository path %s is not a directory", absolute)
+	}
+
+	layers := cli.WritLayersDir()
+	if err := os.MkdirAll(layers, 0o750); err != nil {
+		return err
+	}
+
+	link := filepath.Join(layers, layer)
+	if _, err := os.Lstat(link); err == nil {
+		return fmt.Errorf("layer %s is already registered; run 'writ repo remove %s' first", layer, layer)
+	}
+
+	if err := os.Symlink(absolute, link); err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s -> %s\n", layer, absolute)
+	return err
+}
+
+// runRepoRemove unregisters `layer` by removing its layers-directory symlink; files are untouched.
+//
+// Parameters:
+//   - `cmd`: the invoking command; supplies the output stream.
+//   - `layer`: the layer name; must be one of [LayerOrder] and currently registered.
+//
+// Returns:
+//   - `error`: an unknown layer, an unregistered layer, or a filesystem failure.
+func runRepoRemove(cmd *cobra.Command, layer string) error {
+
+	if !slices.Contains(LayerOrder, layer) {
+		return fmt.Errorf("unknown layer %q (layers: base, team, personal)", layer)
+	}
+
+	link := filepath.Join(cli.WritLayersDir(), layer)
+	if _, err := os.Lstat(link); err != nil {
+		return fmt.Errorf("layer %s is not registered", layer)
+	}
+
+	if err := os.Remove(link); err != nil {
+		return err
+	}
+
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s unregistered\n", layer)
+	return err
+}
+
+// runRepoList prints every layer in order with its registration state.
+//
+// Parameters:
+//   - `cmd`: the invoking command; supplies the output stream.
+//
+// Returns:
+//   - `error`: a write failure on the output stream.
+func runRepoList(cmd *cobra.Command) error {
+
+	out := cmd.OutOrStdout()
+
+	for _, layer := range LayerOrder {
+
+		line := repoListLine(layer)
+		if _, err := fmt.Fprint(out, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// repoListLine renders one layer's registration line for the list report.
+//
+// Parameters:
+//   - `layer`: the layer name to render.
+//
+// Returns:
+//   - `string`: the newline-terminated report line.
+func repoListLine(layer string) string {
+
+	link := filepath.Join(cli.WritLayersDir(), layer)
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		return fmt.Sprintf("%-8s (not registered)\n", layer)
+	}
+
+	target := link
+	if info.Mode()&os.ModeSymlink != 0 {
+		if target, err = os.Readlink(link); err != nil {
+			return fmt.Sprintf("%-8s (unreadable link)\n", layer)
+		}
+	}
+
+	if _, err := filepath.EvalSymlinks(link); err != nil {
+		return fmt.Sprintf("%-8s -> %s (broken)\n", layer, target)
+	}
+
+	return fmt.Sprintf("%-8s -> %s\n", layer, target)
+}

--- a/cmd/writ/writ/repo_cmd_test.go
+++ b/cmd/writ/writ/repo_cmd_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package writ
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runRepo executes the repo command family against a sandboxed layers directory and returns its output.
+func runRepo(t *testing.T, args ...string) (string, error) {
+
+	t.Helper()
+
+	cmd := newRepoCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestRepo_AddListRemove_RoundTrip(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	if _, err := runRepo(t, "add", "personal", repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	listed, err := runRepo(t, "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(listed, "personal") || !strings.Contains(listed, repo) {
+		t.Fatalf("list output missing the registration:\n%s", listed)
+	}
+	if !strings.Contains(listed, "base     (not registered)") {
+		t.Fatalf("list output missing the unregistered marker:\n%s", listed)
+	}
+
+	if _, err := runRepo(t, "remove", "personal"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	listed, err = runRepo(t, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(listed, "personal (not registered)") {
+		t.Fatalf("expected personal unregistered after remove:\n%s", listed)
+	}
+}
+
+func TestRepo_BareInvocation_Lists(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	listed, err := runRepo(t)
+	if err != nil {
+		t.Fatalf("bare repo: %v", err)
+	}
+	for _, layer := range LayerOrder {
+		if !strings.Contains(listed, layer) {
+			t.Fatalf("bare listing missing layer %s:\n%s", layer, listed)
+		}
+	}
+}
+
+func TestRepo_Aliases_RmAndLs(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	if _, err := runRepo(t, "add", "team", repo); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := runRepo(t, "ls")
+	if err != nil {
+		t.Fatalf("ls alias: %v", err)
+	}
+	if !strings.Contains(listed, "team") || !strings.Contains(listed, repo) {
+		t.Fatalf("ls output missing the registration:\n%s", listed)
+	}
+	if _, err := runRepo(t, "rm", "team"); err != nil {
+		t.Fatalf("rm alias: %v", err)
+	}
+}
+
+func TestRepo_Add_Errors(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	if _, err := runRepo(t, "add", "sideways", repo); err == nil || !strings.Contains(err.Error(), "unknown layer") {
+		t.Fatalf("expected unknown-layer error, got %v", err)
+	}
+	if _, err := runRepo(t, "add", "personal", filepath.Join(repo, "absent")); err == nil {
+		t.Fatal("expected missing-path error")
+	}
+	if _, err := runRepo(t, "add", "personal", repo); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runRepo(t, "add", "personal", repo); err == nil || !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("expected already-registered error, got %v", err)
+	}
+}
+
+func TestRepo_Remove_Unregistered_Errors(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if _, err := runRepo(t, "remove", "team"); err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected not-registered error, got %v", err)
+	}
+}
+
+func TestRepo_List_MarksBrokenLink(t *testing.T) {
+
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	repo := t.TempDir()
+
+	if _, err := runRepo(t, "add", "personal", repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := runRepo(t, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(listed, "(broken)") {
+		t.Fatalf("expected broken marker after target removal:\n%s", listed)
+	}
+}

--- a/cmd/writ/writ/root.go
+++ b/cmd/writ/writ/root.go
@@ -51,6 +51,7 @@ Declare your environment once — writ deploys it everywhere you work.`,
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newAdoptCmd())
 	rootCmd.AddCommand(newMigrateCmd())
+	rootCmd.AddCommand(newRepoCmd())
 
 	return rootCmd
 }

--- a/docs/guides/writ/repositories.md
+++ b/docs/guides/writ/repositories.md
@@ -27,89 +27,69 @@ layer wins:
 | `team` | Team-specific config | Backend team's database tools, frontend linting |
 | `personal` | Individual preferences | Editor config, shell aliases, custom scripts |
 
-## Setting up a repository
+## Registering repositories
 
-Writ is VCS-agnostic. Use your preferred version control system to manage
-repositories, then register them with writ.
-
-### Clone an existing repository
+Registration is `writ repo`:
 
 ```bash
-# Clone with git
-git clone git@github.com:me/environment.git ~/environment
-
-# Register with writ
-writ config set writ.repos.personal ~/environment
+writ repo add personal ~/Workspace/Personal    # register a layer
+writ repo                                      # list registrations (same as: writ repo list / ls)
+writ repo remove team                          # unregister (same as: writ repo rm team)
 ```
 
-### Create a new repository
-
-```bash
-# Create directory structure
-mkdir -p ~/environment/myproject/Home/.config
-
-# Initialize git (optional)
-cd ~/environment
-git init
-
-# Register with writ
-writ config set writ.repos.personal ~/environment
-```
-
-### Register an existing directory
-
-If you already have a configuration directory:
-
-```bash
-writ config set writ.repos.personal ~/Workspace/Personal/Configs
-```
-
-## List registered repositories
-
-```bash
-writ config get writ.repos
-```
-
-## Remove a repository registration
-
-Unregister a repository from writ (does not delete files):
-
-```bash
-writ config unset writ.repos.team
-```
+A registration is a symlink in the writ layers directory
+(`XDG_DATA_HOME/devlore/writ/layers/<layer>`) pointing at the repository —
+packaging, not configuration. Registrations never appear in `config.yaml`,
+and `writ repo remove` never deletes repository files.
 
 To also clean up deployed files, decommission projects first:
 
 ```bash
-# Decommission specific projects from the team layer
 writ decommission shared-tools backend-config
+writ repo remove team
+```
 
-# Then unregister the repository
-writ config unset writ.repos.team
+## Setting up a repository
+
+Writ is VCS-agnostic. Use your preferred version control system to manage
+repositories, then register them:
+
+```bash
+# Clone an existing repository and register it
+git clone git@github.com:me/environment.git ~/environment
+writ repo add personal ~/environment
+
+# Or create a new one
+mkdir -p ~/environment/Home/myproject
+cd ~/environment && git init
+writ repo add personal ~/environment
 ```
 
 ## Repository structure
 
-A repository contains one or more projects (subdirectories), plus optional
-metadata files:
+A repository holds a `Home/` tree (deployed into `$HOME`) and optionally a
+`System/` tree (deployed into `/`). Directly under each sits one directory per
+**project**, with platform variants as dot-suffixed siblings — see
+[Platform awareness](/guides/writ/platform-awareness/) for the segment values:
 
 ```
 environment/
-├── .age-recipients          # Encryption recipients
 ├── .gitignore
-├── noblefactor/             # Project: personal config
-│   ├── Home/
-│   │   ├── .zshrc
-│   │   └── .config/git/config
-│   └── packages-manifest.yaml
-├── thenobles/               # Project: family-shared config
-│   └── Home/
-│       └── .config/shared/
-└── work/                    # Project: work-specific overrides
-    └── Home/
-        ├── .config/git/config   # Overrides noblefactor's git config
-        └── .npmrc
+└── Home/
+    ├── noblefactor/                  # Project: every platform
+    │   ├── .config/git/config
+    │   └── packages-manifest.yaml    # Optional: the project's software
+    ├── noblefactor.Unix/             # Variant: Darwin and Linux only
+    │   └── local/bin/my-script
+    ├── thenobles/                    # Project: family-shared config
+    │   └── .config/shared/family.conf
+    └── thenobles.Darwin/             # Variant: macOS only
+        └── local/bin/Backup-TimeCapsule
 ```
+
+Everything inside a project directory is home-relative: `Home/noblefactor/.config/git/config`
+deploys to `~/.config/git/config`. A file named `<name>.template` renders with
+segment data and deploys as `<name>`.
 
 ## Multi-layer deployment
 
@@ -121,28 +101,10 @@ writ deploy all
 
 Writ scans all registered repositories and deploys projects from each.
 When the same file path appears in multiple layers, the highest-precedence
-layer wins silently.
+layer wins.
 
-To see which layer a file comes from:
-
-```bash
-writ inspect ~/.config/git/config
-```
-
-## Configuration storage
-
-Repository registrations are stored in `~/.config/devlore/config.d/writ.yaml`:
-
-```yaml
-writ:
-  repos:
-    personal: ~/environment
-    team: /path/to/team-repo
-```
-
-Edit directly or use:
+To see what is deployed, where it came from, and whether it has drifted:
 
 ```bash
-writ config set writ.repos.team /path/to/team-repo
-writ config get writ.repos
+writ status
 ```

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -183,13 +183,24 @@ branch's content evolves, the fixture is refreshed deliberately.
 3. **CI matrix — done 2026-08-08.** The `scenario` job in `ci.yaml`: ubuntu-latest +
    macos-latest, checkout + Go + `make test-scenario` only (the full gate stays ubuntu).
    The landing PR's own checks are the first cross-platform proof.
-4. **Windows — in progress 2026-08-08 (the #91 audit slice, empirical via CI).** The
-   known gaps fixed up front: binaries carry `$(GOEXE)` (`.exe` on Windows), the harness
-   resolves the suffixed binary, and the scenario job forces `shell: bash` (Windows
-   `run:` defaults to PowerShell). Symlink creation relies on the runner's admin
-   privilege. The harness sets both `HOME` and `USERPROFILE`; **product gap noted for the
-   fuller #91 audit**: `TargetOrder` reads `HOME` only, which real Windows users lack.
-   The windows-latest matrix leg is the proof; iteration happens on the PR.
+4. **Windows — done 2026-08-09 (PR #351; scenario green on all three platforms).** Four
+   iterations of the empirical #91 audit slice: (1) the inventory generator emitted
+   backslashed import paths — `ToSlash` fixed, plus `fail-fast: false` so legs report
+   independently; (2) drive letters parsed as one-letter URI schemes in the resource
+   constructors — resolved by deleting the unused file-URI input grammar entirely
+   (paths-only constructors; rehydration's round-trip strips the provider's own emitted
+   prefix; input-domain tests pin the contract); (3) `$(GOEXE)` suffixing, `.exe`-aware
+   binary resolution, `shell: bash`; (4) the status-entry floor made platform-aware
+   (Windows matches the two base projects). Remaining product gaps recorded on #91:
+   the `HOME`-only `TargetOrder` read, end-user symlink privilege policy, and the
+   nonstandard Windows `file://` specific spelling.
+
+## Queued questions
+
+1. **Tuckr parity at the dogfooding cutover (queued 2026-08-09):** if `~/Workspace/Personal`
+   restructures on `main` to the writ layout, what — if anything — does the owner lose that
+   Tuckr provides, given actual Tuckr usage there (`Install-Tuckr`, `Complete-TuckrSetup`
+   in the repo) and writ's current feature set? Answer before the cutover.
 
 ## Acceptance criteria
 

--- a/docs/plans/writ-repo-command.md
+++ b/docs/plans/writ-repo-command.md
@@ -1,0 +1,31 @@
+---
+title: "Writ Repo Command"
+status: complete
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Writ Repo Command
+
+## Summary
+
+The fresh-user packaging command chartered from the writ-deploy scenario's Q2 re-ruling:
+layer registration had no first-class surface (a hand-made symlink), and the repositories
+guide documented a `writ config set writ.repos.*` mechanism nothing reads. `writ repo`
+closes both: `add <layer> <path>`, `remove <layer>` (alias `rm`), `list` (alias `ls`), and
+bare `writ repo` acting as list (ruled 2026-08-09; git-remote's idiom, docker's aliases).
+Registration remains what it always was — a symlink under `XDG_DATA_HOME/devlore/writ/layers`
+— packaging, never configuration, so the future config API owes this nothing.
+
+## Delivered
+
+1. `cmd/writ/writ/repo_cmd.go` + unit tests (round-trip, bare invocation, aliases,
+   unknown-layer / missing-path / double-add / remove-unregistered errors, broken-link
+   marker in list).
+2. The scenario harness dogfoods `writ repo add` for its layer registration — the
+   fresh-user path proven on ubuntu, macos, and windows by every scenario run.
+3. `docs/guides/writ/repositories.md` rewritten onto reality: `writ repo` registration
+   (the config-set fiction removed), the corrected `Home/<project>[.<Segment>]` structure
+   (was upside-down `<project>/Home/`), `writ status` in place of the retired
+   `writ inspect`, and the fictional "Configuration storage" section replaced by the
+   layers-directory truth.


### PR DESCRIPTION
The chartered fresh-user packaging command: `writ repo add/remove/list` (`rm`/`ls` aliases; bare `writ repo` lists) over the settled layers-directory symlink mechanism — packaging, never configuration, zero config-API debt. Unit tests cover the round-trip, aliases, bare invocation, all error paths, and the broken-link marker. The scenario harness now registers its layer through the command, so the fresh-user path is proven on ubuntu, macos, and windows by every scenario run. The repositories guide is rewritten onto reality (config-set fiction removed, structure corrected to `Home/<project>[.<Segment>]`, `writ status` for the retired `writ inspect`, layers-directory truth for the fictional storage section). Also rides the scenario plan's phase-4 closure and the queued Tuckr-parity question.