### PR TITLE
docs: layer-scope writ secret; charter decrypt and list (six members)

### DIFF
--- a/docs/architecture/3.5.13-encryption-provider.md
+++ b/docs/architecture/3.5.13-encryption-provider.md
@@ -60,13 +60,20 @@ execution store, plans, or providers are healthy. It sits beside the provider as
 The `writ secret` family: [init](../plans/writ-secret-init.md) (the BYOK ceremony —
 generate, import, custody, wire) · [encrypt](../plans/writ-secret-encrypt.md)
 (authoring, via the provider and the standard pipeline) ·
+[decrypt](../plans/writ-secret-decrypt.md) (authoring-side read, stdout only) ·
 [rekey](../plans/writ-secret-rekey.md) (recipient maintenance) ·
+[list](../plans/writ-secret-list.md) (inventory and recipient-drift audit) ·
 [recover](../plans/writ-secret-recover.md) (break-glass, pipeline-free). The family is
 keysource-generic across the three major clouds — `azure_kv`, `kms` (AWS), `gcp_kms`
 flow through decrypt, encrypt, and rekey untouched; the per-provider work concentrates
-in init's import ceremonies and recover's local-unwrap adapters.
+in init's import ceremonies and recover's local-unwrap adapters. The lifecycle commands
+are layer-scoped (ruled 2026-08-10): init takes registered-layer names and writes
+`.sops.yaml` at each layer's root; encrypt, decrypt, rekey, and list refuse paths
+outside a registered layer. recover alone stays unrestricted — break-glass assumes no
+writ state, the layers registry included.
 
 ## Status
 
 Implemented in full; the seam bypass is the recorded open item (step 49). The `writ
-secret` family (init, encrypt, rekey, recover) is chartered, not yet implemented.
+secret` family (init, encrypt, decrypt, rekey, list, recover) is chartered, not yet
+implemented.

--- a/docs/plans/result-text-formatter.md
+++ b/docs/plans/result-text-formatter.md
@@ -1,0 +1,43 @@
+---
+title: "Result Text Formatter"
+status: proposed
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Plan: Result Text Formatter
+
+## Summary
+
+`text` joins `pkg/result` as the fourth designed format — chartered 2026-08-10,
+**implementation deferred until it can be done fully** (ruled). The model, in the
+owner's words: a production on an array of json documents, no normalization, top-level
+elements only — which is exactly the model [CSVFormatter](../../pkg/result/csv.go)
+already implements: header inference from struct fields (declaration order, `csv:` tag
+overrides) or the sorted union of map keys, the `HasHeaders` opt-in for odd shapes,
+cells via `fmt.Sprint`. `TextFormatter` is csv's sibling: the same inference, emitted
+as tabwriter-aligned columns under a header row.
+
+## Design
+
+1. **Extract the shared inference** — the header/row derivation moves out of `csv.go`
+   into a common helper both formatters call; csv's output stays byte-identical
+   (regression-tested).
+2. **`TextFormatter`** — `text/tabwriter` alignment, one header row, empty input
+   renders nothing (csv parity), compile-time `Formatter` guard.
+3. **Registration** — `FormatterByName` gains `"text"`; the `--format` help string in
+   `cli.AddOutputFlags` updates to name five values.
+4. **Per-command defaults are the consumer's choice** — `writ secret list` flips its
+   default from json to text when this lands (recorded in its plan); nothing else
+   changes defaults implicitly.
+
+## Verification
+
+1. Golden tables for struct slices, map slices, and a `HasHeaders` type; the empty and
+   single-row edges; csv regression byte-identical.
+2. `make test`; dual-GOOS lint recount at zero.
+
+## Open questions
+
+1. Nested-value cells: `fmt.Sprint` parity with csv, or compact JSON — resolve at
+   implementation with real documents on screen.

--- a/docs/plans/writ-secret-decrypt.md
+++ b/docs/plans/writ-secret-decrypt.md
@@ -1,0 +1,43 @@
+---
+title: "Writ Secret Decrypt"
+status: proposed
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Plan: Writ Secret Decrypt
+
+## Summary
+
+`writ secret decrypt <file>...` — the everyday authoring-side read, ruled 2026-08-10:
+**stdout only**. No output flag, no sibling files — plaintext written beside a `.sops`
+document inside the layer tree would sit one `git add` from the repository, the exact
+hazard the migration removes. Decryption uses the embedded client's ambient keyservices
+(config-free; under BYOK every read is a Key Vault unwrap and lands in the vault's audit
+log), which is the boundary against [recover](writ-secret-recover.md) —
+supplied-material-and-offline versus ambient-and-audited. Editing stays with `sops edit`;
+decrypt is read-only inspection. Completes the family's everyday story: writ writes,
+writ reads.
+
+## Design
+
+1. **Surface**: `writ secret decrypt <file>...` — layer-scoped like its authoring
+   siblings (every argument inside a registered layer); multiple files stream to stdout
+   in argument order.
+2. **Pipeline-free**: an effectless read mints no graph, no trace, no receipt — the
+   pipeline exists for effects. (The vault's own unwrap log is the audit record.)
+3. **Implementation**: a thin front over the embedded client's existing decrypt path —
+   the code deploy exercises daily; no provider or `pkg/sops` growth.
+4. Replaces `sops -d` in the migration's verification steps (validation round-trips,
+   the cutover byte-match), making the drills writ-native.
+
+## Verification
+
+1. Round-trip against `writ secret encrypt` fixtures (age pattern); containment
+   refusal; multi-file ordering.
+2. `make test`; dual-GOOS lint recount at zero.
+
+## Open questions
+
+None — scope is deliberately minimal; anything beyond a stdout read belongs to deploy,
+recover, or `sops edit`.

--- a/docs/plans/writ-secret-encrypt.md
+++ b/docs/plans/writ-secret-encrypt.md
@@ -38,6 +38,12 @@ surface, not the everyday path.
 5. **Starlark**: expose the encryption sub-namespace through the starlarkbridge adapter,
    same pattern as the existing planable providers.
 
+## Amendment (2026-08-10)
+
+Layer-scoped (ruled): every argument must resolve to a path inside a registered writ
+layer's working tree — the refusal names `writ repo add`. Discovery's Root is the
+containing layer's root, which mechanically enforces the root-`.sops.yaml` shape.
+
 ## Verification
 
 1. Unit tests: output naming, existing-output refusal, no-governing-rule error, multiple

--- a/docs/plans/writ-secret-init.md
+++ b/docs/plans/writ-secret-init.md
@@ -32,24 +32,46 @@ recovery.
    import jobs) and each is its own follow-on delivery.
 3. **The passphrase is never stored** — double interactive prompt; no flag, no
    environment variable, no history.
+4. **Layer-scoped** (ruled 2026-08-10): targets are registered layers by name; the
+   command refuses a name with no registration, pointing at `writ repo add`.
+5. **Config conflict refuses without `-f/--force`** (ruled 2026-08-10): when a named
+   layer's root `.sops.yaml` already carries different recipients, init fails and
+   changes nothing; `--force` proceeds with the write. Deliberate contrast: the vault
+   deletion-protection gate has no force — custody loss is unrecoverable, a config
+   file is editable.
 
 ## Design
 
-1. **Surface (v1, Azure)**: `writ secret init --vault <name> [--key-name <name>]
-   [--out-dir <dir>]` — key-name defaults to `byok-rsa4096`; out-dir defaults to the
-   current directory. Reference identifiers elsewhere in the family are
+1. **Surface**: `writ secret init <layer>... [--azure-kv <vault> | --aws-kms <key> |
+   --gcp-kms <ring>] [--key-name <name>] [-o|--output-dir <dir>] [-f|--force]` — each
+   `<layer>` names a registered writ layer (personal, team, base; ruled 2026-08-10),
+   and one ceremony may seed several: one key, one custody emission, one `.sops.yaml`
+   write per named layer. Exactly one targeting flag, mirroring sops' own vocabulary;
+   v1 implements `--azure-kv`, the other two refuse as chartered until their
+   deliveries. key-name defaults to `byok-rsa4096`; output-dir defaults to the current
+   directory.
+2. **Assets at `--output-dir`** — exactly two files, never touched again by writ
+   (replication is the owner's, per the custody ruling): `<key-name>.pem.age`, the
+   passphrase-encrypted private key (age v1, scrypt); and `<key-name>.recovery.yaml`,
+   the recovery bundle (publishable-without-harm). Invariant: the plaintext private key
+   never exists on disk — generated in memory, encrypted, written once. One ceremony
+   emits one asset pair regardless of layer count. Reference identifiers elsewhere in the family are
    self-describing (ARN / GCP resource path / AKV URL), so consuming commands need no
    provider flag; init alone targets per-provider (a vault to import *into* has no
    universal identifier shape).
-2. **Ceremony steps**: verify the vault and its protections (gate) → generate locally
+3. **Ceremony steps**: verify the vault and its protections (gate) → generate locally
    (`crypto/rsa`, 4096) → import via the Azure SDK (`azkeys`, already in the dependency
-   graph — no `az` shell-out) → write `<out-dir>/byok-rsa4096.pem.age` (passphrase,
-   scrypt) and the recovery bundle per the custody design's template → add the
-   `azure_kv` recipient to the governing `.sops.yaml`.
-3. **Shared spine with rekey**: replacing a key is this ceremony plus rekey's sweep —
+   graph — no `az` shell-out) → write `<output-dir>/byok-rsa4096.pem.age` (passphrase,
+   scrypt) and the recovery bundle per the custody design's template → write or amend
+   `.sops.yaml` at each named layer's working-tree **root**, never deeper — the root
+   file is the only shape where writ's chain discovery and the sops CLI resolve
+   identically — carrying the `azure_kv` recipient.
+4. **Shared spine with rekey**: replacing a key is this ceremony plus rekey's sweep —
    one implementation, two entry points.
-4. **Pipeline**: rides the standard writ pipeline (graph, trace, receipts) — the
-   ceremony is an ordinary planned execution; only `recover` is pipeline-free.
+5. **Pipeline**: rides the standard writ pipeline (graph, trace, receipts) — the
+   ceremony is an ordinary planned execution; recover and decrypt sit outside the
+   pipeline — disaster tooling assumes nothing, and an effectless stdout read has
+   nothing to trace or compensate.
 
 ## Verification
 
@@ -61,9 +83,8 @@ recovery.
 
 ## Open questions
 
-1. `.sops.yaml` conflict: when a different recipient already governs the paths — amend
-   beside it or refuse and require explicit editing.
-2. AWS/GCP targeting flags for their import ceremonies (chartered follow-ons).
-3. Whether the Personal migration waits for init or performs the ceremony manually
+1. AWS/GCP import-ceremony details behind `--aws-kms` / `--gcp-kms` (chartered
+   follow-ons; the flag surface is ruled).
+2. Whether the Personal migration waits for init or performs the ceremony manually
    (openssl + `az keyvault key import` per the custody design) — the migration is not
    blocked on this plan either way.

--- a/docs/plans/writ-secret-list.md
+++ b/docs/plans/writ-secret-list.md
@@ -1,0 +1,58 @@
+---
+title: "Writ Secret List"
+status: proposed
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Plan: Writ Secret List
+
+## Summary
+
+`writ secret list [<layer>...]` — inventory with a **recipient-drift audit**, chartered
+2026-08-10. The reason it exists is the audit, not the inventory: a SOPS document's
+recipient set is public metadata, readable with no credentials and no unwrap, so list
+can show for every document *who can open it* — and mark every document whose actual
+recipients differ from what the governing `.sops.yaml` would mint today. Drift is a
+document encrypted before a rule change, a file a rekey sweep missed, or a foreign
+recipient that should not be there. Delivered **with [rekey](writ-secret-rekey.md)**
+(ruled): the drift audit is the sweep's completion proof — one work item, two commands.
+Pure inventory alone would be `find`-replaceable and would not justify the surface.
+
+## Design
+
+1. **Surface**: `writ secret list [<layer>...]` — registered-layer names, all registered
+   layers when none are named (the grammar init and rekey's sweep share); layer-scoped
+   like the other authoring commands.
+2. **Per document**: path (layer-relative), format, recipient set (key URLs, age
+   recipients), and the drift marker from comparing the document's key groups against
+   the resolution the governing `.sops.yaml` produces for that path today.
+3. **Output** (ruled 2026-08-10): binds the shared result seam (`cli.AddOutputFlags`)
+   unchanged — `--format` json (v1 default) | yaml | csv | template, with `template`
+   retained as the user-authored escape hatch and `--filter`/`--jq` composing ahead of
+   the formatter. **`text` is chartered, not built**
+   ([result-text-formatter](result-text-formatter.md)): a generic tabular production
+   over the same header inference csv already owns; when it lands, list's default
+   flips from json to text — recorded here so the flip is deliberate, not drift. csv
+   is **one row per document**: recipients joined with `"; "` in a single column,
+   drift and drift-reason as their own columns — spreadsheets are csv's audience;
+   machines take json plus `--jq`.
+4. **Pipeline-free**: an effectless metadata read — no graph, no trace, no credentials,
+   no network.
+5. **The check logic is reusable, the command is presentation** — the drift comparison
+   is the seed of a future `writ secret verify` and must not be welded to the table
+   renderer.
+6. Migration bonus: the cutover verification gains a writ-native "every document carries
+   exactly the BYOK recipient" check.
+
+## Verification
+
+1. Fixtures with matching and mismatched recipient sets (drift detected, clean tree
+   silent); containment refusal; multi-layer enumeration.
+2. `make test`; dual-GOOS lint recount at zero.
+
+## Open questions
+
+None — the output-format rulings (2026-08-10) closed the format question; the text
+default arrives with the chartered formatter
+([result-text-formatter](result-text-formatter.md)).

--- a/docs/plans/writ-secret-recover.md
+++ b/docs/plans/writ-secret-recover.md
@@ -66,3 +66,9 @@ one adapter each — `azure_kv`: RSA-OAEP-256 with the held PEM (the original sc
 the import-job material. The recovery bundle's provider block records which form a key
 uses. Verification items before implementing the AWS/GCP adapters: the exact wrap
 algorithms sops applies against asymmetric imports on each cloud.
+
+**Scope exemption** (ruled 2026-08-10): recover is deliberately NOT layer-scoped. Its
+founding property — no assumption that the machine's writ state is healthy — includes
+the layers registry itself; a fresh machine holding one blob and one bundle must be able
+to recover with no registration at all. Arbitrary paths stay accepted here even though
+init, encrypt, decrypt, and rekey refuse them.

--- a/docs/plans/writ-secret-rekey.md
+++ b/docs/plans/writ-secret-rekey.md
@@ -50,3 +50,10 @@ migration (it needs an encrypted fleet to operate on).
 2. **Multi-cloud**: the sweep is keysource-generic already (`azure_kv`, `kms`,
    `gcp_kms` key groups pass through the encrypter verbatim); no rekey-specific
    provider work.
+
+3. **Layer-scoped** (ruled 2026-08-10): file arguments carry the same
+   inside-a-registered-layer requirement as encrypt, and the sweep form refines to the
+   layer-name grammar mirroring init — `writ secret rekey [<layer>...]` sweeps the named
+   layers (all registered layers when none are named is the open sub-question).
+4. **Delivered with [list](writ-secret-list.md)** (ruled 2026-08-10): the drift audit is
+   the sweep's completion proof — one work item, two commands.


### PR DESCRIPTION
Docs only, applying the hardened layer-scoping ruling plus the surface refinements: `writ secret init <layer>...` (registered names; one ceremony may seed several layers; `.sops.yaml` written at each layer root, never deeper) with the provider-neutral targeting trio (`--azure-kv | --aws-kms | --gcp-kms`, exactly one, mirroring sops' vocabulary; v1 Azure), `-o/--output-dir`, and the Assets section (two files — `<key-name>.pem.age`, `<key-name>.recovery.yaml`; plaintext key never on disk). Config conflict ruled: refuse without `-f/--force` — deliberately unlike the vault gate, which has no force. `decrypt` joins as the fifth member (ruled: stdout only, ambient keyservices with every read vault-audited, pipeline-free as an effectless read) — writ writes, writ reads. `list` joins as the sixth (ruled: inventory whose reason to exist is the recipient-drift audit — public metadata, no credentials, no unwrap; delivered with rekey as the sweep's completion proof; the drift logic stays reusable as the seed of a future verify). Output rulings: `template` stays as the escape hatch; csv is one row per document, recipients joined `"; "`, drift + drift-reason columns; and the `text` formatter is **chartered, not built** (`result-text-formatter.md` — a generic tabular production over the header inference csv already owns, deferred until it can be done fully) — list defaults json in v1 and flips to text deliberately when the formatter lands. encrypt/decrypt/rekey refuse paths outside registered layers (Root = containing layer root), rekey's sweep refines to the layer-name grammar, and recover is explicitly exempt — break-glass assumes no writ state, including the layers registry. 3.5.13 carries the family-level statement.
