### PR TITLE
feat(fsroot): enforce restrictive modes on Windows with a protected DACL

### DIFF
--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -41,12 +41,20 @@ into a `0700` directory, both unenforced on Windows.
    `cmd/writ/writ/snapshot/protect_darwin.go` already sets the precedent of platform-specific file
    protection via `x/sys`. No shelling out to `icacls.exe` — no PATH dependency, no locale-sensitive
    output parsing.
-4. **Mapping: private-vs-not.** When the requested mode denies group and other
-   (`perm&0o077 == 0`), write a **protected** DACL (inheritance broken) granting the file owner,
-   plus `SYSTEM` and `Administrators`. Otherwise leave the inherited default. Restricting SYSTEM and
-   Administrators is theater — they can take ownership at will — and breaks backup and AV tooling
-   for no defensive gain. Accepted consequence: `0640` and `0600` are indistinguishable on Windows;
-   Windows has no honest analogue for the Unix group bit.
+4. **Mapping: private-vs-not.** When the requested mode denies **other** (`perm&0o007 == 0`), write
+   a **protected** DACL (inheritance broken) granting the file owner, plus `SYSTEM` and
+   `Administrators`. Otherwise leave the inherited default. Restricting SYSTEM and Administrators is
+   theater — they can take ownership at will — and breaks backup and AV tooling for no defensive
+   gain.
+
+   **Corrected 2026-08-13** — as first written this ruling said `perm&0o077 == 0` while also
+   claiming `0640` and `0600` were indistinguishable; those cannot both be true, and a test caught
+   the seam. The boundary is **other**, not **group and other**: `0600`, `0640` and `0660` are all
+   private on Windows. We can express "other is excluded"; we have no group principal to grant to,
+   so the group bit is inexpressible and collapses into the owner. The rejected reading failed
+   **open** — a file its author restricted to a group would have inherited a DACL readable by
+   everyone, which is the failure class this issue exists to eliminate. Accepted consequence: a
+   `0660` file intended for genuine group collaboration becomes owner-only on Windows.
 5. **`file.Observe` reports the real mode plus an access fact.** `Mode.Perm()` stays truthful to
    what the OS reports (`0666`); a separate observed fact — `restricted`, derived by reading the
    DACL back — carries the enforcement state. Nothing is fabricated. Accepted consequence: a
@@ -174,6 +182,35 @@ Two residuals accepted with the ruling:
    the tree cannot be removed while any handle inside it is open, so #393's failure shape returns
    wearing new clothes. Same discipline, and now the same tests.
 
+### R4b — the validation helper (`IsRestricted`), modeled on Win32-OpenSSH
+
+**Prior art, researched 2026-08-13.** The two POSIX-on-Windows layers took opposite approaches, and
+neither is the right model for us:
+
+- **Cygwin** translates fully with `acl` mounts: owner → owner SID, group → group SID, other →
+  `Everyone` (S-1-1-0), using deny *and* allow ACEs and **deliberately violating canonical ACE
+  order** because "canonical ACLs are unable to reflect each possible combination of POSIX
+  permissions." Upstream acknowledges the cost in a thread titled *"Cygwin's ACL handling is NOT
+  interoperable with Windows."* It works because Cygwin maintains a POSIX-group-to-SID mapping —
+  **which we do not have**, and inventing one would be policy dressed as fidelity.
+- **MSYS2** declines to map at all: `noacl` by default, `chmod` silently ignored, permissions
+  approximated from the DOS read-only attribute and the file extension. That is the
+  "document the limitation" disposition already rejected for this work.
+- **Win32-OpenSSH** — shipped and maintained by Microsoft, and facing our exact problem (protecting
+  a private key on Windows) — requires that only the **owner, SYSTEM, and Administrators** have
+  access, strictly enough to reject even an `OWNER RIGHTS` (S-1-3-4) entry. Decisively, it
+  **validates rather than translates**: it reads the DACL and refuses an over-permissive key.
+
+Adopt the validation half explicitly. `IsRestricted(p Path) (bool, error)` answers "is this object
+actually private?" — on Windows by reading the DACL back (protected, and no trustee beyond owner /
+SYSTEM / Administrators), on Unix by reading the mode bits. It is the mechanism R5's observed fact
+reports, and it is what lets a future `writ doctor`-style check refuse to proceed over a secret
+that is not actually protected, exactly as `ssh` refuses an unprotected key.
+
+Note it departs from ruling 6's parity in the additive direction: `*os.Root` has no such method.
+Parity means the interface *includes* everything `os.Root` offers, not that it may include nothing
+else.
+
 ### R5 — `Observe` access fact
 
 Add the DACL-derived `restricted` fact per ruling 5, and the read-back helper it needs.
@@ -223,14 +260,38 @@ Pure API growth. No call site moved, no behavior changed, nothing Windows-specif
 - `Chown`/`Lchown` failures on Windows are surfaced, not masked; the parity test asserts the
   platform split rather than skipping it.
 
