### PR TITLE
test: finish moving test sessions onto the real constructor

### DIFF
--- a/cmd/star/provider/starcode/provider_test.go
+++ b/cmd/star/provider/starcode/provider_test.go
@@ -4,13 +4,42 @@
 package starcode
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
+
+// testEnvironment builds a session rooted at `dir` through the real constructor.
+//
+// Tests travel the same construction path production does: the session mints the root from the spec's anchor and
+// wires the recovery site and resource catalog itself, so nothing here hand-assembles filesystem access.
+//
+// Parameters:
+//   - `t`: the test harness.
+//   - `dir`: the anchor the session's root is minted at.
+//
+// Returns:
+//   - `*op.RuntimeEnvironment`: the constructed session, closed at test cleanup.
+func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
+
+	t.Helper()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return runtimeEnvironment
+}
 
 func testdataDir(t *testing.T) string {
 
@@ -29,11 +58,8 @@ func TestCaptureAllStar(t *testing.T) {
 	root := testdataDir(t)
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{
-			ResourceCatalog: op.NewResourceCatalog(),
-			Root:            fsroot.OpenWritableUnconfined(root),
-		}),
-		Root: root,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, root)),
+		Root:         root,
 	}
 
 	sources, err := provider.Capture("*.star", false)
@@ -58,12 +84,8 @@ func TestCaptureRecursive(t *testing.T) {
 	root := testdataDir(t)
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(
-			&op.RuntimeEnvironment{
-				ResourceCatalog: op.NewResourceCatalog(),
-				Root:            fsroot.OpenWritableUnconfined(root),
-			}),
-		Root: root,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, root)),
+		Root:         root,
 	}
 
 	sources, err := provider.Capture("**/*.star", false)
@@ -81,12 +103,8 @@ func TestCaptureEmptyPattern(t *testing.T) {
 	tempDir := t.TempDir()
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(
-			&op.RuntimeEnvironment{
-				Root:            fsroot.OpenWritableUnconfined(tempDir),
-				ResourceCatalog: op.NewResourceCatalog(),
-			}),
-		Root: tempDir,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, tempDir)),
+		Root:         tempDir,
 	}
 
 	sources, err := provider.Capture("*.star", false)
@@ -113,12 +131,8 @@ func TestCaptureGitignore(t *testing.T) {
 	writeFile(t, filepath.Join(tempDir, "ignored.star"), "y = 2\n")
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(
-			&op.RuntimeEnvironment{
-				ResourceCatalog: op.NewResourceCatalog(),
-				Root:            fsroot.OpenWritableUnconfined(tempDir),
-			}),
-		Root: tempDir,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, tempDir)),
+		Root:         tempDir,
 	}
 
 	// Excluding git-ignored files (default): ignored.star is filtered out.
@@ -148,11 +162,8 @@ func TestSourcesPaths(t *testing.T) {
 	root := testdataDir(t)
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{
-			ResourceCatalog: op.NewResourceCatalog(),
-			Root:            fsroot.OpenWritableUnconfined(root),
-		}),
-		Root: root,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, root)),
+		Root:         root,
 	}
 
 	sources, err := provider.Capture("*.star", false)
@@ -178,11 +189,8 @@ func TestSourcesFilesAreSorted(t *testing.T) {
 	root := testdataDir(t)
 
 	provider := &Provider{
-		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{
-			ResourceCatalog: op.NewResourceCatalog(),
-			Root:            fsroot.OpenWritableUnconfined(root),
-		}),
-		Root: root,
+		ProviderBase: op.NewProviderBase(testEnvironment(t, root)),
+		Root:         root,
 	}
 
 	sources, err := provider.Capture("*.star", false)

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -320,7 +320,7 @@ This fails closed. A caller asking for `0600` gets a private file whether or not
 able to swap the path between the write and the DACL call could redirect it. Closing that needs
 handle-based `SetSecurityInfo` at every creation site; tracked on #405 rather than solved here.
 
-### Phase 2b: session-owned filesystem access — branch per PR below — status: in progress (2b.1a merged 2026-08-14)
+### Phase 2b: session-owned filesystem access — branch per PR below — status: in progress (2b.1 complete; 2b.2 next)
 
 **Inserted before the migration, 2026-08-13, after phase 3's first call site exposed a wrong
 pattern.** Migrating `pkg/signing` by having it construct its own root drew the ruling that makes
