### PR TITLE
fix(file): make Find's glob matcher slash-native so ** patterns work on Windows

### DIFF
--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -157,6 +157,18 @@ consequence demonstrating itself in CI** rather than by analysis. Zero packages 
 The 34→85 jump is measurement honesty, not regression: every one of these failures existed on
 every prior run, invisible.
 
+#### Phase 3e progress — the `TestLintCopyright` cluster (2026-08-12)
+
+The five `TestLintCopyright` failures were a **product defect in `file.Find`**, not fixture
+problems: `matchDoubleStar`/`splitFindPattern` split on `filepath.Separator` and matched via
+`filepath.Match`, so on Windows every `**` glob returned nothing — the copyright linter (and any
+Starlark `file.find` caller) silently found zero source files there. Fix: the matcher is
+slash-native (`path.Match`; glob patterns are a slash-form language on every platform, the same
+contract as `io/fs` and canonical `rel`), patterns normalize at `splitFindPattern`, and the walk
+converts OS-native paths at the single boundary in `findWalkFunc`. Mutation-verified against the
+lint-copyright suite. Expected windows-leg effect: the 5-cluster clears; `Find`-dependent
+failures elsewhere in the remainder may clear with it.
+
 #### Phase 1b results (2026-08-12)
 
 `make vet-all`, `make lint-all`, and `make build-all` exist and are wired into `quality-gate` in

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -12,6 +12,10 @@ import (
 	"io"
 	"os"
 	"os/user"
+
+	// Aliased: three functions in this file take a `path` parameter, and the slash-form glob
+	// matcher needs the stdlib path package beside them.
+	slashpath "path"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -295,60 +299,63 @@ func kindMismatchError(typeName, path string, observed os.FileMode) error {
 		typeName, path, errKindMismatch, observed)
 }
 
-// matchDoubleStar reports whether `path` matches `pattern`, supporting `**` recursive wildcards.
+// matchDoubleStar reports whether `relPath` matches `pattern`, supporting `**` recursive wildcards.
 //
-// A pattern with no `**` is delegated to [filepath.Match] semantics; a single `**` is handled segment-by-segment; and
-// multiple `**` fall back to matching the trailing component against the path's base name.
+// A pattern with no `**` is delegated to [path.Match] semantics; a single `**` is handled segment-by-segment; and
+// multiple `**` fall back to matching the trailing component against the path's base name. Both inputs are
+// slash-form on every platform — glob patterns are a slash-form language, and the caller converts walked paths at
+// the boundary.
 //
 // Parameters:
-//   - `pattern`: the glob pattern, which may contain `**`.
-//   - `path`: the path to test.
+//   - `pattern`: the slash-form glob pattern, which may contain `**`.
+//   - `relPath`: the slash-form path to test.
 //
 // Returns:
