### PR TITLE
feat(writ): secret encrypt — the family's first implementation

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_encryption.star
+++ b/cmd/devlore-test/devloretest/data/test_encryption.star
@@ -1,8 +1,10 @@
-# test_encryption.star — Dry-run: encryption.decrypt_sops_file creates a graph node.
+# test_encryption.star — Dry-run: encryption nodes project through plan.encryption.
 #
-# Validates: plan.encryption.decrypt_sops_file (registration + node creation)
+# Validates: plan.encryption.decrypt_sops_file and plan.encryption.encrypt_file
+# (registration + node creation)
 
 graph = plan.assemble_definition([
     plan.encryption.decrypt_sops_file(source="/tmp/fake.enc", destination_path="/tmp/fake.dec"),
+    plan.encryption.encrypt_file(source="/tmp/fake.dec", destination_path="/tmp/fake.enc"),
 ])
-t.expect_unit_count(1)
+t.expect_unit_count(2)

--- a/cmd/writ/writ/root.go
+++ b/cmd/writ/writ/root.go
@@ -52,6 +52,7 @@ Declare your environment once — writ deploys it everywhere you work.`,
 	rootCmd.AddCommand(newAdoptCmd())
 	rootCmd.AddCommand(newMigrateCmd())
 	rootCmd.AddCommand(newRepoCmd())
+	rootCmd.AddCommand(newSecretCmd())
 
 	return rootCmd
 }

--- a/cmd/writ/writ/secret/encrypt.go
+++ b/cmd/writ/writ/secret/encrypt.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+// Package secret implements the writ secret family: SOPS lifecycle operations scoped to registered layers.
+//
+// Encrypt writes the `<file>.sops` sibling of each argument through the standard pipeline — one
+// `encryption.encrypt_file` unit per file, one graph per containing layer, graphs and traces persisted to the
+// execution store. Every argument must lie inside a registered layer's working tree (ruled 2026-08-10); the
+// containing layer's root is the runtime environment's confinement root, which bounds `.sops.yaml` discovery
+// to the layer and mechanically enforces the root-config shape. Plan: docs/plans/writ-secret-encrypt.md;
+// architecture: docs/architecture/3.5.13-encryption-provider.md.
+package secret
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/NobleFactor/devlore-cli/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
+)
+
+// EncryptConfig carries the resolved settings for one encrypt operation.
+type EncryptConfig struct {
+
+	// Files are the plaintext paths to encrypt; each must lie inside a registered layer's working tree.
+	Files []string
+
+	// DryRun serializes the planned graphs to stdout instead of executing them.
+	DryRun bool
+
+	// Verbose narrates per-run receipt paths via [cli.Note].
+	Verbose bool
+}
+
+// ExecuteEncrypt runs the full encrypt operation: contain the arguments in registered layers, plan one graph
+// per layer, and execute them.
+//
+// Each argument's `<file>.sops` sibling is the destination — an existing sibling refuses before any planning,
+// and the plaintext source is never deleted. Recipients and document format come from the `.sops.yaml`
+// resolved within the containing layer (the confinement root); a file no creation rule governs fails the run
+// with the resolver's error verbatim. Each graph persists via [cli.WriteGraph] before its run and each run's
+// trace persists via [cli.WriteTrace] win or lose.
+//
+// Parameters:
+//   - `ctx`: the cancellation context for planning and execution.
+//   - `cfg`: the resolved encrypt configuration.
+//
+// Returns:
+//   - `error`: non-nil when containment fails, a destination exists, planning fails, or a run fails.
+func ExecuteEncrypt(ctx context.Context, cfg *EncryptConfig) error {
+
+	groups, err := assignToLayers(cfg.Files)
+	if err != nil {
+		return err
+	}
+
+	if err := refuseExistingDestinations(groups); err != nil {
+		return err
+	}
+
+	var graphs []*op.Graph
+	for i := range groups {
+		graph, err := buildLayerGraph(ctx, cfg, &groups[i])
+		if err != nil {
+			return err
+		}
+		graphs = append(graphs, graph)
+	}
+
+	if cfg.DryRun {
+		return op.SerializeGraphs(os.Stdout, graphs)
+	}
+
+	return runAll(ctx, cfg, graphs)
+}
+
+// region HELPER FUNCTIONS
+
+// assignToLayers canonicalizes the files and groups them by the registered layer containing each.
+//
+// The longest matching layer root wins when registrations nest. A file outside every registered layer is an
+// error naming `writ repo add` — the layer-scoping ruling (2026-08-10).
+//
+// Parameters:
+//   - `files`: the argument paths, absolute or relative.
+//
+// Returns:
+//   - `[]layerGroup`: one group per containing layer, layers and files in deterministic order.
+//   - `error`: non-nil when a file does not exist or lies outside every registered layer.
+func assignToLayers(files []string) ([]layerGroup, error) {
+
+	layers, err := registeredLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	byRoot := make(map[string]*layerGroup)
+	for _, file := range files {
+
+		canonical, err := canonicalPath(file)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s: %w", file, err)
+		}
+
+		name, root := containingLayer(layers, canonical)
+		if root == "" {
+			return nil, fmt.Errorf(
+				"%s is not inside a registered layer; register its repository with 'writ repo add'", file)
+		}
+
+		group, ok := byRoot[root]
+		if !ok {
+			group = &layerGroup{name: name, root: root}
+			byRoot[root] = group
+		}
+		group.files = append(group.files, canonical)
+	}
+
+	groups := make([]layerGroup, 0, len(byRoot))
+	for _, group := range byRoot {
+		sort.Strings(group.files)
+		groups = append(groups, *group)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].name < groups[j].name })
+
+	return groups, nil
+}
+
+// buildLayerGraph plans one layer's encrypt graph: one `encryption.encrypt_file` unit per file, source order.
+//
+// Parameters:
+//   - `ctx`: the planning context.
+//   - `cfg`: the encrypt configuration.
+//   - `group`: the layer and its files.
+//
+// Returns:
+//   - `*op.Graph`: the assembled graph.
+//   - `error`: non-nil when the spec cannot be configured, or planning or assembly fails.
+func buildLayerGraph(ctx context.Context, cfg *EncryptConfig, group *layerGroup) (*op.Graph, error) {
+
+	spec, err := encryptSpec(group.root, cfg.DryRun)
+	if err != nil {
+		return nil, err
+	}
+
+	return op.Plan(ctx, spec, func(env *op.RuntimeEnvironment) (*op.Graph, error) {
+
+		provider := plan.NewProvider(env)
+		fileMetas := make(map[string]any, len(group.files))
+
+		for _, source := range group.files {
+
+			destination := source + sopsSuffix
+			invocation, err := provider.Plan(encryption.EncryptFile, nil, map[string]any{
+				"source":           source,
+				"destination_path": destination,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("plan encrypt %s: %w", source, err)
+			}
+
+			fileMetas[invocation.Target.ID()] = map[string]any{
+				"source":      source,
+				"destination": destination,
+				"layer":       group.name,
+			}
+		}
+
+		var units []op.ExecutableUnit
+		for _, invocation := range provider.InvocationRegistry().All() {
+			if invocation.Target.ParentID() == "" {
+				units = append(units, invocation.Target)
+			}
+		}
+
+		origin := op.NewOriginBase("writ", "", op.NewAnnotationMap(map[string]any{
+			"layer":    group.name,
+			"run_root": group.root,
+			"files":    fileMetas,
+		}))
+
+		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...))
+		if err != nil {
+			return nil, fmt.Errorf("assemble layer %q: %w", group.name, err)
+		}
+		return graph, nil
+	})
+}
+
+// canonicalPath resolves a path to its absolute, symlink-free form.
+//
+// Parameters:
+//   - `path`: the path to resolve; must exist.
+//
+// Returns:
+//   - `string`: the canonical path.
+//   - `error`: non-nil when the path cannot be made absolute or does not exist.
+func canonicalPath(path string) (string, error) {
+
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(absolute)
+}
+
+// containingLayer returns the registered layer containing the canonical path; the longest root wins.
+//
+// Parameters:
+//   - `layers`: the registered layers, name to canonical root.
+//   - `canonical`: the canonical file path.
+//
+// Returns:
+//   - `name`: the containing layer's name, or empty.
+//   - `root`: the containing layer's root, or empty.
+func containingLayer(layers map[string]string, canonical string) (name, root string) {
+
+	for candidate, candidateRoot := range layers {
+		if canonical != candidateRoot && !strings.HasPrefix(canonical, candidateRoot+string(filepath.Separator)) {
+			continue
+		}
+		if len(candidateRoot) > len(root) {
+			name, root = candidate, candidateRoot
+		}
+	}
+	return name, root
+}
+
+// encryptSpec constructs a fresh [op.RuntimeEnvironmentSpec] confined at the layer root.
+//
+// The confinement root doubles as the `.sops.yaml` discovery boundary, so resolution can only ever find the
+// layer's root configuration or the XDG fallback.
+//
+// Parameters:
+//   - `root`: the containing layer's canonical root.
+//   - `dryRun`: forwarded to the application flag map.
+//
+// Returns:
+//   - `*op.RuntimeEnvironmentSpec`: the constructed spec.
+//   - `error`: non-nil when [fsroot.OpenConfined] fails.
+func encryptSpec(root string, dryRun bool) (*op.RuntimeEnvironmentSpec, error) {
+
+	confined, err := fsroot.OpenConfined(root)
+	if err != nil {
+		return nil, fmt.Errorf("open layer root %s: %w", root, err)
+	}
+
+	return op.NewRuntimeEnvironmentSpec("writ").
+		WithStatus(cli.UI()).
+		WithRoot(confined).
+		WithApplication(&application.Application{
+			Name:  "writ",
+			Flags: map[string]any{"dry-run": dryRun},
+		}), nil
+}
+
+// refuseExistingDestinations fails when any file's `.sops` sibling already exists — encrypt never overwrites.
+//
+// Parameters:
+//   - `groups`: the layer groups whose destinations are checked.
+//
+// Returns:
+//   - `error`: non-nil listing every existing destination.
+func refuseExistingDestinations(groups []layerGroup) error {
+
+	var existing []string
+	for i := range groups {
+		for _, source := range groups[i].files {
+			if _, err := os.Lstat(source + sopsSuffix); err == nil {
+				existing = append(existing, source+sopsSuffix)
+			}
+		}
+	}
+
+	if len(existing) > 0 {
+		return fmt.Errorf(
+			"refusing to overwrite existing destination(s): %s — writ secret encrypt never overwrites",
+			strings.Join(existing, ", "))
+	}
+	return nil
+}
+
+// registeredLayers enumerates the registered layers as name to canonical working-tree root.
+//
+// A missing layers directory yields an empty map (every file then fails containment); broken registrations
+// are skipped.
+//
+// Returns:
+//   - `map[string]string`: the registered layers.
+//   - `error`: non-nil when the layers directory exists but cannot be read.
+func registeredLayers() (map[string]string, error) {
+
+	layers := make(map[string]string)
+
+	entries, err := os.ReadDir(cli.WritLayersDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return layers, nil
+		}
+		return nil, fmt.Errorf("read layers directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		root, err := filepath.EvalSymlinks(filepath.Join(cli.WritLayersDir(), entry.Name()))
+		if err != nil {
+			continue
+		}
+		layers[entry.Name()] = root
+	}
+	return layers, nil
+}
+
+// runAll executes every graph, collecting per-layer failures.
+//
+// Parameters:
+//   - `ctx`: the execution context.
+//   - `cfg`: the encrypt configuration.
+//   - `graphs`: the assembled graphs, in layer order.
+//
+// Returns:
+//   - `error`: the joined per-layer failures, or nil when every layer succeeds.
+func runAll(ctx context.Context, cfg *EncryptConfig, graphs []*op.Graph) error {
+
+	var failures []error
+
+	for _, graph := range graphs {
+		if runErr := runGraph(ctx, cfg, graph); runErr != nil {
+			layer := layerAnnotation(graph)
+			cli.Warn("encrypt layer %s failed: %v", layer, runErr)
+			failures = append(failures, fmt.Errorf("layer %s: %w", layer, runErr))
+		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("%d layer(s) failed: %w", len(failures), errors.Join(failures...))
+	}
+	return nil
+}
+
+// runGraph executes one layer's graph: persist the plan, run, persist the trace, report the summary.
+//
+// Parameters:
+//   - `ctx`: the cancellation context for the run.
+//   - `cfg`: the encrypt configuration (dry-run flag, verbosity).
+//   - `graph`: the layer graph to execute.
+//
+// Returns:
+//   - `error`: non-nil when the spec cannot be configured, the plan cannot persist, or the run fails.
+func runGraph(ctx context.Context, cfg *EncryptConfig, graph *op.Graph) error {
+
+	runRoot := ""
+	if value, ok := graph.Origin().Annotations().Get("run_root"); ok {
+		runRoot = assert.Type[string]("run_root annotation", value)
+	}
+
+	spec, err := encryptSpec(runRoot, cfg.DryRun)
+	if err != nil {
+		return err
+	}
+
+	if _, err := cli.WriteGraph(graph); err != nil {
+		return fmt.Errorf("persist graph: %w", err)
+	}
+
+	executor := op.NewGraphExecutor(graph, spec)
+	_, runErr := executor.Run(ctx, nil)
+
+	if trace := executor.Trace(); trace != nil {
+		if receiptPath, writeErr := cli.WriteTrace(trace); writeErr != nil {
+			cli.Warn("failed to write receipt: %v", writeErr)
+		} else if cfg.Verbose {
+			cli.Note("Receipt: %s", receiptPath)
+		}
+
+		if runErr == nil {
+			summary := trace.Summarize(graph)
+			encrypted := summary.ByAction()[string(encryption.EncryptFile)].Completed()
+			cli.Success("Encrypted %d file(s) [%s]", encrypted, layerAnnotation(graph))
+		}
+	}
+
+	return runErr
+}
+
+// layerAnnotation returns the graph's layer annotation, or "unknown".
+//
+// Parameters:
+//   - `graph`: the graph whose layer is wanted.
+//
+// Returns:
+//   - `string`: the layer name.
+func layerAnnotation(graph *op.Graph) string {
+
+	if value, ok := graph.Origin().Annotations().Get("layer"); ok {
+		return assert.Type[string]("layer annotation", value)
+	}
+	return "unknown"
+}
+
+// layerGroup collects one registered layer's files for a single graph.
+type layerGroup struct {
+	name  string
+	root  string
+	files []string
+}
+
+// sopsSuffix is the destination naming convention: `<file>.sops` deploys as `<file>`.
+const sopsSuffix = ".sops"
+
+// endregion

--- a/cmd/writ/writ/secret/encrypt_test.go
+++ b/cmd/writ/writ/secret/encrypt_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package secret
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
+	"github.com/NobleFactor/devlore-cli/pkg/sops"
+)
+
+// setupLayer sandboxes the XDG triplet, creates a layer working tree, and registers it as `personal`.
+//
+// Parameters:
+//   - `t`: the test context.
+//   - `withConfig`: whether the layer root receives a catch-all `.sops.yaml` for the generated identity.
+//
+// Returns:
+//   - `string`: the canonical layer root.
+//   - `*age.X25519Identity`: the identity whose recipient governs the layer.
+func setupLayer(t *testing.T, withConfig bool) (string, *age.X25519Identity) {
+	t.Helper()
+
+	base := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(base, "data"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "config"))
+
+	tree := filepath.Join(base, "personal")
+	mustMkdirAll(t, filepath.Join(tree, "Home", "demo"))
+
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	if withConfig {
+		config := "creation_rules:\n  - path_regex: .*\n    age: " + identity.Recipient().String() + "\n"
+		mustWriteFile(t, filepath.Join(tree, ".sops.yaml"), config)
+	}
+
+	layers := filepath.Join(base, "data", "devlore", "writ", "layers")
+	mustMkdirAll(t, layers)
+	if err := os.Symlink(tree, filepath.Join(layers, "personal")); err != nil {
+		t.Fatalf("register layer: %v", err)
+	}
+
+	canonical, err := filepath.EvalSymlinks(tree)
+	if err != nil {
+		t.Fatalf("canonicalize tree: %v", err)
+	}
+	return canonical, identity
+}
+
+func TestExecuteEncrypt_RoundTrip(t *testing.T) {
+
+	tree, identity := setupLayer(t, true)
+	source := filepath.Join(tree, "Home", "demo", "app.yaml")
+	mustWriteFile(t, source, "credential: hello world\n")
+
+	if err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{source}}); err != nil {
+		t.Fatalf("ExecuteEncrypt: %v", err)
+	}
+
+	plaintext, err := os.ReadFile(source)
+	if err != nil || string(plaintext) != "credential: hello world\n" {
+		t.Fatalf("plaintext source altered: %q, %v", plaintext, err)
+	}
+
+	ciphertext, err := os.ReadFile(source + ".sops")
+	if err != nil {
+		t.Fatalf("destination missing: %v", err)
+	}
+	if strings.Contains(string(ciphertext), "hello world") {
+		t.Fatalf("destination carries plaintext")
+	}
+
+	t.Setenv("SOPS_AGE_KEY", identity.String())
+	decrypted, err := (&sops.Client{}).Decrypt(ciphertext, source+".sops")
+	if err != nil {
+		t.Fatalf("round-trip decrypt: %v", err)
+	}
+	if string(decrypted) != "credential: hello world\n" {
+		t.Fatalf("round-trip mismatch: %q", decrypted)
+	}
+
+	graphs, err := os.ReadDir(filepath.Join(os.Getenv("XDG_STATE_HOME"), "devlore", "graphs"))
+	if err != nil || len(graphs) != 1 {
+		t.Fatalf("expected exactly one persisted graph, got %d, %v", len(graphs), err)
+	}
+}
+
+func TestExecuteEncrypt_RefusesExistingDestination(t *testing.T) {
+
+	tree, _ := setupLayer(t, true)
+	source := filepath.Join(tree, "Home", "demo", "app.yaml")
+	mustWriteFile(t, source, "credential: hello\n")
+	mustWriteFile(t, source+".sops", "occupied")
+
+	err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{source}})
+	if err == nil || !strings.Contains(err.Error(), "never overwrites") {
+		t.Fatalf("expected overwrite refusal, got %v", err)
+	}
+
+	occupant, readErr := os.ReadFile(source + ".sops")
+	if readErr != nil || string(occupant) != "occupied" {
+		t.Fatalf("existing destination altered: %q, %v", occupant, readErr)
+	}
+}
+
+func TestExecuteEncrypt_RefusesOutsideLayer(t *testing.T) {
+
+	_, _ = setupLayer(t, true)
+	outside := filepath.Join(t.TempDir(), "loose.yaml")
+	mustWriteFile(t, outside, "credential: hello\n")
+
+	err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{outside}})
+	if err == nil || !strings.Contains(err.Error(), "writ repo add") {
+		t.Fatalf("expected containment refusal naming writ repo add, got %v", err)
+	}
+}
+
+func TestExecuteEncrypt_NoGoverningRule(t *testing.T) {
+
+	tree, _ := setupLayer(t, false)
+	source := filepath.Join(tree, "Home", "demo", "app.yaml")
+	mustWriteFile(t, source, "credential: hello\n")
+
+	err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{source}})
+	if err == nil || !strings.Contains(err.Error(), "no .sops.yaml creation rule governs") {
+		t.Fatalf("expected the resolver's no-rule error verbatim, got %v", err)
+	}
+}
+
+func TestExecuteEncrypt_MultipleFilesOneGraph(t *testing.T) {
+
+	tree, _ := setupLayer(t, true)
+	first := filepath.Join(tree, "Home", "demo", "first.yaml")
+	second := filepath.Join(tree, "Home", "demo", "second.yaml")
+	mustWriteFile(t, first, "a: 1\n")
+	mustWriteFile(t, second, "b: 2\n")
+
+	if err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{first, second}}); err != nil {
+		t.Fatalf("ExecuteEncrypt: %v", err)
+	}
+
+	for _, source := range []string{first, second} {
+		if _, err := os.Stat(source + ".sops"); err != nil {
+			t.Fatalf("destination missing for %s: %v", source, err)
+		}
+	}
+
+	graphs, err := os.ReadDir(filepath.Join(os.Getenv("XDG_STATE_HOME"), "devlore", "graphs"))
+	if err != nil || len(graphs) != 1 {
+		t.Fatalf("expected one graph for one layer, got %d, %v", len(graphs), err)
+	}
+}
+
+func TestExecuteEncrypt_DryRunWritesNothing(t *testing.T) {
+
+	tree, _ := setupLayer(t, true)
+	source := filepath.Join(tree, "Home", "demo", "app.yaml")
+	mustWriteFile(t, source, "credential: hello\n")
+
+	if err := ExecuteEncrypt(context.Background(), &EncryptConfig{Files: []string{source}, DryRun: true}); err != nil {
+		t.Fatalf("ExecuteEncrypt dry-run: %v", err)
+	}
+
+	if _, err := os.Lstat(source + ".sops"); !os.IsNotExist(err) {
+		t.Fatalf("dry-run wrote a destination: %v", err)
+	}
+	if _, err := os.ReadDir(filepath.Join(os.Getenv("XDG_STATE_HOME"), "devlore", "graphs")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run persisted to the store: %v", err)
+	}
+}
+
+// mustMkdirAll creates the directory tree or fails the test.
+//
+// Parameters:
+//   - `t`: the test context.
+//   - `dir`: the directory path to create.
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+// mustWriteFile writes content or fails the test.
+//
+// Parameters:
+//   - `t`: the test context.
+//   - `path`: the file path to write.
+//   - `content`: the file content.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cmd/writ/writ/secret_cmd.go
+++ b/cmd/writ/writ/secret_cmd.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package writ
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/secret"
+)
+
+// newSecretCmd creates the `writ secret` parent command.
+//
+// Returns:
+//   - `*cobra.Command`: the secret family parent with its implemented subcommands attached.
+func newSecretCmd() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "SOPS secrets for layer repositories",
+		Long: `SOPS secrets for layer repositories.
+
+The family (docs/plans/writ-secret-*.md): encrypt (authoring) is implemented;
+init (the BYOK ceremony), decrypt, rekey, list, and recover are chartered.
+Lifecycle commands operate only within registered layers; deploy-time
+decryption is writ deploy's native behavior (<name>.sops deploys as <name>).`,
+	}
+
+	cmd.AddCommand(newSecretEncryptCmd())
+
+	return cmd
+}
+
+// newSecretEncryptCmd creates the `writ secret encrypt` subcommand.
+//
+// Returns:
+//   - `*cobra.Command`: the encrypt command.
+func newSecretEncryptCmd() *cobra.Command {
+
+	return &cobra.Command{
+		Use:   "encrypt <file>...",
+		Short: "Encrypt files to .sops siblings per the governing .sops.yaml",
+		Long: `Encrypt files to .sops siblings per the governing .sops.yaml.
+
+The <file>.sops sibling is written beside each input — deployed names are
+unchanged (foo.env.sops deploys as foo.env). Recipients and document format
+come from the .sops.yaml resolved within the containing layer; a file no
+creation rule governs fails with the resolver's error. An existing sibling
+refuses — encrypt never overwrites — and the plaintext source is never
+deleted; removal belongs to the caller.
+
+Every argument must lie inside a registered layer's working tree; register a
+repository with 'writ repo add'. The run rides the standard pipeline: the
+graph and trace persist to the execution store with receipts recorded.`,
+		Example: `  writ secret encrypt Home/noblefactor/.config/service/credentials.yaml
+  writ secret encrypt Home/common/.ssh/id_ed25519 Home/common/.ssh/id_rsa
+  writ secret encrypt --dry-run Home/thenobles/.Personal-secrets/keys.json`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runSecretEncrypt,
+	}
+}
+
+// runSecretEncrypt implements the encrypt command on the secret package.
+func runSecretEncrypt(cmd *cobra.Command, args []string) error {
+
+	return secret.ExecuteEncrypt(cmd.Context(), &secret.EncryptConfig{
+		Files:   args,
+		DryRun:  viper.GetBool("writ.dry-run"),
+		Verbose: viper.GetBool("writ.verbose"),
+	})
+}