@@ -372,7 +372,7 @@ test constructor must land **first** or nothing is actually split.
 | PR | Scope | Status |
 | --- | --- | --- |
 | **2b.1a** | First 6 test files onto the real constructor — branch `test-env-constructor` | ✅ **merged 2026-08-14 (#410)** |
-| **2b.1b** | Remaining 13 files / 26 sites — branch `test-env-constructor-remainder` | **next** |
+| **2b.1b** | Remaining **26 sites / 12 files** — branch `test-env-constructor-remainder` | ✅ **complete 2026-08-14** |
 | **2b.2** | Field → private, `HasRoot()` / `Root()` / `Scratch()`, `Dir.CreateTemp` + `Dir.MkdirTemp`, lazy allocation, **82 sites / 20 files** (1 write, 81 reads) | ready — design ruled 2026-08-14 |
 | **2b.3** | Move `archive`'s spool and `devlore-test`'s runner onto `Scratch()` (optional; may fold into 2b.2) | pending |
 
@@ -536,30 +536,53 @@ itself; place imports by hand to the stdlib / third-party / project convention.)
 runs no pre-commit hooks — `pre-commit` was evaluated and rejected 2026-08-14 — so `make lint-all`
 before the commit and CI after it are the only gates that exist.
 
-#### PR 2b.1b — branch `test-env-constructor-remainder` — status: next
+#### PR 2b.1b — branch `test-env-constructor-remainder` — status: complete (2026-08-14)
 
-Completes 2b.1. One PR rather than five: the pattern is proven, the gotchas are known, and a
+Completes 2b.1. One PR rather than five: the pattern was proven, the gotchas were known, and a
 half-converted test suite is the worst state to leave 2b.2 waiting behind.
 
-**Scope — 13 files, 26 sites**, in the order they should be converted (largest and most
-pattern-heavy first, so a mistake surfaces on the biggest sample rather than the last file):
+**Delivered — 26 sites across 12 files** (as converted, with the pre-flight estimate beside it):
 
 | # | Target | Sites | Note |
 | --- | --- | --- | --- |
-| 1 | `pkg/op/provider/git/` — `provider` 4, `resource_input` 2, `checkout_pull_observe` 2, `receipt` 1, `resource` 1 | 10 | five files, one shared helper |
-| 2 | `cmd/star/provider/starcode/provider_test.go` | 6 | **only 6 of its 12 `Root:` lines are the environment**; the other six are `starcode.Provider.Root string` and must not be touched |
-| 3 | `pkg/op/provider/{json,yaml,service,mem,function}/resource_test.go` | 6 | `mem` 2, the rest 1 each; each behind a package-local `newTestRuntimeEnvironment`, so mostly one rewrite per file |
-| 4 | `pkg/op/provider/file/provider_test.go` | 3 | also sets `BackupSuffix`, which the constructor does **not** default — assign it after construction or the test loses its meaning |
-| 5 | `pkg/op/starlarkbridge/runtime_test.go` | 1 | |
+| 1 | `pkg/op/provider/git/` — `provider` 5, `resource_input` 2, `checkout_pull_observe` 2, `receipt` 1, `resource` 1 | **11** (est. 10) | one shared helper; `checkout_pull_observe`'s narrating provider needed a bespoke spec for `WithStatus` and the dry-run flag |
+| 2 | `cmd/star/provider/starcode/provider_test.go` | 6 | only 6 of its 12 `Root:` lines were the environment; the other six are `starcode.Provider.Root string` and were left untouched |
+| 3 | `pkg/op/provider/{json,yaml,service,mem,function}/resource_test.go` | 6 | `mem` 2, the rest 1 each; five identical `newTestRuntimeEnvironment` helpers |
+| 4 | `pkg/op/provider/file/provider_test.go` | 3 | `BackupSuffix` plus a catalog-free session |
+| 5 | `pkg/op/starlarkbridge/runtime_test.go` | **0** (est. 1) | no `Root:` site at all — see the enumeration correction below |
 
-Also in this PR: flip this plan's 2b.1 status, rather than spending a commit on the doc alone.
+**Two enumeration errors, which cancelled.** `git` had **11** sites, not 10: a bare
+`&op.RuntimeEnvironment{}` that the `Root:.*fsroot\.` grep could not see, since it sets no field at
+all. `starlarkbridge` had **0**, not 1: its literals set `Modules`, and the counting regex matched
+the word "Root" inside fixture *names* like `bridgePlannedRootFixture`. The total held at 26 by
+coincidence, and the file count was 12 rather than 13. Recorded because the cancellation is exactly
+what makes such an error survive review — the headline number looked right.
 
