### PR TITLE
test(lore): restore the characterization tests lost from PR #371

### DIFF
--- a/cmd/lore/lore/commands_test.go
+++ b/cmd/lore/lore/commands_test.go
@@ -6,9 +6,17 @@ package lore
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/NobleFactor/devlore-cli/cmd/lore/lore/onboard"
+	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/internal/manifest"
+	"github.com/NobleFactor/devlore-cli/pkg/sink"
+	"github.com/NobleFactor/devlore-cli/pkg/status"
 )
 
 func TestManifestLoad_YAML(t *testing.T) {
@@ -158,5 +166,302 @@ func TestManifestLoad_NotFound(t *testing.T) {
 	_, err := manifest.Load("/nonexistent/path/manifest.yaml")
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+// The onboard helper tests below pin the behavior runOnboard delegates to. Their expectations are
+// hand-derived from the pre-decomposition runOnboard, so a decomposition that changed behavior
+// fails them rather than being absorbed by them.
+
+// newOnboardTestCommand builds a command carrying the same flags newOnboardCmd registers, so
+// parseLoreOnboardConfig can be exercised without constructing the real command tree.
+//
+// Parameters:
+//   - `t`: the running test.
+//   - `args`: the command line to parse, excluding the command name.
+//
+// Returns:
+//   - `*cobra.Command`: the command with its flags parsed.
+func newOnboardTestCommand(t *testing.T, args ...string) *cobra.Command {
+
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "onboard"}
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("output", "", "")
+	cmd.Flags().String("format", "plain", "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().Bool("explain", false, "")
+	cmd.Flags().Int("max-fetches", 5, "")
+
+	if err := cmd.Flags().Parse(args); err != nil {
+		t.Fatalf("parsing flags: %v", err)
+	}
+
+	return cmd
+}
+
+func TestParseLoreOnboardConfig_DefaultsOutputDirToWorkingDirectory(t *testing.T) {
+
+	cfg := parseLoreOnboardConfig(newOnboardTestCommand(t, "--from", "https://example.test/wiki"))
+
+	if cfg.OutputDir != "." {
+		t.Errorf("OutputDir = %q, want %q", cfg.OutputDir, ".")
+	}
+	if cfg.Source != "https://example.test/wiki" {
+		t.Errorf("Source = %q, want %q", cfg.Source, "https://example.test/wiki")
+	}
+}
+
+func TestParseLoreOnboardConfig_CarriesEveryFlag(t *testing.T) {
+
+	cmd := newOnboardTestCommand(t,
+		"--from", "setup.sh",
+		"--output", "/tmp/out",
+		"--format", "yaml",
+		"--verbose",
+		"--explain",
+		"--max-fetches", "9",
+	)
+
+	cfg := parseLoreOnboardConfig(cmd)
+
+	if cfg.Source != "setup.sh" {
+		t.Errorf("Source = %q, want %q", cfg.Source, "setup.sh")
+	}
+	if cfg.OutputDir != "/tmp/out" {
+		t.Errorf("OutputDir = %q, want %q", cfg.OutputDir, "/tmp/out")
+	}
+	if cfg.Format != "yaml" {
+		t.Errorf("Format = %q, want %q", cfg.Format, "yaml")
+	}
+	if !cfg.Verbose {
+		t.Error("Verbose = false, want true")
+	}
+	if !cfg.Explain {
+		t.Error("Explain = false, want true")
+	}
+	if cfg.MaxFetches != 9 {
+		t.Errorf("MaxFetches = %d, want 9", cfg.MaxFetches)
+	}
+}
+
+func TestNewOnboardProvider_RefusesWhenNoProviderConfigured(t *testing.T) {
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	_, err := newOnboardProvider()
+
+	if err == nil {
+		t.Fatal("expected an error when lore.model.provider is unset")
+	}
+	if !strings.Contains(err.Error(), "lore config model") {
+		t.Errorf("error %q does not name the remedy 'lore config model'", err)
+	}
+}
+
+func TestNewOnboardProvider_ConstructsTheConfiguredProvider(t *testing.T) {
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("lore.model.provider", "ollama")
+	viper.Set("lore.model.model", "llama3")
+	viper.Set("lore.model.endpoint", "http://localhost:11434")
+
+	provider, err := newOnboardProvider()
+
+	if err != nil {
+		t.Fatalf("newOnboardProvider: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("provider is nil")
+	}
+}
+
+func TestNewOnboardProvider_WrapsAConstructionFailure(t *testing.T) {
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("lore.model.provider", "anthropic") // requires an api_key, which is absent
+
+	_, err := newOnboardProvider()
+
+	if err == nil {
+		t.Fatal("expected an error constructing a provider with no api_key")
+	}
+	if !strings.Contains(err.Error(), "creating AI provider") {
+		t.Errorf("error %q is not wrapped with 'creating AI provider'", err)
+	}
+}
+
+// captureNarration installs a capturing narrator for the duration of the test and returns a
+// function reading what was written.
+//
+// Parameters:
+//   - `t`: the running test.
+//
+// Returns:
+//   - `func() string`: reads the narration captured so far.
+func captureNarration(t *testing.T) func() string {
+
+	t.Helper()
+
+	previous := cli.UI()
+	captured, buffer := sink.Capture()
+	cli.SetUI(status.NewNarrator("", captured))
+	t.Cleanup(func() { cli.SetUI(previous) })
+
+	return buffer.String
+}
+
+func TestReportOnboardResult_ReportsProductVendorAndVersion(t *testing.T) {
+
+	narration := captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{
+		Product: &onboard.ProductInfo{
+			Name:     "ripgrep",
+			Category: "cli",
+			Vendor:   "BurntSushi",
+			Version:  "14.1.0",
+		},
+	})
+
+	for _, want := range []string{"ripgrep", "cli", "BurntSushi", "14.1.0"} {
+		if !strings.Contains(narration(), want) {
+			t.Errorf("narration does not mention %q\nnarration: %s", want, narration())
+		}
+	}
+}
+
+func TestReportOnboardResult_OmitsAnEmptyVendorAndVersion(t *testing.T) {
+
+	narration := captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{
+		Product: &onboard.ProductInfo{Name: "fd", Category: "cli"},
+	})
+
+	for _, unwanted := range []string{"Vendor:", "Version:"} {
+		if strings.Contains(narration(), unwanted) {
+			t.Errorf("narration mentions %q for an absent field\nnarration: %s", unwanted, narration())
+		}
+	}
+}
+
+func TestReportOnboardResult_ReportsEveryConcernOfAComplexInstallation(t *testing.T) {
+
+	narration := captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{
+		Complexity: &onboard.ComplexityInfo{
+			Rating:   "complex",
+			Concerns: []string{"requires sudo", "builds a kernel module"},
+		},
+	})
+
+	for _, want := range []string{"complex", "requires sudo", "builds a kernel module"} {
+		if !strings.Contains(narration(), want) {
+			t.Errorf("narration does not mention %q\nnarration: %s", want, narration())
+		}
+	}
+}
+
+func TestReportOnboardResult_ReportsASimpleRatingWithoutConcerns(t *testing.T) {
+
+	narration := captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{
+		Complexity: &onboard.ComplexityInfo{Rating: "simple", Concerns: []string{"unreported"}},
+	})
+
+	if !strings.Contains(narration(), "simple") {
+		t.Errorf("narration does not mention the simple rating\nnarration: %s", narration())
+	}
+	if strings.Contains(narration(), "unreported") {
+		t.Errorf("concerns are reported for a non-complex rating\nnarration: %s", narration())
+	}
+}
+
+func TestReportOnboardResult_ReportsAModerateRatingWithoutConcerns(t *testing.T) {
+
+	narration := captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{
+		Complexity: &onboard.ComplexityInfo{Rating: "moderate", Concerns: []string{"unreported"}},
+	})
+
+	if !strings.Contains(narration(), "moderate") {
+		t.Errorf("narration does not mention the moderate rating\nnarration: %s", narration())
+	}
+	if strings.Contains(narration(), "unreported") {
+		t.Errorf("concerns are reported for a non-complex rating\nnarration: %s", narration())
+	}
+}
+
+func TestReportOnboardResult_ReportsTheSlotCountOnlyWhenSlotsExist(t *testing.T) {
+
+	withSlots := captureNarration(t)
+	reportOnboardResult(&onboard.Result{
+		Slots: []onboard.ExtractedSlot{{Name: "install_command"}, {Name: "package_manager"}},
+	})
+	if !strings.Contains(withSlots(), "2") {
+		t.Errorf("narration does not report the slot count\nnarration: %s", withSlots())
+	}
+
+	withoutSlots := captureNarration(t)
+	reportOnboardResult(&onboard.Result{})
+	if strings.Contains(withoutSlots(), "configuration slots") {
+		t.Errorf("slot count reported for an empty slot list\nnarration: %s", withoutSlots())
+	}
+}
+
+func TestReportOnboardResult_ToleratesAnEmptyResult(t *testing.T) {
+
+	captureNarration(t)
+
+	reportOnboardResult(&onboard.Result{})
+}
+
+func TestWriteOnboardManifest_WritesTheManifestAndNamesThePath(t *testing.T) {
+
+	narration := captureNarration(t)
+	outputDir := t.TempDir()
+
+	err := writeOnboardManifest(outputDir, &onboard.Result{Manifest: "# PkgPath: ripgrep\n"})
+
+	if err != nil {
+		t.Fatalf("writeOnboardManifest: %v", err)
+	}
+
+	manifestPath := filepath.Join(outputDir, "packages-manifest.yaml")
+	written, readErr := os.ReadFile(manifestPath) //nolint:gosec // G704: path built from t.TempDir
+	if readErr != nil {
+		t.Fatalf("reading the written manifest: %v", readErr)
+	}
+	if string(written) != "# PkgPath: ripgrep\n" {
+		t.Errorf("manifest contents = %q, want %q", string(written), "# PkgPath: ripgrep\n")
+	}
+
+	if !strings.Contains(narration(), manifestPath) {
+		t.Errorf("narration does not name the written path\nnarration: %s", narration())
+	}
+	if !strings.Contains(narration(), "lore deploy @packages-manifest.yaml") {
+		t.Errorf("narration does not print the next steps\nnarration: %s", narration())
+	}
+}
+
+func TestWriteOnboardManifest_FailsWhenTheDirectoryDoesNotExist(t *testing.T) {
+
+	captureNarration(t)
+
+	err := writeOnboardManifest(filepath.Join(t.TempDir(), "absent"), &onboard.Result{Manifest: "x"})
+
+	if err == nil {
+		t.Fatal("expected an error writing into a nonexistent directory")
+	}
+	if !strings.Contains(err.Error(), "writing manifest") {
+		t.Errorf("error %q is not wrapped with 'writing manifest'", err)
 	}
 }

