### PR TITLE
docs: charter writ secret recover (break-glass, pipeline-free)

### DIFF
--- a/docs/architecture/3.5.13-encryption-provider.md
+++ b/docs/architecture/3.5.13-encryption-provider.md
@@ -37,6 +37,31 @@ func (p *Provider) EncryptFile(activationRecord *op.ActivationRecord, source *fi
 func (p *Provider) CompensateEncryptFile(activationRecord *op.ActivationRecord, receipt *Receipt) error
 ```
 
+## Key custody and break-glass recovery
+
+Decryption is config-free by construction: each SOPS document embeds its own metadata —
+one wrapped copy of the document's data key per recipient — and `pkg/sops` walks the
+generic keyservice set with ambient credentials (an age identity via `SOPS_AGE_KEY` /
+`~/.config/sops/age/keys.txt`; Azure Key Vault via the `azidentity` default chain). The
+framework holds no opinion on key custody: which recipients a layer uses, and where any
+held key material lives, is the layer owner's design (recorded in that repository — e.g.
+the personal layer's `design/secrets-key-custody.md`).
+
+**The break-glass gap.** When no keyservice can run — vault purged, subscription gone,
+account dead — the envelope model still permits recovery with raw held key material (an
+RSA private key whose public half wrapped the data key), but no off-the-shelf sops input
+accepts a raw RSA PEM; only age identities are native. `writ secret recover` is chartered
+to close this ([writ-secret-recover](../plans/writ-secret-recover.md)): local unwrap of
+the document's data key with supplied key material, then standard store decryption —
+**pipeline-free by design**, because disaster tooling must not assume the machine's
+execution store, plans, or providers are healthy. It sits beside the provider as a direct
+`pkg/sops` consumer, deliberately outside the graph.
+
+The `writ secret` family: [encrypt](../plans/writ-secret-encrypt.md) (authoring, via the
+provider and the standard pipeline) · [rekey](../plans/writ-secret-rekey.md) (recipient
+maintenance) · [recover](../plans/writ-secret-recover.md) (break-glass, pipeline-free).
+
 ## Status
 
-Implemented in full; the seam bypass is the recorded open item (step 49).
+Implemented in full; the seam bypass is the recorded open item (step 49). The `writ
+secret` family (encrypt, rekey, recover) is chartered, not yet implemented.

--- a/docs/plans/writ-secret-recover.md
+++ b/docs/plans/writ-secret-recover.md
@@ -1,0 +1,59 @@
+---
+title: "Writ Secret Recover"
+status: proposed
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Plan: Writ Secret Recover
+
+## Summary
+
+`writ secret recover` — break-glass decryption of SOPS documents using raw held key
+material, when no configured keyservice can run (vault purged, subscription lapsed,
+account dead). Chartered 2026-08-10 by the owner from the key-custody design's BYOK
+class-ii recovery runbook (personal layer, `design/secrets-key-custody.md`): the envelope
+model makes recovery possible with the held RSA private key, but no off-the-shelf sops
+input accepts a raw PEM — only age identities are native. The primary need arises under a
+BYOK custody ruling; the charter is unconditional and the age path rides along for
+symmetry. Architecture home:
+[3.5.13-encryption-provider](../architecture/3.5.13-encryption-provider.md) § Key custody
+and break-glass recovery.
+
+## Design
+
+1. **Command**: `writ secret recover --key <material-file> [--stdout] <file>...` under
+   the `writ secret` family beside [encrypt](writ-secret-encrypt.md) and
+   [rekey](writ-secret-rekey.md). Without `--stdout`, each `<name>.sops` recovers to the
+   `<name>` sibling, refusing an existing destination.
+2. **Pipeline-free by design.** No graph, no trace, no execution store, no provider
+   dispatch — disaster tooling must not assume the machine's writ state is healthy. The
+   command calls `pkg/sops` directly; this deliberately differs from `encrypt` (which
+   rides the standard pipeline) and the difference is documented in 3.5.13.
+3. **Mechanics**, per document: parse the SOPS metadata; select the wrapped data-key
+   entry matching the supplied material — an RSA private key (PEM) unwraps an
+   `azure_kv` entry locally via RSA-OAEP-256; an age identity delegates to the native
+   age path; then the recovered data key decrypts the content through the getsops store
+   machinery and the plaintext is emitted. Nothing touches the network.
+4. **`pkg/sops` growth**: a `Recover` entry point (material + document bytes + format →
+   plaintext). The encryption provider's API is unchanged — recover sits beside it, not
+   inside it.
+
+## Verification
+
+1. In-process fixtures constructing `azure_kv`-shaped metadata with a locally generated
+   RSA key (the pattern the provider tests use for age): PEM round-trip, age round-trip,
+   wrong-material refusal, existing-destination refusal.
+2. `make test`; dual-GOOS lint recount at zero.
+3. The custody design's drill requirement exercises this command for real under a BYOK
+   ruling before the migration completes.
+
+## Sequencing
+
+After [writ-secret-encrypt](writ-secret-encrypt.md) lands (shared `writ secret` command
+scaffolding); independent of rekey. Activated for the drill by the custody ruling.
+
+## Open questions
+
+1. Whether a `--data-key <hex>` last-resort input (raw recovered DK) belongs in the
+   first delivery or waits for a demonstrated need.


### PR DESCRIPTION
Docs only. Charters `writ secret recover` — break-glass decryption of SOPS documents with raw held key material (RSA PEM unwrap of `azure_kv`-wrapped data keys; age for symmetry), pipeline-free by design (no graph, trace, store, or provider dispatch — disaster tooling assumes nothing healthy). Architecture home: 3.5.13 gains the "Key custody and break-glass recovery" section naming the `writ secret` family. Chartered from the personal layer's key-custody design (BYOK class-ii runbook); the custody decision itself remains open.