-//   - `bool`: true when `path` matches `pattern`.
-func matchDoubleStar(pattern, path string) bool {
+//   - `bool`: true when `relPath` matches `pattern`.
+func matchDoubleStar(pattern, relPath string) bool {
 
 	parts := strings.Split(pattern, "**")
 	if len(parts) == 1 {
-		return pathMatch(pattern, path)
+		return pathMatch(pattern, relPath)
 	}
 
 	if len(parts) == 2 {
-		return matchDoubleStarSingle(parts[0], parts[1], path)
+		return matchDoubleStarSingle(parts[0], parts[1], relPath)
 	}
 
-	tail := strings.TrimLeft(parts[len(parts)-1], string(filepath.Separator))
-	return pathMatch(tail, filepath.Base(path))
+	tail := strings.TrimLeft(parts[len(parts)-1], "/")
+	return pathMatch(tail, slashpath.Base(relPath))
 }
 
-// matchDoubleStarSingle reports whether `path` matches a single-`**` pattern split into `rawPrefix` and `rawSuffix`.
+// matchDoubleStarSingle reports whether `relPath` matches a single-`**` pattern split into `rawPrefix` and
+// `rawSuffix`.
 //
-// The prefix must match the head of `path`; the suffix is then matched against every trailing sub-path so `**` spans
-// zero or more intermediate segments.
+// The prefix must match the head of `relPath`; the suffix is then matched against every trailing sub-path so `**`
+// spans zero or more intermediate segments. All inputs are slash-form on every platform.
 //
 // Parameters:
-//   - `rawPrefix`: the pattern text before the `**`.
-//   - `rawSuffix`: the pattern text after the `**`.
-//   - `path`: the path to test.
+//   - `rawPrefix`: the slash-form pattern text before the `**`.
+//   - `rawSuffix`: the slash-form pattern text after the `**`.
+//   - `relPath`: the slash-form path to test.
 //
 // Returns:
-//   - `bool`: true when `path` matches the prefix/suffix around `**`.
-func matchDoubleStarSingle(rawPrefix, rawSuffix, path string) bool {
+//   - `bool`: true when `relPath` matches the prefix/suffix around `**`.
+func matchDoubleStarSingle(rawPrefix, rawSuffix, relPath string) bool {
 
-	prefix := strings.TrimRight(rawPrefix, string(filepath.Separator))
-	suffix := strings.TrimLeft(rawSuffix, string(filepath.Separator))
+	prefix := strings.TrimRight(rawPrefix, "/")
+	suffix := strings.TrimLeft(rawSuffix, "/")
 
 	if prefix != "" {
-		if !strings.HasPrefix(path, prefix+string(filepath.Separator)) && path != prefix {
+		if !strings.HasPrefix(relPath, prefix+"/") && relPath != prefix {
 			return false
 		}
-		path = strings.TrimPrefix(path, prefix+string(filepath.Separator))
+		relPath = strings.TrimPrefix(relPath, prefix+"/")
 	}
 
-	segments := strings.Split(path, string(filepath.Separator))
+	segments := strings.Split(relPath, "/")
 
 	for i := range segments {
-		tail := strings.Join(segments[i:], string(filepath.Separator))
+		tail := strings.Join(segments[i:], "/")
 		if pathMatch(suffix, tail) {
 			return true
 		}
@@ -398,16 +405,21 @@ func parseChown(spec string) (uid, gid int, err error) {
 	return uid, gid, nil
 }
 
-// pathMatch wraps [filepath.Match], treating a malformed-pattern error as no match.
+// pathMatch wraps [path.Match], treating a malformed-pattern error as no match.
+//
+// [path.Match], not [filepath.Match]: glob patterns are a slash-form language on every platform
+// (the same contract as [io/fs] and the canonical [fsroot.Path] rel form), and the matcher's
+// inputs are slash-normalized before they arrive here. [filepath.Match] would flip separator and
+// escape semantics on Windows — the defect that made Find return nothing there.
 //
 // Parameters:
-//   - `pattern`: the [filepath.Match] pattern.
-//   - `name`: the name to test.
+//   - `pattern`: the slash-form [path.Match] pattern.
+//   - `name`: the slash-form name to test.
 //
 // Returns:
 //   - `bool`: true when `name` matches `pattern` and the pattern is well-formed.
 func pathMatch(pattern, name string) bool {
-	ok, err := filepath.Match(pattern, name)
+	ok, err := slashpath.Match(pattern, name)
 	return err == nil && ok
 }
 
@@ -497,23 +509,26 @@ func resolveUser(s string) (int, error) {
 
 // splitFindPattern splits `pattern` into a base directory and the match expression beneath it.
 //
-// When the pattern contains `**`, the base is everything before it; otherwise the base is the pattern's directory and
-// the match is its base name.
+// The pattern is normalized to slash form first — glob patterns are a slash-form language on every platform, and the
+// downstream matcher is slash-native. When the pattern contains `**`, the base is everything before it; otherwise
+// the base is the pattern's directory and the match is its base name.
 //
 // Parameters:
-//   - `pattern`: the find pattern to split.
+//   - `pattern`: the find pattern to split; any separator form.
 //
 // Returns:
-//   - `string`: the base directory portion.
-//   - `string`: the match expression portion.
+//   - `root`: the base directory portion, slash-form.
+//   - `match`: the match expression portion, slash-form.
 func splitFindPattern(pattern string) (root, match string) {
+
+	pattern = filepath.ToSlash(pattern)
 
 	idx := strings.Index(pattern, "**")
 	if idx < 0 {
-		return filepath.Dir(pattern), filepath.Base(pattern)
+		return slashpath.Dir(pattern), slashpath.Base(pattern)
 	}
 
-	root = strings.TrimRight(pattern[:idx], string(filepath.Separator))
+	root = strings.TrimRight(pattern[:idx], "/")
 	match = pattern[idx:]
 
 	return root, match

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -1151,7 +1151,9 @@ func (p *Provider) findWalkFunc(
 			return nil
 		}
 
-		if matchDoubleStar(matchPattern, relativePath) {
+		// The matcher is slash-native (glob patterns are a slash-form language on every
+		// platform); the walked path is OS-native and converts at this boundary.
+		if matchDoubleStar(matchPattern, filepath.ToSlash(relativePath)) {
 			*matches = append(*matches, absolutePath)
 		}
 


### PR DESCRIPTION
Issue #373 phase 3e — the `TestLintCopyright` cluster of the Windows remainder, and the verdict is a **product defect, not a fixture problem**: `file.Find` returned nothing on Windows for any `**` pattern.

## The defect

`matchDoubleStar`/`splitFindPattern` split on `filepath.Separator` and matched via `filepath.Match`. On Windows, walked paths carry `\` while patterns arrive slash-form — prefix/suffix splits never aligned, and `filepath.Match` flips escape semantics there. Every `file.find` caller silently discovered zero files; the copyright linter's five failures all showed `No source files found`.

## The fix

Glob patterns are a slash-form language on every platform — the same contract as `io/fs` and fsroot's canonical `rel`:

- `pathMatch` → stdlib `path.Match` (aliased `slashpath`; three functions in the file take a `path` parameter)
- `splitFindPattern` normalizes with `ToSlash`, splits on `/`
- `findWalkFunc` converts the walked OS-native path at the **one** boundary where native form meets the matcher

On Unix this is behavior-identical (`/` is the separator; `path.Match` ≡ `filepath.Match`). The suite passes unmodified, and it's **mutation-verified** — removing the suffix trim fails exactly the four lint-copyright fix/check tests.

Expected windows-leg effect: the 5-failure cluster clears, plus anything else in the remainder that depends on `Find` discovering files.

Verified: `make vet-all`, `make lint-all`, full `make test` green; gofmt clean.
