### PR TITLE
fix(devlore-test): route output streams portably instead of via /dev paths

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -133,19 +133,19 @@ func TestCLI_RunMissingFile(t *testing.T) {
 }
 
 func TestCLI_ScriptFirst(t *testing.T) {
-	stdout, _, code := run("run", scriptPath, "--output", "receipt=/dev/null", "--output", "graph=/dev/null")
+	stdout, _, code := run("run", scriptPath, "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptMiddle(t *testing.T) {
-	stdout, _, code := run("run", "--output", "receipt=/dev/null", scriptPath, "--output", "graph=/dev/null")
+	stdout, _, code := run("run", "--output", "receipt="+os.DevNull, scriptPath, "--output", "graph="+os.DevNull)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptLast(t *testing.T) {
-	stdout, _, code := run("run", "--output", "receipt=/dev/null", "--output", "graph=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
@@ -161,7 +161,7 @@ func TestCLI_DefaultAllToStdout(t *testing.T) {
 }
 
 func TestCLI_SummaryOnly(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 	assertNotContains(t, stdout, "Hello World!")
@@ -169,7 +169,7 @@ func TestCLI_SummaryOnly(t *testing.T) {
 }
 
 func TestCLI_GraphOnly(t *testing.T) {
-	stdout, _, code := run("run", "--output", "summary=/dev/null", "--output", "receipt=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--output", "summary="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertContains(t, stdout, "Hello World!")
 	assertNotContains(t, stdout, `"passed"`)
@@ -177,7 +177,7 @@ func TestCLI_GraphOnly(t *testing.T) {
 }
 
 func TestCLI_ReceiptOnlyYAML(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph=/dev/null", "--output", "summary=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertNotContains(t, stdout, `"passed"`)
 	assertValidYAML(t, stdout)
@@ -186,7 +186,7 @@ func TestCLI_ReceiptOnlyYAML(t *testing.T) {
 }
 
 func TestCLI_ReceiptOnlyJSON(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph=/dev/null", "--output", "summary=/dev/null", "--receipt-format=json", scriptPath)
+	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, "--receipt-format=json", scriptPath)
 	assertExit(t, 0, code)
 	assertValidJSON(t, stdout)
 	assertContains(t, stdout, "shell.exec")
@@ -231,8 +231,8 @@ func TestCLI_JSONReceiptToFile(t *testing.T) {
 
 	_, _, code := run("run",
 		"--output", "receipt="+receiptPath,
-		"--output", "graph=/dev/null",
-		"--output", "summary=/dev/null",
+		"--output", "graph="+os.DevNull,
+		"--output", "summary="+os.DevNull,
 		"--receipt-format=json",
 		scriptPath)
 	assertExit(t, 0, code)
@@ -247,19 +247,19 @@ func TestCLI_JSONReceiptToFile(t *testing.T) {
 // --- Flags ---
 
 func TestCLI_DryRun(t *testing.T) {
-	stdout, _, code := run("run", "--dry-run", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--dry-run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_Trace(t *testing.T) {
-	stdout, _, code := run("run", "--trace", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
+	stdout, _, code := run("run", "--trace", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertContains(t, stdout, `"trace"`)
 }
 
 func TestCLI_Silent(t *testing.T) {
-	_, stderr, code := run("--silent", "run", "--output", "graph=/dev/null", "--output", "receipt=/dev/null", scriptPath)
+	_, stderr, code := run("--silent", "run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	if stderr != "" {
 		t.Errorf("--silent should suppress stderr, got: %q", stderr)
@@ -269,7 +269,7 @@ func TestCLI_Silent(t *testing.T) {
 // --- Error cases ---
 
 func TestCLI_InvalidOutputStream(t *testing.T) {
-	_, _, code := run("run", "--output", "bogus=/dev/null", scriptPath)
+	_, _, code := run("run", "--output", "bogus="+os.DevNull, scriptPath)
 	assertExit(t, 1, code)
 }
 
@@ -279,7 +279,7 @@ func TestCLI_MalformedOutput(t *testing.T) {
 }
 
 func TestCLI_InvalidReceiptFormat(t *testing.T) {
-	_, _, code := run("run", "--receipt-format=xml", "--output", "receipt=/dev/null", "--output", "graph=/dev/null", scriptPath)
+	_, _, code := run("run", "--receipt-format=xml", "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull, scriptPath)
 	assertExit(t, 1, code)
 }
 

--- a/cmd/devlore-test/devloretest/commands.go
+++ b/cmd/devlore-test/devloretest/commands.go
@@ -6,6 +6,7 @@ package devloretest
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -48,17 +49,23 @@ func (o *outputFlags) Type() string {
 	return "stream=dest"
 }
 
+// stdoutSentinel names the process's standard output in --output routing. [openDest] intercepts
+// it instead of opening it, so the name need not exist as a filesystem path — which it does not on
+// Windows. The discard destination needs no sentinel: os.DevNull already names the platform's own
+// device (/dev/null, or NUL on Windows) and opens correctly on each.
+const stdoutSentinel = "/dev/stdout"
+
 func newRunCmd() *cobra.Command {
 	outputs := &outputFlags{entries: map[string]string{
-		"summary": "/dev/stdout",
-		"receipt": "/dev/stdout",
-		"graph":   "/dev/stdout",
+		"summary": stdoutSentinel,
+		"receipt": stdoutSentinel,
+		"graph":   stdoutSentinel,
 	}}
 
 	cmd := &cobra.Command{
 		Use:   "run [flags] <script.star>",
 		Short: "Run a Starlark test script that plans and executes a graph",
-		Long: `Run a Starlark test script through the graph execution engine.
+		Long: fmt.Sprintf(`Run a Starlark test script through the graph execution engine.
 
 The script uses plan.* bindings to build a graph and t.* assertions to
 verify expectations after execution.
@@ -68,14 +75,14 @@ Three output streams can be independently routed:
   summary  JSON test result (passed, node_count, failures)
   receipt  Full serialized execution graph
 
-All streams default to /dev/stdout. Route to files or /dev/null:
+All streams default to %[1]s. Route to files or %[2]s:
   devlore-test run --output receipt=receipt.yaml test.star
-  devlore-test run --output graph=/dev/null test.star`,
-		Example: `  devlore-test run test.star
+  devlore-test run --output graph=%[2]s test.star`, stdoutSentinel, os.DevNull),
+		Example: fmt.Sprintf(`  devlore-test run test.star
   devlore-test run --dry-run test.star
   devlore-test run --trace test.star
   devlore-test run --output receipt=receipt.yaml --receipt-format=json test.star
-  devlore-test run --output graph=/dev/null --output receipt=/dev/null test.star`,
+  devlore-test run --output graph=%[1]s --output receipt=%[1]s test.star`, os.DevNull),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTest(cmd, args[0], outputs)
@@ -144,10 +151,37 @@ func runTest(cmd *cobra.Command, script string, outputs *outputFlags) (err error
 	return nil
 }
 
-// openDest opens a destination path for writing. The caller must close the returned file.
-func openDest(path string) (*os.File, error) {
+// openDest opens a destination for writing.
+//
+// [stdoutSentinel] is intercepted rather than opened: it is not a filesystem path on Windows, and
+// the process's standard output must survive the caller's Close. Every other destination is a real
+// path — including the discard device, which os.DevNull names correctly on each platform.
+//
+// Parameters:
+//   - `path`: the destination, either [stdoutSentinel] or a filesystem path.
+//
+// Returns:
+//   - `io.WriteCloser`: the destination; the caller must close it, which is a no-op for standard
+//     output.
+//   - `error`: non-nil when a filesystem destination cannot be opened.
+func openDest(path string) (io.WriteCloser, error) {
+
+	if path == stdoutSentinel {
+		return nopWriteCloser{os.Stdout}, nil
+	}
+
 	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // G304: path from CLI flag
 }
+
+// nopWriteCloser adapts a writer whose lifetime the caller does not own, so a deferred Close does
+// not shut the process's standard output.
+type nopWriteCloser struct{ io.Writer }
+
+// Close discards the request, leaving the underlying writer open.
+//
+// Returns:
+//   - `error`: always nil.
+func (nopWriteCloser) Close() error { return nil }
 
 func writeSummary(dest string, result *Result) (err error) {
 	f, err := openDest(dest)

--- a/cmd/devlore-test/devloretest/commands_test.go
+++ b/cmd/devlore-test/devloretest/commands_test.go
@@ -160,9 +160,9 @@ t.expect_unit_count(1)
 	cmd.SetArgs([]string{
 		"--dry-run",
 		"--receipt-format", "json",
-		"--output", "summary=/dev/null",
+		"--output", "summary=" + os.DevNull,
 		"--output", "receipt=" + receiptFile,
-		"--output", "graph=/dev/null",
+		"--output", "graph=" + os.DevNull,
 		script,
 	})
 	if err := cmd.Execute(); err != nil {
@@ -195,7 +195,7 @@ t.expect_unit_count(1)
 		"--dry-run",
 		"--output", "summary=" + summaryFile,
 		"--output", "receipt=" + receiptFile,
-		"--output", "graph=/dev/null",
+		"--output", "graph=" + os.DevNull,
 		script,
 	})
 	if err := cmd.Execute(); err != nil {

--- a/cmd/devlore-test/devloretest/root.go
+++ b/cmd/devlore-test/devloretest/root.go
@@ -6,6 +6,7 @@ package devloretest
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -30,7 +31,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "devlore-test",
 		Short: "Graph test harness for Starlark plan + execute + verify",
-		Long: `devlore-test is the graph test harness for the devlore execution engine.
+		Long: fmt.Sprintf(`devlore-test is the graph test harness for the devlore execution engine.
 
 It executes a Starlark test script that builds an execution graph, runs the
 graph through the engine, and verifies expectations against the results.
@@ -40,9 +41,9 @@ Output streams:
   summary  Test result with pass/fail and expectation counts (default: stdout)
   receipt  Full execution graph transaction log (default: stdout)
 
-Use --output to route streams to files or /dev/null:
-  devlore-test run --output receipt=/tmp/receipt.yaml test.star
-  devlore-test run --output graph=/dev/null --output receipt=/dev/null test.star`,
+Use --output to route streams to files or %[1]s:
+  devlore-test run --output receipt=receipt.yaml test.star
+  devlore-test run --output graph=%[1]s --output receipt=%[1]s test.star`, os.DevNull),
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},

--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -144,7 +144,7 @@ func initializeRepo(t *testing.T, dest string) {
 		cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dest}, args...)...)
 		// The real user's global git config must not reach the sandbox repo (branch-protection
 		// hooks would reject the baseline commit on main).
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}

--- a/cmd/writ/writ/repo_cmd_test.go
+++ b/cmd/writ/writ/repo_cmd_test.go
@@ -35,7 +35,7 @@ func sourceRepository(t *testing.T) string {
 		{"-c", "user.name=t", "-c", "user.email=t@invalid", "commit", "--quiet", "--allow-empty", "-m", "seed"},
 	} {
 		command := exec.CommandContext(context.Background(), "git", append([]string{"-C", root}, args...)...)
-		command.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		command.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
 		if output, err := command.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -167,7 +167,7 @@ packages, the first time it had ever run on Darwin. `test (windows-latest)` fail
 
 | Cause | Failures | Bucket | Disposition |
 | --- | --- | --- | --- |
-| `binary` lacks `.exe`, so every exec returns -1 | ~37 | 2 | Fixed — `cli_test.go` |
+| `binary` lacks `.exe`, so every exec returns -1 | est. ~37 | 2 | Fixed — `cli_test.go` |
 | `Rel()` returns `\` separators | 6 | **1** | **Issue #377** |
 | Permission-bit assertions (`document_test.go`, `sops_integration_test.go`) | 5 | 2 | Pending |
 | `open /dev/null` | 2 | 1 or 2 | Pending — depends whether the product hardcodes it |
@@ -192,6 +192,38 @@ both filed rather than patched inline:
 Clearing the `.exe` cause first is deliberate: ~37 masked failures may be concealing others, and
 the next run reveals what was behind them. The remaining counts above should be treated as a
 lower bound until that run reports.
+
+#### Phase 2 results, corrected — second run, PR #378 / commit `762c61ec`
+
+**63 → 47.** The `.exe` estimate was wrong: it cleared **16**, not ~37. The fix itself worked —
+exit codes became real numbers instead of `-1`, so the binary starts — but fourteen `TestCLI_*`
+tests were failing for a *second* reason sitting behind the first. The masking risk named above
+was real, which is why the table's counts were labelled a lower bound.
+
+| Cause | Failures | Bucket | Disposition |
+| --- | --- | --- | --- |
+| Output streams default to `/dev/stdout`; `/dev/null` in examples | ~16 | **1** | **Issue #379** |
+| Separator form — `Rel`, `Abs`, `String`, `registry.FilePath` | 11 | mixed | **Issue #377**, needs splitting |
+| Permission-bit assertions | 5 | 2 | Pending |
+| `runner_test` file and compensation failures | 4 | ? | Pending — needs reading |
+| Windows path breaks Starlark escape parsing | 1 | **1** | **Issue #376**, correctly sized |
+
+**#379 is the dominant remaining cause and a genuine product defect.**
+`cmd/devlore-test/devloretest/commands.go:53-55` defaults every stream to `/dev/stdout`, and
+`openDest` (`commands.go:148`) is a plain `os.OpenFile`. On Windows the open fails and
+`devlore-test run` aborts before emitting anything — the CLI cannot run there at all. The
+documented examples route to `/dev/null`, so the shipped guidance is Unix-only too.
+
+**#376 was correctly sized** — `invalid escape sequence` appears exactly once in the log.
+
+**#377 needs its classification split.** `Rel()` returning `\` is bucket 1: `Path` is serialized,
+so document bytes and checksums differ per platform. But `Abs()` and `String()` returning
+`\project\src\main.go` is *correct* on Windows — those three assertions feed Unix literals like
+`/project/src/main.go` and expect them back, making them bucket 2. The two groups must not be
+fixed the same way.
+
+Three product defects have now been surfaced by one CI change — #376, #377, #379 — none of them
+reachable by the previous ubuntu-only gate.
 
 ### Phase 3: Fix — one branch per cluster
 


### PR DESCRIPTION
Issue #379, phase 3 of #373.

## The defect

`devlore-test run` could not execute on Windows **at all**. Every output stream defaulted to `/dev/stdout`, `openDest` was a plain `os.OpenFile`, and the open failed before the command produced anything:

```
error: opening graph output: open /dev/null: The system cannot find the path specified.
```

## Two sentinels, two treatments

Per the ruling, because they are genuinely different problems:

**Standard output is intercepted.** `stdoutSentinel` is matched in `openDest` and never reaches the filesystem. This also fixes a latent bug the Unix path was hiding: callers `defer` a `Close` on whatever `openDest` returns, so routing to stdout was **closing the process's own standard output**. `openDest` now returns an `io.WriteCloser`, and the stdout case is a `nopWriteCloser`.

**Discard needs no interception.** `os.DevNull` already names each platform's device — `/dev/null` on Unix, `NUL` on Windows — and opens correctly on both. The fix there is spelling, not mechanism.

## Scope

Four further sites carried the identical mistake and are corrected together rather than split out: `commands_test.go` routed to `/dev/null` directly, and `scenario_integration_test.go` and `repo_cmd_test.go` set `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to `/dev/null` to suppress ambient git config. **No `/dev/null` literal remains in non-prototype Go code** — asserted by the commit script.

The root help also advertised `/tmp/receipt.yaml`; now a bare relative filename, meaningful everywhere.

This should clear roughly **16 of the 47** remaining Windows failures.

## Deliberately not in this PR

`data/test_compensation.star` forces a failure via `destination_path="/dev/null/impossible/path.txt"`. On Windows that path is apparently creatable, so the copy succeeds where the fixture expects an error. That's the impossible-path idiom, not the discard sentinel — a different problem deserving its own change.

## Plan update

The corrected phase 2 triage rides along: the `.exe` fix cleared **16**, not the ~37 I estimated, because 14 `TestCLI_*` cases were failing for this second reason hidden behind the first.

Verified on Darwin: `make vet`, `make build`, full `make test` green (zero FAIL/panic by count), `gofmt` clean, and `run --help` renders `/dev/null` here — which is what `os.DevNull` is on this platform. CI's windows leg is the real verification.
