### PR TITLE
docs: two bugs from the phase 1b review, and the measured 1b verdicts

### DIFF
--- a/docs/plans/audit-remediation.md
+++ b/docs/plans/audit-remediation.md
@@ -101,6 +101,10 @@ is the critical-bug class from the CLAUDE.md checklist. They are chartered debt.
    status reported for each — all ~244, not just the 41 that lack a status field.
 4. **The nine complexity suppressions are decomposed, not annotated** — the #312 discipline
    applied verbatim, and the suppressions deleted rather than argued.
+5. **Treatment is decided per function by whether it reads as steps** (2026-08-11). Extract only
+   where named steps fall out; flatten where the problem is depth; argue the suppression where
+   splitting would fragment a coherent unit. Measured verdicts are in phase 1b below. Ruling 4
+   stands as the default; this is the criterion that decides how each one is met.
 
 ### Status mapping implied by ruling 2
 
@@ -133,8 +137,8 @@ and PR history bear that out.
 
 | Component | Status | Notes |
 | --- | --- | --- |
-| `nolint` reasons | ❌ 18 bare | Of 315 directives; 9 `errcheck`, 9 complexity |
-| Complexity gate | ❌ 9 escapees | Functions exempted rather than decomposed under #312 |
+| `nolint` reasons | ⚠️ 9 bare | Was 18 of 315; the 9 `errcheck` fixed by 1a (PR #367) |
+| Complexity gate | ❌ 8 escapees | Was 9; `applyGraphModifications` measured under both thresholds |
 | goast `Type` comments | ❌ Inaccurate | 2 comments + 2 test names call a live field "legacy" |
 | Plan status convention | ❌ 4 conventions | 186 YAML, 16 bold, 1 table, 41 none |
 | Plan status values | ❌ 59 free-text | Paragraph-length values in a machine-readable field |
@@ -147,18 +151,23 @@ and PR history bear that out.
 
 Ruling 4 splits this into a mechanical stage and a decomposition campaign.
 
-#### 1a — `errcheck` reasons — branch `lint/errcheck-reasons`
+#### 1a — `errcheck` reasons — branch `lint/errcheck-reasons` — **COMPLETED**
 
-- [ ] `cmd/lore/lore/commands.go:224` — `fmt.Scanln` at an interactive confirmation prompt; a
+Landed as PR #367, merged 2026-08-11 (develop `e19d35cd`).
+
+- [x] `cmd/lore/lore/commands.go:224` — `fmt.Scanln` at an interactive confirmation prompt; a
       short read leaves `response` empty, which the following `EqualFold` treats as "not y" and
-      cancels. State exactly that.
-- [ ] `cmd/lore/lore/commands.go:628` — `MarkFlagRequired` on a flag registered immediately
+      cancels. Stated exactly that.
+- [x] `cmd/lore/lore/commands.go:628` — `MarkFlagRequired` on a flag registered immediately
       above; it fails only if the flag name is absent, which the same function guarantees.
-- [ ] `internal/pwsh/pwsh.go:291` and the six `internal/console/console.go` sites (118, 123,
+- [x] `internal/pwsh/pwsh.go:291` and the six `internal/console/console.go` sites (118, 123,
       128, 133, 138, 143) — terminal writes with no recovery path.
 
-**Files**: `cmd/lore/lore/commands.go`, `internal/pwsh/pwsh.go`, `internal/console/console.go`
-— Modify.
+All nine follow the convention already used at 32 sites: the directive on its own line above the
+statement, `diagnose-ignored-error: <reason>; see
+docs/architecture/2.8-eventing-infrastructure.md`. **Bare directives 18 → 9**, re-enumerated
+uncapped. Verified: `make vet`, `make build`, full `make test` green (zero FAIL/panic lines by
+count); `gofmt -l` empty.
 
 #### 1b — Complexity decomposition — four branches
 
@@ -169,16 +178,40 @@ semantic changes; the existing test suite passes unmodified. Each suppression is
 not rewritten. Per-branch verification: the target functions enumerate to zero findings, no new
 findings anywhere, `make vet` and full `make test` green, gofmt clean.
 
-| Branch | Functions |
-| --- | --- |
-| `refactor/complexity-lore` | `runOnboard` (`commands.go:633`), `generateManifest` (`onboard.go:311`) |
-| `refactor/complexity-writ-migrate` | `buildMultiSource` (`builder.go:232`), `buildTree` (`gather.go:64`), `applyGraphModifications` (`session.go:374`) |
-| `refactor/complexity-internal` | `promptForProvider` (`config.go:224`), `main` (`devlore-index/main.go:95`) |
-| `refactor/complexity-bindgen` | `findPackages` (`extractor.go:103`), `extractFromFunction` (`extractor.go:214`) |
+All nine were read in full and measured with `gocyclo` and `gocognit` (2026-08-11). Ruling 5's
+criterion produced five distinct treatments, not one.
 
-`generateManifest` has already been read: 49 lines, nesting four deep, a straight-line document
-builder. Its seams are the product-header block, the complexity-warning block, and the slot
-loop. The other eight are read at the start of their branch, not presumed here.
+| Function | gocyclo | gocognit | Verdict |
+| --- | --- | --- | --- |
+| `promptForProvider` (`config.go:224`) | 16 | 17 | **Extract** — steps; four switch arms are one table |
+| `main` (`devlore-index/main.go:95`) | 15 | 28 | **Extract** — steps |
+| `runOnboard` (`commands.go:635`) | 18 | 21 | **Extract** — steps |
+| `generateManifest` (`onboard.go:311`) | 16 | 26 | **Extract** — steps |
+| `extractFromFunction` (`extractor.go:214`) | 19 | 51 | **Extract** — a named operation, not steps; a six-deep AST ladder |
+| `buildMultiSource` (`builder.go:232`) | 12 | 31 | **Extract** — a named domain rule, not steps. **BLOCKED on #369** |
+| `findPackages` (`extractor.go:103`) | 11 | 23 | **Flatten** — depth, not sequence; invert one condition |
+| `buildTree` (`gather.go:64`) | 13 | 23 | **Argue** — a `WalkDir` guard chain returning distinct sentinels; splitting fragments the filter |
+| `applyGraphModifications` (`session.go:374`) | 7 | 8 | **Delete the directive** — under both thresholds; it suppresses nothing |
+
+Branch split, revised:
+
+| Branch | Work |
+| --- | --- |
+| `refactor/complexity-lore` | `runOnboard`, `generateManifest` — extract |
+| `refactor/complexity-internal` | `promptForProvider`, `main` — extract |
+| `refactor/complexity-bindgen` | `extractFromFunction` — extract; `findPackages` — flatten |
+| `refactor/complexity-writ-migrate` | `applyGraphModifications` — delete; `buildTree` — argue |
+
+**`buildMultiSource` is deferred to issue #369.** Its collision predicate at `builder.go:280` has
+zero coverage (`make cover`: `builder.go:280.45,282.7 1 0`) and is reachable only through a
+specificity tie whose winner is undefined — `sort.Slice` at `matcher.go:61` is unstable. A
+behavior-preserving refactor of a predicate with no defined behavior is not possible. #369 gives
+specificity a total order, which is expected to make that branch unreachable and deletable rather
+than testable.
+
+Thresholds for reference: `.golangci.yaml` sets `gocyclo` 15 and `gocognit` 20;
+`Makefile:163` gates at `gocyclo -over 20`. None of the nine trips the Makefile gate — every one
+is a golangci-only finding, which is how the suppressions were reachable.
 
 ### Phase 2: goast naming accuracy — branch `chore/goast-type-field-naming`
 
@@ -258,4 +291,9 @@ None outstanding. Rulings 1–4 close every question this plan opened.
 - [docs/plans/TEMPLATE.md](./TEMPLATE.md) — the status enum, rewritten by phase 3.0
 - [docs/plans/complexity-refactors.md](./complexity-refactors.md) — issue #312; its `complete`
   status is a phase 3.1 candidate
+- [docs/plans/segment-grammar-enforcement.md](./segment-grammar-enforcement.md) — issue #369;
+  **blocks** phase 1b's `buildMultiSource` decomposition
+- [docs/plans/deploy-manifest-error-propagation.md](./deploy-manifest-error-propagation.md) —
+  issue #368; found during the phase 1b review of the same file, kept out of the
+  behavior-preserving work
 - Issue #65 — the standing ledger of judgment errors; no mechanical audit covers it

--- a/docs/plans/deploy-manifest-error-propagation.md
+++ b/docs/plans/deploy-manifest-error-propagation.md
@@ -1,0 +1,120 @@
+---
+title: "Deploy manifest error propagation"
+issue: https://github.com/NobleFactor/devlore-cli/issues/368
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+---
+
+# Plan: Deploy manifest error propagation
+
+## Summary
+
+`lore deploy` swallows a manifest it cannot load. `parseLoreDeployConfig` logs the failure and
+continues, so the command deploys whatever else parsed and exits 0 — reporting success for a
+request it only partly fulfilled. This plan propagates the failure and removes the dead error
+return that the swallow created.
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| `manifest.Load` failure | ❌ Swallowed | Logged and `continue`d at `cmd/lore/lore/commands.go:111` |
+| `parseLoreDeployConfig` error return | ❌ Dead | Always `nil`; masked by `//nolint:unparam` |
+| Exit code on partial deploy | ❌ Wrong | 0, despite an unfulfilled request |
+| Diagnosis on total failure | ❌ Misleading | "no packages to deploy", not the load error |
+| Test coverage | ❌ None | No test exercises an unloadable manifest |
+
+### The defect
+
+`cmd/lore/lore/commands.go:108` loads each `@manifest` argument. On failure,
+`cmd/lore/lore/commands.go:110` prints and `cmd/lore/lore/commands.go:111` skips it. Because
+every failure is absorbed there, `cmd/lore/lore/commands.go:126` can return `nil`
+unconditionally — and the signature at `cmd/lore/lore/commands.go:89` carries
+`//nolint:unparam // error return reserved for future use`, which describes the consequence as
+though it were the design.
+
+`manifest.Load` is `document.ReadFile[PackagesManifest]` (`internal/manifest/manifest.go:81`),
+so it fails on a missing file, an unreadable file, a malformed document, or a schema mismatch.
+A filename typo is enough.
+
+### Two observable failures
+
+1. **`lore deploy @typo.yaml some-package`** — the manifest is skipped, `some-package` deploys,
+   `len(resolved) != 0`, and `runDeploy` returns `nil`. **Exit 0 on a partial deploy.** CI
+   wrapping this goes green.
+2. **`lore deploy @typo.yaml`** — `cfg.Packages` is empty and `runDeploy` returns
+   "no packages to deploy" from `cmd/lore/lore/commands.go:81`. Correct exit code, wrong cause;
+   the real error has scrolled past.
+
+## Goals
+
+1. **A manifest the user named and that cannot be loaded fails the command** — no silent skip.
+2. **The reported error names the manifest and the underlying cause** — never "no packages to
+   deploy" standing in for "that file does not exist".
+3. **`parseLoreDeployConfig`'s error return is live**, and the `//nolint:unparam` is deleted
+   rather than re-argued.
+4. **Regression tests pin both failure modes.**
+
+## Design decision required
+
+Parsing completes before any deployment executes, so aborting costs the user nothing already
+done. That rules out any "best effort" argument grounded in partial work. Three candidates:
+
+| Option | Behavior | Residual failure |
+| --- | --- | --- |
+| **A — fail fast** | The first unloadable manifest aborts with its error | A user with three broken manifests fixes them one run at a time |
+| **B — collect, then abort** (recommended) | Attempt every manifest, join all failures via `errors.Join`, abort before deploying anything | Slightly more code; error output is multi-line |
+| **C — skip, but exit non-zero** | Current behavior, with a correct exit code and a summary of what was skipped | Preserves partial deploys as a *feature*. A green-looking run still under-deploys, and the greenfield principle argues against keeping a behavior only because it exists |
+
+**Recommendation: B.** Same safety as A, strictly better diagnostics, and it matches the fact
+that nothing has been executed yet at parse time. Requires the user's ruling before
+implementation.
+
+## Implementation Phases
+
+### Phase 1: Propagate — branch `fix/deploy-manifest-error-propagation`
+
+- [ ] Replace the `cli.Error` + `continue` at `cmd/lore/lore/commands.go:110` with error
+      collection per the approved option.
+- [ ] Return the joined error from `parseLoreDeployConfig`; delete the `//nolint:unparam` at
+      `cmd/lore/lore/commands.go:89`.
+- [ ] Confirm `runDeploy`'s existing `if err != nil` at `cmd/lore/lore/commands.go:64` already
+      surfaces it — it does; no change expected there, verify rather than assume.
+- [ ] Re-read "no packages to deploy" at `cmd/lore/lore/commands.go:81`. With load failures now
+      propagating, that message should only appear when the user genuinely named nothing
+      deployable. Confirm it is still reachable and still correct.
+
+**Files**: `cmd/lore/lore/commands.go` — Modify.
+
+### Phase 2: Tests
+
+- [ ] Unloadable manifest alone → the returned error names the manifest path and wraps the
+      `document.ReadFile` cause.
+- [ ] Unloadable manifest plus a valid direct package → the command **fails**; nothing deploys.
+      This is the exit-0 regression and is the most important test in the plan.
+- [ ] Two unloadable manifests → both are reported (option B only).
+- [ ] Valid manifest plus valid package → unchanged behavior; guards against over-correction.
+- [ ] A genuinely empty but well-formed manifest → still "no packages to deploy", not a load
+      error.
+
+**Files**: `cmd/lore/lore/commands_test.go` — Create or Modify, per what exists.
+
+## Verification
+
+`make vet`, `make build`, and full `make test` green; `gofmt` clean over the change set. The
+exit code is asserted directly in the phase 2 tests, not inferred.
+
+## Open Questions
+
+- [ ] Which option — A, B, or C? B is recommended.
+- [ ] Should a manifest that loads but contains zero packages be an error, or is that a valid
+      no-op? Current behavior treats it as contributing nothing, which then trips "no packages
+      to deploy" if it was the only argument. That seems right, but it is worth an explicit
+      ruling since phase 2 pins it.
+
+## Related Documents
+
+- Issue #368 — this bug
+- [docs/plans/audit-remediation.md](./audit-remediation.md) — issue #365; found during its phase
+  1b review, deliberately kept out of that behavior-preserving decomposition

--- a/docs/plans/segment-grammar-enforcement.md
+++ b/docs/plans/segment-grammar-enforcement.md
@@ -1,0 +1,148 @@
+---
+title: "Segment grammar enforcement"
+issue: https://github.com/NobleFactor/devlore-cli/issues/369
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+---
+
+# Plan: Segment grammar enforcement
+
+## Summary
+
+The layer directory grammar is `[<project>|common][.<os>][.<distro>][.<arch>][.<custom>...]`.
+`cmd/writ/writ/segment/segment.go:18` declares it; nothing enforces it. Suffixes are parsed into
+a positionless list and matched against one flat set of every dimension's values, so order is
+never checked, position never selects a dimension, and specificity degrades to a suffix count
+that cannot rank DISTRO above OS. The resulting ties are then resolved by an unstable sort.
+
+This plan makes the grammar the parser's contract. Specificity becomes a dimension tuple with a
+total order, which dissolves the tie problem instead of patching it.
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| Grammar | ❌ Documented only | `segment.go:18` states it; no code asserts it |
+| `ParseDirName` | ❌ Positionless | Returns `parts[1:]`; position discarded at `segment.go:79` |
+| `Segments.Match` | ❌ Dimension-blind | Flat `AllValues()` membership at `segment.go:93` |
+| `Specificity()` | ❌ A count | `len(m.Suffixes)` at `segment.go:120` |
+| Tie ordering | ❌ Undefined | `sort.Slice` (unstable) at `matcher.go:61` and `matcher.go:108` |
+| Tie-break branch | ❌ Untested | `builder.go:280` — `make cover` reports count 0 |
+
+### Live failure cases
+
+1. **`common.Unix` vs `common.Darwin` on macOS.** `AllValues` adds the OS family
+   (`segment.go:64`), so both are specificity 1 and tie. `Darwin` should win. `noblefactor.Unix`
+   is a form the codebase documents at `cmd/writ/writ/migrate/session.go:316`, so this is live.
+2. **`common.Linux` vs `common.Debian` on Debian.** Both specificity 1. A distro-specific file
+   ties with an OS-generic one.
+3. **`common.arm64.Darwin`** matches identically to `common.Darwin.arm64`. Both specificity 2,
+   both accepted, one ungrammatical.
+4. **`common.desktop.Darwin`** with `ROLE=desktop` matches — a custom value in the OS slot.
+
+## Goals
+
+1. **The grammar is the contract** — a directory name that violates the documented order is
+   rejected loudly, not silently matched.
+2. **Position selects a dimension** — a suffix in the OS slot is checked against OS, not against
+   every value in every dimension.
+3. **Specificity ranks dimensions** — a total order in which `Darwin` beats `Unix` and a
+   distro-specific directory beats an OS-generic one.
+4. **No undefined ordering** — the sort is stable or the comparison is total. Ties reduce to
+   identical names, which cannot occur within one directory.
+5. **The `builder.go:280` branch gets defined behavior and a test**, or is removed because the
+   total order makes it unreachable.
+
+## Design
+
+Parsing becomes dimension resolution rather than a split:
+
+1. Split the directory name on `.`; `parts[0]` is the project.
+2. Resolve each suffix to the dimension it belongs to, consulting that dimension's value
+   (OS including its family, DISTRO, ARCH, then each custom segment in configured order).
+3. A suffix resolving to no dimension means the directory targets a different machine —
+   no match, as today.
+4. Verify the resolved dimensions appear in canonical order. Out-of-order is a **grammar
+   violation**, reported against the directory, not a silent non-match.
+5. Specificity becomes a tuple over dimensions, compared by the precedence ruled below.
+
+Within the OS dimension, an exact OS beats its family: `Darwin` > `Unix`.
+
+## Implementation Phases
+
+### Phase 1: Typed parse — branch `fix/segment-grammar-parse`
+
+- [ ] Replace `ParseDirName`'s `[]string` return with a structured result carrying the resolved
+      dimension of each suffix.
+- [ ] Resolve suffixes against their dimension rather than the flat `AllValues()` set.
+- [ ] Report out-of-order suffixes as a grammar violation.
+- [ ] Keep `Match` semantics otherwise unchanged so the phase is independently reviewable.
+
+**Files**: `cmd/writ/writ/segment/segment.go` — Modify.
+
+### Phase 2: Total-order specificity — branch `fix/segment-specificity-order`
+
+- [ ] Replace `Specificity() int` with the dimension tuple and its comparison.
+- [ ] `sort.Slice` → `sort.SliceStable` at `matcher.go:61` and `matcher.go:108`, or make the
+      comparison total so stability is moot. Prefer total.
+- [ ] Re-examine `builder.go:280`. If the total order makes same-layer ties impossible, delete
+      the branch rather than leave dead code with a suppression.
+
+**Files**: `cmd/writ/writ/segment/segment.go`, `cmd/writ/writ/segment/matcher.go`,
+`cmd/writ/writ/tree/builder.go` — Modify.
+
+### Phase 3: Tests
+
+- [ ] `common.Unix` vs `common.Darwin` on Darwin — `Darwin` wins, deterministically.
+- [ ] `common.Linux` vs `common.Debian` on Debian — `Debian` wins.
+- [ ] `common.arm64.Darwin` — grammar violation, reported.
+- [ ] `common.desktop.Darwin` with `ROLE=desktop` — no longer matches via the OS slot.
+- [ ] A custom segment whose value collides with an OS/distro/arch name resolves to its own
+      dimension.
+- [ ] Existing `TestBuildMultiSource*` tests pass unchanged — they encode intended behavior and
+      must not be edited to accommodate the fix.
+
+**Files**: `cmd/writ/writ/segment/segment_test.go`, `cmd/writ/writ/tree/tree_test.go` — Modify.
+
+### Phase 4: The `all` → `common` sweep — branch `docs/common-project-rename`
+
+Separate concern, same neighborhood; sequenced last so it does not muddy the semantic diffs.
+
+- [ ] `cmd/writ/writ/commands.go:113` — user-facing help still teaches `writ decommission all`.
+- [ ] `cmd/writ/writ/migrate/session.go:316` — user-facing guidance, `e.g., all.Darwin`.
+- [ ] `cmd/writ/writ/tree/builder.go:127` — doc comment.
+- [ ] `cmd/writ/writ/deploy/deploy.go:45` — doc comment.
+- [ ] 30 `"all"` occurrences across the writ tests.
+- [ ] `docs/architecture/7-registry-knowledge.md:158` — `Home/Configs/all/`.
+- [ ] Verify `docs/plans/writ-deploy-scenario.md:39` — it lists `all`, `microsoft`,
+      `noblefactor`, `thenobles`, which may correctly describe the real Tuckr-era layout rather
+      than being stale.
+
+## Open Questions
+
+- [ ] **Dimension precedence.** The grammar orders OS, DISTRO, ARCH. Is that increasing
+      specificity — does `common.Debian` (DISTRO) beat `common.amd64` (ARCH) when both are
+      present at equal count? A tuple needs a defined precedence, and left-to-right is an
+      assumption until ruled.
+- [ ] **Custom segment ranking.** Custom segments append after ARCH. Do they outrank ARCH (they
+      are more situational) or rank below it? With several custom segments, does configured
+      order define their precedence?
+- [ ] **Out-of-order handling.** Hard error naming the directory, or a warning that skips it?
+      An error is the greenfield answer, but it turns an existing misnamed directory into a
+      failed deploy rather than a quiet mismatch.
+- [ ] **Ambiguous values.** If a custom segment's value equals an OS or arch name, does the
+      earliest dimension in canonical order claim it, or is the configuration itself rejected as
+      ambiguous?
+
+## Verification
+
+`make vet`, `make build`, full `make test` green; `gofmt` clean. `make cover` shows the
+`builder.go` collision block fully covered, or the branch removed. No existing
+`TestBuildMultiSource*` assertion is weakened to accommodate the change.
+
+## Related Documents
+
+- Issue #369 — this bug
+- [docs/plans/audit-remediation.md](./audit-remediation.md) — issue #365; this blocks its phase
+  1b `buildMultiSource` decomposition


### PR DESCRIPTION
Records two correctness bugs found while reviewing `cmd/lore` and `cmd/writ` for the issue #365 phase 1b decomposition, plus the measured verdicts for all nine phase 1b targets.

Both bugs are their own issues and plans rather than folded into phase 1b — a semantic fix hidden inside an extract-method diff is exactly what the #312 discipline forbids.

## Issue #368 — `lore deploy` silently skips an unloadable manifest

`parseLoreDeployConfig` logs the `manifest.Load` failure and `continue`s, which is why its error return is dead and why the `//nolint:unparam` on it documents a consequence as though it were an intention.

- `lore deploy @typo.yaml some-package` — deploys `some-package`, **exits 0**, having fulfilled half the request. CI wrapping this goes green.
- `lore deploy @typo.yaml` — reports "no packages to deploy", which is the wrong cause.

Parsing completes before any deployment executes, so aborting costs nothing already done.

## Issue #369 — writ segment matching ignores its own suffix grammar

The grammar is `[<project>|common][.<os>][.<distro>][.<arch>][.<custom>...]` and `segment.go:18` states it as the contract. `ParseDirName` discards position; `Match` tests each suffix against one flat set of every dimension's values.

- Order is never validated — `common.arm64.Darwin` is accepted.
- Position never selects a dimension — `common.desktop.Darwin` matches with `ROLE=desktop`.
- Specificity is a suffix count, so it cannot rank DISTRO above OS. `common.Unix` and `common.Darwin` both measure 1 on a Mac and **tie**.
- Ties resolve via `sort.Slice`, which is unstable — the winner is undefined by contract.

## Phase 1b verdicts

All nine read in full and measured. Ruling 5 is added — treatment decided per function by whether it reads as steps — which produced five treatments rather than one:

| Verdict | Functions |
| --- | --- |
| Extract (steps) | `promptForProvider`, `main`, `runOnboard`, `generateManifest` |
| Extract (named operation) | `extractFromFunction`, `buildMultiSource` |
| Flatten | `findPackages` |
| Argue the suppression | `buildTree` |
| Delete the directive | `applyGraphModifications` — gocyclo 7, gocognit 8, under both thresholds |

`buildMultiSource` is **deferred to #369**: its collision predicate at `builder.go:280` has zero coverage (`make cover` reports `builder.go:280.45,282.7 1 0`) and is reachable only through a tie whose winner is undefined.

Phase 1a is marked completed — PR #367, bare `nolint` directives 18 → 9.

Documentation only; no code changes.