--- a/docs/plans/writ-secret-encrypt.md
+++ b/docs/plans/writ-secret-encrypt.md
@@ -1,8 +1,8 @@
 ---
 title: "Writ Secret Encrypt"
-status: proposed
+status: complete
 created: 2026-08-09
-updated: 2026-08-09
+updated: 2026-08-11
 ---
 
 # Plan: Writ Secret Encrypt
@@ -58,3 +58,19 @@ containing layer's root, which mechanically enforces the root-`.sops.yaml` shape
 None — scope is deliberately minimal. Siblings chartered separately:
 [writ-secret-init](writ-secret-init.md), [writ-secret-rekey](writ-secret-rekey.md),
 [writ-secret-recover](writ-secret-recover.md).
+
+## Outcome (2026-08-11)
+
+Implemented as planned on `feat/writ-secret-encrypt` (`cmd/writ/writ/secret/`):
+containment with longest-root resolution and the `writ repo add`-naming refusal;
+layer-root confinement bounding `.sops.yaml` discovery; one `encryption.encrypt_file`
+unit per file, one graph per layer through the standard pipeline with graph, trace, and
+receipts persisted; existing-sibling refusal before planning; the resolver's no-rule
+error verbatim; dry-run serializes and writes nothing. One delta from the plan: the
+Starlark surfacing needed no new adapter — the `plan.encryption` projection is
+registry-generic and already carried both actions — so the surfacing is **proven**, not
+built, by extending `test_encryption.star` to assert the `encrypt_file` node.
+Test-binary provider registration follows the established blank `pkg/op/inventory`
+integration-test import. Verified: build, full suite green, gofmt clean, golangci at
+zero on Darwin and GOOS=linux. (The local complexity gate's two over-limit functions
+pre-exist this delivery and are tracked separately.)


### PR DESCRIPTION
`writ secret encrypt <file>...` per its plan and the 2026-08-10 rulings: layer containment (longest-root; refusal names `writ repo add`), the containing layer's root as confinement root (bounding `.sops.yaml` discovery — the root-config shape enforced mechanically), one `encryption.encrypt_file` unit per file in one graph per layer through the standard pipeline (graph + trace + receipts persisted), existing-sibling refusal before planning, plaintext never deleted, the resolver's no-rule error verbatim. Starlark surfacing proven by extending `test_encryption.star` with the `encrypt_file` node. Tests: age-fixture round-trip via the embedded decrypt, both refusals, no-rule error, multi-file single graph, dry-run writes nothing. Verified: build, full suite, gofmt, lint zero on Darwin and GOOS=linux. Note: the local `make check` complexity gate fails on two pre-existing functions outside this change (`guessDirName`, `runSelfInstall`) — reported separately.