-### Phase 2: Windows enforcement inside `fsroot` — branch `fsroot-windows-acl` — status: pending
+### Phase 2: Windows enforcement inside `fsroot` — branch `fsroot-windows-acl` — status: implemented, CI-gated (2026-08-13)
 
-- [ ] R2: the `applyMode` platform split; protected DACL per ruling 4; wired into `WriteFile`,
-      `OpenFile` (on create), `Mkdir`, `MkdirAll`, and `Chmod`.
-- [ ] R6's `_windows_test.go`: read the DACL **back** and assert the ACE set — never merely that
-      the call returned nil, since a wrong DACL fails open while a nil-check passes.
-- [ ] Exit gate: a `0600` write, a `0700` mkdir, and a post-hoc `Chmod` are provably restricted on
-      the windows leg **before** any call site migrates.
+- [x] R2: the `applyMode` platform split — a no-op on Unix (the syscall already honored the mode),
+      a protected DACL on Windows per ruling 4 — wired into `WriteFile`, `OpenFile` (on
+      `O_CREATE`), `Mkdir`, `MkdirAll`, and `Chmod` on both writable implementations.
+- [x] R6's `_windows_test.go`: six tests that read the security descriptor **back** and assert
+      `SE_DACL_PROTECTED` plus the trustee set, printing the SDDL on failure. Read-back via SDDL
+      rather than an ACE walk — no `unsafe`, and a failure prints the ACL the object actually
+      carries.
+- [x] `isPrivateMode` covered cross-platform (12 modes plus the type/setuid-bit cases), because the
+      predicate decides enforcement for every call site at once and the rule is arithmetic, not a
+      syscall.
+- [x] `make test` zero failures; `make build-all`, `vet-all`, `lint-all` green on all three GOOS;
+      gofmt and style detectors clean.
+- [ ] **Exit gate, CI-side:** the Windows tests pass on `test (windows-latest)`. This code cannot
+      be executed on a development Mac — cross-compilation proves it *builds*, not that the DACL is
+      right — so the leg is the only proof, and no call site migrates until it is green.
+
+**Ruling 4's contradiction, found by a test.** As merged, ruling 4 gave the formula
+`perm&0o077 == 0` while also asserting `0640` and `0600` were indistinguishable. Those cannot both
+hold: the formula leaves `0640` inheriting its parent's DACL. The implementation followed the
+formula, the test followed the prose, and `make test` failed. **Corrected to `perm&0o007 == 0`** —
+see ruling 4. The rejected reading failed *open*, which is the failure class this issue exists to
+eliminate.
+
+**Deliberate divergence from Unix, recorded:** enforcement is applied whenever a private mode is
+requested, including on an object that already exists — where Unix would ignore the perm argument.
+This fails closed. A caller asking for `0600` gets a private file whether or not it was the creator.
+
+**Residual, not hidden:** enforcement is applied by path, not by handle, so a privileged attacker
+able to swap the path between the write and the DACL call could redirect it. Closing that needs
+handle-based `SetSecurityInfo` at every creation site; tracked on #405 rather than solved here.
 
 ### Phase 3: migrate the security-relevant sites — branch `fsroot-migrate-secure` — status: pending
 
@@ -260,6 +321,8 @@ Areas in ascending order of ambiguity, each its own PR:
 
 - [ ] Verify the mechanism can see `// Confinement:` comments before committing to `forbidigo`.
 - [ ] R4: the guard, wired into `make check` and `quality-gate`.
+- [ ] **R4b: `IsRestricted`** — the Win32-OpenSSH-style validation helper. Lands before R5, which
+      consumes it.
 - [ ] R5: `Observe`'s DACL-derived `restricted` fact.
 - [ ] Exit gate: a deliberately reintroduced unjustified `os.WriteFile` fails the build.
 

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -278,6 +278,30 @@ Pure API growth. No call site moved, no behavior changed, nothing Windows-specif
       be executed on a development Mac — cross-compilation proves it *builds*, not that the DACL is
       right — so the leg is the only proof, and no call site migrates until it is green.
 
+#### First windows run — the DACL was right; the assertion was not (PR #408, 2026-08-13)
+
+`test (windows-latest)` reported **29** (28 + one new), and the one new failure was
+`TestApplyMode_PrivateFileGetsProtectedDACL`. The SDDL it printed is the whole story:
+
+```
+D:PAI(A;;FA;;;LA)(A;;FA;;;SY)(A;;FA;;;BA)
+```
+
+`P` is `SE_DACL_PROTECTED` — inheritance broken — followed by exactly three full-access ACEs: the
+owner (`LA`, the runner's account), SYSTEM (`SY`), and Built-in Administrators (`BA`). **That is the
+target DACL exactly, produced on the first attempt.** The control-bit assertion passed and five of
+the six DACL tests passed, including the directory, `Chmod`, non-private, scratch, and `OpenFile`
+cases.
+
+The failure was the test's own trustee check: it asserted the **numeric** SIDs (`S-1-5-18`,
+`S-1-5-32-544`) while SDDL renders well-known accounts as **aliases** (`SY`, `BA`). Fixed to match
+either rendering, anchored on the ACE's trustee field (`;;;X)`) so an alias cannot match inside an
+unrelated SID, and an exact-count assertion added — a DACL with a fourth allow ACE would still be
+"protected" while granting someone else access, so the count is as load-bearing as the flag.
+
+Worth recording as evidence for the campaign's method: the read-back assertion did its job. Had the
+test checked only that the call returned nil, it would have passed and told us nothing.
+
 **Ruling 4's contradiction, found by a test.** As merged, ruling 4 gave the formula
 `perm&0o077 == 0` while also asserting `0640` and `0600` were indistinguishable. Those cannot both
 hold: the formula leaves `0640` inheriting its parent's DACL. The implementation followed the

