### PR TITLE
docs: scenario completion addendum + 3.5.13 status refresh

### DIFF
--- a/docs/architecture/3.5.13-encryption-provider.status.md
+++ b/docs/architecture/3.5.13-encryption-provider.status.md
@@ -1,7 +1,9 @@
 # Status: Encryption Provider
 
 **Architecture document:** [3.5.13-encryption-provider.md](3.5.13-encryption-provider.md)
-**State:** implemented; first design doc written 2026-07-22 (phase-8 step 39). Matrix greped, not asserted.
+**State:** implemented; first design doc written 2026-07-22 (phase-8 step 39); document
+extended 2026-08-10 with § Key custody and break-glass recovery and the four-member
+`writ secret` family (chartered, not yet implemented). Matrix greped, not asserted.
 
 ## Completion
 
@@ -11,9 +13,18 @@
 | `EncryptFile` / `CompensateEncryptFile` | Landed |
 | `Receipt.RestoreEncoded` via the catalog | Landed (step 44) |
 
+## Chartered, not yet implemented (2026-08-10)
+
+| Piece | Plan |
+|---|---|
+| `writ secret init` (BYOK ceremony) | [writ-secret-init](../plans/writ-secret-init.md) |
+| `writ secret encrypt` | [writ-secret-encrypt](../plans/writ-secret-encrypt.md) |
+| `writ secret rekey` (+ purge preflight) | [writ-secret-rekey](../plans/writ-secret-rekey.md) |
+| `writ secret recover` (pipeline-free) | [writ-secret-recover](../plans/writ-secret-recover.md) |
+
 ## Document Discrepancies
 
-None known — written 2026-07-22 against the tree.
+None known — refreshed 2026-08-10 against the tree.
 
 ## Test matrix (verified 2026-07-22)
 

--- a/docs/plans/writ-deploy-scenario.md
+++ b/docs/plans/writ-deploy-scenario.md
@@ -1,9 +1,9 @@
 ---
 title: "Writ Deploy Scenario"
 issue: https://github.com/NobleFactor/devlore-cli/issues/346
-status: in-progress
+status: complete
 created: 2026-08-08
-updated: 2026-08-08
+updated: 2026-08-10
 ---
 
 # Plan: Writ Deploy Scenario
@@ -234,3 +234,19 @@ refreshes. Tuckr retires group by group as `all` and `microsoft` migrate.
 - No network beyond the sandbox; no LLM; no package-manager mutations (per Q1's v1
   scope).
 - `make test` runtime unaffected.
+
+## Completion addendum (2026-08-10)
+
+The acceptance criteria are met — the scenario is green on ubuntu, macos, and windows in
+every PR gate since #351 — and the cutover record above is superseded by events:
+
+1. The `all` project migrated as the reserved `common` (implicit in deploy/upgrade,
+   [implicit-common-project](implicit-common-project.md)); the takeover deploy runs
+   282/282 healthy.
+2. The `microsoft` group audit showed it was never deployed on this machine; Tuckr's
+   live domain was five stale legacy links, all removed.
+3. `Home/Configs` (Tuckr's source tree) was removed (personal#111, with the
+   Declare-BashScript resolution repair).
+4. The retirement goal is ruled: **`writ secret` complete means git-crypt and tuckr
+   both retire** — no ad-hoc carve-out — with the two-cut bootstrap rehab and the
+   writ-layer→main promotion sequenced in the personal repo's sops-migration plan.

--- a/docs/plans/writ-secret-encrypt.md
+++ b/docs/plans/writ-secret-encrypt.md
@@ -49,5 +49,6 @@ surface, not the everyday path.
 
 ## Open questions
 
-None — scope is deliberately minimal; `rekey` is chartered separately
-([writ-secret-rekey](writ-secret-rekey.md)).
+None — scope is deliberately minimal. Siblings chartered separately:
+[writ-secret-init](writ-secret-init.md), [writ-secret-rekey](writ-secret-rekey.md),
+[writ-secret-recover](writ-secret-recover.md).


### PR DESCRIPTION
Docs only, closing the staleness audit: the scenario plan gains its completion addendum (three-platform green; cutover record superseded by the common migration, microsoft audit, Configs removal, and the ruled retirement goal) and flips to complete; the 3.5.13 status companion catches up with its document (chartered `writ secret` family table, refreshed discrepancy line); the encrypt plan names all three siblings.