--- a/cmd/lore/lore/onboard/manifest_test.go
+++ b/cmd/lore/lore/onboard/manifest_test.go
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+package onboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// The expectations in this file are hand-derived from the manifest generator's behavior, not
+// captured from its output. Every byte asserted below — the `# PkgPath:` header, the `#\n`
+// separators, the blank line between the header and the commands, the two-space annotation
+// indent, and the trailing newline after each command — was read off the implementation and
+// written down independently, so a change in behavior fails these tests rather than being
+// absorbed by them.
+
+// region generateManifest
+
+func TestGenerateManifest(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		discovery *discoveryResult
+		slots     []ExtractedSlot
+		want      string
+	}{
+		{
+			name: "product header, platform-qualified command, canonical name already present",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{
+					Name:          "ripgrep",
+					CanonicalName: "ripgrep",
+					Vendor:        "BurntSushi",
+					Version:       "14.1.0",
+				},
+			},
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "brew install ripgrep", Platform: "Darwin"},
+			},
+			want: "# PkgPath: ripgrep\n" +
+				"# Vendor: BurntSushi\n" +
+				"# Version: 14.1.0\n" +
+				"#\n" +
+				"\n" +
+				"# Platform: Darwin\n" +
+				"brew install ripgrep\n" +
+				"\n",
+		},
+		{
+			name:      "no product and no slots yields only the section separator",
+			discovery: &discoveryResult{},
+			slots:     nil,
+			want:      "\n",
+		},
+		{
+			name: "vendor and version are omitted when empty",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "fd", CanonicalName: "fd"},
+			},
+			slots: nil,
+			want: "# PkgPath: fd\n" +
+				"#\n" +
+				"\n",
+		},
+		{
+			name: "a complex rating emits the warning block and every concern",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{
+					Rating:   "complex",
+					Concerns: []string{"requires sudo", "builds a kernel module"},
+				},
+			},
+			slots: nil,
+			want: "# WARNING: Complex installation\n" +
+				"#   - requires sudo\n" +
+				"#   - builds a kernel module\n" +
+				"#\n" +
+				"\n",
+		},
+		{
+			name: "a non-complex rating emits nothing",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{Rating: "moderate", Concerns: []string{"ignored"}},
+			},
+			slots: nil,
+			want:  "\n",
+		},
+		{
+			name: "the placeholder fires when the canonical name is absent from the document",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "rg", CanonicalName: "ripgrep"},
+			},
+			slots: nil,
+			want: "# PkgPath: rg\n" +
+				"#\n" +
+				"\n" +
+				"# TODO: Add installation method for ripgrep\n" +
+				"# ripgrep\n",
+		},
+		{
+			name:      "platform \"all\" is not qualified",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "apt install ripgrep", Platform: "all"},
+			},
+			want: "\napt install ripgrep\n\n",
+		},
+		{
+			name:      "an empty platform is not qualified",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "cargo install ripgrep"},
+			},
+			want: "\ncargo install ripgrep\n\n",
+		},
+		{
+			name:      "annotations follow their command, indented two spaces",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{
+					Name:        "package_manager",
+					Value:       "brew",
+					Annotations: []string{"requires a tap", "v2 only"},
+				},
+			},
+			want: "\nbrew\n  # requires a tap\n  # v2 only\n\n",
+		},
+		{
+			// Pins the dropped `len(slot.Annotations) > 0` guard: ranging an empty slice is
+			// already a no-op, so removing the guard must not change a byte.
+			name:      "a slot with no annotations emits only its command",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "apk add ripgrep"},
+			},
+			want: "\napk add ripgrep\n\n",
+		},
+		{
+			name:      "slots that are neither install_command nor package_manager are skipped",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{Name: "config_path", Value: "/etc/ripgrep"},
+				{Name: "install_command", Value: "dnf install ripgrep"},
+				{Name: "license", Value: "MIT"},
+			},
+			want: "\ndnf install ripgrep\n\n",
+		},
+		{
+			name:      "multiple matching slots each get their own block",
+			discovery: &discoveryResult{},
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "brew install fd", Platform: "Darwin"},
+				{Name: "package_manager", Value: "apt", Platform: "Linux"},
+			},
+			want: "\n" +
+				"# Platform: Darwin\n" +
+				"brew install fd\n" +
+				"\n" +
+				"# Platform: Linux\n" +
+				"apt\n" +
+				"\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			got := generateManifest(test.discovery, test.slots, "")
+
+			if got != test.want {
+				t.Errorf("generateManifest() mismatch\n got: %q\nwant: %q", got, test.want)
+			}
+		})
+	}
+}
+
+// endregion
+
+// region writeProductHeader
+
+func TestWriteProductHeader(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		discovery *discoveryResult
+		want      string
+	}{
+		{
+			name:      "a nil product writes nothing",
+			discovery: &discoveryResult{},
+			want:      "",
+		},
+		{
+			name: "name only, followed by the separator",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "fd"},
+			},
+			want: "# PkgPath: fd\n#\n",
+		},
+		{
+			name: "vendor is written when present",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "fd", Vendor: "sharkdp"},
+			},
+			want: "# PkgPath: fd\n# Vendor: sharkdp\n#\n",
+		},
+		{
+			name: "version is written when present",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "fd", Version: "10.2.0"},
+			},
+			want: "# PkgPath: fd\n# Version: 10.2.0\n#\n",
+		},
+		{
+			name: "vendor precedes version",
+			discovery: &discoveryResult{
+				Product: &ProductInfo{Name: "fd", Vendor: "sharkdp", Version: "10.2.0"},
+			},
+			want: "# PkgPath: fd\n# Vendor: sharkdp\n# Version: 10.2.0\n#\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			var sb strings.Builder
+			writeProductHeader(&sb, test.discovery)
+
+			if got := sb.String(); got != test.want {
+				t.Errorf("writeProductHeader() mismatch\n got: %q\nwant: %q", got, test.want)
+			}
+		})
+	}
+}
+
+// endregion
+
+// region writeComplexityWarning
+
+func TestWriteComplexityWarning(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		discovery *discoveryResult
+		want      string
+	}{
+		{
+			name:      "nil complexity writes nothing",
+			discovery: &discoveryResult{},
+			want:      "",
+		},
+		{
+			name: "a simple rating writes nothing",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{Rating: "simple", Concerns: []string{"ignored"}},
+			},
+			want: "",
+		},
+		{
+			name: "a moderate rating writes nothing",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{Rating: "moderate", Concerns: []string{"ignored"}},
+			},
+			want: "",
+		},
+		{
+			name: "a complex rating with no concerns still writes the banner",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{Rating: "complex"},
+			},
+			want: "# WARNING: Complex installation\n#\n",
+		},
+		{
+			name: "every concern is written, indented",
+			discovery: &discoveryResult{
+				Complexity: &ComplexityInfo{
+					Rating:   "complex",
+					Concerns: []string{"requires sudo", "builds a kernel module"},
+				},
+			},
+			want: "# WARNING: Complex installation\n" +
+				"#   - requires sudo\n" +
+				"#   - builds a kernel module\n" +
+				"#\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			var sb strings.Builder
+			writeComplexityWarning(&sb, test.discovery)
+
+			if got := sb.String(); got != test.want {
+				t.Errorf("writeComplexityWarning() mismatch\n got: %q\nwant: %q", got, test.want)
+			}
+		})
+	}
+}
+
+// endregion
+
+// region writeInstallCommands
+
+func TestWriteInstallCommands(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		slots []ExtractedSlot
+		want  string
+	}{
+		{
+			name:  "no slots writes nothing",
+			slots: nil,
+			want:  "",
+		},
+		{
+			name: "install_command is written",
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "brew install fd"},
+			},
+			want: "brew install fd\n\n",
+		},
+		{
+			name: "package_manager is written",
+			slots: []ExtractedSlot{
+				{Name: "package_manager", Value: "brew"},
+			},
+			want: "brew\n\n",
+		},
+		{
+			name: "any other slot name is skipped",
+			slots: []ExtractedSlot{
+				{Name: "config_path", Value: "/etc/fd"},
+			},
+			want: "",
+		},
+		{
+			name: "a named platform is qualified",
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "brew install fd", Platform: "Darwin"},
+			},
+			want: "# Platform: Darwin\nbrew install fd\n\n",
+		},
+		{
+			name: "platform \"all\" is not qualified",
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "apt install fd", Platform: "all"},
+			},
+			want: "apt install fd\n\n",
+		},
+		{
+			name: "annotations are indented two spaces and follow the command",
+			slots: []ExtractedSlot{
+				{Name: "install_command", Value: "brew install fd", Annotations: []string{"a", "b"}},
+			},
+			want: "brew install fd\n  # a\n  # b\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			var sb strings.Builder
+			writeInstallCommands(&sb, test.slots)
+
+			if got := sb.String(); got != test.want {
+				t.Errorf("writeInstallCommands() mismatch\n got: %q\nwant: %q", got, test.want)
+			}
+		})
+	}
+}
+
+// endregion

