### PR TITLE
docs: publish DevLore trademark policy

### DIFF
--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,79 @@
+# DevLore Trademark Policy
+
+**DevLore™** and the DevLore logo (when published) are trademarks of
+Noble Factor LLC. "DevLore Verified" is reserved for the DevLore
+conformance program described below.
+
+DevLore's software is licensed under the Apache License 2.0. That licence
+grants copyright and patent rights — it does **not** grant trademark rights
+(see Apache-2.0 §6). This policy governs use of the marks. Its model is the
+one used by Mozilla, the Apache Software Foundation, and the CNCF: honest,
+descriptive uses are welcome without asking; uses that could confuse people
+about origin, endorsement, or certification are not.
+
+## Uses that are always fine (no permission needed)
+
+- **Referring to the software.** Truthful statements like "built with
+  DevLore", "works with DevLore", "compatible with DevLore", "a plugin for
+  DevLore", in text, talks, articles, tutorials, courses, and reviews.
+- **Unmodified redistribution.** Distributing official, unmodified DevLore
+  releases under the DevLore name — including through package managers
+  (Homebrew, MacPorts, apt, dnf, winget, and similar).
+- **Packaging patches.** Distribution packages that carry the customary
+  minor patches packaging requires (paths, build flags, integration
+  scripts) may keep the DevLore name, per normal distro conventions.
+- **Community activity.** User groups, meetups, and non-commercial
+  community sites that make clear they are community-run and not Noble
+  Factor ("DevLore Users Berlin" is fine; "DevLore HQ" is not).
+- **Package names that follow ecosystem convention** for add-ons, such as
+  `devlore-plugin-foo` or `foo-for-devlore`, provided the package does not
+  claim to be official.
+
+## Uses that need permission first
+
+- Using "DevLore" (or anything confusingly similar) in the **name of a
+  product, service, company, domain name, or app** — including hosted or
+  managed offerings of the software.
+- Using the marks in a way that **implies sponsorship, endorsement, or
+  affiliation** with Noble Factor.
+- **Merchandise** bearing the marks.
+- Logo uses beyond unmodified reproduction alongside truthful reference.
+
+Ask via <devlore@noblefactor.com>. We answer quickly and we say yes to
+honest uses.
+
+## Uses that are not permitted
+
+- **Forks and substantively modified versions may not ship under the
+  DevLore name.** Rename your fork. You may — and should — say truthfully
+  that it is "a fork of DevLore" or "derived from DevLore".
+- Claiming or implying that modified packages, forks, or third-party
+  services are official DevLore.
+- Using "DevLore Verified", "DevLore Certified", or any confusingly
+  similar designation, or any DevLore verification badge or signature
+  branding, without a current conformance agreement (below).
+- Registering trademarks, company names, or domain names containing
+  "DevLore" or confusingly similar terms.
+
+## The DevLore Verified program
+
+"DevLore Verified" designates packages and offerings that pass DevLore's
+conformance and verification requirements under a written agreement with
+Noble Factor — the same model as the CNCF's Certified Kubernetes program:
+the software is open, the *mark of conformance* is earned and licensed.
+Until the program's public documents are published, no third party may use
+the designation. Programme terms will live alongside this policy.
+
+## The short version
+
+Use "DevLore" to tell the truth about DevLore; don't use it in ways that
+make people think you are us, that your changes are ours, or that
+something is verified when it isn't.
+
+## Reservation and updates
+
+Noble Factor LLC reserves all rights in the marks not expressly stated
+here. This policy may be revised; the version in the repository at
+[github.com/NobleFactor/devlore-cli](https://github.com/NobleFactor/devlore-cli)
+is current. Questions, permission requests, and reports of misuse:
+<devlore@noblefactor.com>.


### PR DESCRIPTION
## Summary

- **TRADEMARK.md added** at the repo root: Mozilla/Apache/CNCF-model policy
- Pre-approved: truthful references, tutorials, unmodified redistribution
  via package managers, customary distro packaging patches, community
  groups, ecosystem plugin naming
- Permission-gated: product/service/company/domain names, endorsement
  implications, merchandise
- Hard lines: forks must rename ("fork of DevLore" reference allowed);
  "DevLore Verified" reserved for the conformance program (Certified
  Kubernetes model)
- Common-law ™ assertions only — no registration claims until USPTO
  filing completes

Plan basis: licensing-readme-plan v0.2 §7 / task list item 12.

Assisted-by: Claude

## Test plan

- [x] Markdown renders correctly; links resolve
- [x] No registration (®) claims anywhere