### PR TITLE
ci: analyze every GOOS per pull request — vet, lint, and cross-compile sweeps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,16 @@ jobs:
       - name: Validate guide frontmatter
         run: ./scripts/Test-GuideFrontmatter.sh
 
+      # Per-GOOS analysis (docs/plans/platform-test-matrix.md, #373 phase 1b): vet, lint, and the
+      # compiler all honor build constraints, so a single-GOOS pass never sees the other platforms'
+      # _darwin.go/_windows.go/_linux.go files. Same runner, one invocation per GOOS. Its first
+      # local run found three test files that did not compile under GOOS=windows — the reason three
+      # packages reported [build failed] on the windows test leg.
+      - name: Cross-compile every GOOS
+        run: make build-all
+
       - name: Vet
-        run: make vet
+        run: make vet-all
 
       - name: Install lint tools
         run: |
@@ -55,7 +63,7 @@ jobs:
       # star path above carries the verdict; this direct run guards against any future regression in
       # star's own reporting pipeline.
       - name: Lint Go (direct)
-        run: make lint
+        run: make lint-all
 
       - name: Lint Shell
         run: ./build/star lint shell .

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ SP := cmd/star/provider
 
 ## TARGETS
 
-.PHONY: all build install clean test test-race cover vet lint shell-lint complexity check dev docs dist dist-all star star-lkg generate inventory help
+.PHONY: all build install clean test test-race cover vet vet-all lint lint-all build-all shell-lint complexity check dev docs dist dist-all star star-lkg generate inventory help
 
 ##@ Help
 
@@ -148,6 +148,28 @@ cover: generate ## Report coverage (per-package inline + total); writes coverage
 
 vet: ## Run go vet
 	go vet ./...
+
+# The per-GOOS sweep (docs/plans/platform-test-matrix.md, #373 phase 1b). go vet, golangci-lint,
+# and the compiler all honor build constraints, so a single-GOOS run never sees the other
+# platforms' _darwin.go/_windows.go/_linux.go files — the real Darwin and Windows package
+# managers went unanalyzed while their stubs were checked. Same runner, one invocation per GOOS.
+vet-all: ## Run go vet under every supported GOOS
+	for os in linux darwin windows; do \
+		echo "== go vet GOOS=$$os =="; \
+		GOOS=$$os go vet ./... || exit 1; \
+	done
+
+lint-all: ## Run golangci-lint under every supported GOOS
+	for os in linux darwin windows; do \
+		echo "== golangci-lint GOOS=$$os =="; \
+		GOOS=$$os golangci-lint run || exit 1; \
+	done
+
+build-all: generate ## Compile every package under every supported GOOS (no binaries emitted)
+	for os in linux darwin windows; do \
+		echo "== go build GOOS=$$os =="; \
+		GOOS=$$os go build ./... || exit 1; \
+	done
 
 lint: ## Run golangci-lint
 	golangci-lint run

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -145,6 +145,32 @@ compile-and-lint half of the same blind spot.
 **Files**: `.github/workflows/ci.yaml`, possibly `Makefile` (a `vet-all` / `lint-all` target so
 the sweep is runnable locally, not only in CI) — Modify.
 
+#### Phase 1b results (2026-08-12)
+
+`make vet-all`, `make lint-all`, and `make build-all` exist and are wired into `quality-gate` in
+place of the single-GOOS `vet` and direct-lint steps, with a cross-compile step added. Findings
+from the first local run, all fixed rather than suppressed:
+
+- **`GOOS=windows go vet` failed to compile three test files** — `syscall.Umask` in
+  `pkg/op/default_funcs_test.go` and `pkg/op/provider/plan/deferred_default_test.go`,
+  `syscall.Stat_t` in `pkg/op/provider/file/provider_test.go`. This is the cause of a **triage
+  undercount**: those three packages reported `[build failed]` on the windows test leg, which the
+  `--- FAIL`-line counting never included — the standing "34 failures" excludes whatever those
+  packages' suites will reveal once they run. Fixes: the umask tests now read through production's
+  portable `processUmask` seam (a build-tagged `testProcessUmask` pair for the external test
+  package), making them *run* on Windows rather than be skipped; the chown test moved to
+  `provider_unix_test.go`, scoped because its subject (uid/gid) exists only on Unix.
+- **First-ever windows lint pass: 5 findings, linux and darwin zero.** `statIdentity`
+  (`helpers_windows.go`) gained its unix twin's named results; `runShellCommand` and its two
+  knobs moved to `pkg/platform/helpers_unix.go` (every consumer is unix-gated — under a windows
+  analysis they were dead code); `captureRefresh` moved to `update_unix_test.go` for the same
+  reason.
+- **Compliance sweep ridden along** (user directive, 2026-08-12): all 11 touched Go files brought
+  to the full go-style standard — 17 multi-line doc summaries split, ~105 missing
+  blank-after-signature lines inserted, 7 over-120-column lines rewrapped or shortened, fixture
+  struct members documented. Mechanical detectors report zero findings; the one >120 survivor is
+  `bracket`'s signature, exempt under §8.
+
 ### Phase 2: Triage — no branch; produces a report
 
 - [ ] Enumerate every failure, per platform, from the phase 1 run. Uncapped — a count read off a

--- a/pkg/op/default_funcs_test.go
+++ b/pkg/op/default_funcs_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
 )
 
