### PR TITLE
docs: record the 48 → 28 burn-down and correct the #393 attribution

### DIFF
--- a/docs/plans/env-minted-root.md
+++ b/docs/plans/env-minted-root.md
@@ -1,7 +1,7 @@
 ---
 title: "Environment-Minted Root"
 issue: https://github.com/NobleFactor/devlore-cli/issues/393
-status: in-progress
+status: complete
 created: 2026-08-13
 updated: 2026-08-13
 ---
@@ -249,8 +249,27 @@ singles, unchanged, and no failure anywhere traces to the new mint or preflight 
       `builder_test.go`) hold no handle; `TestNewRuntimeEnvironment_BadAnchorFails` mints nothing
       because the mint is what fails.
 - [x] `make test` zero failures; `make lint-all` 0 issues per GOOS; gofmt clean.
-- [ ] Second windows measurement. Expected 45 → ~30 — and unlike the first estimate, this one
-      names its mechanism: 15 unclosed handles, 15 cleanups.
+- [x] Second windows measurement (head `27d23e8e`, uncapped): **28** `--- FAIL`, **0** leak
+      signature, 0 panics, 0 `[build failed]`. Seventeen `--- FAIL` lines cleared, none added —
+      the 17-vs-15 gap is naming, not extra wins (two cleared tests are parent/subtest pairs
+      whose `/json` child counts a second `--- FAIL` line against one cleanup).
+
+## Outcome
+
+**48 → 28 across the branch; the handle-leak cluster is closed (18 → 0).** PR
+[#402](https://github.com/NobleFactor/devlore-cli/pull/402) merged to develop as `810745cf`.
+
+| Measurement | `--- FAIL` | leak-signature |
+| --- | --- | --- |
+| baseline (develop) | 48 | 18 |
+| framework change only (`dd72af4`) | 45 | 15 |
+| with test cleanups (`27d23e8`) | **28** | **0** |
+
+The −18 this plan opened with was close to the −20 delivered, but its reasoning was wrong: 3 came
+from the framework change and 17 from closing test environments. The production defects #393
+named were real and are fixed; they simply were not what those tests were failing on. Recorded
+here rather than smoothed over, because the campaign's counts are only as trustworthy as their
+attributions.
 
 **Known non-blocker:** `make check` fails its `complexity` step on two pre-existing functions this
 branch never touched — `git guessDirName` (27) and `cli runSelfInstall` (22). The gate is

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -157,7 +157,36 @@ consequence demonstrating itself in CI** rather than by analysis. Zero packages 
 The 34→85 jump is measurement honesty, not regression: every one of these failures existed on
 every prior run, invisible.
 
-#### Phase 3e state — first fully honest count (2026-08-13)
+#### Phase 3e state — the handle-leak cluster is CLOSED, 48 → 28 (PR #402, 2026-08-13)
+
+The burn-down is now **85 → 57 → 48 → 50 → 48 → 28**. PR #402 (issue #393, plan
+[env-minted-root.md](./env-minted-root.md)) cleared the entire handle-leak cluster: the leak
+signature (`TempDir RemoveAll cleanup: … being used by another process`) went **18 → 0**, with
+zero panics and zero `[build failed]` packages, measured uncapped against head `27d23e8e`'s
+check-runs. Seventeen `--- FAIL` lines cleared and none appeared.
+
+**The attribution the earlier estimate got wrong.** This plan predicted −18 from the #393 ruling
+(a spec no longer carrying a live Root). The framework change alone delivered **−3**; the
+remaining **−17** came from a second commit closing fifteen *test* environments that were never
+closed. The production leaks #393 diagnosed were real and are fixed — lore's deploy loop handing
+one spec to N executors (so every iteration after the first ran against a closed Root), writ
+verify and readback never closing their loading environments, devlore-test's root aliasing — but
+they were not what those eighteen tests were failing on. The proof was a natural experiment
+inside one package: the three plan-package helpers that close their environment had no failing
+tests; the five that did not accounted for exactly fifteen. A right number reached by wrong
+reasoning is still a miss; inherited estimates get their own enumeration.
+
+**The 28 that remain** are the phase-3e grind, one failing package each across twelve packages:
+file-provider write/permission semantics (`TestWrite_*`, `TestCopy_WritesNewFile`,
+`TestWriteBytes_*`), path semantics (`TestName_*`, `TestParent_*`, `TestCommonAncestor`,
+`TestSourcePath_ShardedLayout`), chown (`TestApplyChown_*`, `TestParseChown_*`), git argv
+(`TestCheckout_BuildsArgv`, `TestPull_BuildsArgv`), 2 CLI error-text expectations
+(`TestCLI_ConfigPath`, `TestCLI_RunMissingFile`), and singles including
+`TestSourceFile_StarlarkIntegration` (#376). Two survivors — `TestGatherFailureUnwind_ViaPublicAPI`
+and the git clone resume test — were failing for a second reason behind the leak, now their only
+reason.
+
+#### Phase 3e state — first fully honest count (2026-08-13, superseded above)
 
 The burn-down: **85 → 57 → 48 → 50 → 48**, with the two rises being unmaskings (panics abort a
 package's whole test binary; clearing them lets more tests run). As of PR #400's leg there are
@@ -167,11 +196,9 @@ slash-native `Find` matcher (#395), the ten fixture-root anchors (#398), the gen
 (#399, closing #396), and the file-package trio (#400) — including `resolveFindRoot`'s
 rooted-pattern scope defect, a product fix.
 
-The 48 decompose to: **18** handle-leak failures (#393 — diagnosed: unclosed confined-Root
-directory handles from pre-Run error paths and the resume family's closed-Root reuse; **ruled
-2026-08-13**: executor owns the Root from construction, resume re-mints; implementation
-deferred to a fresh session with the full design banked on the issue), ~25 write/path/chown
-semantics (3e grind), 1 Starlark escape (#376), 2 CLI error-text expectations, ~2 singles.
+The 48 decompose to: **18** handle-leak failures (#393 — CLOSED by PR #402; see the section
+above, including the correction to this row's diagnosis), ~25 write/path/chown semantics (3e
+grind), 1 Starlark escape (#376), 2 CLI error-text expectations, ~2 singles.
 
 #### Phase 3e progress — the `TestLintCopyright` cluster (2026-08-12)
 


### PR DESCRIPTION
## Summary

Ledger update after [#402](https://github.com/NobleFactor/devlore-cli/pull/402) merged and
[#393](https://github.com/NobleFactor/devlore-cli/issues/393) closed.

**Burn-down: 85 → 57 → 48 → 50 → 48 → 28.** The handle-leak cluster is closed — leak signature
18 → 0, zero panics, zero `[build failed]`, measured uncapped against head `27d23e8e`'s
check-runs.

## The correction

This campaign predicted **−18** from the #393 ruling. The framework change alone delivered
**−3**; the remaining **−17** came from closing fifteen *test* runtime environments that were
never closed. The production leaks #393 diagnosed were real and are fixed, but they were not what
those eighteen tests were failing on — proven by a natural experiment inside the plan package:
the three helpers that close their environment had no failing tests, and the five that did not
accounted for exactly fifteen.

A right number reached by wrong reasoning is still a miss, so both plans record it rather than
quietly restating the target. The campaign's counts are only as trustworthy as their
attributions.

## Changes

- `docs/plans/platform-test-matrix.md` — new phase-3e section for the 48 → 28 measurement and the
  attribution correction; the old 48-row now points at it instead of the superseded diagnosis.
- `docs/plans/env-minted-root.md` — status `complete`, with the three-point measurement table
  (48 / 45 / 28) and the outcome section.

Docs only; no code paths touched.

Assisted-by: Claude
