### PR TITLE
docs(plans): writ secret encrypt and rekey charters

### DIFF
--- a/docs/plans/writ-secret-encrypt.md
+++ b/docs/plans/writ-secret-encrypt.md
@@ -1,0 +1,53 @@
+---
+title: "Writ Secret Encrypt"
+status: proposed
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Writ Secret Encrypt
+
+## Summary
+
+`writ secret encrypt <file>...` — the user-facing front for the shipped
+`encryption.encrypt_file` action, pulled forward (ruled 2026-08-09) so the personal-repo
+SOPS migration runs through writ itself. The action already discovers the `.sops.yaml`
+governing each source (walking up from the file, then the XDG fallback) and carries
+generic key groups — age and Azure Key Vault both flow through untouched. Interactive
+editing stays with `sops edit`; the everyday authoring path is sops, age, or — we hope —
+writ. The provider is also surfaced in Starlark (agreed 2026-08-09) as a scripting
+surface, not the everyday path.
+
+## Design
+
+1. **Command**: `secret` parent under writ with `encrypt` as its first subcommand
+   (`cmd/writ/writ/secret_cmd.go`), `MinimumNArgs(1)` file arguments.
+2. **Per file**: resolve the absolute path; the output is the `<file>.sops` sibling —
+   matching the deploy convention (`foo.env.sops` deploys as `foo.env`). An existing
+   output refuses loudly (no `--force` until a need is shown). The plaintext source is
+   never deleted — writ performs no hidden destructive operations; removal belongs to
+   the caller (`git rm` in the migration sweep).
+3. **Execution**: spec-based graph construction through `plan.Provider` — one
+   `encryption.encrypt_file` unit per file — executed and persisted through the standard
+   writ pipeline: graph and trace in the execution store, receipts recorded
+   (compensation removes the ciphertext).
+4. **No-rule failure**: when no `.sops.yaml` creation rule governs a source, the
+   encrypter's existing error surfaces verbatim
+   ([encrypter.go:144](../../pkg/sops/encrypter.go)) — configuration is authored, never
+   inferred.
+5. **Starlark**: expose the encryption sub-namespace through the starlarkbridge adapter,
+   same pattern as the existing planable providers.
+
+## Verification
+
+1. Unit tests: output naming, existing-output refusal, no-governing-rule error, multiple
+   files in one invocation.
+2. Round-trip: `writ secret encrypt` output decrypts byte-identically through the
+   embedded client (age fixture, the pattern of the existing provider tests).
+3. `make test`, dual-GOOS lint recount at zero.
+4. Live proof: the personal-repo migration sweep (sops-migration plan, phase 3).
+
+## Open questions
+
+None — scope is deliberately minimal; `rekey` is chartered separately
+([writ-secret-rekey](writ-secret-rekey.md)).

--- a/docs/plans/writ-secret-rekey.md
+++ b/docs/plans/writ-secret-rekey.md
@@ -1,0 +1,41 @@
+---
+title: "Writ Secret Rekey"
+status: proposed
+created: 2026-08-09
+updated: 2026-08-09
+---
+
+# Plan: Writ Secret Rekey
+
+## Summary
+
+`writ secret rekey [<file>...]` — re-wrap the data keys of existing SOPS documents
+against the current `.sops.yaml` recipients, the `sops updatekeys` equivalent. This is
+the day-two operation for key custody changes: adding an escrow recipient, rotating the
+Azure Key Vault key version, or removing a compromised recipient. Chartered 2026-08-09;
+sequenced after [writ-secret-encrypt](writ-secret-encrypt.md) and the personal-repo
+migration (it needs an encrypted fleet to operate on).
+
+## Design sketch
+
+1. **New provider action** `encryption.rekey_file`: load the SOPS document, rebuild its
+   key groups from the governing `.sops.yaml` (the encrypter's existing discovery),
+   re-wrap the data key, write back. Compensable — the receipt carries the original
+   document bytes for restore.
+2. **Command**: `rekey` beside `encrypt` under `writ secret`; with no arguments it
+   sweeps every `*.sops` file governed by a discoverable `.sops.yaml` under the current
+   tree, with arguments it takes explicit files.
+3. **Distinction to preserve**: `updatekeys` re-wraps the data key only (content
+   untouched, cheap); `rotate` generates a new data key and re-encrypts content. This
+   plan delivers the former; `rotate` waits for a demonstrated need.
+
+## Verification
+
+1. Unit: recipient-set change reflected in document metadata; content bytes decrypt
+   identically before and after; no-governing-rule error.
+2. `make test`, dual-GOOS lint recount at zero.
+
+## Open questions
+
+1. Whether the no-argument sweep form belongs in the first delivery or arguments-only
+   ships first.


### PR DESCRIPTION
Two plan docs, no code. `writ-secret-encrypt` (pulled forward 2026-08-09): `writ secret encrypt <file>...` over the shipped `encryption.encrypt_file` — `.sops` sibling output, no plaintext deletion, starlark surfacing included; first consumer is the personal-repo SOPS migration sweep. `writ-secret-rekey`: the `sops updatekeys` equivalent, chartered behind encrypt and the migration.