--- a/docs/plans/audit-remediation.md
+++ b/docs/plans/audit-remediation.md
@@ -213,7 +213,28 @@ Branch split, revised:
 | `generateManifest` | gocyclo 16 / gocognit 26 | gocyclo 3 / gocognit 2 |
 
 No helper exceeds a threshold; the largest is `reportOnboardResult` at gocyclo 10 / gocognit 12.
-Bare directives 9 → 7. Behavior preserved: no test was modified, and the suite is green.
+Bare directives 9 → 7.
+
+**Characterization tests landed with the refactor.** The first pass offered "no test was modified"
+as behavior-preservation evidence, which was worthless: `cmd/lore/lore/onboard` had **0%**
+coverage and both target functions measured zero covered blocks, so there were no tests to
+modify. Tests were written before the commit, with expectations hand-derived from the
+pre-decomposition implementations rather than captured from the new code, and both suites were
+mutation-checked — a one-space change to the annotation indent and a `"."` → `"./"` change to the
+output-directory default each failed exactly the tests that should have failed.
+
+| Package | Before | After |
+| --- | --- | --- |
+| `cmd/lore/lore/onboard` | 0% | 25.8% |
+| `cmd/lore/lore` | 12% | 19.8% |
+
+Per-helper: `parseLoreOnboardConfig` 3/3 blocks, `newOnboardProvider` 5/5,
+`reportOnboardResult` 13/13, `writeOnboardManifest` 3/3. `syncedRegistry` (0/6) and `runOnboard`
+itself (0/7) stay uncovered — both are bound to the registry and the network. The decomposition
+is what made the other four testable at all.
+
+**Standing rule for the remaining 1b branches: tests land before the refactor commit**, since a
+behavior-preserving claim is unverifiable without them.
 
 **`buildMultiSource` is deferred to issue #369.** Its collision predicate at `builder.go:280` has
 zero coverage (`make cover`: `builder.go:280.45,282.7 1 0`) and is reachable only through a