-**Exit gate:** zero `op.RuntimeEnvironment{…Root…}` literals remain in any `_test.go`; `make test`
-zero failures; `make lint-all` zero issues on all three GOOS **before** `../go` is written;
-`test (windows-latest)` holds at the same 28 failures, verified name by name rather than by count.
+**A second construction special case, beyond `BackupSuffix`.** `mem`'s
+`TestNewResource_NilCatalogReturnsUnlinkedCandidate` builds its environment with a **nil
+`ResourceCatalog` on purpose** — that is the test's whole subject — and the constructor defaults
+one. Same shape in `file`'s `mustRegular`, whose "unlinked" result depends on the same nil. Both now
+construct through the helper and then clear the catalog, with a comment saying why. **The general
+rule: where the constructor's defaulting *is* the thing under test, construct and then undo, never
+route around the constructor.**
 
-**Not unblocked by this PR:** 2b.2 still waits on the no-root question below. Finishing the test
-conversion removes a merge-conflict surface; it does not answer the design question.
+**`BackupSuffix`'s old comment was wrong about mechanism** — it claimed `NewRuntimeEnvironment`
+derives the value, and the constructor never sets the field at all
+(`runtime_environment.go:211`). The value matches `NewRuntimeEnvironmentConfig`'s builtin floor. The
+replacement comment says so.
+
+**`make lint-all` earned its place again:** it flagged `file`'s `testRoot` helper as dead once its
+last caller was rewritten. `make test` was perfectly happy. Deleted, not suppressed.
+
+**Exit gate — met.** Zero `Root:`-setting literals remain in any `_test.go`; `make test` reports
+zero failures; `make lint-all` reports zero issues on linux, darwin, and windows, run **before**
+`../go` was written.
+
+**Left alone deliberately:** `starlarkbridge`'s `&op.RuntimeEnvironment{Modules: …}` literals set no
+root, so 2b.2 does not break them.
+
+**Not unblocked by this PR:** nothing — 2b.2's design was ruled separately (#411). Finishing the
+conversion removes the merge-conflict surface 2b.2 would otherwise fight.
 
 **The pattern** — a local `testEnvironment(t, dir)` helper per package:
 
@@ -615,7 +638,7 @@ phase 3's PR rather than decided in passing.
 `TODO(#405)` and still writes through `os.*` — the private key is **not** enforced on Windows until
 that lands.
 
-### Phase 3: migrate the security-relevant sites — branch `fsroot-migrate-secure` — status: blocked on 2b
+### Phase 3: migrate the security-relevant sites — branch `fsroot-migrate-secure` — status: sequenced after 2b
 
 - [ ] The 31 restrictive-perm sites, **`pkg/signing` first** (the private key).
 - [ ] Then `internal/cli`'s restrictive set (state home, run index, user config, self-install

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -4,6 +4,7 @@
 package file
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/google/uuid"
@@ -19,27 +21,44 @@ import (
 
 // --- Test Helpers ---
 
-// testRoot creates an unconfined read-write Root for test I/O.
-func testRoot(t *testing.T, dir string) fsroot.Root {
+// testEnvironment builds a session rooted at `dir` through the real constructor.
+//
+// Tests travel the same construction path production does: the session mints the root from the spec's anchor and
+// wires the recovery site and resource catalog itself, so nothing here hand-assembles filesystem access.
+//
+// Parameters:
+//   - `t`: the test harness.
+//   - `dir`: the anchor the session's root is minted at.
+//
+// Returns:
+//   - `*op.RuntimeEnvironment`: the constructed session, closed at test cleanup.
+func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	t.Helper()
-	return fsroot.OpenWritableUnconfined(dir)
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return runtimeEnvironment
 }
 
 // testProvider creates a Provider rooted at the given directory.
 //
-// The bare-literal environment mirrors [op.NewRuntimeEnvironment]'s defaulting where a method under test depends on
-// it: BackupSuffix is what the constructor would derive for the devlore program (".<ProgramName>-backup").
+// BackupSuffix is assigned after construction because [op.NewRuntimeEnvironment] does not set it; the value is
+// [op.NewRuntimeEnvironmentConfig]'s builtin floor, which the methods under test depend on.
 func testProvider(t *testing.T, dir string) Provider {
 
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(dir)
-	runtimeEnvironment := &op.RuntimeEnvironment{
-		Root:            root,
-		ResourceCatalog: op.NewResourceCatalog(),
-		BackupSuffix:    ".devlore-backup",
-	}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
+
+	runtimeEnvironment := testEnvironment(t, dir)
+	runtimeEnvironment.BackupSuffix = ".devlore-backup"
+
 	return Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}
 }
 