--- a/pkg/fsroot/applymode_test.go
+++ b/pkg/fsroot/applymode_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package fsroot
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIsPrivateMode pins the one distinction Windows can honor faithfully (issue #405).
+//
+// The predicate decides whether a write gets a protected DACL, so a wrong answer here fails open on
+// Windows for every call site at once. It runs on every platform because the rule is arithmetic,
+// not a syscall.
+//
+// The boundary is **other**, not **group and other**: we can express "other is excluded" but have
+// no group principal to grant to, so a group grant collapses into the owner rather than falling
+// back to an inherited — potentially world-readable — DACL.
+func TestIsPrivateMode(t *testing.T) {
+
+	for _, tc := range []struct {
+		perm os.FileMode
+		want bool
+		why  string
+	}{
+		{0o600, true, "owner read/write only"},
+		{0o400, true, "owner read only"},
+		{0o700, true, "owner everything, typical of a state directory"},
+		{0o000, true, "no access at all is still not shared"},
+		{0o640, true, "group is inexpressible on Windows, so it collapses into the owner"},
+		{0o660, true, "same: a group grant cannot be honored, and failing open is not an option"},
+		{0o620, true, "group write is still not other access"},
+		{0o644, false, "other can read"},
+		{0o666, false, "the Create default — unrestricted by definition"},
+		{0o755, false, "other can traverse"},
+		{0o604, false, "other can read even with no group access"},
+		{0o001, false, "other can execute"},
+	} {
+		if got := isPrivateMode(tc.perm); got != tc.want {
+			t.Errorf("isPrivateMode(%#o) = %v, want %v (%s)", tc.perm, got, tc.want, tc.why)
+		}
+	}
+}
+
+// TestIsPrivateMode_IgnoresTypeAndSetuidBits verifies the predicate reads permission bits only.
+//
+// [os.FileMode] packs type and setuid/sticky bits above the permission bits; a directory mode or a
+// setuid file must not change the private/not-private answer.
+func TestIsPrivateMode_IgnoresTypeAndSetuidBits(t *testing.T) {
+
+	if !isPrivateMode(os.ModeDir | 0o700) {
+		t.Error("isPrivateMode(ModeDir|0o700) = false, want true (type bits are not permissions)")
+	}
+	if !isPrivateMode(os.ModeSetuid | 0o600) {
+		t.Error("isPrivateMode(ModeSetuid|0o600) = false, want true")
+	}
+	if isPrivateMode(os.ModeDir | 0o755) {
+		t.Error("isPrivateMode(ModeDir|0o755) = true, want false")
+	}
+}

--- a/pkg/fsroot/applymode_unix.go
+++ b/pkg/fsroot/applymode_unix.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build !windows
+
+package fsroot
+
+import "os"
+
+// applyMode is a no-op on Unix, where the creating syscall already honored the mode.
+//
+// The Windows build carries the real implementation: see applymode_windows.go and issue #405. This
+// file exists so the call sites in root.go stay platform-free.
+//
+// Parameters:
+//   - `path`: the absolute path just created or modified; unused here.
+//   - `perm`: the permission bits the caller requested; unused here.
+//   - `isDir`: whether `path` is a directory; unused here.
+//
+// Returns:
+//   - `error`: always nil.
+func applyMode(_ string, _ os.FileMode, _ bool) error { return nil }

--- a/pkg/fsroot/applymode_windows.go
+++ b/pkg/fsroot/applymode_windows.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package fsroot
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// applyMode enforces a restrictive Unix mode as a Windows DACL (issue #405).
+//
+// Go's [os.Chmod] on Windows toggles only the read-only attribute, so a 0o600 request otherwise
+// produces a file every account with directory access can read. This translates the one distinction
+// Windows can honor faithfully — private versus not — into an access-control list.
+//
+// A mode that grants anything to group or other is left alone: the file keeps whatever DACL it
+// inherited, which is the correct meaning of "not private". A mode that denies both
+// (`perm&0o077 == 0`) gets a **protected** DACL granting the file's own owner, SYSTEM, and
+// Administrators, and nothing else.
+//
+// Two choices deserve stating. The DACL is protected — inheritance is broken — because otherwise
+// the inherited ACEs survive and the file stays readable no matter what is granted; breaking
+// inheritance is the entire point rather than an optimization. And SYSTEM and Administrators are
+// kept because excluding them buys nothing (an administrator takes ownership at will) while
+// breaking backup and anti-malware tooling.
+//
+// Directories additionally propagate the restriction to their children
+// ([windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT]); files carry no inheritance flags.
+//
+// Residual, stated rather than hidden: enforcement is applied by path, not by handle, so a
+// sufficiently privileged attacker who can replace the path between the write and this call could
+// redirect it. Closing that gap requires handle-based [windows.SetSecurityInfo] at every creation
+// site and is tracked with #405 rather than solved here.
+//
+// Parameters:
+//   - `path`: the absolute path just created or modified.
+//   - `perm`: the permission bits the caller requested.
+//   - `isDir`: whether `path` is a directory, which selects the inheritance flags.
+//
+// Returns:
+//   - `error`: non-nil when the owner cannot be read or the DACL cannot be built or applied. A mode
+//     that is not private returns nil without touching the object.
+func applyMode(path string, perm os.FileMode, isDir bool) error {
+
+	if !isPrivateMode(perm) {
+		return nil
+	}
+
+	owner, err := ownerSID(path)
+	if err != nil {
+		return err
+	}
+
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return fmt.Errorf("fsroot: create SYSTEM sid: %w", err)
+	}
+
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return fmt.Errorf("fsroot: create Administrators sid: %w", err)
+	}
+
+	inheritance := uint32(windows.NO_INHERITANCE)
+	if isDir {
+		inheritance = windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT
+	}
+
+	entries := []windows.EXPLICIT_ACCESS{
+		grantFullControl(owner, windows.TRUSTEE_IS_USER, inheritance),
+		grantFullControl(system, windows.TRUSTEE_IS_USER, inheritance),
+		grantFullControl(administrators, windows.TRUSTEE_IS_GROUP, inheritance),
+	}
+
+	acl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return fmt.Errorf("fsroot: build dacl for %s: %w", path, err)
+	}
+
+	// PROTECTED_DACL_SECURITY_INFORMATION is what breaks inheritance. Without it the inherited ACEs
+	// remain in force and the object stays accessible regardless of the entries above.
+	err = windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil)
+	if err != nil {
+		return fmt.Errorf("fsroot: apply dacl to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// region HELPER FUNCTIONS
+
+// grantFullControl builds one allow-everything access entry for `sid`.
+//
+// Parameters:
+//   - `sid`: the trustee to grant.
+//   - `trusteeType`: [windows.TRUSTEE_IS_USER] or [windows.TRUSTEE_IS_GROUP].
+//   - `inheritance`: the inheritance flags, per object kind.
+//
+// Returns:
+//   - `windows.EXPLICIT_ACCESS`: the constructed entry.
+func grantFullControl(
+	sid *windows.SID, trusteeType windows.TRUSTEE_TYPE, inheritance uint32,
+) windows.EXPLICIT_ACCESS {
+
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  trusteeType,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}
+
+// ownerSID reads the object's current owner.
+//
+// The owner is read back rather than assumed to be the calling account: a file created inside a
+// directory with an owner-defaulting ACL may belong to someone else, and granting the caller
+// instead would lock the real owner out of their own file.
+//
+// Parameters:
+//   - `path`: the object to query.
+//
+// Returns:
+//   - `*windows.SID`: the object's owner.
+//   - `error`: non-nil when the security information or its owner cannot be read.
+func ownerSID(path string) (*windows.SID, error) {
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return nil, fmt.Errorf("fsroot: read owner of %s: %w", path, err)
+	}
+
+	owner, _, err := descriptor.Owner()
+	if err != nil {
+		return nil, fmt.Errorf("fsroot: owner sid of %s: %w", path, err)
+	}
+
+	return owner, nil
+}
+
+// endregion

--- a/pkg/fsroot/applymode_windows_test.go
+++ b/pkg/fsroot/applymode_windows_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package fsroot
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// The proof for issue #405. A DACL that is subtly wrong fails OPEN — the object stays accessible
+// while every "did the call return nil" assertion passes — so these tests read the access-control
+// list back off the object and inspect it. Asserting the absence of an error would prove nothing.
+//
+// The read-back uses the descriptor's SDDL form, which names the protection flag and every trustee
+// in one auditable string, so a failure prints what the object actually carries.
+
+// systemSID and administratorsSID are the two well-known trustees ruling 4 keeps alongside the
+// owner: excluding them buys nothing (an administrator takes ownership at will) and breaks backup
+// and anti-malware tooling.
+const (
+	systemSID         = "S-1-5-18"
+	administratorsSID = "S-1-5-32-544"
+)
+
+func TestApplyMode_PrivateFileGetsProtectedDACL(t *testing.T) {
+
+	root := testConfinedRoot(t)
+
+	target := root.NewPath("secret.txt")
+	if err := root.WriteFile(target, []byte("private"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	control, sddl := readSecurity(t, target.Abs())
+
+	// The load-bearing assertion: inheritance must be broken. Without SE_DACL_PROTECTED the parent's
+	// inherited ACEs survive and the file stays accessible no matter what was granted.
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("DACL is not protected; inherited ACEs survive and the file is not private: %s", sddl)
+	}
+
+	for _, want := range []string{systemSID, administratorsSID} {
+		if !strings.Contains(sddl, want) {
+			t.Errorf("DACL is missing trustee %s: %s", want, sddl)
+		}
+	}
+}
+
+func TestApplyMode_PrivateDirectoryGetsProtectedDACL(t *testing.T) {
+
+	root := testConfinedRoot(t)
+
+	target := root.NewPath("state")
+	if err := root.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	control, sddl := readSecurity(t, target.Abs())
+
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("directory DACL is not protected; inherited ACEs survive: %s", sddl)
+	}
+}
+
+func TestApplyMode_ChmodRestrictsAnExistingFile(t *testing.T) {
+
+	root := testConfinedRoot(t)
+
+	target := root.NewPath("later.txt")
+	if err := root.WriteFile(target, []byte("shared"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, target.Abs()); control&windows.SE_DACL_PROTECTED != 0 {
+		t.Errorf("0o644 file has a protected DACL; a non-private mode must be left alone: %s", sddl)
+	}
+
+	if err := root.Chmod(target, 0o600); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, target.Abs()); control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("after Chmod(0o600) the DACL is still not protected: %s", sddl)
+	}
+}
+
+func TestApplyMode_NonPrivateModeIsLeftAlone(t *testing.T) {
+
+	root := testConfinedRoot(t)
+
+	target := root.NewPath("shared.txt")
+	if err := root.WriteFile(target, []byte("shared"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, target.Abs()); control&windows.SE_DACL_PROTECTED != 0 {
+		t.Errorf("a 0o644 write produced a protected DACL; only private modes are enforced: %s", sddl)
+	}
+}
+
+func TestApplyMode_ScratchRootRestrictsItsContents(t *testing.T) {
+
+	scratch, err := OpenScratch("fsroot-acl-*")
+	if err != nil {
+		t.Fatalf("OpenScratch: %v", err)
+	}
+	t.Cleanup(func() { _ = scratch.Close() })
+
+	// Scratch holds the most sensitive transient data — spooled archives, and decrypted plaintext if
+	// it ever spools — so a private write there must be enforced exactly as in a target tree.
+	target := scratch.NewPath("spool.bin")
+	if err := scratch.WriteFile(target, []byte("transient"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, target.Abs()); control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("scratch file DACL is not protected: %s", sddl)
+	}
+}
+
+func TestApplyMode_OpenFileCreateIsEnforced(t *testing.T) {
+
+	root := testConfinedRoot(t)
+
+	target := root.NewPath("opened.txt")
+
+	file, err := root.OpenFile(target, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, target.Abs()); control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("OpenFile(O_CREATE, 0o600) did not enforce the mode: %s", sddl)
+	}
+}
+
+// region HELPER FUNCTIONS
+
+// testConfinedRoot opens a confined root at a per-test temporary directory, closed at test end.
+//
+// Parameters:
+//   - `t`: the test.
+//
+// Returns:
+//   - `Root`: the confined root.
+func testConfinedRoot(t *testing.T) Root {
+
+	t.Helper()
+
+	root, err := OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenConfined: %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	return root
+}
+
+// readSecurity returns the object's security-descriptor control bits and its SDDL form.
+//
+// Parameters:
+//   - `t`: the test.
+//   - `path`: the object to inspect.
+//
+// Returns:
+//   - `control`: the control bits, carrying SE_DACL_PROTECTED.
+//   - `sddl`: the SDDL form, printed on failure so the actual ACL is visible.
+func readSecurity(
+	t *testing.T, path string,
+) (control windows.SECURITY_DESCRIPTOR_CONTROL, sddl string) {
+
+	t.Helper()
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%s): %v", path, err)
+	}
+
+	control, _, err = descriptor.Control()
+	if err != nil {
+		t.Fatalf("Control(%s): %v", path, err)
+	}
+
+	return control, descriptor.String()
+}
+
+// endregion

