### PR TITLE
fix(file): rooted patterns are absolute in Find's scope check; two Windows test fixes

### DIFF
--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -1095,8 +1095,14 @@ func (p *Provider) Find(pattern string, includeGitignored bool) (product []Entry
 //   - `error`: non-nil when the root escapes the scoped root.
 func resolveFindRoot(scopedRoot, root string) (string, error) {
 
+	// A rooted-but-driveless form ("/etc") is not filepath.IsAbs on Windows, yet it addresses a
+	// volume root, never the scoped root — treating it as relative silently walked <scope>/etc
+	// there (#373 phase 3e). Any rooted form takes the absolute branch; filepath.Rel then errors
+	// on the volume mismatch, which the outside-scope error correctly reports.
+	rooted := filepath.IsAbs(root) || strings.HasPrefix(root, "/")
+
 	var absoluteRoot string
-	if filepath.IsAbs(root) {
+	if rooted {
 		absoluteRoot = filepath.Clean(root)
 	} else {
 		absoluteRoot = filepath.Clean(filepath.Join(scopedRoot, root))

--- a/pkg/op/provider/file/regular_test.go
+++ b/pkg/op/provider/file/regular_test.go
@@ -204,8 +204,9 @@ func TestRegularConvertFrom_Unlinked(t *testing.T) {
 	if !ok {
 		t.Fatalf("ConvertFrom returned %T; want *Regular", projected)
 	}
-	if regular.SourcePath.Abs() != "/some/path.txt" {
-		t.Errorf("projected path = %q; want /some/path.txt", regular.SourcePath.Abs())
+	// Abs is OS-native, so the expectation is platform-correct rather than a slash literal.
+	if want := filepath.FromSlash("/some/path.txt"); regular.SourcePath.Abs() != want {
+		t.Errorf("projected path = %q; want %q", regular.SourcePath.Abs(), want)
 	}
 
 	if _, err := (*Regular)(nil).ConvertFrom(42); err == nil {

--- a/pkg/op/provider/file/resource_input_test.go
+++ b/pkg/op/provider/file/resource_input_test.go
@@ -38,9 +38,17 @@ func TestDiscoverRegular_WindowsShapedPath_IsAPath(t *testing.T) {
 
 	// `D:\...` used to die as `expected file scheme, got "d"` — url.Parse reads the drive letter as a
 	// one-letter URI scheme. Under the paths-only domain there is no scheme grammar to collide with.
-	p := testProvider(t, t.TempDir())
+	// On Windows the input borrows the fixture root's own volume — a foreign volume cannot be made
+	// root-relative (#392) — while on Unix VolumeName is empty and the literal "D:" shape survives.
+	tmp := t.TempDir()
+	p := testProvider(t, tmp)
 
-	if _, err := DiscoverRegular(p.RuntimeEnvironment(), `D:\a\b.txt`); err != nil {
+	volume := filepath.VolumeName(tmp)
+	if volume == "" {
+		volume = "D:"
+	}
+
+	if _, err := DiscoverRegular(p.RuntimeEnvironment(), volume+`\a\b.txt`); err != nil {
 		t.Fatalf("windows-shaped path rejected: %v", err)
 	}
 }


### PR DESCRIPTION
Three file-package items from the Windows remainder (#373 phase 3e), one a **product defect**.

## The defect: Find's scope check missed rooted patterns on Windows

`resolveFindRoot` used `filepath.IsAbs` to decide whether a pattern's base escapes the scoped root. `/etc` is **not** `IsAbs` on Windows (no drive letter), so `Find("/etc/**/*.conf")` took the relative branch and silently walked `<scope>/etc` — the confinement contract violated for exactly the shape it exists to refuse. Any rooted form now takes the absolute branch; `filepath.Rel` errors on the volume mismatch and the outside-scope error reports correctly.

Unix is unchanged (`IsAbs` already catches `/`) — which is also why no Darwin-side mutation can prove this: the existing `TestFind_AbsolutePatternOutsideScope_Errors` is the pin, and **CI's windows leg is where it bites**.

## The two test fixes

- `TestDiscoverRegular_WindowsShapedPath_IsAPath` — fed a literal `D:\` path against a C: temp root (cross-volume → panic, aborting the whole package's binary). Now borrows the fixture root's own volume on Windows; Unix keeps the literal `D:` shape. Same treatment as its git-package twin (#398).
- `TestRegularConvertFrom_Unlinked` — asserted a slash literal against `Abs`, which is OS-native by the #377 ruling; expectation now `filepath.FromSlash`-built.

Expected windows-leg effect: the surviving `makePath` panic clears (plus whatever its binary abort was hiding), and the Find-scope and ConvertFrom failures with it.

Verified: `make vet`, `make lint-all`, full `make test` green; gofmt clean.
