### PR TITLE
ci: run the unit suite on every platform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,6 @@ jobs:
       - name: Lint Go (direct)
         run: make lint
 
-      - name: Test
-        run: make test-race
-
       - name: Lint Shell
         run: ./build/star lint shell .
 
@@ -67,6 +64,42 @@ jobs:
         run: |
           go install github.com/boyter/scc/v3@latest
           scc .
+
+  # Every test on every platform (docs/plans/platform-test-matrix.md, #373). The unit suite used to
+  # run in quality-gate on ubuntu alone — 121 packages there, while macOS and Windows ran only the
+  # single writ-deploy scenario below. A green scenario leg attested to one test, not to the suite.
+  #
+  # Non-blocking for now (plan ruling 2), but WITHOUT continue-on-error: the develop ruleset
+  # requires exactly one check, `quality-gate`, so a job absent from that list cannot block a merge
+  # whatever it reports. continue-on-error would only suppress the red — and the red is the phase-2
+  # triage data. Phase 4 is therefore a ruleset change alone, adding the three `test (…)` contexts;
+  # this file does not change again. A gate nobody has watched refuse anything is a claim, not a
+  # gate, so phase 4 also proves it by making a Windows test fail on purpose.
+  test:
+    strategy:
+      # Every platform reports independently — a failing leg must not cancel the others' evidence.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      # -race requires cgo and a C toolchain. Set explicitly rather than relying on the default,
+      # which varies by platform and by whether a compiler is discoverable; the windows runner
+      # ships mingw-w64. `make test-race` depends on `generate`, a chain the scenario job below
+      # already exercises on all three platforms.
+      - name: Test with race detector
+        env:
+          CGO_ENABLED: "1"
+        run: make test-race
 
   # The writ-deploy scenario (docs/plans/writ-deploy-scenario.md, #346): the real binaries driven
   # end-to-end in a pristine sandbox, on all three platforms (#91 phase-4 audit slice).

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -64,10 +64,21 @@ is real behavior on that platform, not a missing conditional.
 
 1. **`-race` on every leg.** Not Linux-only. Windows needs `CGO_ENABLED=1` and the runner's
    mingw-w64 toolchain, and the run is slower; that cost is accepted.
-2. **Non-blocking first.** The `test` job lands with `continue-on-error: true` so phase 2 gets
-   real triage data without halting branches in flight. Phase 4 removes it and makes the legs
-   required — that phase is mandatory, not optional, and must not be deferred past the next merge
-   after phase 3.
+2. **Non-blocking first**, so phase 2 gets real triage data without halting branches in flight.
+   Phase 4 makes the legs required — mandatory, not optional, and not to be deferred past the next
+   merge after phase 3.
+
+   **Mechanism corrected during phase 1.** The original wording specified
+   `continue-on-error: true`. That is both unnecessary and harmful here. The `develop` ruleset
+   (`12426847`) requires exactly one status check — `quality-gate` — so any job absent from that
+   list cannot block a merge whatever it reports. `continue-on-error` would add nothing except
+   suppressing the red, and **the red is the phase-2 triage data**. The job therefore lands
+   without it: failing legs report as failures, visibly, and still block nothing. Phase 4 reduces
+   to a ruleset change with no further edit to `ci.yaml`.
+
+   A side finding from the same query, recorded for its own sake: the existing
+   `scenario (macos-latest)` and `scenario (windows-latest)` legs are **not** required checks
+   either. A red Windows scenario does not block a merge today.
 3. **`quality-gate` stays on ubuntu-latest.** macOS runners bill at 10× and the shell-lint step
    installs `shellcheck` via `apt`. Darwin was considered and rejected on cost and tooling.
 
@@ -110,8 +121,9 @@ The `Test` step is removed from `quality-gate`; the matrix's ubuntu leg covers i
 - [ ] Run `make test-race` in it, on every leg, per ruling 1. Set `CGO_ENABLED=1` on the Windows
       leg so the race detector finds the runner's mingw-w64 toolchain.
 - [ ] Remove the `Test` step from `quality-gate`; the matrix's ubuntu leg covers it.
