### PR TITLE
lint(migrate): delete a dead complexity directive, argue the live one

### DIFF
--- a/cmd/writ/writ/migrate/gather.go
+++ b/cmd/writ/writ/migrate/gather.go
@@ -61,7 +61,9 @@ func GatherInputs(root string, maxDepth, maxScriptBytes int) (*GatherInput, erro
 
 // buildTree walks the directory and builds the TreeNode structure.
 // Returns the tree and a list of executable paths found.
-func buildTree(root string, maxDepth int) (*TreeNode, []string, error) { //nolint:gocognit
+//
+//nolint:gocognit // one WalkDir filter: a guard chain whose branches return distinct sentinels (SkipDir vs nil); splitting it fragments the filter
+func buildTree(root string, maxDepth int) (*TreeNode, []string, error) {
 	var executables []string
 
 	rootNode := &TreeNode{

--- a/cmd/writ/writ/migrate/session.go
+++ b/cmd/writ/writ/migrate/session.go
@@ -371,7 +371,7 @@ func (s *Session) formatGraphForPrompt() string {
 }
 
 // applyGraphModifications parses AI response for graph modifications and applies them.
-func (s *Session) applyGraphModifications(content string) { //nolint:gocognit
+func (s *Session) applyGraphModifications(content string) {
 	lines := strings.Split(content, "\n")
 	inModifications := false
 

--- a/docs/plans/audit-remediation.md
+++ b/docs/plans/audit-remediation.md
@@ -200,7 +200,7 @@ Branch split, revised:
 | `refactor/complexity-lore` | `runOnboard`, `generateManifest` — extract | **completed** |
 | `refactor/complexity-internal` | `promptForProvider`, `main` — extract | **completed** |
 | `refactor/complexity-bindgen` | `extractFromFunction`, `findPackages` | **resolved by deletion** |
-| `refactor/complexity-writ-migrate` | `applyGraphModifications` — delete; `buildTree` — argue | chartered |
+| `refactor/complexity-writ-migrate` | `applyGraphModifications` — delete; `buildTree` — argue | **completed** |
 
 **1b-i landed 2026-08-11.** `runOnboard` decomposed into `parseLoreOnboardConfig`,
 `newOnboardProvider`, `syncedRegistry`, `reportOnboardResult`, and `writeOnboardManifest`;
@@ -282,6 +282,21 @@ is excluded in `.golangci.yaml`" was true of the config but false in effect for 
 functions — a build tag excludes a file from the linter as thoroughly as any config entry, and
 the audit never checked tags. And the repo-wide gocognit sweep's "11 over-threshold functions,
 every one suppressed" counted these two, which were never live findings: the true count was 9.
+
+**1b-iv landed 2026-08-12, closing phase 1b's active work.** `applyGraphModifications`' directive
+deleted — the function measures gocognit 8 against a threshold of 20, so it suppressed nothing.
+`buildTree` (gocognit 23) keeps its suppression with the argued justification the convention
+requires: one `WalkDir` filter, a guard chain whose branches return distinct sentinels (`SkipDir`
+vs `nil`); splitting it fragments the filter. Comment-only changes; no behavior, no new tests
+owed. **Bare directives 3 → 1** — the survivor is `buildMultiSource`, deliberately parked on
+#369, and phase 1b-v remains the only open 1b item.
+
+Final 1b accounting for the nine original suppressions: six decomposed (1b-i, 1b-ii), one
+deleted as dead-on-a-live-function (`applyGraphModifications`), one argued (`buildTree`), two
+removed with their dead file (bindgen), one parked on a correctness bug (`buildMultiSource`).
+That sums to eleven because the audit's nine included the two bindgen entries that were never
+live findings — the corrected count of nine live suppressions resolves as: six decomposed, one
+deleted, one argued, one parked.
 
 **`buildMultiSource` is deferred to issue #369.** Its collision predicate at `builder.go:280` has
 zero coverage (`make cover`: `builder.go:280.45,282.7 1 0`) and is reachable only through a


### PR DESCRIPTION
Phase 1b-iv of issue #365 — the last active 1b item. **Comment-only**: no behavior changes, no signatures.

## The two items

1. **`applyGraphModifications` loses its `//nolint:gocognit`.** The function measures gocognit **8** against a threshold of 20 — the directive suppressed nothing, and a suppression that suppresses nothing is misinformation for the next audit.
2. **`buildTree` (gocognit 23) keeps its suppression, argued.** One `WalkDir` filter: a guard chain whose branches return distinct sentinels (`SkipDir` vs `nil`). It is already flat, so flattening does not apply, and extraction would split one coherent filter across functions — harder to read, not easier. The directive now carries that reason in the repository's argued-suppression form.

## Phase 1b closes

Bare `nolint` directives: **3 → 1**. The survivor is `buildMultiSource`, deliberately parked on #369 — its collision predicate's only reachable branch has undefined behavior under the current unstable sort, so no behavior-preserving refactor of it exists to write.

Final accounting of the audit's nine live complexity suppressions:

| Disposition | Functions |
| --- | --- |
| Decomposed | `runOnboard`, `generateManifest`, `promptForProvider`, `main` (devlore-index) — plus their nine tested helpers |
| Deleted as dead | `applyGraphModifications` (here), plus bindgen's two with their file (#386) |
| Argued | `buildTree` (here) |
| Parked on #369 | `buildMultiSource` |

Verified: `make vet`, full `make test` green (zero FAIL/panic by count), `gofmt` clean.
