### PR TITLE
lint(errcheck): reasons for the nine bare suppressions

### DIFF
--- a/cmd/lore/lore/commands.go
+++ b/cmd/lore/lore/commands.go
@@ -221,7 +221,8 @@ func filterLowConfidence(resolved []resolvedPackage, cfg *loreDeployConfig) ([]r
 	fmt.Printf("\nProceed anyway? [y/N]: ")
 
 	var response string
-	_, _ = fmt.Scanln(&response) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: a failed read leaves response empty, which cancels; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Scanln(&response)
 	if !strings.EqualFold(response, "y") {
 		return nil, fmt.Errorf("deployment canceled by user")
 	}
@@ -625,7 +626,8 @@ environment repository.`,
 	cmd.Flags().Bool("verbose", false, "Show AI reasoning")
 	cmd.Flags().Bool("explain", false, "Show detailed reasoning for each confidence decision")
 	cmd.Flags().Int("max-fetches", 5, "Maximum additional URLs to fetch")
-	_ = cmd.MarkFlagRequired("from") //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: "from" is registered immediately above; see docs/architecture/2.8-eventing-infrastructure.md
+	_ = cmd.MarkFlagRequired("from")
 
 	return cmd
 }

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -115,30 +115,36 @@ func (c *Console) Styles() *Styles {
 
 // Print outputs styled text without a session.
 func (c *Console) Print(text string) {
-	_, _ = fmt.Fprint(c.output, text) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprint(c.output, text)
 }
 
 // PrintStyled outputs text with the given style.
 func (c *Console) PrintStyled(text string, style func(string) string) {
-	_, _ = fmt.Fprint(c.output, style(text)) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprint(c.output, style(text))
 }
 
 // Success prints a success message.
 func (c *Console) Success(msg string) {
-	_, _ = fmt.Fprintln(c.output, c.styles.Success.Render("✓ "+msg)) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprintln(c.output, c.styles.Success.Render("✓ "+msg))
 }
 
 // Warning prints a warning message.
 func (c *Console) Warning(msg string) {
-	_, _ = fmt.Fprintln(c.output, c.styles.Warning.Render("⚠ "+msg)) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprintln(c.output, c.styles.Warning.Render("⚠ "+msg))
 }
 
 // Error prints an error message.
 func (c *Console) Error(msg string) {
-	_, _ = fmt.Fprintln(c.output, c.styles.Error.Render("✗ "+msg)) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprintln(c.output, c.styles.Error.Render("✗ "+msg))
 }
 
 // Info prints an info message.
 func (c *Console) Info(msg string) {
-	_, _ = fmt.Fprintln(c.output, c.styles.Highlighted.Render("ℹ "+msg)) //nolint:errcheck
+	//nolint:errcheck // diagnose-ignored-error: console write; see docs/architecture/2.8-eventing-infrastructure.md
+	_, _ = fmt.Fprintln(c.output, c.styles.Highlighted.Render("ℹ "+msg))
 }

--- a/internal/pwsh/pwsh.go
+++ b/internal/pwsh/pwsh.go
@@ -288,7 +288,8 @@ func (s *Session) Run(command string) *Result {
 	s.history = append(s.history, result)
 
 	if s.audit != nil {
-		_, _ = fmt.Fprintln(s.audit, result.JSON()) //nolint:errcheck
+		//nolint:errcheck // diagnose-ignored-error: audit log write; see docs/architecture/2.8-eventing-infrastructure.md
+		_, _ = fmt.Fprintln(s.audit, result.JSON())
 	}
 
 	return result


### PR DESCRIPTION
Phase 1a of the audit remediation plan (issue #365).

Nine `//nolint:errcheck` directives carried no reason. The repository already has a convention for this — 32 sites use it — placing the directive on its own line above the statement:

```go
//nolint:errcheck // diagnose-ignored-error: <reason>; see docs/architecture/2.8-eventing-infrastructure.md
```

These nine now match it, rather than inventing new wording.

| Site | Reason given |
| --- | --- |
| `internal/console/console.go` ×6 | console write |
| `internal/pwsh/pwsh.go` | audit log write |
| `cmd/lore/lore/commands.go` (`Scanln`) | a failed read leaves `response` empty, which cancels |
| `cmd/lore/lore/commands.go` (`MarkFlagRequired`) | `"from"` is registered immediately above |

The two `cmd/lore` reasons cite the specific behavior that makes each discard safe, rather than asserting it is safe. For `Scanln`, a short read leaves `response` empty and the following `EqualFold` treats that as "not y" — the prompt cancels, which is the correct outcome.

**Bare `nolint` directives: 18 → 9.** The nine remaining are all `gocognit`/`gocyclo` and belong to stage 1b, where ruling 4 decomposes them under the #312 discipline and deletes the suppressions rather than annotating them.

Verified: `make vet`, `make build`, and the full `make test` suite green — zero `FAIL` or `panic` lines, counted rather than read off a truncated tail. `gofmt` clean over the change set. Comment-only; no behavior change.
