### PR TITLE
docs: charter writ secret init — the family complete

### DIFF
--- a/docs/architecture/3.5.13-encryption-provider.md
+++ b/docs/architecture/3.5.13-encryption-provider.md
@@ -57,11 +57,16 @@ the document's data key with supplied key material, then standard store decrypti
 execution store, plans, or providers are healthy. It sits beside the provider as a direct
 `pkg/sops` consumer, deliberately outside the graph.
 
-The `writ secret` family: [encrypt](../plans/writ-secret-encrypt.md) (authoring, via the
-provider and the standard pipeline) · [rekey](../plans/writ-secret-rekey.md) (recipient
-maintenance) · [recover](../plans/writ-secret-recover.md) (break-glass, pipeline-free).
+The `writ secret` family: [init](../plans/writ-secret-init.md) (the BYOK ceremony —
+generate, import, custody, wire) · [encrypt](../plans/writ-secret-encrypt.md)
+(authoring, via the provider and the standard pipeline) ·
+[rekey](../plans/writ-secret-rekey.md) (recipient maintenance) ·
+[recover](../plans/writ-secret-recover.md) (break-glass, pipeline-free). The family is
+keysource-generic across the three major clouds — `azure_kv`, `kms` (AWS), `gcp_kms`
+flow through decrypt, encrypt, and rekey untouched; the per-provider work concentrates
+in init's import ceremonies and recover's local-unwrap adapters.
 
 ## Status
 
 Implemented in full; the seam bypass is the recorded open item (step 49). The `writ
-secret` family (encrypt, rekey, recover) is chartered, not yet implemented.
+secret` family (init, encrypt, rekey, recover) is chartered, not yet implemented.

--- a/docs/plans/writ-secret-init.md
+++ b/docs/plans/writ-secret-init.md
@@ -1,0 +1,69 @@
+---
+title: "Writ Secret Init"
+status: proposed
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Plan: Writ Secret Init
+
+## Summary
+
+`writ secret init` — the BYOK ceremony, the family's fourth member (named 2026-08-10;
+`init` over `create`/`key`/`provision` — the terraform-shaped precedent: make this
+repository ready to work against remote provider state). One run per key: generate the
+RSA-4096 keypair locally; import it to the target cloud KMS; emit the custody artifacts
+— the passphrase-encrypted PEM blob (age, scrypt) and the recovery bundle — and seed the
+governing `.sops.yaml` recipient. The custody boundary is the owner's ruling made
+mechanical: writ emits blob and bundle to `--out-dir`; replication to the owner's sites
+is the owner's. Architecture home:
+[3.5.13](../architecture/3.5.13-encryption-provider.md) § Key custody and break-glass
+recovery.
+
+## Ruled requirements
+
+1. **Deletion protection is a hard gate, no bypass flag.** Azure: refuse a vault
+   without soft-delete + purge protection, naming what's missing and the `az` command
+   that fixes it. When AWS/GCP land: AWS's 7–30 day deletion window is verified
+   (platform-enforced); GCP requires a destroy-scheduled-duration floor.
+2. **Three-cloud support** (AWS KMS, Azure Key Vault, GCP KMS) is the product
+   requirement; v1 implements Azure behind a provider-neutral design. Import ceremonies
+   differ per cloud (Azure: PEM import; AWS: external-key-material wrap ceremony; GCP:
+   import jobs) and each is its own follow-on delivery.
+3. **The passphrase is never stored** — double interactive prompt; no flag, no
+   environment variable, no history.
+
+## Design
+
+1. **Surface (v1, Azure)**: `writ secret init --vault <name> [--key-name <name>]
+   [--out-dir <dir>]` — key-name defaults to `byok-rsa4096`; out-dir defaults to the
+   current directory. Reference identifiers elsewhere in the family are
+   self-describing (ARN / GCP resource path / AKV URL), so consuming commands need no
+   provider flag; init alone targets per-provider (a vault to import *into* has no
+   universal identifier shape).
+2. **Ceremony steps**: verify the vault and its protections (gate) → generate locally
+   (`crypto/rsa`, 4096) → import via the Azure SDK (`azkeys`, already in the dependency
+   graph — no `az` shell-out) → write `<out-dir>/byok-rsa4096.pem.age` (passphrase,
+   scrypt) and the recovery bundle per the custody design's template → add the
+   `azure_kv` recipient to the governing `.sops.yaml`.
+3. **Shared spine with rekey**: replacing a key is this ceremony plus rekey's sweep —
+   one implementation, two entry points.
+4. **Pipeline**: rides the standard writ pipeline (graph, trace, receipts) — the
+   ceremony is an ordinary planned execution; only `recover` is pipeline-free.
+
+## Verification
+
+1. Unit: gate refusal (missing soft-delete, missing purge protection, both), passphrase
+   double-prompt mismatch, bundle schema completeness, `.sops.yaml` seeding, refusal
+   shapes below.
+2. Import path against a mocked/gated-live vault; `make test`; dual-GOOS lint at zero.
+3. The custody drill (design doc, verification 1) consumes this command's artifacts.
+
+## Open questions
+
+1. `.sops.yaml` conflict: when a different recipient already governs the paths — amend
+   beside it or refuse and require explicit editing.
+2. AWS/GCP targeting flags for their import ceremonies (chartered follow-ons).
+3. Whether the Personal migration waits for init or performs the ceremony manually
+   (openssl + `az keyvault key import` per the custody design) — the migration is not
+   blocked on this plan either way.

--- a/docs/plans/writ-secret-recover.md
+++ b/docs/plans/writ-secret-recover.md
@@ -57,3 +57,12 @@ scaffolding); independent of rekey. Activated for the drill by the custody rulin
 
 1. Whether a `--data-key <hex>` last-resort input (raw recovered DK) belongs in the
    first delivery or waits for a demonstrated need.
+
+## Amendment (2026-08-10)
+
+Multi-cloud (ruled): recovery material differs per keysource, so the local unwrap grows
+one adapter each — `azure_kv`: RSA-OAEP-256 with the held PEM (the original scope);
+`kms` (AWS): the imported external key material (AES or RSA per import form); `gcp_kms`:
+the import-job material. The recovery bundle's provider block records which form a key
+uses. Verification items before implementing the AWS/GCP adapters: the exact wrap
+algorithms sops applies against asymmetric imports on each cloud.

--- a/docs/plans/writ-secret-rekey.md
+++ b/docs/plans/writ-secret-rekey.md
@@ -39,3 +39,14 @@ migration (it needs an encrypted fleet to operate on).
 
 1. Whether the no-argument sweep form belongs in the first delivery or arguments-only
    ships first.
+
+## Amendment (2026-08-10)
+
+1. **Purge-protection preflight** (ruled — "no support calls of that nature"): before
+   the sweep, verify every vault the current `.sops.yaml` names carries the platform's
+   deletion protection (Azure: soft-delete + purge protection; AWS: the enforced 7–30
+   day deletion window; GCP: a destroy-scheduled-duration floor). Refuse otherwise; no
+   bypass flag.
+2. **Multi-cloud**: the sweep is keysource-generic already (`azure_kv`, `kms`,
+   `gcp_kms` key groups pass through the encrypter verbatim); no rekey-specific
+   provider work.


### PR DESCRIPTION
Docs only, closing the 2026-08-10 design loop. Charters `writ secret init` (the BYOK ceremony — generate, import, custody, wire; named over create/key/provision) with the ruled requirements: deletion-protection hard gate with no bypass, three-cloud support (v1 Azure behind a provider-neutral design), never-stored passphrase, the custody boundary, and the shared spine with rekey. 3.5.13's family grows to four with the keysource-generic multi-cloud statement; rekey gains the purge-preflight amendment; recover gains the per-keysource adapter amendment.