-- [ ] **Land it non-blocking** (`continue-on-error: true`) per ruling 2, so the triage in phase 2
-      has real data without halting every other branch in flight.
+- [ ] **Land it non-blocking without `continue-on-error`** — see ruling 2's correction. The job is
+      not in the ruleset's required list, so it blocks nothing; suppressing its red would only
+      destroy the triage signal.
 
 **Files**: `.github/workflows/ci.yaml` — Modify.
 
@@ -157,10 +169,14 @@ the sweep is runnable locally, not only in CI) — Modify.
 
 Branch count and grouping are sized after phase 2, since the failure count is unknown today.
 
-### Phase 4: Enforce — branch `ci/require-platform-tests`
+### Phase 4: Enforce — no branch; a ruleset change
 
-- [ ] Remove `continue-on-error` from the `test` job.
-- [ ] Add the three `test (…)` legs to the required checks on `develop` (ruleset `12426847`).
+Nothing in `ci.yaml` changes, per ruling 2's correction.
+
+- [ ] Add the three `test (…)` legs to `required_status_checks` on ruleset `12426847`, which
+      today lists only `quality-gate`.
+- [ ] Consider adding the three `scenario (…)` legs at the same time — they are not required
+      either, so a red Windows scenario does not currently block a merge.
 - [ ] Confirm a deliberately failing test on Windows blocks a merge. The gate is not proven until
       it has refused something.
 


### PR DESCRIPTION
Phase 1 of issue #373.

## What changes

A new `test` job runs `make test-race` on a three-platform matrix. The `Test` step leaves `quality-gate` — the matrix's ubuntu leg covers it. Lint, `go mod tidy`, frontmatter validation, shell lint, and code metrics stay on the one ubuntu runner; they are platform-invariant and should not triple.

`CGO_ENABLED: "1"` is explicit: `-race` needs cgo and a C toolchain, the default varies by platform and by whether a compiler is discoverable, and the windows runner ships mingw-w64.

## A correction to the plan, in the same commit

The plan specified `continue-on-error: true` for this phase. That is both unnecessary and harmful, and the plan is updated here.

Ruleset `12426847` on `develop` requires **exactly one** status check — `quality-gate`. A job absent from that list cannot block a merge whatever it reports. So `continue-on-error` would add nothing except suppressing the red — and **the red is the phase-2 triage data**. The job lands without it: failing legs report as failures, visibly, and still block nothing.

Phase 4 therefore reduces to a ruleset change with no further edit to `ci.yaml`.

Recorded from the same query: the existing `scenario (macos-latest)` and `scenario (windows-latest)` legs are **not** required checks either. A red Windows scenario does not block a merge today.

## Why this is cheaper than it looks

`test-scenario` → `build` → `generate`, so the existing scenario job **already runs the whole codegen chain on all three platforms**, green — including `make` and bash working on the windows runner. `test-race: generate` inherits a proven chain. And `TestWritDeployScenario` is symlink-based deployment passing on windows-latest, so symlink creation works there.

## Expect red

The first runs will likely fail on macOS and Windows. Those are **pre-existing defects being revealed, not regressions introduced here.** Measured signals across the test tree: 66 hardcoded `/tmp`|`/usr`|`/etc`|`/bin` references, 66 permission-bit assertions, 14 expected values containing `/`, 9 files calling `os.Symlink`, 6 shelling out — and **zero** `runtime.GOOS == "windows"` branches in production code.

Phase 2 classifies every failure as a genuine platform defect, a Unix-assuming test, or a test whose subject exists on one platform only. The third moves into a build-tagged `_linux_test.go`, which is scoping. **A `t.Skip` added to turn a leg green is not an outcome this plan permits.**

Verified: `actionlint` clean on `ci.yaml`.
