### PR TITLE
test(git,encryption): anchor fixture roots at temp directories, not "/"

### DIFF
--- a/pkg/op/provider/encryption/receipt_test.go
+++ b/pkg/op/provider/encryption/receipt_test.go
@@ -5,6 +5,7 @@ package encryption
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -21,11 +22,14 @@ import (
 func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 	for _, format := range []string{"json", "yaml"} {
 		t.Run(format, func(t *testing.T) {
+			// The root anchors at the temp directory, never the Unix literal "/": a
+			// whole-filesystem root cannot address absolute Windows paths (#392).
+			tmp := t.TempDir()
 			runtimeEnvironment := &op.RuntimeEnvironment{
-				Root:            fsroot.OpenWritableUnconfined("/"),
+				Root:            fsroot.OpenWritableUnconfined(tmp),
 				ResourceCatalog: op.NewResourceCatalog(),
 			}
-			resource, err := file.DiscoverRegular(runtimeEnvironment, t.TempDir()+"/decrypted.yaml")
+			resource, err := file.DiscoverRegular(runtimeEnvironment, filepath.Join(tmp, "decrypted.yaml"))
 			if err != nil {
 				t.Fatalf("file.DiscoverRegular: %v", err)
 			}

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -37,7 +37,7 @@ func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) 
 		Context:     context.Background(),
 		Application: &application.Application{Flags: map[string]any{"dry_run": dryRun}},
 		Status:      status.NewNarrator("test", captureSink),
-		Root:        fsroot.OpenWritableUnconfined("/"),
+		Root:        fsroot.OpenWritableUnconfined(t.TempDir()),
 	}
 	return &Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}, buf
 }
@@ -52,7 +52,7 @@ func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) 
 //   - `*Provider`: the initialized provider bound to an fsroot-anchored execution context.
 func newObserveProvider(t *testing.T) *Provider {
 	t.Helper()
-	return &Provider{ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")})}
+	return &Provider{ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(t.TempDir())})}
 }
 
 // --- Checkout ---