--- a/pkg/fsroot/applymode_windows_test.go
+++ b/pkg/fsroot/applymode_windows_test.go
@@ -20,12 +20,18 @@ import (
 // The read-back uses the descriptor's SDDL form, which names the protection flag and every trustee
 // in one auditable string, so a failure prints what the object actually carries.
 
-// systemSID and administratorsSID are the two well-known trustees ruling 4 keeps alongside the
-// owner: excluding them buys nothing (an administrator takes ownership at will) and breaks backup
-// and anti-malware tooling.
+// The two well-known trustees ruling 4 keeps alongside the owner: excluding them buys nothing (an
+// administrator takes ownership at will) and breaks backup and anti-malware tooling.
+//
+// SDDL renders well-known accounts as two-letter aliases rather than numeric SIDs — SYSTEM prints
+// as `SY`, Built-in Administrators as `BA` — so each trustee is matched in either rendering. The
+// first CI run failed here on the numeric form alone while the DACL itself was already correct.
 const (
-	systemSID         = "S-1-5-18"
-	administratorsSID = "S-1-5-32-544"
+	systemAlias   = "SY"
+	systemSID     = "S-1-5-18"
+	adminsAlias   = "BA"
+	adminsSID     = "S-1-5-32-544"
+	aceTrusteeEnd = ")"
 )
 
 func TestApplyMode_PrivateFileGetsProtectedDACL(t *testing.T) {
@@ -45,10 +51,18 @@ func TestApplyMode_PrivateFileGetsProtectedDACL(t *testing.T) {
 		t.Errorf("DACL is not protected; inherited ACEs survive and the file is not private: %s", sddl)
 	}
 
-	for _, want := range []string{systemSID, administratorsSID} {
-		if !strings.Contains(sddl, want) {
-			t.Errorf("DACL is missing trustee %s: %s", want, sddl)
-		}
+	if !hasTrustee(sddl, systemAlias, systemSID) {
+		t.Errorf("DACL is missing SYSTEM: %s", sddl)
+	}
+	if !hasTrustee(sddl, adminsAlias, adminsSID) {
+		t.Errorf("DACL is missing Administrators: %s", sddl)
+	}
+
+	// Exactly three trustees — owner, SYSTEM, Administrators — and no fourth. A DACL carrying an
+	// extra allow ACE would still be "protected" while granting someone else access, so the count
+	// is as load-bearing as the protection flag.
+	if got := strings.Count(sddl, "(A;"); got != 3 {
+		t.Errorf("DACL has %d allow ACEs, want exactly 3 (owner, SYSTEM, Administrators): %s", got, sddl)
 	}
 }
 
@@ -144,6 +158,26 @@ func TestApplyMode_OpenFileCreateIsEnforced(t *testing.T) {
 }
 
 // region HELPER FUNCTIONS
+
+// hasTrustee reports whether the SDDL grants a trustee named by either its well-known alias or its
+// numeric SID.
+//
+// The trustee is the final field of an ACE, so each form is matched with the `;;;` separator before
+// it and the closing parenthesis after it — a bare substring search would match an alias inside an
+// unrelated SID and report a grant that is not there.
+//
+// Parameters:
+//   - `sddl`: the security descriptor's SDDL form.
+//   - `alias`: the two-letter SDDL alias, e.g. "SY".
+//   - `sid`: the numeric SID, e.g. "S-1-5-18".
+//
+// Returns:
+//   - `bool`: true when an ACE names the trustee in either rendering.
+func hasTrustee(sddl, alias, sid string) bool {
+
+	return strings.Contains(sddl, ";;;"+alias+aceTrusteeEnd) ||
+		strings.Contains(sddl, ";;;"+sid+aceTrusteeEnd)
+}
 
 // testConfinedRoot opens a confined root at a per-test temporary directory, closed at test end.
 //

--- a/pkg/fsroot/root.go
+++ b/pkg/fsroot/root.go
@@ -284,9 +284,24 @@ func (r *confinedRoot) Name() string { return r.inner.Name() }
 //   - `p`: the target path.
 //   - `mode`: the permission bits to apply.
 //
+// On Windows a restrictive mode is additionally enforced as an access-control list, because
+// [os.Root.Chmod] there toggles only the read-only attribute (issue #405).
+//
 // Returns:
-//   - `error`: any error from [os.Root.Chmod].
-func (r *confinedRoot) Chmod(p Path, mode os.FileMode) error { return r.inner.Chmod(p.rel, mode) }
+//   - `error`: any error from [os.Root.Chmod], or from the Windows enforcement pass.
+func (r *confinedRoot) Chmod(p Path, mode os.FileMode) error {
+
+	if err := r.inner.Chmod(p.rel, mode); err != nil {
+		return err
+	}
+
+	info, err := r.inner.Stat(p.rel)
+	if err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, mode, info.IsDir())
+}
 
 // Chown changes the numeric owner and group of the path, confined to the root.
 //
@@ -381,8 +396,15 @@ func (r *confinedRoot) Lstat(p Path) (fs.FileInfo, error) { return r.inner.Lstat
 //   - `perm`: the permission bits for the created directory.
 //
 // Returns:
-//   - `error`: any error from [os.Root.Mkdir].
-func (r *confinedRoot) Mkdir(p Path, perm os.FileMode) error { return r.inner.Mkdir(p.rel, perm) }
+//   - `error`: any error from [os.Root.Mkdir], or from the Windows enforcement pass.
+func (r *confinedRoot) Mkdir(p Path, perm os.FileMode) error {
+
+	if err := r.inner.Mkdir(p.rel, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, true)
+}
 
 // MkdirAll creates the directory at the path along with any necessary parents, confined to the root.
 //
@@ -391,8 +413,15 @@ func (r *confinedRoot) Mkdir(p Path, perm os.FileMode) error { return r.inner.Mk
 //   - `perm`: the permission bits for created directories.
 //
 // Returns:
-//   - `error`: any error from [os.Root.MkdirAll].
-func (r *confinedRoot) MkdirAll(p Path, perm os.FileMode) error { return r.inner.MkdirAll(p.rel, perm) }
+//   - `error`: any error from [os.Root.MkdirAll], or from the Windows enforcement pass.
+func (r *confinedRoot) MkdirAll(p Path, perm os.FileMode) error {
+
+	if err := r.inner.MkdirAll(p.rel, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, true)
+}
 
 // NewPath builds a [Path] from an input path, resolved against the confined root directory.
 //
@@ -424,7 +453,19 @@ func (r *confinedRoot) Open(p Path) (*os.File, error) { return r.inner.Open(p.re
 //   - `*os.File`: the opened file.
 //   - `error`: any error from [os.Root.OpenFile].
 func (r *confinedRoot) OpenFile(p Path, flag int, perm os.FileMode) (*os.File, error) {
-	return r.inner.OpenFile(p.rel, flag, perm)
+
+	file, err := r.inner.OpenFile(p.rel, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	if flag&os.O_CREATE != 0 {
+		if modeErr := applyMode(p.abs, perm, false); modeErr != nil {
+			return nil, errors.Join(modeErr, file.Close())
+		}
+	}
+
+	return file, nil
 }
 
 // OpenRoot opens the directory at the path as its own [Root], confined to this root.
@@ -531,9 +572,14 @@ func (r *confinedRoot) Symlink(target string, link Path) error {
 //   - `perm`: the permission bits applied on creation.
 //
 // Returns:
-//   - `error`: any error from [os.Root.WriteFile].
+//   - `error`: any error from [os.Root.WriteFile], or from the Windows enforcement pass.
 func (r *confinedRoot) WriteFile(p Path, data []byte, perm os.FileMode) error {
-	return r.inner.WriteFile(p.rel, data, perm)
+
+	if err := r.inner.WriteFile(p.rel, data, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, false)
 }
 
 // endregion
@@ -746,10 +792,23 @@ func OpenWritableUnconfined(dir string) Root {
 //   - `p`: the target path.
 //   - `mode`: the permission bits to apply.
 //
+// On Windows a restrictive mode is additionally enforced as an access-control list, because
+// [os.Chmod] there toggles only the read-only attribute (issue #405).
+//
 // Returns:
-//   - `error`: any error from [os.Chmod].
+//   - `error`: any error from [os.Chmod], or from the Windows enforcement pass.
 func (r *unconfinedRootReaderWriter) Chmod(p Path, mode os.FileMode) error {
-	return os.Chmod(p.abs, mode)
+
+	if err := os.Chmod(p.abs, mode); err != nil {
+		return err
+	}
+
+	info, err := os.Stat(p.abs)
+	if err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, mode, info.IsDir())
 }
 
 // Chown changes the numeric owner and group of the path.
@@ -830,9 +889,14 @@ func (r *unconfinedRootReaderWriter) Link(oldPath, newPath Path) error {
 //   - `perm`: the permission bits for the created directory.
 //
 // Returns:
-//   - `error`: any error from [os.Mkdir].
+//   - `error`: any error from [os.Mkdir], or from the Windows enforcement pass.
 func (r *unconfinedRootReaderWriter) Mkdir(p Path, perm os.FileMode) error {
-	return os.Mkdir(p.abs, perm)
+
+	if err := os.Mkdir(p.abs, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, true)
 }
 
 // MkdirAll creates the directory at the path along with any necessary parents.
@@ -842,9 +906,14 @@ func (r *unconfinedRootReaderWriter) Mkdir(p Path, perm os.FileMode) error {
 //   - `perm`: the permission bits for created directories.
 //
 // Returns:
-//   - `error`: any error from [os.MkdirAll].
+//   - `error`: any error from [os.MkdirAll], or from the Windows enforcement pass.
 func (r *unconfinedRootReaderWriter) MkdirAll(p Path, perm os.FileMode) error {
-	return os.MkdirAll(p.abs, perm)
+
+	if err := os.MkdirAll(p.abs, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, true)
 }
 
 // OpenFile opens the path with the given flags and permissions.
@@ -858,7 +927,19 @@ func (r *unconfinedRootReaderWriter) MkdirAll(p Path, perm os.FileMode) error {
 //   - `*os.File`: the opened file.
 //   - `error`: any error from [os.OpenFile].
 func (r *unconfinedRootReaderWriter) OpenFile(p Path, flag int, perm os.FileMode) (*os.File, error) {
-	return os.OpenFile(p.abs, flag, perm)
+
+	file, err := os.OpenFile(p.abs, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	if flag&os.O_CREATE != 0 {
+		if modeErr := applyMode(p.abs, perm, false); modeErr != nil {
+			return nil, errors.Join(modeErr, file.Close())
+		}
+	}
+
+	return file, nil
 }
 
 // OpenRoot opens the directory at the path as its own read-write [Root].
@@ -926,7 +1007,7 @@ func (r *unconfinedRootReaderWriter) Symlink(target string, link Path) error {
 //   - `perm`: the permission bits applied on creation.
 //
 // Returns:
-//   - `error`: any error from [os.WriteFile].
+//   - `error`: any error from [os.WriteFile], or from the Windows enforcement pass.
 func (r *unconfinedRootReaderWriter) WriteFile(p Path, data []byte, perm os.FileMode) error {
 	return os.WriteFile(p.abs, data, perm)
 }
@@ -1115,6 +1196,26 @@ func (p *Path) UnmarshalYAML(value *yaml.Node) error {
 // endregion
 
 // region HELPER FUNCTIONS
+
+// isPrivateMode reports whether `perm` denies all access to other.
+//
+// This is the one distinction Windows can honor faithfully (issue #405), and the boundary is
+// deliberately "other", not "group and other". We can express *other is excluded*; we have no group
+// principal to grant to, so the group bit is inexpressible and collapses into the owner. 0o600,
+// 0o640 and 0o660 therefore all become owner-only on Windows.
+//
+// The alternative — treating 0o640 as non-private and leaving it to inherit — fails **open**: a
+// file its author deliberately restricted would become readable by everyone. Cygwin can preserve
+// the group triad only because it maintains a POSIX-group-to-SID mapping and emits non-canonical
+// ACLs its own documentation calls non-interoperable with Windows; Win32-OpenSSH, facing this exact
+// problem for private keys, has no group axis at all and requires owner + SYSTEM + Administrators.
+//
+// Parameters:
+//   - `perm`: the permission bits the caller requested.
+//
+// Returns:
+//   - `bool`: true when other is granted nothing.
+func isPrivateMode(perm os.FileMode) bool { return perm.Perm()&0o007 == 0 }
 
 // makePath computes a [Path] from a root directory name and an input path.
 //


### PR DESCRIPTION
## Summary

Phase 2 of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)). Go's `os.Chmod` on Windows toggles
only the read-only attribute, so **every restrictive mode this codebase requests has been silently
unenforced there** — including the private key at `pkg/signing/signing.go:202`.

`applyMode` is a platform split: a no-op on Unix, and on Windows a **protected** DACL granting the
object's own owner plus SYSTEM and Administrators. Breaking inheritance is the whole point —
without `SE_DACL_PROTECTED` the parent's ACEs survive and the object stays accessible regardless of
what is granted. The owner is read back rather than assumed to be the caller, so a file owned by
someone else is not locked away from them.

Wired into `WriteFile`, `OpenFile` (on `O_CREATE`), `Mkdir`, `MkdirAll` and `Chmod` on both
writable implementations.

## A test caught a contradiction in the ruling

As merged, ruling 4 gave the formula `perm&0o077 == 0` **and** asserted that `0640` and `0600` were
indistinguishable. Those cannot both hold — the formula leaves `0640` inheriting its parent's DACL.
The implementation followed the formula, the test followed the prose, and `make test` failed.

**Corrected to `perm&0o007 == 0`.** We can express "other is excluded"; we have no group principal
to grant to, so the group bit is inexpressible and collapses into the owner — `0600`, `0640` and
`0660` are all private. The rejected reading failed **open**, which is the failure class #405 exists
to eliminate.

## Prior art

| System | Approach | Why not ours |
| --- | --- | --- |
| **Cygwin** | Full translation: owner/group/`Everyone` SIDs, deny + allow ACEs, deliberately non-canonical ACE order | Needs a POSIX-group-to-SID map we don't have; upstream documents the result as *"NOT interoperable with Windows"* |
| **MSYS2** | Declines to map — `noacl` by default, `chmod` ignored | The "document the limitation" disposition already rejected |
| **Win32-OpenSSH** | Requires owner + SYSTEM + Administrators; **validates** rather than translates | ✅ adopted; its validation half chartered as **R4b** |

## Tests that actually prove something

The Windows tests read the security descriptor **back** and assert `SE_DACL_PROTECTED` plus the
trustee set, printing SDDL on failure. A subtly wrong DACL **fails open** while every "did it return
nil" assertion passes — so proving enforcement requires reading the ACL, not the error. Cases: private
file, private directory, `Chmod` on an existing file, a non-private mode left alone, `OpenFile` with
`O_CREATE`, and a scratch root's contents.

## Stated rather than hidden

- Enforcement applies whenever a private mode is requested, **including on an existing object**,
  where Unix ignores the perm argument. A deliberate fail-closed divergence.
- Enforcement is applied **by path, not by handle**, so a privileged attacker able to swap the path
  between the write and the DACL call could redirect it. Closing that needs handle-based
  `SetSecurityInfo` at every creation site; tracked on #405.

## Verification

- [x] `make test` zero failures; `build-all`, `vet-all`, `lint-all` green on linux, darwin, windows
- [x] gofmt and style detectors clean
- [ ] **`test (windows-latest)` — the real gate.** This code cannot be executed on a development
      Mac; cross-compilation proves it *builds*, not that the DACL is *right*. No call site migrates
      until this leg is green.

Assisted-by: Claude
