### PR TITLE
test(op): build test sessions through the real constructor, not literals

### DIFF
--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -3,7 +3,7 @@ title: "Windows native permissions: enforce restrictive modes, route every mutat
 issue: https://github.com/NobleFactor/devlore-cli/issues/405
 status: draft
 created: 2026-08-13
-updated: 2026-08-13
+updated: 2026-08-14
 ---
 
 # Plan: Windows native permissions
@@ -348,6 +348,8 @@ root bypasses the session that owns it.**
       is an error, any failure after verification is an assert — and keeps ~40 provider call sites
       as one-liners. Accepted residual: a genuine mid-run environmental failure (handle exhaustion,
       a yanked mount) panics rather than unwinding through compensation.
+      **Incomplete as written** — it does not cover the session that legitimately has *no* root, a
+      case seven existing call sites depend on; see the open question under the 2b delivery plan.
 - [ ] **Scratch is anchored at the OS temp directory, with no spec field.** `os.MkdirTemp("")`
       resolves through `os.TempDir()`, which already honors `TMPDIR` on Unix and `TMP`/`TEMP` on
       Windows — every environment-configuration reason to relocate scratch (small tmpfs, encrypted
@@ -356,6 +358,100 @@ root bypasses the session that owns it.**
       stage-then-rename into a target tree is only atomic on the same filesystem, and `TMPDIR`
       cannot know the target's device. That is a per-operation need, answered by a scratch *inside*
       the target root, not by a session-level anchor.
+
+#### Phase 2b delivery plan — three PRs, revised 2026-08-14
+
+The split exists because making the field private breaks every test literal that sets it, and the
+test constructor must land **first** or nothing is actually split.
+
+| PR | Scope | Status |
+| --- | --- | --- |
+| **2b.1** | Move test literals that set `Root:` onto the real constructor | **in progress — 6 of 19 files** |
+| **2b.2** | Field → private, `Root()` / `Scratch()`, lazy allocation, **82 sites / 20 files** (1 write, 81 reads) | pending |
+| **2b.3** | Move `archive`'s spool and `devlore-test`'s runner onto `Scratch()` (optional; may fold into 2b.2) | pending |
+
+**A codegen PR was planned and proved unnecessary.** The `receiver_type.gen_test.go` template emits
+`Application` / `Context` / `Status` and **never `Root`**, so no generated file breaks. Verified by
+enumeration, after an earlier estimate wrongly assumed every `RuntimeEnvironment` literal in the
+tests was affected.
+
+**Scope, re-enumerated 2026-08-14.** The earlier "28 sites in 18 files" was itself a filtered-grep
+figure and does not survive counting: the **13 unconverted files alone hold 26 sites**, and every
+converted file held at least one, so the total is **19 files** and at least 32 sites. The trap that
+inflates a naive count is the reverse one — `cmd/star/provider/starcode/provider_test.go` shows 12
+`Root:` lines but only **6** are `RuntimeEnvironment`; the other six are `starcode.Provider.Root`,
+an unrelated `string` field. Counts here are of `RuntimeEnvironment` literals specifically.
+
+**PR 2b.2's production surface, enumerated 2026-08-14 — 82 sites in 20 files.** The `~85` estimate
+survived counting roughly intact, unlike the test-side figures.
+
+| Area | Sites |
+| --- | --- |
+| `pkg/op/provider/file` (6 files) | 44 |
+| `pkg/op/recovery_site.go` | 13 |
+| `cmd/star/provider/{starcode,staranalysis,starcomplexity,starindex,starstats}` | 10 |
+| `pkg/op/provider/{encryption 4, mem 4, archive 2, function 2, git 1, plan 1}` | 14 |
+| `pkg/op/runtime_environment.go` | 1 |
+
+Method: every non-test `.Root` reference (220), less `os.Root` / `fsroot.Root` type names and
+comments (133), then classified by receiver — cobra's `cmd.Root()`, `Graph`/`GraphSpec.Root`,
+`text/template`'s `tree.Root`, go-git's `Filesystem.Root()`, `fsroot`-internal `decoded.Root`, and
+the star providers' own `Provider.Root string` field are all unrelated. The star sites read
+`ctx.Root`, where `ctx` is a `*op.RuntimeEnvironment` — a receiver-name grep misses them entirely.
+(Separately: that parameter should be named `runtimeEnvironment`; `ctx` reads as a
+`context.Context`. Fix it in the PR that touches those ten sites.)
+
+**Exactly one production site writes the field** — the constructor at `runtime_environment.go:218`.
+Privatizing is a one-line write change; the other 81 are reads.
+
+**Open question 2b.2 must answer first: what does `Root()` do when the session has no root?** Seven
+sites nil-check it today — the five star providers' `if ctx.Root != nil`, plus
+`provider/mem/resource.go:337` and `provider/file/provider.go:62`. They exist because a spec with an
+empty `RootPath` legitimately yields a nil root (`runtime_environment.go:786`: "Empty means no root:
+the environment's `Root` stays nil"), which is exactly the planning-only session lazy allocation is
+meant to serve. So the asserting accessor ruled above **cannot serve these seven** as written: it
+would panic for a session that never had a root, as distinct from one whose mint failed after
+validation. Decide the split — a second `HasRoot()` predicate, an `(fsroot.Root, bool)` return, or
+making no-root sessions impossible — before the mechanical pass starts, not during it.
+
+**Review hazard:** `file.Provider` already has `Root() string`
+(`provider/file/provider.go:60`), itself a nil-tolerant wrapper returning `""`. Forty-four of the 82
+sites live in that package, so `p.Root()` (a path string) will sit beside
+`p.RuntimeEnvironment().Root()` (an `fsroot.Root`) — two `Root()` methods of different types in one
+file. Phase 6's `fsroot.Dir` rename does not resolve this; the collision is between two accessors,
+not two types.
+
+**PR 2b.1 — converted and green (2026-08-14):** `pkg/op/recovery_site_test.go`,
+`pkg/op/triad_test.go`, `pkg/op/inventory/seam_test.go`,
+`pkg/op/provider/encryption/{provider,receipt}_test.go`,
+`pkg/op/provider/archive/provider_test.go`.
+
+**Remaining (13 files, 26 sites):** `pkg/op/provider/git/` 10 (`provider` 4, `resource_input` 2,
+`checkout_pull_observe` 2, `receipt` 1, `resource` 1), `cmd/star/provider/starcode/provider_test.go`
+6, `pkg/op/provider/{json,yaml,service,mem,function}/resource_test.go` 6 (`mem` 2, the rest 1 each),
+`pkg/op/provider/file/provider_test.go` 3, `pkg/op/starlarkbridge/runtime_test.go` 1.
+
+**The pattern** — a local `testEnvironment(t, dir)` helper per package:
+
+```go
+runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+    op.NewRuntimeEnvironmentSpec("test").
+        WithRoot(dir, fsroot.ModeWritableUnconfined).
+        WithApplication(&application.Application{Name: "test"}))
+if err != nil { t.Fatalf("op.NewRuntimeEnvironment: %v", err) }
+t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+```
+
+**Three gotchas, each already hit once:**
+
+1. The constructor **already wires `RecoverySite` and defaults `ResourceCatalog`** — those
+   hand-assembled lines are deleted, not ported.
+2. `Application` must be non-nil; `NewRuntimeEnvironment` asserts on it.
+3. Removing the `fsroot.Open*` call often **orphans the `fsroot` import** — this broke the build
+   once already in `encryption/receipt_test.go`.
+
+One special case: `pkg/op/provider/file/provider_test.go` also sets `BackupSuffix`, which the
+constructor does **not** default. Assign it after construction or the test loses its meaning.
 
 **Why before the migration:** this changes `RuntimeEnvironment.Root` from a field to an accessor,
 touching many of the files the migration would touch. The same argument that puts the
@@ -469,6 +565,8 @@ seven permission failures cleared **by enforcement, not by scoping**; DACL asser
 
 ## Open Questions
 
+- [ ] What does `Root()` return for a session that legitimately has no root? Blocks PR 2b.2; seven
+      call sites nil-check the field today. Detailed under the phase 2b delivery plan.
 - [ ] Which root instance serves `internal/cli` (one per base — state home, config, install prefix —
       or one anchored higher)? Settle in phase 3, not by accident in the first migrated file.
 - [ ] Does `fsroot` need anything beyond `Chmod` (R1's audit answers this)?

--- a/pkg/op/inventory/seam_test.go
+++ b/pkg/op/inventory/seam_test.go
@@ -4,6 +4,9 @@
 package inventory
 
 import (
+	"context"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,11 +28,15 @@ import (
 func seamEnv(t *testing.T, dir string) *op.RuntimeEnvironment {
 	t.Helper()
 
-	runtimeEnvironment := &op.RuntimeEnvironment{
-		Root:            fsroot.OpenWritableUnconfined(dir),
-		ResourceCatalog: op.NewResourceCatalog(),
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
 	}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 

--- a/pkg/op/inventory/seam_test.go
+++ b/pkg/op/inventory/seam_test.go
@@ -5,12 +5,11 @@ package inventory
 
 import (
 	"context"
-
-	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -4,13 +4,11 @@
 package archive
 
 import (
-	"context"
-
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
-	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"io"
 	"os"
 	"path/filepath"
@@ -20,6 +18,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -4,10 +4,13 @@
 package archive
 
 import (
+	"context"
+
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
 	"encoding/base64"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,14 +27,29 @@ import (
 )
 
 // testProvider creates a Provider rooted at the given directory with a Catalog and RecoverySite.
+// testEnvironment builds a session rooted at `dir` through the real constructor.
+//
+// Tests travel the same construction path production does: the session mints the root from the spec's anchor and
+// wires the recovery site and resource catalog itself, so nothing here hand-assembles filesystem access.
+func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
+
+	t.Helper()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return runtimeEnvironment
+}
+
 func testProvider(t *testing.T, dir string) *Provider {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(dir)
-	runtimeEnvironment := &op.RuntimeEnvironment{
-		Root:            root,
-		ResourceCatalog: op.NewResourceCatalog(),
-	}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
+	runtimeEnvironment := testEnvironment(t, dir)
 	return &Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}
 }
 

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -4,10 +4,8 @@
 package encryption
 
 import (
-	"context"
-
 	"bytes"
-	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +17,7 @@ import (
 	sopsage "github.com/getsops/sops/v3/age"
 	"github.com/getsops/sops/v3/stores/yaml"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -4,7 +4,10 @@
 package encryption
 
 import (
+	"context"
+
 	"bytes"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,10 +31,29 @@ func testActivation(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment) *op
 
 // testProvider creates a Provider with a RootReaderWriter for the given directory. It goes through NewProvider so the
 // Encrypter is wired (EncryptFile needs it).
+// testEnvironment builds a session rooted at `dir` through the real constructor.
+//
+// Tests travel the same construction path production does: the session mints the root from the spec's anchor and
+// wires the recovery site and resource catalog itself, so nothing here hand-assembles filesystem access.
+func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
+
+	t.Helper()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return runtimeEnvironment
+}
+
 func testProvider(t *testing.T, dir string) *Provider {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(dir)
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
+	runtimeEnvironment := testEnvironment(t, dir)
 	return NewProvider(runtimeEnvironment)
 }
 
@@ -39,8 +61,7 @@ func testProvider(t *testing.T, dir string) *Provider {
 // embedded SOPS metadata and the ambient SOPS_AGE_KEY — so no sops client configuration is needed.
 func testProviderWithSops(t *testing.T, dir string) *Provider {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(dir)
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
+	runtimeEnvironment := testEnvironment(t, dir)
 	return &Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}
 }
 

--- a/pkg/op/provider/encryption/receipt_test.go
+++ b/pkg/op/provider/encryption/receipt_test.go
@@ -10,7 +10,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -25,10 +24,7 @@ func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 			// The root anchors at the temp directory, never the Unix literal "/": a
 			// whole-filesystem root cannot address absolute Windows paths (#392).
 			tmp := t.TempDir()
-			runtimeEnvironment := &op.RuntimeEnvironment{
-				Root:            fsroot.OpenWritableUnconfined(tmp),
-				ResourceCatalog: op.NewResourceCatalog(),
-			}
+			runtimeEnvironment := testEnvironment(t, tmp)
 			resource, err := file.DiscoverRegular(runtimeEnvironment, filepath.Join(tmp, "decrypted.yaml"))
 			if err != nil {
 				t.Fatalf("file.DiscoverRegular: %v", err)

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -5,12 +5,14 @@ package op
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/google/uuid"
 )
@@ -18,12 +20,24 @@ import (
 var errSyntheticRead = errors.New("synthetic read error")
 
 // newTestRecoverySite creates a RecoverySite backed by a RootReaderWriter at a temp directory.
+//
+// The environment is built through [NewRuntimeEnvironment] rather than assembled as a literal, so the test travels
+// the same construction path production does — the session mints the root from the spec's anchor, and nothing here
+// constructs filesystem access of its own.
 func newTestRecoverySite(t *testing.T) (*RecoverySite, fsroot.Root) {
+
 	t.Helper()
-	tmp := t.TempDir()
-	root := fsroot.OpenWritableUnconfined(tmp)
-	runtimeEnvironment := &RuntimeEnvironment{Root: root}
-	return NewRecoverySite(runtimeEnvironment), root
+
+	runtimeEnvironment, err := NewRuntimeEnvironment(context.Background(),
+		NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return NewRecoverySite(runtimeEnvironment), runtimeEnvironment.Root
 }
 
 func TestArchiveFile_MovesFile(t *testing.T) {

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -5,11 +5,13 @@ package op_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/google/uuid"
 
@@ -26,31 +28,38 @@ type triadEnv struct {
 	Dir  string // underlying directory
 }
 
-func newTriad(t *testing.T, root fsroot.Root, dir string) triadEnv {
+// newTriad wires a triad for `dir` in the given access mode.
+//
+// The mode is passed rather than a constructed [fsroot.Root]: the session mints its own root from the spec's
+// anchor, so callers name the tree and the access they want instead of handing over filesystem access.
+func newTriad(t *testing.T, mode fsroot.Mode, dir string) triadEnv {
+
 	t.Helper()
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	site := op.NewRecoverySite(runtimeEnvironment)
-	return triadEnv{Root: root, Site: site, Dir: dir}
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, mode).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return triadEnv{Root: runtimeEnvironment.Root, Site: op.NewRecoverySite(runtimeEnvironment), Dir: dir}
 }
 
 func newTriadRW(t *testing.T) triadEnv {
+
 	t.Helper()
-	dir := t.TempDir()
-	return newTriad(t, fsroot.OpenWritableUnconfined(dir), dir)
+
+	return newTriad(t, fsroot.ModeWritableUnconfined, t.TempDir())
 }
 
 func newTriadConfined(t *testing.T) triadEnv {
 
 	t.Helper()
-	dir := t.TempDir()
 
-	root, err := fsroot.OpenConfined(dir)
-	if err != nil {
-		t.Fatalf("fsroot.OpenConfined: %v", err)
-	}
-
-	t.Cleanup(func() { _ = root.Close() })
-	return newTriad(t, root, dir)
+	return newTriad(t, fsroot.ModeConfined, t.TempDir())
 }
 
 func TestTriad_RootProducesPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase 2b, **PR 2b.1** of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)). **Partial by design: 6 files
converted**; the remaining **13 files / 26 sites** are listed in the plan.

`RuntimeEnvironment.Root` must become an accessor so the root can be allocated lazily and owned by
the session. Making the field private breaks every test that sets it in a struct literal — so those
move onto the real constructor **first**, or the field change and every test conversion land in one
unreviewable commit and nothing is actually split.

## What changed

Each converted package gains a local `testEnvironment(t, dir)` helper calling
`NewRuntimeEnvironment` with a spec. Tests now travel the same construction path production does:
the session mints the root from the spec's anchor instead of receiving access someone else opened.

**The conversion shrinks these tests** — `NewRuntimeEnvironment` already wires `RecoverySite` and
defaults `ResourceCatalog`, which several helpers were hand-assembling.

## A planned PR proved unnecessary

The `receiver_type.gen_test.go` template emits `Application` / `Context` / `Status` and **never
`Root`**, so no generated file breaks and the codegen PR is not needed. Verified by enumeration,
after an earlier estimate wrongly assumed every `RuntimeEnvironment` literal in the tests was
affected.

## Handoff

The plan records the remaining 13 files and 26 sites, the exact pattern, and three gotchas each hit
once: the constructor's defaulting means lines are deleted not ported; `Application` must be
non-nil or the constructor asserts; and dropping the `fsroot.Open*` call orphans the `fsroot`
import (which broke the build once here). `pkg/op/provider/file/provider_test.go` additionally sets `BackupSuffix`,
which the constructor does *not* default.

**No behavior change** — the `Root` field is still exported and still set by the constructor.
`make test` reports zero failures. `test (windows-latest)` expected to hold at the known 28.

Assisted-by: Claude