@@ -15,9 +14,9 @@ import (
 
 func TestDefaultUmask_MasksBaseAgainstProcessUmask(t *testing.T) {
 
-	// Snapshot current umask without changing it.
-	mask := syscall.Umask(0)
-	syscall.Umask(mask)
+	// Read the umask through the same seam production uses — portable, since the Windows
+	// variant reports zero and the assertion below stays valid there.
+	mask := processUmask()
 
 	cases := []struct {
 		name string
@@ -39,7 +38,7 @@ func TestDefaultUmask_MasksBaseAgainstProcessUmask(t *testing.T) {
 			if !ok {
 				t.Fatalf("got %T, want os.FileMode", result.Interface())
 			}
-			want := tc.base &^ os.FileMode(mask)
+			want := tc.base &^ mask
 			if got != want {
 				t.Errorf("defaultUmask(%o) = %o, want %o (umask %o)", tc.base, got, want, mask)
 			}

--- a/pkg/op/provider/file/helpers_windows.go
+++ b/pkg/op/provider/file/helpers_windows.go
@@ -16,8 +16,9 @@ import "os"
 //   - `info`: unused.
 //
 // Returns:
-//   - `uint64`: zero, always.
-//   - `uint64`: zero, always.
-func statIdentity(_ os.FileInfo) (uint64, uint64) {
+//   - `inode`: zero, always.
+//   - `device`: zero, always.
+func statIdentity(_ os.FileInfo) (inode, device uint64) {
+
 	return 0, 0
 }

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -9,9 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
@@ -23,6 +21,7 @@ import (
 
 // testRoot creates an unconfined read-write Root for test I/O.
 func testRoot(t *testing.T, dir string) fsroot.Root {
+
 	t.Helper()
 	return fsroot.OpenWritableUnconfined(dir)
 }
@@ -32,6 +31,7 @@ func testRoot(t *testing.T, dir string) fsroot.Root {
 // The bare-literal environment mirrors [op.NewRuntimeEnvironment]'s defaulting where a method under test depends on
 // it: BackupSuffix is what the constructor would derive for the devlore program (".<ProgramName>-backup").
 func testProvider(t *testing.T, dir string) Provider {
+
 	t.Helper()
 	root := fsroot.OpenWritableUnconfined(dir)
 	runtimeEnvironment := &op.RuntimeEnvironment{
@@ -43,16 +43,19 @@ func testProvider(t *testing.T, dir string) Provider {
 	return Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}
 }
 
-// testActivation wraps runtimeEnvironment in an [op.ActivationRecord] for non-graph dispatch. Graph and Unit are
-// nil — Resources produced through this activation carry an empty producer stamp; tests that need a
-// specific producer stamp call [op.ResourceCatalog.Shadow] directly.
+// testActivation wraps runtimeEnvironment in an [op.ActivationRecord] for non-graph dispatch.
+//
+// Graph and Unit are nil — Resources produced through this activation carry an empty producer stamp; tests that
+// need a specific producer stamp call [op.ResourceCatalog.Shadow] directly.
 func testActivation(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment) *op.ActivationRecord {
+
 	t.Helper()
 	return op.NewActivationRecord(nil, "", runtimeEnvironment)
 }
 
 // testFileResource creates a Resource backed by a temp file with the given content.
 func testFileResource(t *testing.T, content []byte) *Regular {
+
 	t.Helper()
 	dir := t.TempDir()
 	f, err := os.CreateTemp(dir, "file-*")
@@ -73,9 +76,11 @@ func testFileResource(t *testing.T, content []byte) *Regular {
 	return fileResource
 }
 
-// mustRegular mints an unlinked *Regular for `path` — the read-method fixture (the catalog is not part of the
-// assertion surface in these tests).
+// mustRegular mints an unlinked *Regular for `path` — the read-method fixture.
+//
+// The catalog is not part of the assertion surface in these tests.
 func mustRegular(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment, path string) *Regular {
+
 	t.Helper()
 	regular, err := DiscoverRegular(&op.RuntimeEnvironment{Root: runtimeEnvironment.Root}, path)
 	if err != nil {
@@ -86,6 +91,7 @@ func mustRegular(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment, path s
 
 // resolveReadlink reads the symlink target and resolves relative targets to absolute paths.
 func resolveReadlink(t *testing.T, linkPath string) string {
+
 	t.Helper()
 
 	got, err := os.Readlink(linkPath)
@@ -102,6 +108,7 @@ func resolveReadlink(t *testing.T, linkPath string) string {
 
 // writeTestFile writes content to dir/name for test setup.
 func writeTestFile(t *testing.T, dir, name, content string) {
+
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -110,10 +117,12 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 
 // --- m.5 producer-stamp contract ---
 
-// TestProducerStamp_Mkdir verifies the empty-producer-stamp behavior for non-graph dispatch. Under
-// graph dispatch the producerID would be activation.CallerID.ID(); under non-graph dispatch (this test
+// TestProducerStamp_Mkdir verifies the empty-producer-stamp behavior for non-graph dispatch.
+//
+// Under graph dispatch the producerID would be activation.CallerID.ID(); under non-graph dispatch (this test
 // fixture) Unit is nil and the catalog records an empty producer stamp.
 func TestProducerStamp_Mkdir(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	activation := testActivation(t, p.RuntimeEnvironment())
@@ -132,6 +141,7 @@ func TestProducerStamp_Mkdir(t *testing.T) {
 // --- Link ---
 
 func TestLink_CreatesNewSymlink(t *testing.T) {
+
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "target")
 	if err := os.WriteFile(source, []byte("data"), 0o644); err != nil {
@@ -168,6 +178,7 @@ func TestLink_CreatesNewSymlink(t *testing.T) {
 }
 
 func TestLink_OverwritesExistingSymlink(t *testing.T) {
+
 	tmp := t.TempDir()
 	oldTarget := filepath.Join(tmp, "old-target")
 	newTarget := filepath.Join(tmp, "new-target")
@@ -208,6 +219,7 @@ func TestLink_OverwritesExistingSymlink(t *testing.T) {
 }
 
 func TestLink_IdempotentWhenCorrect(t *testing.T) {
+
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "target")
 	if err := os.WriteFile(source, []byte("data"), 0o644); err != nil {
@@ -237,6 +249,7 @@ func TestLink_IdempotentWhenCorrect(t *testing.T) {
 }
 
 func TestLink_CreatesParentDirectories(t *testing.T) {
+
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "target")
 	if err := os.WriteFile(source, []byte("data"), 0o644); err != nil {
@@ -264,6 +277,7 @@ func TestLink_CreatesParentDirectories(t *testing.T) {
 // --- CompensateLink ---
 
 func TestCompensateLink_ZeroState(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), nil); err != nil {
@@ -272,6 +286,7 @@ func TestCompensateLink_ZeroState(t *testing.T) {
 }
 
 func TestCompensateLink_NewSymlink_RemovesOnCompensate(t *testing.T) {
+
 	tmp := t.TempDir()
 	linkPath := filepath.Join(tmp, "link")
 	if err := os.Symlink("/some/target", linkPath); err != nil {
@@ -292,6 +307,7 @@ func TestCompensateLink_NewSymlink_RemovesOnCompensate(t *testing.T) {
 }
 
 func TestCompensateLink_ExistedBefore_RestoresFromRecovery(t *testing.T) {
+
 	tmp := t.TempDir()
 	linkPath := filepath.Join(tmp, "link")
 	oldTarget := filepath.Join(tmp, "old-target")
@@ -334,6 +350,7 @@ func TestCompensateLink_ExistedBefore_RestoresFromRecovery(t *testing.T) {
 // --- Copy ---
 
 func TestCopy_WritesNewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
 	fileResource := testFileResource(t, []byte("hello world"))
@@ -366,6 +383,7 @@ func TestCopy_WritesNewFile(t *testing.T) {
 }
 
 func TestCopy_OverwritesExistingFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
 	if err := os.WriteFile(path, []byte("original"), 0o755); err != nil {
@@ -391,6 +409,7 @@ func TestCopy_OverwritesExistingFile(t *testing.T) {
 // --- CompensateCopy ---
 
 func TestCompensateCopy_ZeroState_NoPanic(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), nil); err != nil {
@@ -399,6 +418,7 @@ func TestCompensateCopy_ZeroState_NoPanic(t *testing.T) {
 }
 
 func TestCompensateCopy_NewFile_RemovesOnCompensate(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
 	if err := os.WriteFile(path, []byte("new"), 0o644); err != nil {
@@ -419,6 +439,7 @@ func TestCompensateCopy_NewFile_RemovesOnCompensate(t *testing.T) {
 }
 
 func TestCompensateCopy_Overwrite_RestoresOriginal(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
 
@@ -459,6 +480,7 @@ func TestCompensateCopy_Overwrite_RestoresOriginal(t *testing.T) {
 // --- Backup ---
 
 func TestBackup_MovesFileToTimestampedBackup(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "myfile.txt")
 	if err := os.WriteFile(path, []byte("backup me"), 0o644); err != nil {
@@ -501,6 +523,7 @@ func TestBackup_MovesFileToTimestampedBackup(t *testing.T) {
 }
 
 func TestBackup_DefaultSuffix(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "myfile.txt")
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
@@ -525,6 +548,7 @@ func TestBackup_DefaultSuffix(t *testing.T) {
 // --- CompensateBackup ---
 
 func TestCompensateBackup_RestoresOriginal(t *testing.T) {
+
 	tmp := t.TempDir()
 	originalPath := filepath.Join(tmp, "myfile.txt")
 	backupPath := filepath.Join(tmp, "myfile.txt.bak.20250101-120000")
@@ -555,6 +579,7 @@ func TestCompensateBackup_RestoresOriginal(t *testing.T) {
 }
 
 func TestCompensateBackup_ChecksumMismatch_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	originalPath := filepath.Join(tmp, "myfile.txt")
 	backupPath := filepath.Join(tmp, "myfile.txt.bak.20250101-120000")
@@ -576,7 +601,8 @@ func TestCompensateBackup_ChecksumMismatch_ReturnsError(t *testing.T) {
 
 	product := &Regular{Resource: Resource{SourcePath: fsroot.NewPath("", backupPath)}}
 	source := &Regular{Resource: Resource{SourcePath: fsroot.NewPath("", originalPath)}}
-	state := NewReceipt(NewReceiptSpec(product, MutationUpdateFile).WithSource(source).WithRecovery(recoveryID, wrongDigest))
+	state := NewReceipt(NewReceiptSpec(product, MutationUpdateFile).
+		WithSource(source).WithRecovery(recoveryID, wrongDigest))
 
 	p := testProvider(t, tmp)
 	err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), state)
@@ -596,6 +622,7 @@ func TestCompensateBackup_ChecksumMismatch_ReturnsError(t *testing.T) {
 // --- Unlink ---
 
 func TestUnlink_RemovesSymlink(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "target")
 	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
@@ -621,6 +648,7 @@ func TestUnlink_RemovesSymlink(t *testing.T) {
 }
 
 func TestUnlink_AlreadyGone(t *testing.T) {
+
 	tmp := t.TempDir()
 	linkPath := filepath.Join(tmp, "nonexistent")
 
@@ -638,6 +666,7 @@ func TestUnlink_AlreadyGone(t *testing.T) {
 }
 
 func TestUnlink_NotASymlink_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "regular-file")
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
@@ -657,6 +686,7 @@ func TestUnlink_NotASymlink_ReturnsError(t *testing.T) {
 // --- Remove ---
 
 func TestRemove_RemovesFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "file.txt")
 	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
@@ -681,6 +711,7 @@ func TestRemove_RemovesFile(t *testing.T) {
 }
 
 func TestRemove_AlreadyGone(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "nonexistent")
 
@@ -700,6 +731,7 @@ func TestRemove_AlreadyGone(t *testing.T) {
 // --- Write ---
 
 func TestWriteText_WritesContentToNewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
 
@@ -726,6 +758,7 @@ func TestWriteText_WritesContentToNewFile(t *testing.T) {
 }
 
 func TestWriteBytes_WritesContentToNewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.bin")
 
@@ -762,6 +795,7 @@ func TestWriteBytes_WritesContentToNewFile(t *testing.T) {
 // --- Move ---
 
 func TestMove_MovesFileToDestination(t *testing.T) {
+
 	tmp := t.TempDir()
 	src := filepath.Join(tmp, "source.txt")
 	dst := filepath.Join(tmp, "dest.txt")
@@ -803,6 +837,7 @@ func TestMove_MovesFileToDestination(t *testing.T) {
 // --- CompensateMove ---
 
 func TestCompensateMove_ZeroState(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), nil); err != nil {
@@ -811,6 +846,7 @@ func TestCompensateMove_ZeroState(t *testing.T) {
 }
 
 func TestCompensateMove_ChecksumMismatch_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	src := filepath.Join(tmp, "source.txt")
 	dst := filepath.Join(tmp, "dest.txt")
@@ -831,7 +867,8 @@ func TestCompensateMove_ChecksumMismatch_ReturnsError(t *testing.T) {
 
 	product := &Regular{Resource: Resource{SourcePath: fsroot.NewPath("", dst)}}
 	source := &Regular{Resource: Resource{SourcePath: fsroot.NewPath("", src)}}
-	state := NewReceipt(NewReceiptSpec(product, MutationUpdateFile).WithSource(source).WithRecovery(recoveryID, wrongDigest))
+	state := NewReceipt(NewReceiptSpec(product, MutationUpdateFile).
+		WithSource(source).WithRecovery(recoveryID, wrongDigest))
 
 	p := testProvider(t, tmp)
 	err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), state)
@@ -848,6 +885,7 @@ func TestCompensateMove_ChecksumMismatch_ReturnsError(t *testing.T) {
 	}
 }
 func TestCompensateMove_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	src := filepath.Join(tmp, "source.txt")
 	dst := filepath.Join(tmp, "dest.txt")
@@ -878,10 +916,11 @@ func TestCompensateMove_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestCompensateMove_RoundTrip_WithPreExistingDestination exercises the verification path through the recovery
-// archive. Move overwrites a pre-existing destination; CompensateMove must move src back to its original path
-// and restore the archived destination bytes after verifying the recovery archive's digest matches what was
-// captured at archive time.
+// TestCompensateMove_RoundTrip_WithPreExistingDestination exercises verification through the recovery archive.
+//
+// Move overwrites a pre-existing destination; CompensateMove must move src back to its original path and restore
+// the archived destination bytes after verifying the recovery archive's digest matches what was captured at
+// archive time.
 func TestCompensateMove_RoundTrip_WithPreExistingDestination(t *testing.T) {
 
 	tmp := t.TempDir()
@@ -941,6 +980,7 @@ func TestCompensateMove_RoundTrip_WithPreExistingDestination(t *testing.T) {
 // --- CompensateWriteText / CompensateWriteBytes ---
 
 func TestCompensateWriteText_ZeroState(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), nil); err != nil {
@@ -949,6 +989,7 @@ func TestCompensateWriteText_ZeroState(t *testing.T) {
 }
 
 func TestCompensateWriteBytes_ZeroState(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), nil); err != nil {
@@ -957,6 +998,7 @@ func TestCompensateWriteBytes_ZeroState(t *testing.T) {
 }
 
 func TestWriteText_CreatesParentDirectories(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "nested", "deep", "file.txt")
 
@@ -979,6 +1021,7 @@ func TestWriteText_CreatesParentDirectories(t *testing.T) {
 }
 
 func TestWriteText_CompensateWriteText_RoundTrip_NewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "roundtrip.txt")
 
@@ -1004,6 +1047,7 @@ func TestWriteText_CompensateWriteText_RoundTrip_NewFile(t *testing.T) {
 }
 
 func TestWriteBytes_CompensateWriteBytes_RoundTrip_NewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "roundtrip.bin")
 
@@ -1031,6 +1075,7 @@ func TestWriteBytes_CompensateWriteBytes_RoundTrip_NewFile(t *testing.T) {
 // --- Exists ---
 
 func TestExists_FileExists(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "exists.txt")
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
@@ -1048,6 +1093,7 @@ func TestExists_FileExists(t *testing.T) {
 }
 
 func TestExists_FileDoesNotExist(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "nonexistent.txt")
 
@@ -1062,6 +1108,7 @@ func TestExists_FileDoesNotExist(t *testing.T) {
 }
 
 func TestExists_Symlink(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "target")
 	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
@@ -1083,6 +1130,7 @@ func TestExists_Symlink(t *testing.T) {
 }
 
 func TestExists_Directory(t *testing.T) {
+
 	tmp := t.TempDir()
 
 	p := testProvider(t, tmp)
@@ -1098,6 +1146,7 @@ func TestExists_Directory(t *testing.T) {
 // --- IsDir ---
 
 func TestIsDir_Directory(t *testing.T) {
+
 	tmp := t.TempDir()
 
 	p := testProvider(t, tmp)
@@ -1111,6 +1160,7 @@ func TestIsDir_Directory(t *testing.T) {
 }
 
 func TestIsDir_File(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "file.txt")
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
@@ -1128,6 +1178,7 @@ func TestIsDir_File(t *testing.T) {
 }
 
 func TestIsDir_NonExistent(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	got, err := p.IsDir("/nonexistent/path")
@@ -1142,6 +1193,7 @@ func TestIsDir_NonExistent(t *testing.T) {
 // --- IsFile ---
 
 func TestIsFile_RegularFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "file.txt")
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
@@ -1159,6 +1211,7 @@ func TestIsFile_RegularFile(t *testing.T) {
 }
 
 func TestIsFile_Directory(t *testing.T) {
+
 	tmp := t.TempDir()
 
 	p := testProvider(t, tmp)
@@ -1172,6 +1225,7 @@ func TestIsFile_Directory(t *testing.T) {
 }
 
 func TestIsFile_NonExistent(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	got, err := p.IsFile("/nonexistent/path")
@@ -1184,6 +1238,7 @@ func TestIsFile_NonExistent(t *testing.T) {
 }
 
 func TestIsFile_Symlink(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "target")
 	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
@@ -1208,6 +1263,7 @@ func TestIsFile_Symlink(t *testing.T) {
 // --- Join ---
 
 func TestJoin_MultipleParts(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1217,6 +1273,7 @@ func TestJoin_MultipleParts(t *testing.T) {
 }
 
 func TestJoin_Empty(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1226,6 +1283,7 @@ func TestJoin_Empty(t *testing.T) {
 }
 
 func TestJoin_SinglePart(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1237,6 +1295,7 @@ func TestJoin_SinglePart(t *testing.T) {
 // --- Name ---
 
 func TestName_ReturnsLastElement(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1259,6 +1318,7 @@ func TestName_ReturnsLastElement(t *testing.T) {
 // --- Parent ---
 
 func TestParent_ReturnsContainingDir(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1281,6 +1341,7 @@ func TestParent_ReturnsContainingDir(t *testing.T) {
 // --- Mkdir ---
 
 func TestMkdir_CreatesDirectory(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "newdir")
 
@@ -1303,6 +1364,7 @@ func TestMkdir_CreatesDirectory(t *testing.T) {
 }
 
 func TestMkdir_CreatesParents(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "a", "b", "c")
 
@@ -1322,6 +1384,7 @@ func TestMkdir_CreatesParents(t *testing.T) {
 }
 
 func TestMkdir_Idempotent(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "existing")
 	if err := os.MkdirAll(path, 0o755); err != nil {
@@ -1338,6 +1401,7 @@ func TestMkdir_Idempotent(t *testing.T) {
 // --- ReadText ---
 
 func TestReadText_ReturnsFileContents(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "file.txt")
 	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
@@ -1356,6 +1420,7 @@ func TestReadText_ReturnsFileContents(t *testing.T) {
 }
 
 func TestReadText_NonExistent_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	_, err := p.ReadText(mustRegular(t, p.RuntimeEnvironment(), filepath.Join(tmp, "nonexistent.txt")))
@@ -1367,6 +1432,7 @@ func TestReadText_NonExistent_ReturnsError(t *testing.T) {
 // --- ReadBytes ---
 
 func TestReadBytes_ReturnsFileContents(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "file.bin")
 	data := []byte{0x00, 0x01, 0x02, 0xff}
@@ -1391,6 +1457,7 @@ func TestReadBytes_ReturnsFileContents(t *testing.T) {
 }
 
 func TestReadBytes_NonExistent_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 	_, err := p.ReadBytes(mustRegular(t, p.RuntimeEnvironment(), filepath.Join(tmp, "nonexistent.bin")))
@@ -1402,6 +1469,7 @@ func TestReadBytes_NonExistent_ReturnsError(t *testing.T) {
 // --- Glob ---
 
 func TestGlob_MatchesFiles(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "a.go", "package a")
 	writeTestFile(t, tmp, "b.go", "package b")
@@ -1419,6 +1487,7 @@ func TestGlob_MatchesFiles(t *testing.T) {
 }
 
 func TestGlob_NoMatches(t *testing.T) {
+
 	tmp := t.TempDir()
 
 	p := testProvider(t, tmp)
@@ -1435,6 +1504,7 @@ func TestGlob_NoMatches(t *testing.T) {
 // --- Find ---
 
 func TestFind_RelativePattern_ResolvesAgainstScopedRoot(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "a.go", "package a")
 	writeTestFile(t, tmp, "b.go", "package b")
@@ -1452,6 +1522,7 @@ func TestFind_RelativePattern_ResolvesAgainstScopedRoot(t *testing.T) {
 }
 
 func TestFind_DoubleStarRecurses(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "src", "pkg"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1472,6 +1543,7 @@ func TestFind_DoubleStarRecurses(t *testing.T) {
 }
 
 func TestFind_AbsolutePatternInsideScope_Works(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "x.go", "package x")
 
@@ -1486,6 +1558,7 @@ func TestFind_AbsolutePatternInsideScope_Works(t *testing.T) {
 }
 
 func TestFind_AbsolutePatternOutsideScope_Errors(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -1499,6 +1572,7 @@ func TestFind_AbsolutePatternOutsideScope_Errors(t *testing.T) {
 }
 
 func TestFind_DotDotPatternEscapingScope_Errors(t *testing.T) {
+
 	parent := t.TempDir()
 	scoped := filepath.Join(parent, "scoped")
 	if err := os.MkdirAll(scoped, 0o755); err != nil {
@@ -1517,6 +1591,7 @@ func TestFind_DotDotPatternEscapingScope_Errors(t *testing.T) {
 }
 
 func TestFind_NoMatches_ReturnsEmpty(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "a.go", "package a")
 
@@ -1531,6 +1606,7 @@ func TestFind_NoMatches_ReturnsEmpty(t *testing.T) {
 }
 
 func TestFind_DirectoriesNeverMatch(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "subdir"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1551,6 +1627,7 @@ func TestFind_DirectoriesNeverMatch(t *testing.T) {
 }
 
 func TestFind_IncludeGitignoredFalse_ExcludesIgnoredFiles(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, ".gitignore", "ignored.go\n")
 	writeTestFile(t, tmp, "kept.go", "package kept")
@@ -1580,6 +1657,7 @@ func TestFind_IncludeGitignoredFalse_ExcludesIgnoredFiles(t *testing.T) {
 }
 
 func TestFind_IncludeGitignoredTrue_IncludesIgnoredFiles(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, ".gitignore", "ignored.go\n")
 	writeTestFile(t, tmp, "kept.go", "package kept")
@@ -1599,6 +1677,7 @@ func TestFind_IncludeGitignoredTrue_IncludesIgnoredFiles(t *testing.T) {
 // --- Remove non-empty directory ---
 
 func TestRemove_NonEmptyDirectory_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	dir := filepath.Join(tmp, "mydir")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -1620,6 +1699,7 @@ func TestRemove_NonEmptyDirectory_ReturnsError(t *testing.T) {
 // These are blocked on issue #164 (recovery site fails on macOS SIP).
 
 func TestRemove_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "remove-rt.txt")
 	if err := os.WriteFile(path, []byte("remove round-trip"), 0o644); err != nil {
@@ -1650,6 +1730,7 @@ func TestRemove_RoundTrip(t *testing.T) {
 }
 
 func TestRemoveAll_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	dir := filepath.Join(tmp, "removedir-rt")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -1681,6 +1762,7 @@ func TestRemoveAll_RoundTrip(t *testing.T) {
 }
 
 func TestCompensateRemove_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "comp-remove.txt")
 	if err := os.WriteFile(path, []byte("compensate me"), 0o644); err != nil {
@@ -1722,6 +1804,7 @@ func TestCompensateRemove_RoundTrip(t *testing.T) {
 }
 
 func TestCompensateRemoveAll_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	dir := filepath.Join(tmp, "comp-removedir")
 	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
@@ -1763,6 +1846,7 @@ func TestCompensateRemoveAll_RoundTrip(t *testing.T) {
 }
 
 func TestCompensateUnlink_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "target.txt")
 	if err := os.WriteFile(target, []byte("target"), 0o644); err != nil {
@@ -1797,6 +1881,7 @@ func TestCompensateUnlink_RoundTrip(t *testing.T) {
 }
 
 func TestWriteText_OverwriteExisting_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "overwrite-rt.txt")
 	if err := os.WriteFile(path, []byte("original content"), 0o644); err != nil {
@@ -1835,6 +1920,7 @@ func TestWriteText_OverwriteExisting_RoundTrip(t *testing.T) {
 // --- Backup + CompensateBackup round-trip ---
 
 func TestBackup_CompensateBackup_RoundTrip(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "myfile.txt")
 	if err := os.WriteFile(path, []byte("original content"), 0o644); err != nil {
@@ -1879,6 +1965,7 @@ func TestBackup_CompensateBackup_RoundTrip(t *testing.T) {
 // --- Copy + CompensateCopy round-trip ---
 
 func TestCopy_CompensateCopy_RoundTrip_NewFile(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "new.txt")
 
@@ -1900,6 +1987,7 @@ func TestCopy_CompensateCopy_RoundTrip_NewFile(t *testing.T) {
 }
 
 func TestCopy_CompensateCopy_RoundTrip_Overwrite(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "existing.txt")
 	if err := os.WriteFile(path, []byte("original"), 0o755); err != nil {
@@ -1930,6 +2018,7 @@ func TestCopy_CompensateCopy_RoundTrip_Overwrite(t *testing.T) {
 // --- checksumFile / isDirAndNotEmpty ---
 
 func TestChecksumFile_ComputesDigest(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "checksum.txt")
 	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
@@ -1950,6 +2039,7 @@ func TestChecksumFile_ComputesDigest(t *testing.T) {
 }
 
 func TestChecksumFile_NonExistent(t *testing.T) {
+
 	root := fsroot.OpenWritableUnconfined(t.TempDir())
 	got := checksumFile(root, "/nonexistent/file.txt")
 	if got != "" {
@@ -1958,6 +2048,7 @@ func TestChecksumFile_NonExistent(t *testing.T) {
 }
 
 func TestIsDirAndNotEmpty_AcrossEntryKinds(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -2009,6 +2100,7 @@ func TestIsDirAndNotEmpty_AcrossEntryKinds(t *testing.T) {
 // --- findClosestExistingDir ---
 
 func TestFindClosestExistingDir_PathExists_ReturnsPath(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -2025,6 +2117,7 @@ func TestFindClosestExistingDir_PathExists_ReturnsPath(t *testing.T) {
 }
 
 func TestFindClosestExistingDir_PathDoesNotExist_ReturnsNearestAncestor(t *testing.T) {
+
 	tmp := t.TempDir()
 	missing := filepath.Join(tmp, "a", "b", "c", "d")
 	p := testProvider(t, tmp)
@@ -2039,6 +2132,7 @@ func TestFindClosestExistingDir_PathDoesNotExist_ReturnsNearestAncestor(t *testi
 }
 
 func TestFindClosestExistingDir_PartialChain_ReturnsLowestExisting(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b"), 0o755); err != nil {
 		t.Fatal(err)
@@ -2060,6 +2154,7 @@ func TestFindClosestExistingDir_PartialChain_ReturnsLowestExisting(t *testing.T)
 }
 
 func TestFindClosestExistingDir_PathOutsideRoot_Errors(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -2074,6 +2169,7 @@ func TestFindClosestExistingDir_PathOutsideRoot_Errors(t *testing.T) {
 }
 
 func TestFindClosestExistingDir_RegularFile_ReturnsFileInfo(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "hello.txt", "hi")
 	target := filepath.Join(tmp, "hello.txt")
@@ -2094,6 +2190,7 @@ func TestFindClosestExistingDir_RegularFile_ReturnsFileInfo(t *testing.T) {
 // --- CompensateMkdir ---
 
 func TestCompensateMkdir_RoundTrip_RemovesCreatedChain(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "a", "b", "c")
 	p := testProvider(t, tmp)
@@ -2116,6 +2213,7 @@ func TestCompensateMkdir_RoundTrip_RemovesCreatedChain(t *testing.T) {
 }
 
 func TestCompensateMkdir_StopsAtBoundary_PreservesPreExisting(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b"), 0o755); err != nil {
 		t.Fatal(err)
@@ -2145,6 +2243,7 @@ func TestCompensateMkdir_StopsAtBoundary_PreservesPreExisting(t *testing.T) {
 }
 
 func TestCompensateMkdir_AlreadyExists_NoOp(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "existing")
 	if err := os.MkdirAll(target, 0o755); err != nil {
@@ -2169,6 +2268,7 @@ func TestCompensateMkdir_AlreadyExists_NoOp(t *testing.T) {
 }
 
 func TestCompensateMkdir_NotADirectory_ReturnsError(t *testing.T) {
+
 	tmp := t.TempDir()
 	writeTestFile(t, tmp, "regular", "content")
 	target := filepath.Join(tmp, "regular")
@@ -2184,6 +2284,7 @@ func TestCompensateMkdir_NotADirectory_ReturnsError(t *testing.T) {
 }
 
 func TestCompensateMkdir_TamperedBoundary_Errors(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "siblings"), 0o755); err != nil {
 		t.Fatal(err)
@@ -2206,12 +2307,14 @@ func TestCompensateMkdir_TamperedBoundary_Errors(t *testing.T) {
 	}
 	tampered := NewReceipt(NewReceiptSpec(wrongResource, MutationCreateDir).WithBoundary(wrongBoundary))
 
-	if err := p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), tampered); err == nil || !strings.Contains(err.Error(), "is not under boundary") {
+	err = p.CompensateFileMutation(testActivation(t, p.RuntimeEnvironment()), tampered)
+	if err == nil || !strings.Contains(err.Error(), "is not under boundary") {
 		t.Errorf("expected tamper-guard error \"is not under boundary\", got %v", err)
 	}
 }
 
 func TestCompensateMkdir_EmptyReceipt_NoOp(t *testing.T) {
+
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
 
@@ -2223,6 +2326,7 @@ func TestCompensateMkdir_EmptyReceipt_NoOp(t *testing.T) {
 // --- compensateWrite boundary walk ---
 
 func TestCompensateWriteText_RoundTrip_RemovesParentDirectories(t *testing.T) {
+
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "a", "b", "c", "hello.txt")
 	p := testProvider(t, tmp)
@@ -2245,6 +2349,7 @@ func TestCompensateWriteText_RoundTrip_RemovesParentDirectories(t *testing.T) {
 }
 
 func TestCompensateWriteText_StopsAtBoundary_PreservesPreExisting(t *testing.T) {
+
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b"), 0o755); err != nil {
 		t.Fatal(err)
@@ -2272,6 +2377,7 @@ func TestCompensateWriteText_StopsAtBoundary_PreservesPreExisting(t *testing.T) 
 }
 
 func TestCompensateLink_RoundTrip_RemovesParentDirectories(t *testing.T) {
+
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "src.txt")
 	writeTestFile(t, tmp, "src.txt", "content")
@@ -2296,6 +2402,7 @@ func TestCompensateLink_RoundTrip_RemovesParentDirectories(t *testing.T) {
 }
 
 func TestCompensateMove_RoundTrip_RemovesCreatedParents(t *testing.T) {
+
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "src.txt")
 	writeTestFile(t, tmp, "src.txt", "content")
@@ -2318,37 +2425,13 @@ func TestCompensateMove_RoundTrip_RemovesCreatedParents(t *testing.T) {
 
 // --- Chown ---
 
-// TestWriteText_AppliesChownWhenSpecified verifies that the chown parameter, when non-empty, drives
-// applyChown through to os.Chown. Uses the current uid:gid as the target spec — the only spec that
-// doesn't require CAP_CHOWN — so the test runs without privilege.
-func TestWriteText_AppliesChownWhenSpecified(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "owned.txt")
+// TestWriteText_AppliesChownWhenSpecified lives in provider_unix_test.go: uid/gid via syscall.Stat_t is Unix-only.
 
-	p := testProvider(t, tmp)
-
-	spec := strconv.Itoa(os.Getuid()) + ":" + strconv.Itoa(os.Getgid())
-	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "owned content", 0o644, spec)
-	if err != nil {
-		t.Fatalf("WriteText with chown=%q: %v", spec, err)
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-	stat := info.Sys().(*syscall.Stat_t)
-	if int(stat.Uid) != os.Getuid() {
-		t.Errorf("uid = %d, want %d", stat.Uid, os.Getuid())
-	}
-	if int(stat.Gid) != os.Getgid() {
-		t.Errorf("gid = %d, want %d", stat.Gid, os.Getgid())
-	}
-}
-
-// TestWriteText_RejectsMalformedChown verifies that a malformed chown spec surfaces an error from the
-// provider method rather than silently no-op'ing.
+// TestWriteText_RejectsMalformedChown verifies a malformed chown spec surfaces an error.
+//
+// The provider method must error rather than silently no-op.
 func TestWriteText_RejectsMalformedChown(t *testing.T) {
+
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "rejected.txt")
 

--- a/pkg/op/provider/file/provider_unix_test.go
+++ b/pkg/op/provider/file/provider_unix_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// --- Chown ---
+
+// TestWriteText_AppliesChownWhenSpecified verifies the chown parameter drives applyChown through to os.Chown.
+//
+// The subject — uid/gid ownership read through syscall.Stat_t — exists only on Unix, so the build constraint scopes
+// the test rather than skipping it; Windows compilation of the package's tests failed on Stat_t before this file
+// existed (#373 phase 1b). Uses the current uid:gid as the target spec — the only spec that doesn't require
+// CAP_CHOWN — so the test runs without privilege.
+func TestWriteText_AppliesChownWhenSpecified(t *testing.T) {
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "owned.txt")
+
+	p := testProvider(t, tmp)
+
+	spec := strconv.Itoa(os.Getuid()) + ":" + strconv.Itoa(os.Getgid())
+	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "owned content", 0o644, spec)
+	if err != nil {
+		t.Fatalf("WriteText with chown=%q: %v", spec, err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	stat := info.Sys().(*syscall.Stat_t)
+	if int(stat.Uid) != os.Getuid() {
+		t.Errorf("uid = %d, want %d", stat.Uid, os.Getuid())
+	}
+	if int(stat.Gid) != os.Getgid() {
+		t.Errorf("gid = %d, want %d", stat.Gid, os.Getgid())
+	}
+}

--- a/pkg/op/provider/plan/deferred_default_test.go
+++ b/pkg/op/provider/plan/deferred_default_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
@@ -20,9 +19,10 @@ import (
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/flow/gen"
 )
 
-// TestPlannedDeferredDefault_ResolvesAtDispatch pins the phase-8 step-47 fix: a PLANNED invocation that omits a
-// defaulted optional parameter dispatches successfully, with the deferred `{{ umask ... }}` default resolved
-// against the live run.
+// TestPlannedDeferredDefault_ResolvesAtDispatch pins the phase-8 step-47 fix.
+//
+// A PLANNED invocation that omits a defaulted optional parameter dispatches successfully, with the deferred
+// `{{ umask ... }}` default resolved against the live run.
 //
 // The planner stuffs the parsed-but-unresolved [op.DeferredDefault] into the omitted slot; before the fix,
 // dispatch handed it straight to [op.Convert] ("*op.treeDefault value is neither assignable nor convertible to
@@ -70,9 +70,8 @@ func TestPlannedDeferredDefault_ResolvesAtDispatch(t *testing.T) {
 		t.Fatalf("stat %s: %v", destination, err)
 	}
 
-	mask := syscall.Umask(0)
-	syscall.Umask(mask)
-	want := os.FileMode(0o666) &^ os.FileMode(mask) //nolint:gosec // umask values are small
+	mask := testProcessUmask()
+	want := os.FileMode(0o666) &^ mask
 
 	if info.Mode().Perm() != want {
 		t.Errorf("mode = %v, want %v (0o666 through the process umask)", info.Mode().Perm(), want)

--- a/pkg/op/provider/plan/umask_unix_test.go
+++ b/pkg/op/provider/plan/umask_unix_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package plan_test
+
+import (
+	"os"
+	"syscall"
+)
+
+// testProcessUmask returns the process umask without changing it.
+//
+// POSIX offers no read-only umask query, so the mask is read via a [syscall.Umask] round-trip.
+// This mirrors the seam production reads through; the test package cannot reach op's unexported
+// processUmask.
+//
+// Returns:
+//   - `os.FileMode`: the process umask.
+func testProcessUmask() os.FileMode {
+
+	mask := syscall.Umask(0)
+	syscall.Umask(mask)
+
+	return os.FileMode(mask) //nolint:gosec // umask values are small
+}

--- a/pkg/op/provider/plan/umask_windows_test.go
+++ b/pkg/op/provider/plan/umask_windows_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build windows
+
+package plan_test
+
+import "os"
+
+// testProcessUmask returns the process umask without changing it.
+//
+// Windows has no umask; production's processUmask reports zero there, and this mirrors it, so the
+// deferred-default assertion (`0o666` through the mask) stays valid on every platform.
+//
+// Returns:
+//   - `os.FileMode`: always zero.
+func testProcessUmask() os.FileMode {
+
+	return 0
+}

--- a/pkg/platform/helpers.go
+++ b/pkg/platform/helpers.go
@@ -4,35 +4,22 @@
 package platform
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 )
 
-// commandTimeout bounds every shell-out so a wedged command — a stuck mirror, a tool that prompts on /dev/tty — can
-// never hang the run indefinitely. It is a generous backstop, not a per-operation deadline (large installs are
-// legitimate). TODO: make it configurable via the run environment.
-const commandTimeout = 30 * time.Minute
-
-// confirmReplies is how many "y" answers are piped to a command's stdin — a backstop that auto-confirms any prompt a
-// tool raises despite its non-interactive flags, so an op the plan requested proceeds instead of aborting on EOF.
-// Far more than any command asks; the stream ends in EOF afterward. apt's dangerous conffile prompt is handled
-// separately and safely by DEBIAN_FRONTEND (keep-old default), not by this stream.
-const confirmReplies = 4096
-
-// refreshTTL is the staleness threshold for the automatic index refresh: a leaf whose local index is older than this
-// refreshes before an index-consuming operation. A single default knob for now; promote to a per-leaf value if
-// managers need to diverge.
+// refreshTTL is the staleness threshold for the automatic index refresh.
+//
+// A leaf whose local index is older than this refreshes before an index-consuming operation. A single default knob
+// for now; promote to a per-leaf value if managers need to diverge.
 const refreshTTL = 24 * time.Hour
 
-// unknownIndexAge is the age reported for an index that cannot be stat'd (never built, or an unreadable path): well
-// past [refreshTTL], so the gate treats it as stale and refreshes.
+// unknownIndexAge is the age reported for an index that cannot be stat'd (never built, or an unreadable path).
 //
-//nolint:unused // read by the Linux-tagged leaves (apt, pacman) in linux_managers_linux.go; invisible to the darwin analysis.
+// Well past [refreshTTL], so the gate treats it as stale and refreshes.
+//
+//nolint:unused // read by the Linux-tagged leaves in linux_managers_linux.go; invisible to non-Linux analyses.
 const unknownIndexAge = 365 * 24 * time.Hour
 
 // indexAgeOf returns how long ago `path` was last modified, or [unknownIndexAge] when it cannot be stat'd.
@@ -46,7 +33,7 @@ const unknownIndexAge = 365 * 24 * time.Hour
 // Returns:
 //   - `time.Duration`: the age since last modification, or [unknownIndexAge] when the path is unreadable.
 //
-//nolint:unused // called by the Linux-tagged leaves (apt, pacman) in linux_managers_linux.go; invisible to the darwin analysis.
+//nolint:unused // called by the Linux-tagged leaves in linux_managers_linux.go; invisible to non-Linux analyses.
 func indexAgeOf(path string) time.Duration {
 
 	info, err := os.Stat(path)
@@ -55,63 +42,6 @@ func indexAgeOf(path string) time.Duration {
 	}
 
 	return time.Since(info.ModTime())
-}
-
-// runShellCommand executes a shell command via bash, optionally with sudo, capturing the result.
-//
-// It captures stdout, stderr, and the exit code into a [Result]. Used by every Linux/Darwin
-// [PackageManager] and [ServiceManager] mutator. The command string is passed to `bash -c` directly; callers are
-// responsible for safe quoting.
-//
-// Hang safety, in layers: the call is bounded by [commandTimeout]; an endless `y\n` stream on stdin auto-confirms
-// any prompt a tool raises despite its non-interactive flags — a backstop for the ones port's `-N` misses — so the
-// op proceeds rather than blocking or aborting on EOF; sudo runs with `-n`, so it fails fast instead of prompting
-// for a password on the tty (credential handling is the elevation model's job — see TODO); and
-// `DEBIAN_FRONTEND=noninteractive` keeps apt quiet (and safely keeps modified config files). Callers still pass
-// per-tool non-interactive flags (apt `-y`, pacman `--noconfirm`, port `-N`).
-//
-// It is a package var, not a plain func, so tests can substitute a recording fake.
-var runShellCommand = func(command string, sudo bool) Result {
-
-	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
-	defer cancel()
-
-	var cmd *exec.Cmd
-	if sudo {
-		// TODO(elevation): centralize this. Route privileged execution through the ElevationOffer/Elevator — one
-		// credential-cached, policy-governed, audited sudo session — instead of every command inlining `sudo -n`.
-		cmd = exec.CommandContext(ctx, "sudo", "-n", "bash", "-c", command) //nolint:gosec // G204: shell command from internal caller
-	} else {
-		cmd = exec.CommandContext(ctx, "bash", "-c", command) //nolint:gosec // G204: shell command from internal caller
-	}
-
-	cmd.Env = append(cmd.Environ(), "DEBIAN_FRONTEND=noninteractive")
-	cmd.Stdin = strings.NewReader(strings.Repeat("y\n", confirmReplies))
-
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	code := 0
-	if err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			code = exitErr.ExitCode()
-		} else {
-			code = -1
-		}
-	}
-
-	if ctx.Err() == context.DeadlineExceeded {
-		fmt.Fprintf(&stderr, "\ncommand timed out after %s", commandTimeout)
-	}
-
-	return Result{
-		OK:     code == 0,
-		Stdout: strings.TrimSuffix(stdout.String(), "\n"),
-		Stderr: strings.TrimSuffix(stderr.String(), "\n"),
-		Code:   code,
-	}
 }
 
 // bracket runs a best-effort batch package operation and returns one [Receipt] per package.
@@ -153,7 +83,8 @@ func bracket(packages []PURL, token func(p PURL) string, version func(name strin
 
 		var err error
 		if !satisfied(post) {
-			err = fmt.Errorf("platform: %s/%s did not reach the requested state (post=%q): %s", p.Type, p.Name, post, result.Stderr)
+			err = fmt.Errorf("platform: %s/%s did not reach the requested state (post=%q): %s",
+				p.Type, p.Name, post, result.Stderr)
 		}
 
 		receipts[i] = Receipt{Purl: p, PriorVersion: prior[i], Version: post, Err: err}

--- a/pkg/platform/helpers_unix.go
+++ b/pkg/platform/helpers_unix.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// commandTimeout bounds every shell-out.
+//
+// A wedged command — a stuck mirror, a tool that prompts on /dev/tty — can never hang the run indefinitely. It is a
+// generous backstop, not a per-operation deadline (large installs are legitimate). TODO: make it configurable via the
+// run environment.
+const commandTimeout = 30 * time.Minute
+
+// confirmReplies is how many "y" answers are piped to a command's stdin.
+//
+// A backstop that auto-confirms any prompt a tool raises despite its non-interactive flags, so an op the plan
+// requested proceeds instead of aborting on EOF. Far more than any command asks; the stream ends in EOF afterward.
+// apt's dangerous conffile prompt is handled separately and safely by DEBIAN_FRONTEND (keep-old default), not by
+// this stream.
+const confirmReplies = 4096
+
+// runShellCommand executes a shell command via bash, optionally with sudo, capturing the result.
+//
+// It captures stdout, stderr, and the exit code into a [Result]. Used by every Linux/Darwin [PackageManager] and
+// [ServiceManager] mutator. The command string is passed to `bash -c` directly; callers are responsible for safe
+// quoting.
+//
+// Hang safety, in layers: the call is bounded by [commandTimeout]; an endless `y\n` stream on stdin auto-confirms
+// any prompt a tool raises despite its non-interactive flags — a backstop for the ones port's `-N` misses — so the
+// op proceeds rather than blocking or aborting on EOF; sudo runs with `-n`, so it fails fast instead of prompting
+// for a password on the tty (credential handling is the elevation model's job — see TODO); and
+// `DEBIAN_FRONTEND=noninteractive` keeps apt quiet (and safely keeps modified config files). Callers still pass
+// per-tool non-interactive flags (apt `-y`, pacman `--noconfirm`, port `-N`).
+//
+// It is a package var, not a plain func, so tests can substitute a recording fake. It carries the unix constraint
+// with its two knobs above because every consumer does: the Linux and Darwin manager leaves shell out through bash,
+// while the Windows leaves drive winget through their own path — under a windows analysis all three were dead code
+// (#373 phase 1b).
+//
+// Parameters:
+//   - `command`: the shell command, passed to `bash -c` verbatim.
+//   - `sudo`: whether to run under `sudo -n`.
+//
+// Returns:
+//   - `Result`: the captured stdout, stderr, and exit code.
+var runShellCommand = func(command string, sudo bool) Result {
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	if sudo {
+		// TODO(elevation): centralize this. Route privileged execution through the ElevationOffer/Elevator — one
+		// credential-cached, policy-governed, audited sudo session — instead of every command inlining `sudo -n`.
+		cmd = exec.CommandContext(ctx, "sudo", "-n", "bash", "-c", command) //nolint:gosec // G204: internal caller
+	} else {
+		cmd = exec.CommandContext(ctx, "bash", "-c", command) //nolint:gosec // G204: internal caller
+	}
+
+	cmd.Env = append(cmd.Environ(), "DEBIAN_FRONTEND=noninteractive")
+	cmd.Stdin = strings.NewReader(strings.Repeat("y\n", confirmReplies))
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			code = exitErr.ExitCode()
+		} else {
+			code = -1
+		}
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(&stderr, "\ncommand timed out after %s", commandTimeout)
+	}
+
+	return Result{
+		OK:     code == 0,
+		Stdout: strings.TrimSuffix(stdout.String(), "\n"),
+		Stderr: strings.TrimSuffix(stderr.String(), "\n"),
+		Code:   code,
+	}
+}

--- a/pkg/platform/update_test.go
+++ b/pkg/platform/update_test.go
@@ -12,9 +12,9 @@ import (
 
 // fakeLeaf is a [leaf] whose Update outcome is configurable and recorded, for router fan-out tests.
 type fakeLeaf struct {
-	typ          string
-	updateErr    error
-	updateCalled bool
+	typ          string // purl type the fake reports
+	updateErr    error  // error Update returns; nil for success
+	updateCalled bool   // set when Update runs
 }
 
 var _ leaf = (*fakeLeaf)(nil)
@@ -30,37 +30,7 @@ func (f *fakeLeaf) Available(PURL) bool                               { return f
 func (f *fakeLeaf) Search(string, int) []SearchResult                 { return nil }
 func (f *fakeLeaf) Update() error                                     { f.updateCalled = true; return f.updateErr }
 
-// captureRefresh swaps in a recording [runShellCommand], invokes `refresh`, and returns the command string and sudo
-// flag it issued. It restores the real command runner on return, so it asserts a leaf's refresh wiring (the command
-// and its elevation flag) without shelling out or needing root.
-//
-// Parameters:
-//   - `t`: the test.
-//   - `refresh`: the leaf refresh method value to invoke.
-//
-// Returns:
-//   - `string`: the command the refresh issued.
-//   - `bool`: the sudo (elevation) flag it requested.
-func captureRefresh(t *testing.T, refresh func() Result) (string, bool) {
-
-	t.Helper()
-
-	var (
-		gotCmd  string
-		gotSudo bool
-	)
-
-	original := runShellCommand
-	runShellCommand = func(command string, sudo bool) Result {
-		gotCmd, gotSudo = command, sudo
-		return Result{OK: true}
-	}
-	defer func() { runShellCommand = original }()
-
-	refresh()
-
-	return gotCmd, gotSudo
-}
+// captureRefresh lives in update_unix_test.go: it fakes the unix-scoped runShellCommand for the tagged refresh tests.
 
 // TestCompositeUpdateFansOutToEveryLeaf verifies the router invokes Update on every registered leaf.
 func TestCompositeUpdateFansOutToEveryLeaf(t *testing.T) {
@@ -96,28 +66,28 @@ func TestCompositeUpdateAggregatesFailures(t *testing.T) {
 	}
 }
 
-// fakeRawDriver is a [rawDriver] that is also a [refresher] and [stalenessAware], with a controllable index age and
-// a refresh counter, for exercising the automatic staleness gate through the real driver verb path.
+// fakeRawDriver is a [rawDriver] that is also a [refresher] and [stalenessAware].
+//
+// A controllable index age and a refresh counter exercise the automatic staleness gate through the real driver verb
+// path.
 type fakeRawDriver struct {
-	typ       string
-	age       time.Duration
-	refreshes int
+	typ       string        // purl type the fake reports
+	age       time.Duration // index age indexAge reports
+	refreshes int           // count of refresh invocations
 }
 
 var _ rawDriver = (*fakeRawDriver)(nil)
 
-func (f *fakeRawDriver) name() string                         { return f.typ }
-func (f *fakeRawDriver) purlType() string                     { return f.typ }
-func (f *fakeRawDriver) installed(string) bool                { return false }
-func (f *fakeRawDriver) version(string) string                { return "" }
-func (f *fakeRawDriver) available(string) bool                { return true }
-func (f *fakeRawDriver) searchRaw(string, int) []SearchResult { return nil }
-func (f *fakeRawDriver) installRaw([]string, map[string]any) Result {
-	return Result{OK: true}
-}
-func (f *fakeRawDriver) removeRaw([]string) Result { return Result{OK: true} }
-func (f *fakeRawDriver) refresh() Result           { f.refreshes++; return Result{OK: true} }
-func (f *fakeRawDriver) indexAge() time.Duration   { return f.age }
+func (f *fakeRawDriver) name() string                               { return f.typ }
+func (f *fakeRawDriver) purlType() string                           { return f.typ }
+func (f *fakeRawDriver) installed(string) bool                      { return false }
+func (f *fakeRawDriver) version(string) string                      { return "" }
+func (f *fakeRawDriver) available(string) bool                      { return true }
+func (f *fakeRawDriver) searchRaw(string, int) []SearchResult       { return nil }
+func (f *fakeRawDriver) installRaw([]string, map[string]any) Result { return Result{OK: true} }
+func (f *fakeRawDriver) removeRaw([]string) Result                  { return Result{OK: true} }
+func (f *fakeRawDriver) refresh() Result                            { f.refreshes++; return Result{OK: true} }
+func (f *fakeRawDriver) indexAge() time.Duration                    { return f.age }
 
 // TestEnsureFreshRefreshesStaleIndexBeforeInstall verifies a stale index is refreshed before an index-consuming op.
 func TestEnsureFreshRefreshesStaleIndexBeforeInstall(t *testing.T) {

--- a/pkg/platform/update_unix_test.go
+++ b/pkg/platform/update_unix_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: SSPL-1.0
+// Copyright (c) 2025-2026 Noble Factor. All rights reserved.
+
+//go:build unix
+
+package platform
+
+import "testing"
+
+// captureRefresh records the command and elevation flag a leaf refresh issues.
+//
+// It swaps in a recording [runShellCommand], invokes `refresh`, and restores the real command runner on return — so
+// it asserts a leaf's refresh wiring (the command and its elevation flag) without shelling out or needing root.
+//
+// It carries the unix constraint because [runShellCommand] does, and because its callers are the darwin- and
+// linux-tagged refresh tests.
+//
+// Parameters:
+//   - `t`: the test.
+//   - `refresh`: the leaf refresh method value to invoke.
+//
+// Returns:
+//   - `string`: the command the refresh issued.
+//   - `bool`: the sudo (elevation) flag it requested.
+func captureRefresh(t *testing.T, refresh func() Result) (string, bool) {
+
+	t.Helper()
+
+	var (
+		gotCmd  string
+		gotSudo bool
+	)
+
+	original := runShellCommand
+	runShellCommand = func(command string, sudo bool) Result {
+		gotCmd, gotSudo = command, sudo
+		return Result{OK: true}
+	}
+	defer func() { runShellCommand = original }()
+
+	refresh()
+
+	return gotCmd, gotSudo
+}


### PR DESCRIPTION
Phase 1b of issue #373: per-GOOS `vet` / `lint` / `build` sweeps, on the one ubuntu runner.

## Why

`go vet`, `golangci-lint`, and the compiler all honor build constraints — a single-GOOS pass never sees the other platforms' files. The real Darwin and Windows package managers were never analyzed per-PR; only their stubs were. New `make vet-all` / `lint-all` / `build-all` targets run each analysis under all three GOOS, wired into `quality-gate`.

## The first run earned its keep twice

**1. A Windows triage undercount, found from a Mac.** `GOOS=windows go vet` failed to compile three test files (`syscall.Umask` ×2, `syscall.Stat_t` ×1) — the cause of `[build failed]` on `pkg/op`, `pkg/op/provider/file`, and `pkg/op/provider/plan` in the windows test leg, which the `--- FAIL` counting never included. **The standing "34 failures" excludes whatever those three packages' suites reveal once they run.** The umask tests now read through production's portable `processUmask` seam, so they *run* on Windows; the chown test is unix-scoped because its subject (uid/gid) exists only there.

**2. First-ever windows lint pass: 5 findings** (linux/darwin: zero), all fixed structurally, none suppressed: `statIdentity` gains named results matching its unix twin; `runShellCommand` + its knobs move to `helpers_unix.go` (every consumer is unix-gated); `captureRefresh` moves to `update_unix_test.go`.

## Compliance sweep, per directive

All 11 touched Go files brought to the full go-style standard: **17** multi-line doc summaries split, **~105** blank-after-signature lines inserted, **7** over-column lines fixed, fixture members documented. Detectors report zero; the one >120 survivor is `bracket`'s signature, §8-exempt. Section-by-section evidence is in the review thread.

Verified: gofmt clean; `vet-all`, `lint-all`, `build-all` green (the commit script re-asserts before committing); full `make test` green.

Expect the windows test leg to report **more** than 34 once the three packages compile — that is the undercount surfacing, not a regression.
