### PR TITLE
feat(writ): repo add takes a repository URL — clone-and-register, one grammar

### DIFF
--- a/cmd/writ/writ/repo_cmd.go
+++ b/cmd/writ/writ/repo_cmd.go
@@ -6,8 +6,10 @@ package writ
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -48,17 +50,37 @@ With no subcommand, repo lists the registrations.`,
 	return cmd
 }
 
-// newRepoAddCmd builds `repo add <layer> <path>`.
+// newRepoAddCmd builds `repo add <layer> <working-tree-root>|<repository-url> [<working-tree-root>]`.
 func newRepoAddCmd() *cobra.Command {
 
-	return &cobra.Command{
-		Use:   "add <layer> <path>",
+	cmd := &cobra.Command{
+		Use:   "add <layer> <working-tree-root>|<repository-url> [<working-tree-root>]",
 		Short: "Register a repository as a layer",
-		Args:  cobra.ExactArgs(2),
+		Long: `Register a repository as a layer.
+
+The location is a local working-tree-root, or a repository URL — which triggers a
+git clone (git-clone's own grammar: the optional trailing working-tree-root is the
+clone destination, defaulting to the writ-owned home under
+XDG_DATA_HOME/devlore/writ/repos). After placement the repository is entirely
+yours: writ performs no hidden git operations, ever.`,
+		Example: `  writ repo add personal ~/Workspace/Personal
+  writ repo add team git@github.com:acme/team-env.git
+  writ repo add personal git@github.com:me/personal.git ~/Workspace/Personal
+  writ repo add personal git@github.com:me/personal.git --branch devlore-cli/writ-layer`,
+		Args: cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRepoAdd(cmd, args[0], args[1])
+			destination := ""
+			if len(args) == 3 {
+				destination = args[2]
+			}
+			branch, _ := cmd.Flags().GetString("branch") //nolint:errcheck // flag registered below
+			return runRepoAdd(cmd, args[0], args[1], destination, branch)
 		},
 	}
+
+	cmd.Flags().String("branch", "", "Branch to clone (repository-url form only)")
+
+	return cmd
 }
 
 // newRepoRemoveCmd builds `repo remove <layer>` (alias `rm`).
@@ -89,33 +111,29 @@ func newRepoListCmd() *cobra.Command {
 	}
 }
 
-// runRepoAdd registers `layer` as a symlink to `path` in the layers directory.
+// runRepoAdd registers `layer` from `location` — a working-tree-root, or a repository URL cloned to
+// `destination` (the writ-owned home when empty).
 //
 // Parameters:
-//   - `cmd`: the invoking command; supplies the output stream.
+//   - `cmd`: the invoking command; supplies the streams and context.
 //   - `layer`: the layer name; must be one of [LayerOrder].
-//   - `path`: the repository path; `~` expands, the path must exist and be a directory.
+//   - `location`: a local working-tree-root (`~` expands; must be a git working tree) or a repository URL.
+//   - `destination`: the clone destination for the URL form; empty selects the writ-owned home. Must be
+//     empty for the working-tree-root form.
+//   - `branch`: the branch to clone; URL form only.
 //
 // Returns:
-//   - `error`: an unknown layer, a missing or non-directory path, an existing registration, or a
-//     filesystem failure.
-func runRepoAdd(cmd *cobra.Command, layer, path string) error {
+//   - `error`: an unknown layer, a malformed combination, a failed clone, a non-working-tree root, an
+//     existing registration, or a filesystem failure.
+func runRepoAdd(cmd *cobra.Command, layer, location, destination, branch string) error {
 
 	if !slices.Contains(LayerOrder, layer) {
 		return fmt.Errorf("unknown layer %q (layers: base, team, personal)", layer)
 	}
 
-	absolute, err := filepath.Abs(expandPath(path))
+	root, err := resolveWorkingTreeRoot(cmd, layer, location, destination, branch)
 	if err != nil {
 		return err
-	}
-
-	info, err := os.Stat(absolute)
-	if err != nil {
-		return fmt.Errorf("repository path: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("repository path %s is not a directory", absolute)
 	}
 
 	layers := cli.WritLayersDir()
@@ -128,12 +146,131 @@ func runRepoAdd(cmd *cobra.Command, layer, path string) error {
 		return fmt.Errorf("layer %s is already registered; run 'writ repo remove %s' first", layer, layer)
 	}
 
-	if err := os.Symlink(absolute, link); err != nil {
+	if err := os.Symlink(root, link); err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s -> %s\n", layer, absolute)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s -> %s\n", layer, root)
 	return err
+}
+
+// resolveWorkingTreeRoot produces the layer's working-tree-root from the location operand: the validated
+// local root, or the destination of a fresh clone for the URL form.
+//
+// Parameters:
+//   - `cmd`: the invoking command; supplies the streams and context for the clone.
+//   - `layer`: the layer name; names the writ-owned default clone destination.
+//   - `location`: the polymorphic location operand.
+//   - `destination`: the URL form's optional clone destination.
+//   - `branch`: the URL form's optional branch.
+//
+// Returns:
+//   - `string`: the absolute working-tree-root to register.
+//   - `error`: a malformed combination, a failed clone, or a root that is not a git working tree.
+func resolveWorkingTreeRoot(cmd *cobra.Command, layer, location, destination, branch string) (string, error) {
+
+	if isRepositoryURL(location) {
+		if destination == "" {
+			destination = filepath.Join(cli.WritReposDir(), layer)
+		}
+		return cloneRepository(cmd, location, expandPath(destination), branch)
+	}
+
+	if destination != "" {
+		return "", fmt.Errorf("a working-tree-root takes no destination (got %q)", destination)
+	}
+	if branch != "" {
+		return "", fmt.Errorf("--branch applies to the repository-url form only")
+	}
+
+	absolute, err := filepath.Abs(expandPath(location))
+	if err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", fmt.Errorf("working-tree-root: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working-tree-root %s is not a directory", absolute)
+	}
+	if _, err := os.Stat(filepath.Join(absolute, ".git")); err != nil {
+		return "", fmt.Errorf(
+			"%s is not a git working tree (deploy pins layers from git history; run 'git init' first)", absolute)
+	}
+
+	return absolute, nil
+}
+
+// isRepositoryURL reports whether `location` is a repository URL rather than a local path, by git-clone's
+// own rules: any scheme (`://`), or the scp-like `[user@]host:path` — a colon before any slash with more
+// than one character before it (a single character is a Windows drive letter).
+//
+// Parameters:
+//   - `location`: the location operand to classify.
+//
+// Returns:
+//   - `bool`: true for a repository URL.
+func isRepositoryURL(location string) bool {
+
+	if strings.Contains(location, "://") {
+		return true
+	}
+
+	colon := strings.Index(location, ":")
+	if colon <= 1 {
+		return false
+	}
+	slash := strings.IndexAny(location, `/\`)
+	return slash == -1 || colon < slash
+}
+
+// cloneRepository clones `url` to `destination` and returns the destination as an absolute path.
+//
+// The clone fully lands before anything registers; a failed clone into a destination this call created is
+// removed best-effort, so nothing half-made survives. Clone output streams to the command's stderr — auth
+// prompts and progress stay visible. After the clone, the repository is entirely the user's: writ performs
+// no further git operations on it.
+//
+// Parameters:
+//   - `cmd`: the invoking command; supplies the streams and context.
+//   - `url`: the repository URL.
+//   - `destination`: the clone destination; must not already exist.
+//   - `branch`: the branch to clone, or "" for the remote's default.
+//
+// Returns:
+//   - `string`: the absolute destination path.
+//   - `error`: an existing destination or a clone failure.
+func cloneRepository(cmd *cobra.Command, url, destination, branch string) (string, error) {
+
+	absolute, err := filepath.Abs(destination)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Lstat(absolute); err == nil {
+		return "", fmt.Errorf("clone destination %s already exists", absolute)
+	}
+
+	arguments := []string{"clone"}
+	if branch != "" {
+		arguments = append(arguments, "--branch", branch)
+	}
+	arguments = append(arguments, url, absolute)
+
+	//nolint:gosec // G204: git with the user's own url and destination — the command's purpose.
+	clone := exec.CommandContext(cmd.Context(), "git", arguments...)
+	clone.Stdout = cmd.ErrOrStderr()
+	clone.Stderr = cmd.ErrOrStderr()
+
+	if err := clone.Run(); err != nil {
+		//nolint:errcheck // diagnose-ignored-error: best-effort cleanup of the half-made clone; see docs/architecture/2.8-eventing-infrastructure.md
+		_ = os.RemoveAll(absolute)
+		return "", fmt.Errorf("git clone %s: %w", url, err)
+	}
+
+	return absolute, nil
 }
 
 // runRepoRemove unregisters `layer` by removing its layers-directory symlink; files are untouched.

--- a/cmd/writ/writ/repo_cmd_test.go
+++ b/cmd/writ/writ/repo_cmd_test.go
@@ -4,11 +4,44 @@
 package writ
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// workingTree creates a temporary directory that passes the add-time git-working-tree validation.
+func workingTree(t *testing.T) string {
+
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// sourceRepository creates a real single-commit git repository for offline file:// clone tests.
+func sourceRepository(t *testing.T) string {
+
+	t.Helper()
+
+	root := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "--quiet", "--initial-branch=main"},
+		{"-c", "user.name=t", "-c", "user.email=t@invalid", "commit", "--quiet", "--allow-empty", "-m", "seed"},
+	} {
+		command := exec.CommandContext(context.Background(), "git", append([]string{"-C", root}, args...)...)
+		command.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	return root
+}
 
 // runRepo executes the repo command family against a sandboxed layers directory and returns its output.
 func runRepo(t *testing.T, args ...string) (string, error) {
@@ -27,7 +60,7 @@ func runRepo(t *testing.T, args ...string) (string, error) {
 func TestRepo_AddListRemove_RoundTrip(t *testing.T) {
 
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	repo := t.TempDir()
+	repo := workingTree(t)
 
 	if _, err := runRepo(t, "add", "personal", repo); err != nil {
 		t.Fatalf("add: %v", err)
@@ -74,7 +107,7 @@ func TestRepo_BareInvocation_Lists(t *testing.T) {
 func TestRepo_Aliases_RmAndLs(t *testing.T) {
 
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	repo := t.TempDir()
+	repo := workingTree(t)
 
 	if _, err := runRepo(t, "add", "team", repo); err != nil {
 		t.Fatal(err)
@@ -94,13 +127,22 @@ func TestRepo_Aliases_RmAndLs(t *testing.T) {
 func TestRepo_Add_Errors(t *testing.T) {
 
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	repo := t.TempDir()
+	repo := workingTree(t)
 
 	if _, err := runRepo(t, "add", "sideways", repo); err == nil || !strings.Contains(err.Error(), "unknown layer") {
 		t.Fatalf("expected unknown-layer error, got %v", err)
 	}
 	if _, err := runRepo(t, "add", "personal", filepath.Join(repo, "absent")); err == nil {
 		t.Fatal("expected missing-path error")
+	}
+	if _, err := runRepo(t, "add", "personal", t.TempDir()); err == nil || !strings.Contains(err.Error(), "not a git working tree") {
+		t.Fatalf("expected working-tree validation error, got %v", err)
+	}
+	if _, err := runRepo(t, "add", "personal", repo, "elsewhere"); err == nil || !strings.Contains(err.Error(), "takes no destination") {
+		t.Fatalf("expected no-destination error, got %v", err)
+	}
+	if _, err := runRepo(t, "add", "personal", "--branch", "main", repo); err == nil || !strings.Contains(err.Error(), "repository-url form") {
+		t.Fatalf("expected branch-on-local error, got %v", err)
 	}
 	if _, err := runRepo(t, "add", "personal", repo); err != nil {
 		t.Fatal(err)
@@ -123,7 +165,7 @@ func TestRepo_List_MarksBrokenLink(t *testing.T) {
 
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)
-	repo := t.TempDir()
+	repo := workingTree(t)
 
 	if _, err := runRepo(t, "add", "personal", repo); err != nil {
 		t.Fatal(err)
@@ -138,5 +180,70 @@ func TestRepo_List_MarksBrokenLink(t *testing.T) {
 	}
 	if !strings.Contains(listed, "(broken)") {
 		t.Fatalf("expected broken marker after target removal:\n%s", listed)
+	}
+}
+
+func TestIsRepositoryURL_Table(t *testing.T) {
+
+	cases := []struct {
+		location string
+		want     bool
+	}{
+		{"https://github.com/me/x.git", true},
+		{"ssh://git@host/x.git", true},
+		{"file:///abs/src.git", true},
+		{"git@github.com:me/x.git", true},
+		{"host:path/to/repo", true},
+		{"/abs/path", false},
+		{"relative/path", false},
+		{"./x:y", false},
+		{`D:\a\b`, false},
+		{"C:/x", false},
+		{"~/Workspace/Personal", false},
+	}
+	for _, c := range cases {
+		if got := isRepositoryURL(c.location); got != c.want {
+			t.Errorf("isRepositoryURL(%q) = %v, want %v", c.location, got, c.want)
+		}
+	}
+}
+
+func TestRepo_Add_ClonesURL_DefaultHome(t *testing.T) {
+
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	source := sourceRepository(t)
+
+	out, err := runRepo(t, "add", "team", "file://"+source)
+	if err != nil {
+		t.Fatalf("add url: %v", err)
+	}
+	expected := filepath.Join(dataHome, "devlore", "writ", "repos", "team")
+	if !strings.Contains(out, expected) {
+		t.Fatalf("expected registration at the writ-owned home %s:\n%s", expected, out)
+	}
+	if _, err := os.Stat(filepath.Join(expected, ".git")); err != nil {
+		t.Fatalf("clone missing at default home: %v", err)
+	}
+}
+
+func TestRepo_Add_ClonesURL_PositionalDestination(t *testing.T) {
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	source := sourceRepository(t)
+	destination := filepath.Join(t.TempDir(), "Personal")
+
+	if _, err := runRepo(t, "add", "personal", "file://"+source, destination); err != nil {
+		t.Fatalf("add url with destination: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, ".git")); err != nil {
+		t.Fatalf("clone missing at positional destination: %v", err)
+	}
+
+	if _, err := runRepo(t, "remove", "personal"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(destination); err != nil {
+		t.Fatal("remove must not delete the cloned repository")
 	}
 }

--- a/docs/guides/writ/repositories.md
+++ b/docs/guides/writ/repositories.md
@@ -29,16 +29,27 @@ layer wins:
 
 ## Registering repositories
 
-Registration is `writ repo`:
+Registration is `writ repo`. The location is a local working-tree-root, or a
+repository URL — which clones first (`git clone`'s own grammar: the optional
+trailing working-tree-root is the destination):
 
 ```bash
-writ repo add personal ~/Workspace/Personal    # register a layer
-writ repo                                      # list registrations (same as: writ repo list / ls)
-writ repo remove team                          # unregister (same as: writ repo rm team)
+writ repo add personal ~/Workspace/Personal              # register an existing working tree
+writ repo add team git@github.com:acme/team-env.git      # clone to the writ-owned home
+writ repo add personal git@github.com:me/env.git ~/Workspace/Personal
+writ repo add personal git@github.com:me/env.git ~/Workspace/Personal --branch writ-layout
+writ repo                                                # list registrations (writ repo list / ls)
+writ repo remove team                                    # unregister (writ repo rm team)
 ```
 
+Without a destination, a URL clones to `XDG_DATA_HOME/devlore/writ/repos/<layer>` —
+right for consume-only base and team layers; your personal layer usually names the
+working tree you edit. **After placement the repository is entirely yours**: writ
+performs no hidden git operations, ever — updating layer content is `git pull`
+followed by `writ upgrade`.
+
 A registration is a symlink in the writ layers directory
-(`XDG_DATA_HOME/devlore/writ/layers/<layer>`) pointing at the repository —
+(`XDG_DATA_HOME/devlore/writ/layers/<layer>`) pointing at the working tree —
 packaging, not configuration. Registrations never appear in `config.yaml`,
 and `writ repo remove` never deletes repository files.
 
@@ -51,13 +62,13 @@ writ repo remove team
 
 ## Setting up a repository
 
-Writ is VCS-agnostic. Use your preferred version control system to manage
-repositories, then register them:
+Writ layers are git repositories — deploy plans against pinned git history, so a
+layer must be a git working tree (`writ repo add` checks, and refuses anything
+else):
 
 ```bash
-# Clone an existing repository and register it
-git clone git@github.com:me/environment.git ~/environment
-writ repo add personal ~/environment
+# One step: clone and register
+writ repo add personal git@github.com:me/environment.git ~/environment
 
 # Or create a new one
 mkdir -p ~/environment/Home/myproject

--- a/docs/plans/writ-repo-remote.md
+++ b/docs/plans/writ-repo-remote.md
@@ -1,0 +1,62 @@
+---
+title: "Writ Repo Remote"
+status: complete
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Writ Repo Remote
+
+## Summary
+
+`writ repo add`'s location operand becomes polymorphic (ruled 2026-08-09):
+
+```
+writ repo add <layer> <working-tree-root>
+writ repo add <layer> <repository-url> [<working-tree-root>]
+```
+
+A repository URL triggers a `git clone`; the optional third positional is `git clone
+<url> [<directory>]`'s own grammar, and it names the same concept as the local form's
+second positional — in every spelling, the working-tree-root is where the layer lives.
+When omitted, the clone lands in the writ-owned home
+(`XDG_DATA_HOME/devlore/writ/repos/<layer>`) — right for consume-only base/team layers;
+personal layers usually name a destination (`~/Workspace/Personal`).
+
+## Rulings
+
+1. **Positional destination**, not `--into` — git-clone's grammar, one operand concept.
+2. **Post-placement the repository is entirely the user's**: writ performs no hidden git
+   operations, ever. Updating layer content is `git pull` + `writ upgrade`.
+3. **The VCS-agnostic claim dies**: deploy pins layers from git history (the scenario
+   proved non-repos are refused), so writ layers ARE git repositories. The guide says so
+   honestly. (The claim survived the #352 rewrite unexamined — one occurrence, corrected
+   here.)
+4. **Add-time validation**: the working-tree-root must be a git working tree (`.git`
+   present) — failing at `add` beats failing at `deploy`'s pin.
+5. **`--branch <name>`** rides as the one flag (git-clone's own), immediately useful:
+   `writ repo add personal <url> --branch devlore-cli/writ-layer` is the pre-dogfooding
+   registration in one line.
+
+## Mechanics
+
+- **URL detection is git-clone's own rule**: `://` anywhere, or scp-like
+  `[user@]host:path` — a colon before any slash with more than one character before it
+  (a single letter is a Windows drive, the lesson already paid for in #351).
+- **Atomicity**: the clone fully lands, then the symlink; a failed clone into a
+  destination we created is cleaned up and nothing registers. Clone output streams to
+  stderr (auth prompts and progress stay visible).
+- **Three-arg local form is an error** ("a working-tree-root takes no destination").
+- Tests: URL-detection table, local-with-destination error, add-time `.git` validation,
+  and a real offline clone via a `file://` URL into both the default home and a
+  positional destination.
+
+## Delivered (2026-08-09)
+
+The polymorphic location, `--branch`, the writ-owned repos home (`cli.WritReposDir`),
+add-time working-tree validation, clone atomicity with cleanup, and the guide correction
+(the VCS-agnostic claim replaced by the honest git basis; the URL form documented with the
+no-hidden-git-operations promise). Tests: the URL-detection table (schemes, scp-like,
+drive letters, relative colons), every malformed combination, and real offline clones via
+`file://` into both the default home and a positional destination — with remove proven to
+leave the clone untouched.

--- a/internal/cli/xdg.go
+++ b/internal/cli/xdg.go
@@ -97,3 +97,10 @@ func DevloreStateHome() string {
 func WritLayersDir() string {
 	return filepath.Join(DevloreDataHome(), "writ", "layers")
 }
+
+// WritReposDir returns the writ-owned repository home — the default clone destination for
+// `writ repo add <layer> <repository-url>`.
+// XDG_DATA_HOME/devlore/writ/repos
+func WritReposDir() string {
+	return filepath.Join(DevloreDataHome(), "writ", "repos")
+}


### PR DESCRIPTION
Ruled 2026-08-09: `writ repo add <layer> <working-tree-root>|<repository-url> [<working-tree-root>]` — the URL form clones first (git-clone's own grammar and detection rules, `--branch` as the one flag), defaulting to the writ-owned home `XDG_DATA_HOME/devlore/writ/repos/<layer>`; a positional destination serves the edit-daily personal layer. After placement the repository is entirely the user's — no hidden git operations. The local form validates git-working-tree-ness at add time. The guide's VCS-agnostic fiction (false since snapshot pinning; carried unexamined through #352) is replaced by the honest git basis. Verified: suite green including real offline `file://` clone tests, scenario green, board zero both GOOS. Plan: `docs/plans/writ-repo-remote.md`.