@@ -67,9 +86,7 @@ func testFileResource(t *testing.T, content []byte) *Regular {
 		t.Fatalf("writing temp file: %v", err)
 	}
 	_ = f.Close()
-	root := testRoot(t, dir)
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	fileResource, err := DiscoverRegular(runtimeEnvironment, f.Name())
+	fileResource, err := DiscoverRegular(testEnvironment(t, dir), f.Name())
 	if err != nil {
 		t.Fatalf("DiscoverRegular: %v", err)
 	}
@@ -82,7 +99,13 @@ func testFileResource(t *testing.T, content []byte) *Regular {
 func mustRegular(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment, path string) *Regular {
 
 	t.Helper()
-	regular, err := DiscoverRegular(&op.RuntimeEnvironment{Root: runtimeEnvironment.Root}, path)
+
+	// A catalog-free session anchored at the same directory: the nil catalog is what leaves the returned
+	// *Regular unlinked, and the constructor defaults one.
+	unlinked := testEnvironment(t, runtimeEnvironment.Root.Name())
+	unlinked.ResourceCatalog = nil
+
+	regular, err := DiscoverRegular(unlinked, path)
 	if err != nil {
 		t.Fatalf("DiscoverRegular(%s): %v", path, err)
 	}

--- a/pkg/op/provider/function/resource_test.go
+++ b/pkg/op/provider/function/resource_test.go
@@ -4,11 +4,13 @@
 package function
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"go.starlark.net/starlark"
@@ -28,10 +30,16 @@ func TestResource_ImplementsResourceInterface(t *testing.T) {
 // RecoverySite — the shape Resource construction requires.
 func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
-	runtimeEnvironment.ResourceCatalog = op.NewResourceCatalog()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -33,12 +33,17 @@ import (
 func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) {
 	t.Helper()
 	captureSink, buf := sink.Capture()
-	runtimeEnvironment := &op.RuntimeEnvironment{
-		Context:     context.Background(),
-		Application: &application.Application{Flags: map[string]any{"dry_run": dryRun}},
-		Status:      status.NewNarrator("test", captureSink),
-		Root:        fsroot.OpenWritableUnconfined(t.TempDir()),
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test", Flags: map[string]any{"dry_run": dryRun}}).
+			WithStatus(status.NewNarrator("test", captureSink)))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
 	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return &Provider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}, buf
 }
 
@@ -52,7 +57,7 @@ func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) 
 //   - `*Provider`: the initialized provider bound to an fsroot-anchored execution context.
 func newObserveProvider(t *testing.T) *Provider {
 	t.Helper()
-	return &Provider{ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(t.TempDir())})}
+	return &Provider{ProviderBase: op.NewProviderBase(testEnvironment(t, t.TempDir()))}
 }
 
 // --- Checkout ---

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -4,15 +4,44 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
+
+// testEnvironment builds a session rooted at `dir` through the real constructor.
+//
+// Tests travel the same construction path production does: the session mints the root from the spec's anchor and
+// wires the recovery site and resource catalog itself, so nothing here hand-assembles filesystem access.
+//
+// Parameters:
+//   - `t`: the test harness.
+//   - `dir`: the anchor the session's root is minted at.
+//
+// Returns:
+//   - `*op.RuntimeEnvironment`: the constructed session, closed at test cleanup.
+func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
+
+	t.Helper()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
+	return runtimeEnvironment
+}
 
 // testActivation returns an [*op.ActivationRecord] for non-graph dispatch, rooted at `rootDir`.
 //
@@ -32,7 +61,7 @@ import (
 //   - `*op.ActivationRecord`: the non-graph activation.
 func testActivation(t *testing.T, rootDir string) *op.ActivationRecord {
 	t.Helper()
-	return op.NewActivationRecord(nil, "", &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(rootDir)})
+	return op.NewActivationRecord(nil, "", testEnvironment(t, rootDir))
 }
 
 // newTestProvider returns a Provider rooted at `rootDir` whose cloneFn hook is replaced with the supplied
@@ -50,7 +79,7 @@ func testActivation(t *testing.T, rootDir string) *op.ActivationRecord {
 func newTestProvider(t *testing.T, rootDir string, hook func(args []string) error) *Provider {
 	t.Helper()
 	return &Provider{
-		ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(rootDir)}),
+		ProviderBase: op.NewProviderBase(testEnvironment(t, rootDir)),
 		cloneFn:      hook,
 	}
 }