### PR DESCRIPTION
Restores the characterization tests that were lost when #371 merged.

## What happened

#371's recorded head was `d75cb867`, its first commit. The test commit `f06cbc9c` was pushed to the branch, but GitHub's pull request head never advanced, so the squash merge took the decomposition **without its tests**.

`f06cbc9c` carries **zero check runs** — CI never executed these tests. The five green checks reported on #371 all belong to `d75cb867`. Nothing was lost: `f06cbc9c` remained intact on GitHub and these three files are restored from it **verbatim**, not rewritten.

Develop currently holds the `runOnboard` and `generateManifest` decomposition with no test covering either function. This PR closes that gap, and is the **first CI execution of these tests** — they assert exact byte sequences including newlines, which so far has only been exercised on macOS.

## The tests

Unchanged from the reviewed commit. Expectations were hand-derived from the pre-decomposition implementations rather than captured from the refactored code, and both suites were mutation-checked:

| Mutation | Failed exactly |
| --- | --- |
| annotation indent `"  # "` → `" # "` | the two annotation-indent subtests |
| output-dir default `"."` → `"./"` | `TestParseLoreOnboardConfig_DefaultsOutputDirToWorkingDirectory` |

## Coverage restored

| Package | Before | After |
| --- | --- | --- |
| `cmd/lore/lore/onboard` | 0% | 25.8% |
| `cmd/lore/lore` | 12% | 19.8% |

Per-helper blocks: `parseLoreOnboardConfig` 3/3, `newOnboardProvider` 5/5, `reportOnboardResult` 13/13, `writeOnboardManifest` 3/3. `syncedRegistry` (0/6) and `runOnboard` itself (0/7) remain uncovered — both are bound to the registry and the network.

Verified locally: `make test` green (zero FAIL/panic by count), `gofmt` clean.
