### PR TITLE
docs(plans): landed-as references for five completed plans

### DIFF
--- a/docs/plans/archive-root-confinement.md
+++ b/docs/plans/archive-root-confinement.md
@@ -44,3 +44,6 @@ deliberate keeps, each site now carrying a one-line confinement-reason comment:
 ## Verification
 
 Suite green, board zero on both GOOS, zero `os.Open` remaining in the archive provider.
+
+Landed as [PR #345](https://github.com/NobleFactor/devlore-cli/pull/345); squash-merged to
+`develop` 2026-08-08.

--- a/docs/plans/git-crypt-pinning.md
+++ b/docs/plans/git-crypt-pinning.md
@@ -30,3 +30,7 @@ The live cutover itself: 75 files deployed from the git-crypt personal layer (se
 plaintext end to end), `writ status` 75/75, zero new broken links against the pre-cutover
 baseline. CI cannot exercise git-crypt (not on runners); the scenario's non-crypt legs
 prove the resequenced path.
+
+Landed as [PR #354](https://github.com/NobleFactor/devlore-cli/pull/354) (with
+[implicit-common-project](implicit-common-project.md)); squash-merged to `develop`
+2026-08-09.

--- a/docs/plans/implicit-common-project.md
+++ b/docs/plans/implicit-common-project.md
@@ -35,3 +35,7 @@ renamed so it cannot be misread as "every project"); the code must always match 
    still naming `all-Windows`; rewritten onto `common.Windows`. The takeover deploy:
    282/282 healthy, zero new broken links. Tuckr's remaining domain: the `microsoft`
    group.
+
+Landed as [PR #354](https://github.com/NobleFactor/devlore-cli/pull/354) (with
+[git-crypt-pinning](git-crypt-pinning.md)); squash-merged to `develop` 2026-08-09 with CI,
+Knowledge Extract, Publish CLI Docs, and Release all green on the squash.

--- a/docs/plans/writ-repo-command.md
+++ b/docs/plans/writ-repo-command.md
@@ -29,3 +29,6 @@ Registration remains what it always was — a symlink under `XDG_DATA_HOME/devlo
    (was upside-down `<project>/Home/`), `writ status` in place of the retired
    `writ inspect`, and the fictional "Configuration storage" section replaced by the
    layers-directory truth.
+
+Landed as [PR #352](https://github.com/NobleFactor/devlore-cli/pull/352); squash-merged to
+`develop` 2026-08-09.

--- a/docs/plans/writ-repo-remote.md
+++ b/docs/plans/writ-repo-remote.md
@@ -60,3 +60,6 @@ no-hidden-git-operations promise). Tests: the URL-detection table (schemes, scp-
 drive letters, relative colons), every malformed combination, and real offline clones via
 `file://` into both the default home and a positional destination — with remove proven to
 leave the clone untouched.
+
+Landed as [PR #353](https://github.com/NobleFactor/devlore-cli/pull/353); squash-merged to
+`develop` 2026-08-09.


### PR DESCRIPTION
Docs-only. A plan committed inside its own PR predates the merge by construction, so no completed plan recorded where it landed. Each of the five now ends with a `Landed as` line naming its PR and squash date: `implicit-common-project` + `git-crypt-pinning` (#354), `writ-repo-remote` (#353), `writ-repo-command` (#352), `archive-root-confinement` (#345).