@@ -60,7 +60,7 @@ func newObserveProvider(t *testing.T) *Provider {
 func TestCheckout_BuildsArgv(t *testing.T) {
 
 	p, buf := newNarratingProvider(t, true)
-	repo := newRes(t, "/tmp/checkout-repo")
+	repo := newRes(t, filepath.Join(t.TempDir(), "checkout-repo"))
 
 	got, err := p.Checkout(repo, "release-1.2")
 	if err != nil {
@@ -125,7 +125,7 @@ func TestCheckout_MovesRef(t *testing.T) {
 func TestPull_BuildsArgv(t *testing.T) {
 
 	p, buf := newNarratingProvider(t, true)
-	repo := newRes(t, "/tmp/pull-repo")
+	repo := newRes(t, filepath.Join(t.TempDir(), "pull-repo"))
 
 	got, err := p.Pull(repo)
 	if err != nil {

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -6,6 +6,7 @@ package git
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -13,31 +14,43 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// testActivation returns an [*op.ActivationRecord] for non-graph dispatch.
+// testActivation returns an [*op.ActivationRecord] for non-graph dispatch, rooted at `rootDir`.
 //
 // `Graph` and `Unit` are both nil — Resources produced through this activation carry an empty producer
 // stamp. Test calls to producer constructors (NewResource for production, or producer methods like Clone)
 // pass this in lieu of the real per-dispatch activation that the framework would build.
-func testActivation(t *testing.T) *op.ActivationRecord {
-	t.Helper()
-	return op.NewActivationRecord(nil, "", &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")})
-}
-
-// newTestProvider returns a Provider whose RuntimeEnvironment has Root anchored at "/" and whose cloneFn hook
-// is replaced with the supplied function. Tests use the hook to capture the argv that would have been passed
-// to `git clone` without executing the real binary.
+//
+// The root is a caller-supplied directory (t.TempDir()), never the Unix literal "/": a
+// whole-filesystem root cannot address absolute Windows paths (#392), and anchoring at the temp
+// directory confines the fixture properly besides.
 //
 // Parameters:
 //   - `t`: the test harness.
+//   - `rootDir`: the directory the activation's Root is anchored at.
+//
+// Returns:
+//   - `*op.ActivationRecord`: the non-graph activation.
+func testActivation(t *testing.T, rootDir string) *op.ActivationRecord {
+	t.Helper()
+	return op.NewActivationRecord(nil, "", &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(rootDir)})
+}
+
+// newTestProvider returns a Provider rooted at `rootDir` whose cloneFn hook is replaced with the supplied
+// function. Tests use the hook to capture the argv that would have been passed to `git clone` without
+// executing the real binary.
+//
+// Parameters:
+//   - `t`: the test harness.
+//   - `rootDir`: the directory the provider's Root is anchored at (see [testActivation] on why never "/").
 //   - `hook`: the test-only replacement for doClone's exec path; nil means fall through to the real binary
 //     (tests never do this).
 //
 // Returns:
 //   - `*Provider`: the initialized provider bound to a fsroot-anchored execution context.
-func newTestProvider(t *testing.T, hook func(args []string) error) *Provider {
+func newTestProvider(t *testing.T, rootDir string, hook func(args []string) error) *Provider {
 	t.Helper()
 	return &Provider{
-		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")}),
+		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(rootDir)}),
 		cloneFn:      hook,
 	}
 }
@@ -46,16 +59,17 @@ func newTestProvider(t *testing.T, hook func(args []string) error) *Provider {
 
 func TestClone_HookReceivesArgv(t *testing.T) {
 
+	root := t.TempDir()
 	var gotArgs []string
-	p := newTestProvider(t, func(args []string) error {
+	p := newTestProvider(t, root, func(args []string) error {
 		gotArgs = args
 		return nil
 	})
 
 	const repo = "https://example.com/repo.git"
-	const dir = "/tmp/clone-dest"
+	dir := filepath.Join(root, "clone-dest")
 
-	result, state, err := p.Clone(testActivation(t), repo, dir, false, "", 0, "", false, false, "", false, false, nil)
+	result, state, err := p.Clone(testActivation(t, root), repo, dir, false, "", 0, "", false, false, "", false, false, nil)
 	if err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
@@ -82,14 +96,15 @@ func TestClone_HookReceivesArgv(t *testing.T) {
 
 func TestClone_HookPropagatesError(t *testing.T) {
 
+	root := t.TempDir()
 	hookErr := errors.New("clone failed")
-	p := newTestProvider(t, func(_ []string) error {
+	p := newTestProvider(t, root, func(_ []string) error {
 		return hookErr
 	})
 
 	result, state, err := p.Clone(
-		testActivation(t),
-		"https://example.com/repo.git", "/tmp/dest",
+		testActivation(t, root),
+		"https://example.com/repo.git", filepath.Join(root, "dest"),
 		false, "", 0, "", false, false, "", false, false, nil,
 	)
 	if !errors.Is(err, hookErr) {
@@ -105,14 +120,15 @@ func TestClone_HookPropagatesError(t *testing.T) {
 
 func TestClone_DirectoryDerivedFromRepository(t *testing.T) {
 
+	root := t.TempDir()
 	var gotArgs []string
-	p := newTestProvider(t, func(args []string) error {
+	p := newTestProvider(t, root, func(args []string) error {
 		gotArgs = args
 		return nil
 	})
 
 	result, _, err := p.Clone(
-		testActivation(t),
+		testActivation(t, root),
 		"https://example.com/org/repo.git", "",
 		false, "", 0, "", false, false, "", false, false, nil,
 	)
@@ -120,31 +136,33 @@ func TestClone_DirectoryDerivedFromRepository(t *testing.T) {
 		t.Fatalf("Clone: %v", err)
 	}
 
-	// guessDirName → "repo"; under Root="/", SourcePath.Abs() resolves to "/repo".
+	// guessDirName → "repo"; SourcePath.Abs() resolves it under the fixture root.
+	wantDir := filepath.Join(root, "repo")
 	if len(gotArgs) != 3 {
 		t.Fatalf("args = %q, want 3 entries", gotArgs)
 	}
-	if gotArgs[len(gotArgs)-1] != "/repo" {
-		t.Errorf("directory arg = %q, want %q", gotArgs[len(gotArgs)-1], "/repo")
+	if gotArgs[len(gotArgs)-1] != wantDir {
+		t.Errorf("directory arg = %q, want %q", gotArgs[len(gotArgs)-1], wantDir)
 	}
-	if result.SourcePath.Abs() != "/repo" {
-		t.Errorf("result.SourcePath.Abs() = %q, want %q", result.SourcePath.Abs(), "/repo")
+	if result.SourcePath.Abs() != wantDir {
+		t.Errorf("result.SourcePath.Abs() = %q, want %q", result.SourcePath.Abs(), wantDir)
 	}
 }
 
 func TestClone_OptionsReachHook(t *testing.T) {
 
+	root := t.TempDir()
 	var gotArgs []string
-	p := newTestProvider(t, func(args []string) error {
+	p := newTestProvider(t, root, func(args []string) error {
 		gotArgs = args
 		return nil
 	})
 
 	const repo = "https://example.com/repo.git"
-	const dir = "/tmp/shallow"
+	dir := filepath.Join(root, "shallow")
 
 	_, _, err := p.Clone(
-		testActivation(t),
+		testActivation(t, root),
 		repo, dir,
 		false,  // bare
 		"main", // branch
@@ -185,17 +203,17 @@ func TestClone_OptionsReachHook(t *testing.T) {
 // producer stamp.
 func TestClone_ProducerStamp(t *testing.T) {
 
-	p := newTestProvider(t, func(_ []string) error { return nil })
+	root := t.TempDir()
+	p := newTestProvider(t, root, func(_ []string) error { return nil })
 
 	activation := op.NewActivationRecord(nil, "", &op.RuntimeEnvironment{
-		Root:            fsroot.OpenWritableUnconfined("/"),
+		Root:            fsroot.OpenWritableUnconfined(root),
 		ResourceCatalog: op.NewResourceCatalog(),
 	})
 
-	const dir = "/tmp/clone-dest"
 	result, _, err := p.Clone(
 		activation,
-		"https://example.com/repo.git", dir,
+		"https://example.com/repo.git", filepath.Join(root, "clone-dest"),
 		false, "", 0, "", false, false, "", false, false, nil,
 	)
 	if err != nil {
@@ -212,19 +230,19 @@ func TestClone_ProducerStamp(t *testing.T) {
 func TestCompensateClone_RemovesDirectory(t *testing.T) {
 
 	tmp := t.TempDir()
-	dir := tmp + "/to-remove"
+	dir := filepath.Join(tmp, "to-remove")
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")}
+	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
 	r, err := DiscoverResource(runtimeEnvironment, dir)
 	if err != nil {
 		t.Fatalf("DiscoverResource(%q): %v", dir, err)
 	}
 
 	p := &Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}
-	if err := p.CompensateClone(testActivation(t), NewReceipt(r)); err != nil {
+	if err := p.CompensateClone(testActivation(t, tmp), NewReceipt(r)); err != nil {
 		t.Fatalf("CompensateClone: %v", err)
 	}
 
@@ -236,7 +254,7 @@ func TestCompensateClone_RemovesDirectory(t *testing.T) {
 func TestCompensateClone_NoResource(t *testing.T) {
 
 	p := &Provider{ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{})}
-	if err := p.CompensateClone(testActivation(t), nil); err != nil {
+	if err := p.CompensateClone(testActivation(t, t.TempDir()), nil); err != nil {
 		t.Fatalf("CompensateClone(nil) = %v, want nil", err)
 	}
 }

--- a/pkg/op/provider/git/receipt_test.go
+++ b/pkg/op/provider/git/receipt_test.go
@@ -5,6 +5,7 @@ package git
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -19,11 +20,13 @@ import (
 func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 	for _, format := range []string{"json", "yaml"} {
 		t.Run(format, func(t *testing.T) {
+			// The root anchors at the temp directory, never the Unix literal "/" (#392).
+			tmp := t.TempDir()
 			runtimeEnvironment := &op.RuntimeEnvironment{
-				Root:            fsroot.OpenWritableUnconfined("/"),
+				Root:            fsroot.OpenWritableUnconfined(tmp),
 				ResourceCatalog: op.NewResourceCatalog(),
 			}
-			resource, err := DiscoverResource(runtimeEnvironment, t.TempDir()+"/repo")
+			resource, err := DiscoverResource(runtimeEnvironment, filepath.Join(tmp, "repo"))
 			if err != nil {
 				t.Fatalf("DiscoverResource: %v", err)
 			}

--- a/pkg/op/provider/git/resource_input_test.go
+++ b/pkg/op/provider/git/resource_input_test.go
@@ -17,8 +17,9 @@ import (
 
 func TestDiscoverResource_PathAndOwnSpecific_SameIdentity(t *testing.T) {
 
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")}
-	path := filepath.Join(t.TempDir(), "repo")
+	tmp := t.TempDir()
+	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
+	path := filepath.Join(tmp, "repo")
 
 	fromPath, err := DiscoverResource(runtimeEnvironment, path)
 	if err != nil {
@@ -38,10 +39,18 @@ func TestDiscoverResource_PathAndOwnSpecific_SameIdentity(t *testing.T) {
 func TestDiscoverResource_WindowsShapedPath_IsAPath(t *testing.T) {
 
 	// `D:\...` used to die as `expected file scheme, got "d"`; the paths-only domain has no scheme
-	// grammar to collide with.
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")}
+	// grammar to collide with. The drive-colon shape is the point of the test, so on Windows the
+	// input borrows the fixture root's own volume — a foreign volume cannot be made root-relative
+	// (#392) — while on Unix VolumeName is empty and the literal "D:" shape survives.
+	tmp := t.TempDir()
+	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
 
-	if _, err := DiscoverResource(runtimeEnvironment, `D:\repos\x`); err != nil {
+	volume := filepath.VolumeName(tmp)
+	if volume == "" {
+		volume = "D:"
+	}
+
+	if _, err := DiscoverResource(runtimeEnvironment, volume+`\repos\x`); err != nil {
 		t.Fatalf("windows-shaped path rejected: %v", err)
 	}
 }

--- a/pkg/op/provider/git/resource_test.go
+++ b/pkg/op/provider/git/resource_test.go
@@ -71,9 +71,12 @@ func commitFile(t *testing.T, dir, name, content string) {
 
 // newRes constructs a *Resource for path against an unconfined runtime environment. Uses DiscoverResource
 // because tests are not claiming production — the file/path being constructed pre-exists or is a fixture.
+//
+// The root anchors at the path's own directory, never the Unix literal "/": a whole-filesystem
+// root cannot make absolute Windows paths relative across volumes (#392).
 func newRes(t *testing.T, path string) *Resource {
 	t.Helper()
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined("/")}
+	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(filepath.Dir(path))}
 	r, err := DiscoverResource(runtimeEnvironment, path)
 	if err != nil {
 		t.Fatalf("DiscoverResource(%q): %v", path, err)


### PR DESCRIPTION
Issue #392's fixture half: ten test fixtures (not the four the issue first said — the enumeration correction is on the issue) built runtime environments on `fsroot.OpenWritableUnconfined("/")`, a whole-filesystem root that cannot address absolute Windows paths — `filepath.Rel("/", "C:\…")` cannot cross volumes, so `makePath`'s assert fired and the receipt tests **panicked** on the windows leg.

## The fix

All ten anchor at temp directories, with path literals derived from the root:

- `encryption/receipt_test.go`, `git/receipt_test.go` — root at `t.TempDir()`, fixture path joined beneath it
- `git/provider_test.go` — `testActivation`/`newTestProvider` take an explicit `rootDir`; every `/tmp/*` literal becomes a `filepath.Join` form and the derived-directory assertions follow the root
- `git/resource_test.go` — `newRes` anchors at the path's own directory
- `git/checkout_pull_observe_test.go` — both provider fixtures root at `t.TempDir()`; the two `/tmp/*` inputs join under it

**One test needed thought, not mechanics:** `TestDiscoverResource_WindowsShapedPath_IsAPath` proves a drive-colon path is a path, not a URI scheme. Its input now borrows the fixture root's own volume on Windows (a foreign volume cannot be made root-relative) while Unix keeps the literal `D:` shape — the scheme-collision subject is exercised on both platforms.

Bonus: every fixture is now properly confined instead of addressing the whole filesystem.

Expected windows-leg effect: the ~5-failure panic cluster clears. The writ System-layer `TargetRoot: "/"` design question is #392's remaining half, deliberately untouched.

Verified: `make vet`, `make lint-all`, full `make test` green (zero FAIL/panic by count); gofmt clean.
