### PR TITLE
docs: triage the remaining 28 and plan native Windows permissions

### DIFF
--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -1,0 +1,278 @@
+---
+title: "Windows native permissions: enforce restrictive modes, route every mutation through fsroot"
+issue: https://github.com/NobleFactor/devlore-cli/issues/405
+status: draft
+created: 2026-08-13
+updated: 2026-08-13
+---
+
+# Plan: Windows native permissions
+
+Go's `os.Chmod` on Windows toggles only the read-only attribute, so **every restrictive mode this
+codebase requests is silently unenforced there**. A `0600` private key lands accessible to anyone
+with directory access. This plan makes Windows permissions real, and does it at a single seam by
+routing every filesystem mutation through `fsroot`.
+
+## Summary
+
+Discovered while triaging the #373 windows leg: seven test failures reading `permission = 666,
+want 600` are not "Unix-only assertions" — they are the product silently failing to honor its own
+intent. Enumeration then showed the surface is far larger than the failures: **84 direct `os.*`
+mutation calls** live outside `fsroot`, **31** of them passing a restrictive permission.
+
+The worst is not the case originally filed. It is
+[pkg/signing/signing.go:202](../../pkg/signing/signing.go) — a **private key** written at `0600`
+into a `0700` directory, both unenforced on Windows.
+
+## Rulings (2026-08-13)
+
+1. **Windows permissions must be enforced.** Native support, not documented resignation. This
+   supersedes the earlier "file an issue and scope the tests to Unix" disposition; the seven
+   permission failures are reclassified **bucket 1 (product defect)**, not bucket 3.
+2. **Every mutation goes through `fsroot`** — all 84 sites, test harnesses
+   (`internal/e2e`, `cmd/devlore-test/devloretest`) and the build tool (`internal/tools/docgen`)
+   included. **Amended the same day** (see ruling 6): the rule is not "no exemptions" but "no
+   *unjustified* exemptions" — a direct `os.*` mutation is permitted only when it carries a
+   `// Confinement:` comment stating why, which is mechanically checkable and cannot be added
+   silently. The amendment came from the code: reading the 13 provider sites found five with
+   principled reasons to bypass, three of which **already carried `// Confinement:` comments**.
+   The convention existed; the guard adopts it.
+3. **Mechanism: `golang.org/x/sys/windows`.** Already a direct dependency (v0.41.0), and
+   `cmd/writ/writ/snapshot/protect_darwin.go` already sets the precedent of platform-specific file
+   protection via `x/sys`. No shelling out to `icacls.exe` — no PATH dependency, no locale-sensitive
+   output parsing.
+4. **Mapping: private-vs-not.** When the requested mode denies group and other
+   (`perm&0o077 == 0`), write a **protected** DACL (inheritance broken) granting the file owner,
+   plus `SYSTEM` and `Administrators`. Otherwise leave the inherited default. Restricting SYSTEM and
+   Administrators is theater — they can take ownership at will — and breaks backup and AV tooling
+   for no defensive gain. Accepted consequence: `0640` and `0600` are indistinguishable on Windows;
+   Windows has no honest analogue for the Unix group bit.
+5. **`file.Observe` reports the real mode plus an access fact.** `Mode.Perm()` stays truthful to
+   what the OS reports (`0666`); a separate observed fact — `restricted`, derived by reading the
+   DACL back — carries the enforcement state. Nothing is fabricated. Accepted consequence: a
+   cross-platform mode comparison still sees `0666` vs `0600` for the same logical state unless it
+   learns the new field.
+
+6. **`fsroot.Root` reaches full `*os.Root` parity.** The interface exposes every method `*os.Root`
+   provides; nine are missing today — `Chmod`, `Chown`, `Chtimes`, `Create`, `Lchown`, `Link`,
+   `Mkdir`, `OpenRoot`, `RemoveAll`. Part of the 84 are not philosophical bypasses at all but code
+   routing around a too-small interface: `os.RemoveAll` alone has **10** call sites with no
+   `fsroot` equivalent. A guard that demands justification must first make the justified path
+   available.
+7. **`fsroot.OpenScratch` — scratch is a `Root` confined to a temp directory.** Not an
+   `os.CreateTemp` wrapper: a `fsroot.Root` anchored at a freshly created temp directory, whose
+   `Close` removes the tree. This keeps the package's meaning intact (scratch is not an escape
+   from confinement; it is its own confined tree with a self-destroying lifetime), removes the
+   most common legitimate reason to reach for `os.*`, and brings scratch under the Windows ACL
+   work automatically — which matters because scratch holds the most sensitive *transient* data
+   (spooled archives, and decrypted plaintext if it ever spools).
+
+**Load-bearing detail:** breaking inheritance is the whole game. Without a *protected* DACL the
+file retains its parent's inherited ACEs and stays accessible no matter what is granted.
+
+**Proof the scratch abstraction is wanted:** it already exists twice, hand-rolled.
+`archive.spooledZipReader` is a type whose entire purpose is pairing a `Close` with a `Remove`,
+and `cmd/devlore-test/devloretest/runner.go:232` hand-wires `os.MkdirTemp` + `defer os.RemoveAll`
++ `fsroot.OpenWritableUnconfined(tmpDir)` — a scratch root assembled from three parts.
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| Restrictive modes on Unix | ✅ honored | `os.WriteFile` / `Chmod` do what is asked |
+| Restrictive modes on Windows | ❌ silently ignored | `Chmod` toggles read-only only; files report `0666` |
+| Single write seam | ❌ absent | 84 mutation calls bypass `fsroot` |
+| `fsroot.Root.Chmod` | ❌ missing | interface has no Chmod; `selfinstall.go:569` needs one |
+| Enforcement observability | ❌ none | `Observe` cannot report Windows access state |
+| Lint guard | ❌ none | nothing prevents a new direct `os.*` site |
+
+### The 84 sites, by package
+
+| Package | Sites | Package | Sites |
+| --- | --- | --- | --- |
+| `internal/cli` | 28 | `cmd/writ/writ/snapshot` | 3 |
+| `cmd/star/config` | 6 | `cmd/star` | 3 |
+| `cmd/devlore-test/devloretest` | 6 | `internal/tools/docgen` | 2 |
+| `cmd/star/provider/setup` | 5 | `internal/registry` | 2 |
+| `cmd/writ/writ` | 4 | `internal/e2e` | 2 |
+| `pkg/signing` | 3 | `internal/document` | 2 |
+| `pkg/op/provider/archive` | 3 | `cmd/writ/writ/migrate` | 2 |
+| `internal/lorepackage` | 3 | `cmd/star/provider/lint` | 2 |
+| `pkg/sink`, `pkg/op/provider/plan`, `pkg/op/provider/git`, `internal/credentials` | 1 each | | |
+
+31 of the 84 pass a restrictive perm; the security-relevant ones are `pkg/signing` (private key +
+its `0700` directory), `internal/cli` (state home `0700`, run index `0600`, user config `0600`,
+self-install manifest `0600`), `internal/document` (`0600` writes), and the SOPS-decrypted output
+reached via the file provider.
+
+## Requirements
+
+### R1 — `fsroot.Root` reaches full `*os.Root` parity
+
+Nine methods are missing and all are thin delegations for `confinedRoot` (`r.inner.X(p.rel, …)`),
+`os.*` calls for `unconfinedRootReaderWriter`, and `errReadOnly` for the read-only variant:
+
+| Method | Call sites needing it today | Note |
+| --- | --- | --- |
+| `RemoveAll` | **10** | the largest single gap |
+| `Create` | 4 | `OpenFile` covers it, but parity is the ruling |
+| `Chmod` | 1 | **where Windows enforcement hooks for existing files** |
+| `Chown` | 1 | pairs with the file provider's `applyChown` |
+| `Chtimes`, `Lchown`, `Link`, `Mkdir`, `OpenRoot` | 0 today | parity per ruling 6 |
+
+`OpenRoot(p Path) (Root, error)` returns a sub-root — confined for `confinedRoot`, a new
+unconfined root at that path otherwise. `Chown`/`Lchown` fail on Windows by `os` design; that is
+expected and must be asserted, not worked around.
+
+This is a **sealed-interface change**: all three implementations live in `pkg/fsroot`, so the
+change is mechanical, but it is a deliberate widening of the package's contract.
+
+### R2 — Windows enforcement inside `fsroot`
+
+A platform-split helper — `applyMode(path string, perm os.FileMode) error`, no-op on Unix (the
+syscall already honored the mode), protected-DACL on Windows per ruling 4 — called from
+`WriteFile`, `OpenFile` (on create), `Mkdir`/`MkdirAll`, and `Chmod`. Applies to directories as
+well as files: `0700` state homes are in the restrictive set.
+
+### R3 — migrate all 84 sites
+
+Each site takes an `fsroot.Root` and calls its method. The sites that own no root today —
+`internal/cli`'s 28 especially — need one plumbed in, most plausibly `OpenWritableUnconfined`
+anchored at the relevant base (state home, config dir, install prefix). **Stated plainly:** an
+unconfined writable root is `os.*` with a base path; the win is the single enforcement seam, not
+confinement.
+
+### R4 — the lint guard: mandatory `// Confinement:` justification
+
+A direct `os.*` mutation outside `pkg/fsroot` is a finding **unless the call carries a
+`// Confinement:` comment** explaining why the root cannot serve it. Six such justifications
+already exist in the providers (one citing "§10 ruling 5"), so the guard formalizes a convention
+rather than inventing one.
+
+This is stronger than an exemption list: exemptions are granted once and forgotten, while a
+justification is written at the call site, reviewed in the diff, and cannot be added silently.
+`golangci-lint`'s `forbidigo` is the candidate mechanism (a `make check` grep is the fallback);
+whichever is used must be able to see the comment. **Verify that before committing to
+`forbidigo`** — if it cannot read adjacent comments, the grep fallback becomes the mechanism.
+
+The guard cannot be switched on until R3 completes.
+
+### R4a — `fsroot.OpenScratch`
+
+`OpenScratch(pattern string) (Root, error)` — a `Root` anchored at a freshly created temp
+directory; `Close` releases the handle **and removes the tree**. Retires `os.CreateTemp` (3 sites)
+and `os.MkdirTemp` (1), the only calls in the inventory with no `*os.Root` equivalent, and folds
+`archive.spooledZipReader` into the root itself.
+
+Two residuals accepted with the ruling:
+
+1. **`Close` carries a second meaning** here (release *and* delete) versus the other three modes.
+   Overloading is the price of making cleanup un-forgettable; the alternative — a separate
+   `Discard()` — restores leak-by-default, the exact failure #393 just cost a campaign to fix.
+   Document it emphatically at the constructor and the method.
+2. **A leaked scratch root is worse than a leaked temp file**, and worse specifically on Windows:
+   the tree cannot be removed while any handle inside it is open, so #393's failure shape returns
+   wearing new clothes. Same discipline, and now the same tests.
+
+### R5 — `Observe` access fact
+
+Add the DACL-derived `restricted` fact per ruling 5, and the read-back helper it needs.
+
+### R6 — tests that prove enforcement
+
+- `_windows_test.go`: read the DACL back and assert the ACE set — owner + SYSTEM + Administrators,
+  inheritance protected — for a `0600` write, a `0700` mkdir, and a post-hoc `Chmod`.
+- `_unix_test.go`: the existing mode-bit assertions, which are genuinely a Unix subject.
+- Coverage therefore **increases** on both platforms rather than being scoped away.
+
+## Implementation Phases
+
+Ordering rationale: the API must exist before anyone can be asked to use it (1); enforcement must
+be *proved* before call sites move, or the migration cannot be said to have achieved anything (2);
+the security-critical sites come next so the gap closes at the earliest possible moment (3); the
+remainder follows (4); and the guard lands last because it cannot pass until the migration is
+complete (5).
+
+### Phase 1: `fsroot` API — parity + scratch — branch `fsroot-parity` — status: pending
+
+Pure API growth. No call site moves, no behavior changes, nothing Windows-specific.
+
+- [ ] R1: the nine missing methods across all three implementations.
+- [ ] R4a: `OpenScratch`, with the `Close`-also-removes contract documented at both the
+      constructor and the method.
+- [ ] Tests per method per implementation, including the read-only variant's `errReadOnly` and
+      `Chown`/`Lchown` failing as `os` designs them on Windows.
+
+### Phase 2: Windows enforcement inside `fsroot` — branch `fsroot-windows-acl` — status: pending
+
+- [ ] R2: the `applyMode` platform split; protected DACL per ruling 4; wired into `WriteFile`,
+      `OpenFile` (on create), `Mkdir`, `MkdirAll`, and `Chmod`.
+- [ ] R6's `_windows_test.go`: read the DACL **back** and assert the ACE set — never merely that
+      the call returned nil, since a wrong DACL fails open while a nil-check passes.
+- [ ] Exit gate: a `0600` write, a `0700` mkdir, and a post-hoc `Chmod` are provably restricted on
+      the windows leg **before** any call site migrates.
+
+### Phase 3: migrate the security-relevant sites — branch `fsroot-migrate-secure` — status: pending
+
+- [ ] The 31 restrictive-perm sites, **`pkg/signing` first** (the private key).
+- [ ] Then `internal/cli`'s restrictive set (state home, run index, user config, self-install
+      manifest), `internal/document`, and the lore/writ sites.
+- [ ] Exit gate: the seven windows permission failures clear **by enforcement**, not by scoping.
+
+### Phase 4: migrate the remainder, by area — branch per area — status: pending
+
+Areas in ascending order of ambiguity, each its own PR:
+
+- [ ] **Providers (13 → 11 migrate, 2 stay justified).** `archive`'s 3 spool sites become
+      `OpenScratch` users rather than bypasses; `star`'s 8 migrate onto the env's root. `git`'s
+      `RemoveAll` (clone tree owned by an external subprocess) and `plan.SaveDefinition`'s
+      `os.Create` (caller-named store document) keep their existing `// Confinement:` comments.
+- [ ] **Shared libraries (12).** `pkg/signing` already done in phase 3; `internal/document`,
+      `internal/lorepackage`, `internal/registry`, `internal/credentials`, `pkg/sink` remain.
+      These own no root, so each needs one supplied by its caller — the design question of phase 4.
+- [ ] **Tooling / harness (11).** `devlore-test` (6, and its `MkdirTemp` becomes `OpenScratch`),
+      `internal/e2e` (2), `docgen` (2), `devlore-inventory` (1).
+- [ ] **CLI (48, minus those done in phase 3).** Preceded by the call-path analysis: enumerate
+      every path that reaches an `os.*` call, so the migrate-or-justify decision is made against
+      evidence rather than per call site. `internal/cli`'s 28 may warrant their own PR.
+
+### Phase 5: guard + observability — branch `fsroot-guard` — status: pending
+
+- [ ] Verify the mechanism can see `// Confinement:` comments before committing to `forbidigo`.
+- [ ] R4: the guard, wired into `make check` and `quality-gate`.
+- [ ] R5: `Observe`'s DACL-derived `restricted` fact.
+- [ ] Exit gate: a deliberately reintroduced unjustified `os.WriteFile` fails the build.
+
+## Verification
+
+`make test` green; `make lint-all` and `make build-all` green on all three GOOS; the windows leg's
+seven permission failures cleared **by enforcement, not by scoping**; DACL assertions passing on
+`test (windows-latest)`; the guard failing a deliberately reintroduced direct `os.WriteFile`.
+
+## Risks, stated
+
+1. **Failing open.** A subtly wrong DACL — missing the protected flag, wrong ACE order — leaves the
+   file accessible while every test that only checks "no error" passes. R6's assertions must read
+   the DACL back and check the ACE set, never merely that the call returned nil.
+2. **CI environment.** The windows runner executes as its own user; DACL assertions must key off
+   the *current* owner rather than a hardcoded principal, or they will pass locally and fail in CI
+   (or worse, the reverse).
+3. **Churn without benefit.** ~53 of the 84 sites carry no security consequence and are migrated for
+   the guard's sake. Reviewers should expect mechanical diffs there and reserve scrutiny for phases
+   1–2.
+4. **Plumbing pressure.** `internal/cli`'s 28 sites may tempt a package-level singleton root. That
+   is a structure decision, not a mechanical one — surface it before adopting.
+
+## Open Questions
+
+- [ ] Which root instance serves `internal/cli` (one per base — state home, config, install prefix —
+      or one anchored higher)? Settle in phase 3, not by accident in the first migrated file.
+- [ ] Does `fsroot` need anything beyond `Chmod` (R1's audit answers this)?
+- [ ] Do we enforce on *existing* files at deploy time (a chmod pass), or only at creation?
+
+## Related Documents
+
+- Issue [#405](https://github.com/NobleFactor/devlore-cli/issues/405) — the gap
+- [windows-phase-3e.md](./windows-phase-3e.md) — cluster 4, reclassified to bucket 1 by ruling 1
+- [platform-test-matrix.md](./platform-test-matrix.md) — the #373 campaign
+- `cmd/writ/writ/snapshot/protect_darwin.go` — the existing `x/sys` platform-protection precedent

--- a/docs/plans/windows-phase-3e.md
+++ b/docs/plans/windows-phase-3e.md
@@ -1,0 +1,269 @@
+---
+title: "Windows phase 3e: the remaining 28"
+issue: https://github.com/NobleFactor/devlore-cli/issues/373
+status: draft
+created: 2026-08-13
+updated: 2026-08-13
+---
+
+# Plan: Windows phase 3e — the remaining 28
+
+The #373 campaign's last grind. Every one of the 28 windows-leg failures on develop `99a0dbbd`
+is enumerated below with its **actual error text**, its root cause read from the source, and its
+campaign bucket. Classification lands here before any fix, per the campaign's phase-2 rule.
+
+## Summary
+
+28 `--- FAIL` lines, 0 `[build failed]`, 0 panics, 0 handle leaks. They resolve into **eleven
+clusters**: **4 product defects** (one security-relevant, one — the permission cluster — large
+enough to have earned its own plan), 4 Unix-assuming test clusters, 1 correctly-platform-scoped
+cluster, and 6 singles that need reading before they can be classified honestly.
+
+## Bucket key (from the campaign)
+
+1. **Bucket 1** — a genuine defect on that platform. Fix the product.
+2. **Bucket 2** — a Unix-assuming test. The product is fine; the test hardcodes a separator,
+   a permission bit, or a message. Fix the test.
+3. **Bucket 3** — correctly platform-scoped. The subject exists only on one platform; the test
+   moves into a build-tagged file. **Not** a `t.Skip`.
+
+## Classification
+
+| # | Cluster | Tests | Lines | Bucket |
+| --- | --- | --- | --- | --- |
+| 1 | `file.Name` / `file.Parent` return OS-native separators | 4 | 4 | **1** |
+| 2 | `mem.SourcePath` — test expects native, product is canonical | 1 | 1 | 2 |
+| 3 | `migrate.commonAncestor` splits on `filepath.Separator` | 1 | 1 | 2 |
+| 4 | Permission-bit assertions — **product defect; see [windows-native-permissions.md](./windows-native-permissions.md)** | 7 | 7 | **1** |
+| 5 | chown identity — `os.Getuid()` is −1 on Windows | 2 | 2 | 3 |
+| 6 | `filepath.IsAbs` misses rooted paths — symlink escape accepted | 1 | 1 | **1 (security)** |
+| 7 | Onboard manifest path built by string concatenation | 1 | 1 | **1** |
+| 8 | git argv narration — substring coincidence on Unix | 2 | 2 | 2 |
+| 9 | CLI error text / path form | 2 | 2 | 2 |
+| 10 | Starlark path escape (#376) | 1 | 1 | **1** |
+| 11 | Undiagnosed singles | 6 | 6 | ? |
+
+Total: 28.
+
+### Cluster 1 — `file.Name` / `file.Parent` return OS-native separators (bucket 1)
+
+```
+Name("/")             = "\"      want "/"
+Name("///")           = "\"      want "/"
+Parent("/a/b/c.txt")  = "\a\b"   want "/a/b"
+Parent("/a/b/.config")= "\a\b"   want "/a/b"
+```
+
+`provider.go:1355` and `:1366` are `filepath.Base(path)` / `filepath.Dir(path)` verbatim. Both are
+Starlark-exposed (`file.name`, `file.parent`); their returns land in graph slots and therefore in
+serialized documents, which is exactly the condition that made `fsroot.Path.Rel()` canonical-slash
+under **#377**. A slash-form input coming back backslashed also silently changes the caller's
+separator style mid-pipeline.
+
+**Ruled (Q1): slash-native** — `path.Base` / `path.Dir`, matching `Rel` (#377) and the `Find`
+matcher (#395). See Rulings below.
+
+### Cluster 2 — `mem.SourcePath` (bucket 2)
+
+```
+SourcePath = ".devlore/mem/resource/sha256/e2/e29154…"
+      want   ".devlore\mem\resource\sha256\e2\e29154…"
+```
+
+The **reverse** of cluster 1: the product returns the canonical slash form and the *test* builds
+its expectation with `filepath.Join`. Under #377 the product is correct; the expectation is
+Unix-assuming (it only ever matched because `filepath.Join` uses `/` on Unix). Fix the test.
+
+### Cluster 3 — `migrate.commonAncestor` (bucket 2, pending a ruling)
+
+```
+commonAncestor("/home/user/repo", "/home/user/.local/…") = "\home\user"  want "/home/user"
+```
+
+`register.go:202` splits and rejoins on `filepath.Separator`, so Unix-literal inputs come back
+backslashed. Its production inputs are real host paths, where OS-native output is correct — which
+makes this a test that feeds literals rather than a product defect.
+
+**Ruled (Q2): bucket 2.** Traced — the result reaches only `cli.Note` and `migrateSpec(root)`'s
+confinement anchor, never document bytes. The helper stays OS-native and states so in its doc
+comment; the test builds inputs with `filepath.Join` / `t.TempDir()`.
+
+### Cluster 4 — permission-bit assertions (bucket 3)
+
+```
+internal/document: TestWrite_YAMLCreatesFileWith0o600   permission = 666, want 600
+internal/document: TestWrite_JSONCreatesFileWith0o600   permission = 666, want 600
+internal/document: TestWrite_WithPermOverridesPermission permission = 666, want 644
+file:  TestCopy_WritesNewFile                            file mode = 666, want 600
+file:  TestWriteBytes_WritesContentToNewFile             file mode = 666, want 600
+file:  TestObserve_ReportsFileFields                     Mode.Perm() = 666, want 640
+deploy: TestExecute_SopsChains                           secret/note mode = -rw-rw-rw-, want 0600
+```
+
+Windows has no Unix permission bits: Go's `Chmod` toggles only the read-only attribute and every
+writable file reports `0666`. The assertions are meaningless there, not wrong. Move each into a
+`_unix_test.go` so the build constraint states it — never a `t.Skip`.
+
+**Ruled (Q3), then REVERSED the same day — this cluster is bucket 1, not bucket 3.** The first
+ruling was "file the gap, scope the assertions to Unix." It was superseded within the hour:
+**Windows permissions must be enforced natively**, so a product that accepts `0600` and silently
+produces an unrestricted file is *wrong on Windows*, not correctly platform-scoped. These seven
+failures are product defects and are cleared by enforcement, not by scoping.
+
+The work moved to its own plan — [windows-native-permissions.md](./windows-native-permissions.md),
+issue [#405](https://github.com/NobleFactor/devlore-cli/issues/405) — because enumeration showed
+the surface is far larger than these tests: **84 direct `os.*` mutation calls** bypass `fsroot`,
+31 of them passing a restrictive perm, including a **private key** at
+`pkg/signing/signing.go:202`. Phase B of this plan therefore no longer moves the permission
+assertions; it keeps only cluster 5 (chown), and the permission work is tracked there.
+
+### Cluster 5 — chown identity (bucket 3)
+
+```
+parseChown("-1"):     invalid ownership "-1": at least one of user or group must be present
+applyChown("-1:-1"):  invalid ownership "-1:-1": …
+```
+
+Root cause found by reading, not inference: **`os.Getuid()` returns −1 on Windows** (documented).
+`helpers_test.go:72` builds its spec from `strconv.Itoa(os.Getuid())`, so the spec literally
+becomes `"-1"`, and `parseChown` correctly rejects a spec naming neither user nor group. The
+product is right on every platform; the tests' *subject* (uid/gid ownership) is Unix-only. Move to
+`helpers_unix_test.go` — the same disposition PR #388 already applied to the sibling chown test.
+
+### Cluster 6 — `filepath.IsAbs` misses rooted paths (bucket 1, security-relevant)
+
+```
+TestExtract_SymlinkTargetEscapes: absolute target = <nil>; want the symlink-target refusal
+```
+
+`containedLinkTarget` (`archive/provider.go:968`) refuses absolute symlink targets with
+`filepath.IsAbs(linkname)`. On Windows `filepath.IsAbs("/etc/passwd")` is **false** — a rooted path
+without a drive letter is not "absolute" there — so **the refusal never fires and the escaping
+symlink is extracted**. This is the same defect class as #400's `resolveFindRoot` rooted-pattern
+fix, and it is a containment check, so it is security-relevant.
+
+**`containedTarget` (`provider.go:933`) has the identical hole** for entry names, currently
+untested. Fix both; add the missing entry-name regression test rather than only the one the
+failure named.
+
+### Cluster 7 — onboard manifest path (bucket 1)
+
+```
+narration: … \001/packages-manifest.yaml     (mixed separators)
+```
+
+`cmd/lore/lore/commands.go:803` builds the path by concatenation —
+`outputDir + "/packages-manifest.yaml"` — instead of `filepath.Join`. The test compares against a
+`filepath.Join` result, so the mismatch is real and the emitted path is non-canonical.
+
+### Cluster 8 — git argv narration (bucket 2)
+
+```
+narrated: "…\git.exe -C …\checkout-repo checkout release-1.2"
+want contains: "git -C …\checkout-repo checkout release-1.2"
+```
+
+The narrator prints the **resolved** binary, identically on both platforms. On Unix the assertion
+passes by coincidence — `/usr/bin/git -C …` happens to *contain* `git -C …`. On Windows the
+resolved name carries `.exe`, breaking the substring. Product behavior is the same; the assertion
+is accidental. Fix the test to assert on the argv tail (or the resolved binary), not a substring
+that only works when the suffix is empty.
+
+### Cluster 9 — CLI error text and path form (bucket 2)
+
+```
+TestCLI_RunMissingFile: output missing "no such file"        (Windows: "The system cannot find the file specified.")
+TestCLI_ConfigPath:     output missing "devlore/config.yaml" (Windows: backslash form)
+```
+
+Assert on the OS-independent part (`errors.Is(fs.ErrNotExist)` semantics at the CLI boundary, or a
+separator-normalized comparison) rather than on a Unix message and a slash path.
+
+### Cluster 10 — Starlark path escape (bucket 1, issue #376)
+
+```
+invalid escape sequence \Users\RUN
+```
+
+A Windows path interpolated into generated `.star` source: `\U` is an invalid Starlark escape.
+Already filed as **#376**; it lands here or in its own PR, not silently.
+
+### Cluster 11 — undiagnosed, six singles
+
+Listed with their evidence; each needs reading before it earns a bucket. **No bucket is asserted
+for these.**
+
+| Test | Evidence |
+| --- | --- |
+| `TestCompensation` (devloretest) | `compensated.txt` exists but should not; `error("file.copy")` — execution succeeded, expected error |
+| `TestShellExec` (devloretest) | `shell_output.txt` not found |
+| `TestSource` (devloretest) | `file.read_text: openat source_input.txt: The system cannot find the file specified` |
+| `TestGatherFailureUnwind_ViaPublicAPI` | run error names `mkdirat blocker: file exists`, not the failing write — the blocker fixture may not reproduce the intended failure on Windows |
+| `TestDiscoverRegular_ForeignSchemeString_IsAPath` | identity carries `file://C:\…\https:\example.com\x` — a foreign-scheme string joined as a path |
+| `TestSymbolicLinkDigest_LiteralTarget` | digest ≠ hash of the literal target |
+
+The first three are all devlore-test `.star` fixtures failing on file operations, which suggests
+one shared cause rather than three; that hypothesis is to be tested, not assumed.
+
+## Implementation Phases
+
+### Phase A: product defects — branch `windows-3e-product` — status: pending
+
+- [ ] Cluster 1 (Q1 ruled slash-native): `file.Name` / `file.Parent` → `path.Base` / `path.Dir`,
+      doc comments stating the slash-form contract.
+- [ ] Cluster 6: `containedLinkTarget` **and** `containedTarget` rooted-path containment, with the
+      missing entry-name regression test.
+- [ ] Cluster 7: `filepath.Join` for the onboard manifest path.
+- [ ] Each with a regression test that fails on Windows before the fix.
+
+### Phase B: platform-scoped tests — branch `windows-3e-scoping` — status: pending
+
+- [ ] Cluster 5: two chown tests into `helpers_unix_test.go` (`os.Getuid()` is −1 on Windows).
+- [x] Cluster 4 **removed from this phase** — reclassified bucket 1 by the Q3 reversal; the seven
+      permission failures are cleared by [windows-native-permissions.md](./windows-native-permissions.md),
+      which lands before the complexity work.
+
+### Phase C: Unix-assuming tests — branch `windows-3e-test-fixes` — status: pending
+
+- [ ] Cluster 2 (`mem.SourcePath` expectation), cluster 3 (Q2 ruled bucket 2 — fix the test, state
+      the OS-native contract in the doc comment), cluster 8 (git argv), cluster 9 (CLI text).
+
+### Phase D: diagnose the six — branch `windows-3e-singles` — status: pending
+
+- [ ] Read each; classify in this document **before** fixing; test the shared-cause hypothesis for
+      the three devlore-test fixtures.
+- [ ] Cluster 10 (#376) lands here or separately.
+
+### Phase E: gate — no branch
+
+- [ ] Windows green, then #373 phase 4: add the three `test (…)` legs to ruleset `12426847` and
+      prove the gate refuses a deliberate failure.
+
+## Rulings (2026-08-13)
+
+**Q1 — `file.Name` / `file.Parent` are slash-native.** They become `path.Base` / `path.Dir`,
+returning the canonical slash form on every platform, joining `fsroot.Path.Rel()` (#377) and the
+slash-native `Find` matcher (#395) under one contract: these helpers describe *logical* paths, and
+logical paths are a slash-form language repository-wide. Consequence a caller must respect: code
+handing these helpers a genuine Windows host path gets a slash-form answer back and must convert
+at its own boundary — the same rule `Rel` already imposes.
+
+**Q2 — `commonAncestor` stays OS-native; the test is wrong (bucket 2).** Resolved by tracing
+rather than judgment: the result flows only to `cli.Note` narration and to `migrateSpec(root)`,
+where it becomes the confinement anchor `fsroot.Open` mints from. It never reaches document bytes,
+so OS-native is correct and `register_test.go` must build its inputs with `filepath.Join` /
+`t.TempDir()` instead of Unix literals. Residual accepted: nothing in the signature states the
+OS-native contract, so a future caller passing a slash-form logical path would get a subtly wrong
+answer — phase C states it in the doc comment to close that.
+
+**Q3 — file the gap, scope the tests (issue [#405](https://github.com/NobleFactor/devlore-cli/issues/405)).**
+The seven permission assertions move to `_unix_test.go`; the unenforced-`0600`-on-Windows problem
+— sharpest for `writ secret`'s decrypted output — is recorded in #405 with the inherited-ACL
+premise named as an assumption to test, not to rely on. 3e stays a classification phase; designing
+an ACL path here would block the gate behind unrelated product work.
+
+## Related Documents
+
+- [platform-test-matrix.md](./platform-test-matrix.md) — the #373 campaign
+- [env-minted-root.md](./env-minted-root.md) — #393, the cluster that preceded this one
+- Issues #373, #376, #377 (precedent), #395 / #400 (rooted-path precedent)


### PR DESCRIPTION
## Summary

Two plans covering the #373 campaign's next step, and the rulings behind them.

**`docs/plans/windows-phase-3e.md`** — all 28 windows-leg failures classified from their **actual
error text** and the source behind them. Eleven clusters: four product defects, four Unix-assuming
test clusters, one correctly-platform-scoped cluster, and six singles deliberately left
unclassified pending reading.

**`docs/plans/windows-native-permissions.md`** — what the triage turned up, tracked as
[#405](https://github.com/NobleFactor/devlore-cli/issues/405).

## The reversal

The permission cluster was first bucket 3 — Windows has no Unix mode bits, so scope the assertions
to `_unix_test.go`. **Reversed the same day:** Windows permissions must be enforced natively, so a
product that accepts `0600` and silently produces an unrestricted file is *wrong on Windows*.
Coverage now increases instead of shrinking.

## What enumeration found

**`pkg/signing` writes a private key at `0600` into a `0700` directory — both unenforced on
Windows.** That, not `writ secret`, is the sharpest case. **84** direct `os.*` mutation calls live
outside `fsroot` (CLI 48, shared libraries 12, tooling 11, starlark 8, graph 5); **31** pass a
restrictive perm.

## Two rulings amended by the code, not by argument

**"Zero exemptions" → "no *unjustified* exemptions."** Reading the 13 provider sites found five
with principled reasons to bypass — an `os.CreateTemp` spool in the system temp dir, a clone tree
owned by an external git subprocess, a caller-named store document — and **three already carried
`// Confinement:` comments** saying so. The convention existed; the guard adopts it. That is
stronger than an exemption list: a justification is written at the call site and reviewed in the
diff, where an exemption is granted once and forgotten.

**Part of the 84 were interface gaps, not bypasses.** `os.RemoveAll` has **10** call sites and
`fsroot.Root` has no `RemoveAll`. Ruled: **full `*os.Root` parity** — `Chmod`, `Chown`, `Chtimes`,
`Create`, `Lchown`, `Link`, `Mkdir`, `OpenRoot`, `RemoveAll`. A guard that demands justification
must first make the justified path available.

## `fsroot.OpenScratch`

A `Root` confined to a temp directory whose `Close` removes the tree — not an `os.CreateTemp`
wrapper. Scratch stops being an escape from confinement and becomes its own confined tree with a
self-destroying lifetime. It already exists twice, hand-rolled: `archive.spooledZipReader` is a
type whose only purpose is pairing `Close` with `Remove`, and devlore-test's runner assembles the
same thing from `MkdirTemp` + `RemoveAll` + a root.

## Phases

Each gated: grow the API → **prove enforcement on the windows leg before a single call site
moves** → migrate the 31 security-relevant sites → migrate the remainder by area → land the guard.

Docs only; no code paths touched. This work lands before the complexity debt (#312 phase 8).

Assisted-by: Claude