@@ -206,10 +235,7 @@ func TestClone_ProducerStamp(t *testing.T) {
 	root := t.TempDir()
 	p := newTestProvider(t, root, func(_ []string) error { return nil })
 
-	activation := op.NewActivationRecord(nil, "", &op.RuntimeEnvironment{
-		Root:            fsroot.OpenWritableUnconfined(root),
-		ResourceCatalog: op.NewResourceCatalog(),
-	})
+	activation := op.NewActivationRecord(nil, "", testEnvironment(t, root))
 
 	result, _, err := p.Clone(
 		activation,
@@ -235,7 +261,7 @@ func TestCompensateClone_RemovesDirectory(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
+	runtimeEnvironment := testEnvironment(t, tmp)
 	r, err := DiscoverResource(runtimeEnvironment, dir)
 	if err != nil {
 		t.Fatalf("DiscoverResource(%q): %v", dir, err)
@@ -253,7 +279,7 @@ func TestCompensateClone_RemovesDirectory(t *testing.T) {
 
 func TestCompensateClone_NoResource(t *testing.T) {
 
-	p := &Provider{ProviderBase: op.NewProviderBase(&op.RuntimeEnvironment{})}
+	p := &Provider{ProviderBase: op.NewProviderBase(testEnvironment(t, t.TempDir()))}
 	if err := p.CompensateClone(testActivation(t, t.TempDir()), nil); err != nil {
 		t.Fatalf("CompensateClone(nil) = %v, want nil", err)
 	}

--- a/pkg/op/provider/git/receipt_test.go
+++ b/pkg/op/provider/git/receipt_test.go
@@ -10,7 +10,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -22,10 +21,7 @@ func TestReceipt_RestoreEncoded_JSONandYAML(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			// The root anchors at the temp directory, never the Unix literal "/" (#392).
 			tmp := t.TempDir()
-			runtimeEnvironment := &op.RuntimeEnvironment{
-				Root:            fsroot.OpenWritableUnconfined(tmp),
-				ResourceCatalog: op.NewResourceCatalog(),
-			}
+			runtimeEnvironment := testEnvironment(t, tmp)
 			resource, err := DiscoverResource(runtimeEnvironment, filepath.Join(tmp, "repo"))
 			if err != nil {
 				t.Fatalf("DiscoverResource: %v", err)

--- a/pkg/op/provider/git/resource_input_test.go
+++ b/pkg/op/provider/git/resource_input_test.go
@@ -6,9 +6,6 @@ package git
 import (
 	"path/filepath"
 	"testing"
-
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
-	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
 // The constructor input domain (paths-only ruling, 2026-08-09): a filesystem path, plus the provider's own
@@ -18,7 +15,7 @@ import (
 func TestDiscoverResource_PathAndOwnSpecific_SameIdentity(t *testing.T) {
 
 	tmp := t.TempDir()
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
+	runtimeEnvironment := testEnvironment(t, tmp)
 	path := filepath.Join(tmp, "repo")
 
 	fromPath, err := DiscoverResource(runtimeEnvironment, path)
@@ -43,7 +40,7 @@ func TestDiscoverResource_WindowsShapedPath_IsAPath(t *testing.T) {
 	// input borrows the fixture root's own volume — a foreign volume cannot be made root-relative
 	// (#392) — while on Unix VolumeName is empty and the literal "D:" shape survives.
 	tmp := t.TempDir()
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(tmp)}
+	runtimeEnvironment := testEnvironment(t, tmp)
 
 	volume := filepath.VolumeName(tmp)
 	if volume == "" {

--- a/pkg/op/provider/git/resource_test.go
+++ b/pkg/op/provider/git/resource_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -76,7 +75,7 @@ func commitFile(t *testing.T, dir, name, content string) {
 // root cannot make absolute Windows paths relative across volumes (#392).
 func newRes(t *testing.T, path string) *Resource {
 	t.Helper()
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: fsroot.OpenWritableUnconfined(filepath.Dir(path))}
+	runtimeEnvironment := testEnvironment(t, filepath.Dir(path))
 	r, err := DiscoverResource(runtimeEnvironment, path)
 	if err != nil {
 		t.Fatalf("DiscoverResource(%q): %v", path, err)

--- a/pkg/op/provider/json/resource_test.go
+++ b/pkg/op/provider/json/resource_test.go
@@ -5,6 +5,7 @@ package json
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
@@ -27,10 +29,16 @@ func TestResource_ImplementsInterface(t *testing.T) {
 
 func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
-	runtimeEnvironment.ResourceCatalog = op.NewResourceCatalog()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -5,6 +5,7 @@ package mem
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
@@ -31,10 +33,16 @@ func TestResource_ImplementsInterface(t *testing.T) {
 // RecoverySite — the shape Resource construction requires when value is []byte or io.Reader.
 func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
-	runtimeEnvironment.ResourceCatalog = op.NewResourceCatalog()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 
@@ -195,8 +203,11 @@ func TestNewResource_StampsProducerID(t *testing.T) {
 }
 
 func TestNewResource_NilCatalogReturnsUnlinkedCandidate(t *testing.T) {
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
+	runtimeEnvironment := newTestRuntimeEnvironment(t)
+
+	// The nil catalog is this test's subject, and NewRuntimeEnvironment defaults one, so clear it
+	// after construction — exactly as the environment would look had no catalog been wired.
+	runtimeEnvironment.ResourceCatalog = nil
 
 	r, err := NewResource(runtimeEnvironment, "", []byte("no-catalog"))
 	if err != nil {

--- a/pkg/op/provider/service/resource_test.go
+++ b/pkg/op/provider/service/resource_test.go
@@ -5,12 +5,14 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
@@ -25,10 +27,16 @@ func TestResource_ImplementsInterface(t *testing.T) {
 
 func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
-	runtimeEnvironment.ResourceCatalog = op.NewResourceCatalog()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 

--- a/pkg/op/provider/yaml/resource_test.go
+++ b/pkg/op/provider/yaml/resource_test.go
@@ -5,6 +5,7 @@ package yaml
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
@@ -26,10 +28,16 @@ func TestResource_ImplementsInterface(t *testing.T) {
 
 func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 	t.Helper()
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	runtimeEnvironment := &op.RuntimeEnvironment{Root: root}
-	runtimeEnvironment.RecoverySite = op.NewRecoverySite(runtimeEnvironment)
-	runtimeEnvironment.ResourceCatalog = op.NewResourceCatalog()
+
+	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
+		op.NewRuntimeEnvironmentSpec("test").
+			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
+
 	return runtimeEnvironment
 }
 


### PR DESCRIPTION
## Summary

Phase 2b, **PR 2b.1b** of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)) — and the completion of 2b.1.
**26 sites across 12 files**, leaving no `_test.go` that sets `RuntimeEnvironment.Root` in a struct
literal, so 2b.2 can privatize the field without dragging test conversions into the same diff.

| Target | Sites |
| --- | --- |
| `pkg/op/provider/git` (5 files) | 11 |
| `cmd/star/provider/starcode` | 6 |
| `pkg/op/provider/{json,yaml,service,mem,function}` | 6 |
| `pkg/op/provider/file` | 3 |

## Where judgment was needed

**Two cases where the constructor's defaulting *is* the subject.** `mem`'s
`TestNewResource_NilCatalogReturnsUnlinkedCandidate` and `file`'s `mustRegular` both depend on a
**nil `ResourceCatalog`** to produce an unlinked resource, and `NewRuntimeEnvironment` defaults one.
Routing them through the helper unchanged would have left the tests passing while testing nothing.
Both construct and then clear the catalog, with a comment. The rule is recorded in the plan: **where
defaulting is the subject, construct and then undo — never route around the constructor.**

**A wrong comment corrected.** `file`'s `BackupSuffix` note claimed the constructor derives the
value; it never sets the field (`runtime_environment.go:211`). The value is
`NewRuntimeEnvironmentConfig`'s builtin floor.

**Two enumeration errors that cancelled**, recorded because the cancellation is what would have let
them survive review: `git` had **11** sites, not 10 — a bare `&op.RuntimeEnvironment{}` invisible to
a `Root:`-anchored grep — and `starlarkbridge` had **0**, not 1, because the counting regex matched
"Root" inside fixture names like `bridgePlannedRootFixture`. Total unchanged at 26; files 12, not 13.

## Verification

`make test` zero failures. `make lint-all` zero issues on linux, darwin, and windows — **run before
the commit**, which is what caught `file`'s now-dead `testRoot` helper (deleted, not suppressed).
`make test` alone was happy with it.

`test (windows-latest)` is expected to hold at its known 28 failures; no production code changed.

Assisted-by: Claude
