### PR TITLE
feat(writ): the reserved common project + git-crypt-aware pinning

### DIFF
--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -391,7 +391,12 @@ func TestWritDeployScenario_Deploy(t *testing.T) {
 		} else {
 			assertAbsent(t, tnDarwin)
 		}
-		assertAbsent(t, filepath.Join(sandbox.Home, "local", "share", "scenario", "all.conf"))
+		// The reserved common project deploys implicitly — never named on the command line.
+		assertLinked(t, filepath.Join(sandbox.Home, "local", "share", "scenario", "common.conf"), "project = common")
+		if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+			assertLinked(t, filepath.Join(sandbox.Home, "local", "share", "scenario", "unix.conf"), "common.Unix")
+		}
+		// microsoft stays explicit-only: never deployed unless named.
 		assertAbsent(t, filepath.Join(sandbox.Home, "scenario-note.md"))
 	}
 
@@ -410,11 +415,11 @@ func TestWritDeployScenario_Deploy(t *testing.T) {
 	if err := json.Unmarshal([]byte(statusOut), &report); err != nil {
 		t.Fatalf("status --json is not parseable: %v\n%s", err, statusOut)
 	}
-	// The fixture yields 2 entries on Windows (both base projects; no variant matches) and at least 3
-	// on the unix platforms (base pair + Unix/Darwin variants).
-	minimumEntries := 3
+	// With the implicit common project: Windows deploys the base pair + common + common.Windows (4);
+	// the unix platforms add their variants (darwin 8, linux 7).
+	minimumEntries := 6
 	if runtime.GOOS == "windows" {
-		minimumEntries = 2
+		minimumEntries = 4
 	}
 	if len(report.Entries) < minimumEntries {
 		t.Fatalf("status reports %d entries, expected at least %d:\n%s", len(report.Entries), minimumEntries, statusOut)

--- a/cmd/writ/testdata/personal-repo/Home/all.Darwin/local/share/scenario/darwin.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Darwin/local/share/scenario/darwin.conf
@@ -1,1 +1,0 @@
-project = all.Darwin

--- a/cmd/writ/testdata/personal-repo/Home/all.Debian/local/share/scenario/debian.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Debian/local/share/scenario/debian.conf
@@ -1,1 +1,0 @@
-project = all.Debian

--- a/cmd/writ/testdata/personal-repo/Home/all.Linux/local/share/scenario/linux.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Linux/local/share/scenario/linux.conf
@@ -1,1 +1,0 @@
-project = all.Linux

--- a/cmd/writ/testdata/personal-repo/Home/all.Unix/local/share/scenario/unix.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Unix/local/share/scenario/unix.conf
@@ -1,1 +1,0 @@
-project = all.Unix

--- a/cmd/writ/testdata/personal-repo/Home/all.Windows/local/share/scenario/windows.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all.Windows/local/share/scenario/windows.conf
@@ -1,1 +1,0 @@
-project = all.Windows

--- a/cmd/writ/testdata/personal-repo/Home/all/local/share/scenario/all.conf
+++ b/cmd/writ/testdata/personal-repo/Home/all/local/share/scenario/all.conf
@@ -1,1 +1,0 @@
-project = all

--- a/cmd/writ/testdata/personal-repo/Home/common.Darwin/local/share/scenario/darwin.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common.Darwin/local/share/scenario/darwin.conf
@@ -1,0 +1,1 @@
+project = common.Darwin

--- a/cmd/writ/testdata/personal-repo/Home/common.Debian/local/share/scenario/debian.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common.Debian/local/share/scenario/debian.conf
@@ -1,0 +1,1 @@
+project = common.Debian

--- a/cmd/writ/testdata/personal-repo/Home/common.Linux/local/share/scenario/linux.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common.Linux/local/share/scenario/linux.conf
@@ -1,0 +1,1 @@
+project = common.Linux

--- a/cmd/writ/testdata/personal-repo/Home/common.Unix/local/share/scenario/unix.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common.Unix/local/share/scenario/unix.conf
@@ -1,0 +1,1 @@
+project = common.Unix

--- a/cmd/writ/testdata/personal-repo/Home/common.Windows/local/share/scenario/windows.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common.Windows/local/share/scenario/windows.conf
@@ -1,0 +1,1 @@
+project = common.Windows

--- a/cmd/writ/testdata/personal-repo/Home/common/local/share/scenario/common.conf
+++ b/cmd/writ/testdata/personal-repo/Home/common/local/share/scenario/common.conf
@@ -1,0 +1,1 @@
+project = common

--- a/cmd/writ/writ/common_project_test.go
+++ b/cmd/writ/writ/common_project_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package writ
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestWithCommonProject(t *testing.T) {
+
+	cases := []struct {
+		name     string
+		projects []string
+		want     []string
+	}{
+		{"injected first", []string{"noblefactor", "thenobles"}, []string{"common", "noblefactor", "thenobles"}},
+		{"not duplicated", []string{"common", "noblefactor"}, []string{"common", "noblefactor"}},
+		{"empty means every project, unchanged", nil, nil},
+	}
+	for _, c := range cases {
+		if got := withCommonProject(c.projects); !slices.Equal(got, c.want) {
+			t.Errorf("%s: withCommonProject(%v) = %v, want %v", c.name, c.projects, got, c.want)
+		}
+	}
+}

--- a/cmd/writ/writ/config.go
+++ b/cmd/writ/writ/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"filippo.io/age"
@@ -26,10 +27,23 @@ import (
 // 2. Environment variables (WRIT_*)
 // 3. Config file (~/.config/devlore/config.yaml)
 // 4. Defaults
+// withCommonProject returns the selection with the reserved `common` project included — common holds
+// configuration that applies everywhere and is always matched (the platform-awareness guide's spec;
+// Ansible's `all` group is the pattern, renamed to kill the every-project misreading). An empty
+// selection returns unchanged: where emptiness is permitted it already means "every project", and
+// decommission never receives the injection — destruction stays explicit.
+func withCommonProject(projects []string) []string {
+
+	if len(projects) == 0 || slices.Contains(projects, "common") {
+		return projects
+	}
+	return append([]string{"common"}, projects...)
+}
+
 func parseDeployConfig(cmd *cobra.Command, args []string) (*DeployConfig, error) {
 	cfg := &DeployConfig{}
 	cfg.Tool = "writ"
-	cfg.Projects = args
+	cfg.Projects = withCommonProject(args)
 
 	// Behavior flags
 	cfg.DryRun = viper.GetBool("writ.dry-run")
@@ -99,7 +113,7 @@ func parseDeployConfig(cmd *cobra.Command, args []string) (*DeployConfig, error)
 func parseUpgradeConfig(cmd *cobra.Command, args []string) (*UpgradeConfig, error) {
 	cfg := &UpgradeConfig{}
 	cfg.Tool = "writ"
-	cfg.Projects = args
+	cfg.Projects = withCommonProject(args)
 
 	// Behavior flags
 	cfg.DryRun = viper.GetBool("writ.dry-run")

--- a/cmd/writ/writ/snapshot/snapshot.go
+++ b/cmd/writ/writ/snapshot/snapshot.go
@@ -296,12 +296,58 @@ func gitRevParseHEAD(ctx context.Context, repoPath string) (string, error) {
 
 // gitWorktreeAdd creates a detached worktree at the given path for the given commit.
 func gitWorktreeAdd(ctx context.Context, repoPath, worktreePath, commitHash string) error {
+
+	// Create without checkout: an unlocked git-crypt repository's smudge filter cannot find its key
+	// from a worktree's private git-dir (git-crypt reads $GIT_DIR/git-crypt, and the key lives in the
+	// COMMON dir). Linking the key dir into the worktree's git-dir before populating fixes the
+	// checkout — caught live by the Personal-repo cutover (2026-08-09).
 	//nolint:gosec // G204: git with constant argv; worktree paths are writ-constructed.
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "--detach", worktreePath, commitHash)
+	cmd := exec.CommandContext(ctx,
+		"git", "-C", repoPath, "worktree", "add", "--no-checkout", "--detach", worktreePath, commitHash)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+
+	if err := linkGitCryptKeys(ctx, repoPath, worktreePath); err != nil {
+		return err
+	}
+
+	//nolint:gosec // G204: git with constant argv; worktree paths are writ-constructed.
+	checkout := exec.CommandContext(ctx, "git", "-C", worktreePath, "checkout", "--force", commitHash)
+	if out, err := checkout.CombinedOutput(); err != nil {
+		return fmt.Errorf("git worktree checkout: %s: %w", strings.TrimSpace(string(out)), err)
+	}
 	return nil
+}
+
+// linkGitCryptKeys links the repository's git-crypt key directory into the worktree's private git-dir,
+// so the smudge filter can decrypt during the worktree's checkout. A repository without git-crypt is a
+// no-op.
+func linkGitCryptKeys(ctx context.Context, repoPath, worktreePath string) error {
+
+	//nolint:gosec // G204: git with constant argv; paths are writ-constructed.
+	common := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	commonOut, err := common.Output()
+	if err != nil {
+		return fmt.Errorf("git rev-parse --git-common-dir: %w", err)
+	}
+	keysDir := filepath.Join(strings.TrimSpace(string(commonOut)), "git-crypt")
+	if _, err := os.Stat(keysDir); err != nil {
+		return nil //nolint:nilerr // an absent key dir is a repository without git-crypt; nothing to link.
+	}
+
+	//nolint:gosec // G204: git with constant argv; paths are writ-constructed.
+	private := exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-parse", "--path-format=absolute", "--git-dir")
+	privateOut, err := private.Output()
+	if err != nil {
+		return fmt.Errorf("git rev-parse --git-dir: %w", err)
+	}
+	link := filepath.Join(strings.TrimSpace(string(privateOut)), "git-crypt")
+	if _, err := os.Lstat(link); err == nil {
+		return nil // already linked (a reused worktree)
+	}
+
+	return os.Symlink(keysDir, link)
 }
 
 // gitWorktreeRemove removes a worktree registration and directory.

--- a/docs/guides/writ/manage-environments.md
+++ b/docs/guides/writ/manage-environments.md
@@ -21,11 +21,9 @@ writ deploy noblefactor
 writ deploy noblefactor thenobles
 ```
 
-Use `all` to deploy every project in the repository:
-
-```bash
-writ deploy all
-```
+The reserved `common` project — configuration that applies everywhere — deploys
+implicitly with every selection; there is nothing to add to the command line.
+To deploy every project, name them.
 
 ### Conflict resolution
 

--- a/docs/guides/writ/platform-awareness.md
+++ b/docs/guides/writ/platform-awareness.md
@@ -144,19 +144,23 @@ For `packages-manifest.yaml` files, variants are **merged** rather than replaced
 This lets you define common packages in the base and platform-specific packages
 in variants.
 
-## The `all` project
+## The `common` project
 
-The project name `all` is reserved and has special behavior:
+The project name `common` is reserved and has special behavior (the same pattern
+as Ansible's implicit `all` group, named `common` so it cannot be misread as
+"every project"):
 
-- **Always matched**: `all` and its variants (`all.Darwin`, `all.Linux`, etc.)
-  are included for every `writ deploy` operation
-- **Implicit inclusion**: Users don't need to specify `all`—it's automatic
-- **Base configuration**: Use `all/` for configuration that applies everywhere
+- **Always matched**: `common` and its variants (`common.Darwin`, `common.Linux`,
+  etc.) are included in every `writ deploy` and `writ upgrade` selection
+- **Implicit inclusion**: Users don't need to specify `common` — it's automatic
+- **Base configuration**: Use `common/` for configuration that applies everywhere
+- **Destruction stays explicit**: `writ decommission` never includes `common`
+  implicitly
 
 ```
 Home/
-├── all/                      # Config for all machines (automatic)
-├── all.Darwin/               # macOS additions (automatic on macOS)
+├── common/                   # Config for all machines (automatic)
+├── common.Darwin/            # macOS additions (automatic on macOS)
 ├── noblefactor/              # Personal project (explicit)
 └── microsoft/                # Work project (explicit)
 ```

--- a/docs/guides/writ/repositories.md
+++ b/docs/guides/writ/repositories.md
@@ -87,6 +87,7 @@ A repository holds a `Home/` tree (deployed into `$HOME`) and optionally a
 environment/
 ├── .gitignore
 └── Home/
+    ├── common/                       # Reserved: deploys implicitly, everywhere
     ├── noblefactor/                  # Project: every platform
     │   ├── .config/git/config
     │   └── packages-manifest.yaml    # Optional: the project's software
@@ -104,13 +105,14 @@ segment data and deploys as `<name>`.
 
 ## Multi-layer deployment
 
-Deploy from multiple layers simultaneously:
+Deployment always draws from every registered layer simultaneously:
 
 ```bash
-writ deploy all
+writ deploy noblefactor
 ```
 
-Writ scans all registered repositories and deploys projects from each.
+Writ scans all registered repositories and deploys the selected projects from
+each — plus the reserved `common` project, which is always included implicitly.
 When the same file path appears in multiple layers, the highest-precedence
 layer wins.
 

--- a/docs/plans/git-crypt-pinning.md
+++ b/docs/plans/git-crypt-pinning.md
@@ -1,0 +1,32 @@
+---
+title: "Git-Crypt Pinning"
+status: complete
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Git-Crypt Pinning
+
+## Summary
+
+Caught live by the Personal-repo dogfooding cutover: writ's snapshot pinning
+(`git worktree add`) fails on an unlocked git-crypt repository — the checkout's smudge
+filter reads `$GIT_DIR/git-crypt` for its key, but a worktree's private git-dir never
+holds it (the key lives in the COMMON dir). Any git-crypt layer broke pinning, on every
+registration path. Reproduced and workaround validated by hand (git-crypt 0.8.0,
+git 2.55) before implementing.
+
+## Fix
+
+`gitWorktreeAdd` becomes three steps: `worktree add --no-checkout --detach`, then
+`linkGitCryptKeys` (symlink the common dir's `git-crypt` into the worktree's private
+git-dir; a repository without git-crypt is a no-op, and a reused worktree skips the
+existing link), then `checkout --force <hash>`. Non-crypt repositories see identical
+behavior through a different sequence.
+
+## Proven by
+
+The live cutover itself: 75 files deployed from the git-crypt personal layer (secrets
+plaintext end to end), `writ status` 75/75, zero new broken links against the pre-cutover
+baseline. CI cannot exercise git-crypt (not on runners); the scenario's non-crypt legs
+prove the resequenced path.

--- a/docs/plans/implicit-common-project.md
+++ b/docs/plans/implicit-common-project.md
@@ -1,0 +1,37 @@
+---
+title: "Implicit Common Project"
+status: complete
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Implicit Common Project
+
+## Summary
+
+The reserved always-deployed project, ruled 2026-08-09. The spec existed
+(platform-awareness guide: reserved `all`, always matched, implicit) but the code never
+implemented it, and a second guide contradicted it with the every-project keyword reading
+— the cutover surfaced both when `all`'s Tuckr links survived a deploy. Ruled:
+platform-awareness wins; the name becomes **`common`** (Ansible's implicit-`all` pattern,
+renamed so it cannot be misread as "every project"); the code must always match it.
+
+## Delivered
+
+1. `withCommonProject` injects `common` into deploy and upgrade selection (never
+   decommission — destruction stays explicit; an empty selection stays empty where it
+   already means "every project"). Unit-tested.
+2. The scenario fixture renamed (`all*` → `common*`) and the deploy leg now asserts the
+   implicit behavior: `common.conf` deploys without being named, `common.Unix` variants
+   ride on unix platforms, microsoft stays explicit-only; platform floors raised (unix 6,
+   windows 4).
+3. All three guides reconciled: platform-awareness spec's `common` (with the Ansible
+   provenance and the decommission boundary), manage-environments' every-project reading
+   is dead, repositories shows `common/` in the structure and correct multi-layer
+   phrasing.
+4. The live repo: `devlore-cli/writ-layer` renamed its six `all*` directories to
+   `common*`, and the post-deploy broken-link guard caught the rename's victims — three
+   committed relative symlinks (`common.Unix` powershell profiles → the Windows tree)
+   still naming `all-Windows`; rewritten onto `common.Windows`. The takeover deploy:
+   282/282 healthy, zero new broken links. Tuckr's remaining domain: the `microsoft`
+   group.

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -197,10 +197,33 @@ branch's content evolves, the fixture is refreshed deliberately.
 
 ## Queued questions
 
-1. **Tuckr parity at the dogfooding cutover (queued 2026-08-09):** if `~/Workspace/Personal`
-   restructures on `main` to the writ layout, what — if anything — does the owner lose that
-   Tuckr provides, given actual Tuckr usage there (`Install-Tuckr`, `Complete-TuckrSetup`
-   in the repo) and writ's current feature set? Answer before the cutover.
+1. **Tuckr parity — ANSWERED 2026-08-09; the cutover is unblocked.** Surveyed against
+   actual usage: Tuckr is live (`TUCKR_HOME=~/Workspace/Personal/Home`, groups under
+   `Home/Configs`, real deployed links), but its Hooks and Secrets features are **unused**
+   (no `Hooks/`, no `Secrets/`; secrets ride git-crypt, which operates below both tools
+   and keeps working unchanged). Feature-for-feature on what IS used — symlink deployment,
+   manual platform groups, status, removal — writ covers everything, and auto segment
+   matching strictly improves on hand-picked dash groups. **Nothing used is lost.** Two
+   real workflow changes to accept, neither a loss of capability: (a) writ deploys from
+   pinned HEAD and refuses dirty trees — edit-then-commit-then-deploy replaces Tuckr's
+   deploy-the-working-tree-as-is (`--allow-dirty` is the escape); (b) the cutover's first
+   deploy meets the existing Tuckr symlinks as foreign occupants — take over with
+   `--conflict replace` (or `tuckr rm` first), a one-time procedure step. Unused Tuckr
+   hooks, if ever wanted, are the chartered #148 lane.
+
+## The cutover (2026-08-09) — dogfooding is LIVE
+
+Executed against the real home: `devlore-cli/writ-layer` pushed; the personal layer
+registered via `writ repo add personal git@github.com:David-Noble-at-work/personal.git
+--branch devlore-cli/writ-layer` (the writ-owned clone); git-crypt unlocked in the clone
+(GPG mode, `git crypt unlock`); `writ deploy noblefactor thenobles --conflict replace`
+deployed 75 files. Guards held: status 75/75, zero new broken links versus the
+pre-cutover baseline, the deployed secrets plaintext, the surviving Tuckr links
+(all/microsoft groups) untouched. The cutover surfaced and fixed a real product blocker —
+git-crypt-incompatible worktree pinning ([git-crypt-pinning.md](git-crypt-pinning.md)).
+Transitional workflow: writ-managed content edits land on the `devlore-cli/writ-layer`
+branch; the clone pulls them explicitly (no hidden git operations) and `writ upgrade`
+refreshes. Tuckr retires group by group as `all` and `microsoft` migrate.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
Two cutover-driven changes. (1) **git-crypt pinning**: snapshot worktree checkouts failed on unlocked git-crypt layers (the smudge filter's key lives in the common git-dir); `gitWorktreeAdd` resequences to no-checkout → key-dir link → checkout. (2) **The reserved `common` project**: the platform-awareness spec (reserved, always matched, implicit) wins over manage-environments' contradictory every-project reading; renamed from `all` (Ansible's implicit-all pattern) so the misreading is unspellable. `withCommonProject` injects it into deploy/upgrade selection — never decommission — with unit tests; the scenario fixture and assertions prove the implicit behavior on all three platforms; all three guides reconciled. Proven live: the personal-layer takeover deploys 282/282 healthy with zero new broken links (the guard also caught three committed relative symlinks broken by the rename, repaired on the writ-layer branch). Plans: `git-crypt-pinning.md`, `implicit-common-project.md`.