### PR TITLE
feat(fsroot): add CreateTemp and MkdirTemp to the Root interface

### DIFF
--- a/pkg/fsroot/root.go
+++ b/pkg/fsroot/root.go
@@ -9,12 +9,14 @@
 package fsroot
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -35,6 +37,14 @@ var (
 // depending on this package.
 var errReadOnly = fmt.Errorf("write operation not available in read-only mode: %w", errors.ErrUnsupported)
 
+// errTempPatternSeparator is returned when a temporary-name pattern contains a path separator, which would let a
+// caller redirect the created object through the name instead of the directory argument. It wraps
+// [fs.ErrInvalid] so callers can test for it without depending on this package.
+var errTempPatternSeparator = fmt.Errorf("temporary name pattern contains a path separator: %w", fs.ErrInvalid)
+
+// maxTempAttempts bounds the collision retries in [createTempIn] and [mkdirTempIn], matching [os.CreateTemp].
+const maxTempAttempts = 10000
+
 // Root provides scoped filesystem operations. All path arguments are [Path] values created through [Root.NewPath].
 //
 // Three concrete implementations provide different access modes:
@@ -49,18 +59,25 @@ var errReadOnly = fmt.Errorf("write operation not available in read-only mode: %
 // The method set mirrors [*os.Root] in full, so code that knows the standard library's root knows
 // this one. Every filesystem mutation in the repository is expected to flow through this interface;
 // a direct os.* call must carry a `// Confinement:` comment stating why the root cannot serve it.
+//
+// [Root.CreateTemp] and [Root.MkdirTemp] go beyond the mirror: [*os.Root] has no equivalent, and
+// [os.CreateTemp] cannot be confined to a root. Choosing between a scratch root and this one is the
+// whole of the decision — use the session's scratch unless the bytes must end up in this tree
+// atomically, since a rename out of scratch can cross a device boundary and degrade to a copy.
 type Root interface {
 	Chmod(p Path, mode os.FileMode) error
 	Chown(p Path, uid, gid int) error
 	Chtimes(p Path, atime, mtime time.Time) error
 	Close() error
 	Create(p Path) (*os.File, error)
+	CreateTemp(dir Path, pattern string) (*os.File, Path, error)
 	FS() fs.FS
 	Lchown(p Path, uid, gid int) error
 	Link(oldPath, newPath Path) error
 	Lstat(p Path) (fs.FileInfo, error)
 	Mkdir(p Path, perm os.FileMode) error
 	MkdirAll(p Path, perm os.FileMode) error
+	MkdirTemp(dir Path, pattern string) (Path, error)
 	Name() string
 	NewPath(path string) Path
 	Open(p Path) (*os.File, error)
@@ -406,6 +423,33 @@ func (r *confinedRoot) Mkdir(p Path, perm os.FileMode) error {
 	return applyMode(p.abs, perm, true)
 }
 
+// CreateTemp creates a uniquely named file under `dir`, confined to the root.
+//
+// Parameters:
+//   - `dir`: the directory within the root to create the file under; use `NewPath(".")` for the root itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `*os.File`: the open file, owned by the caller.
+//   - `Path`: the created file's path.
+//   - `error`: any error from [createTempIn].
+func (r *confinedRoot) CreateTemp(dir Path, pattern string) (*os.File, Path, error) {
+	return createTempIn(r, dir, pattern)
+}
+
+// MkdirTemp creates a uniquely named directory under `dir`, confined to the root.
+//
+// Parameters:
+//   - `dir`: the directory within the root to create the directory under; use `NewPath(".")` for the root itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `Path`: the created directory's path.
+//   - `error`: any error from [mkdirTempIn].
+func (r *confinedRoot) MkdirTemp(dir Path, pattern string) (Path, error) {
+	return mkdirTempIn(r, dir, pattern)
+}
+
 // MkdirAll creates the directory at the path along with any necessary parents, confined to the root.
 //
 // Parameters:
@@ -634,6 +678,16 @@ func (r *unconfinedRootReader) Chtimes(Path, time.Time, time.Time) error { retur
 //   - `error`: always [errReadOnly].
 func (r *unconfinedRootReader) Create(Path) (*os.File, error) { return nil, errReadOnly }
 
+// CreateTemp is unavailable in read-only mode.
+//
+// Returns:
+//   - `*os.File`: always nil.
+//   - `Path`: always the zero Path.
+//   - `error`: always [errReadOnly].
+func (r *unconfinedRootReader) CreateTemp(Path, string) (*os.File, Path, error) {
+	return nil, Path{}, errReadOnly
+}
+
 // Lchown is unavailable in read-only mode.
 //
 // Returns:
@@ -667,6 +721,13 @@ func (r *unconfinedRootReader) Mkdir(Path, os.FileMode) error { return errReadOn
 // Returns:
 //   - `error`: always [errReadOnly].
 func (r *unconfinedRootReader) MkdirAll(Path, os.FileMode) error { return errReadOnly }
+
+// MkdirTemp is unavailable in read-only mode.
+//
+// Returns:
+//   - `Path`: always the zero Path.
+//   - `error`: always [errReadOnly].
+func (r *unconfinedRootReader) MkdirTemp(Path, string) (Path, error) { return Path{}, errReadOnly }
 
 // Open opens the path for reading.
 //
@@ -897,6 +958,33 @@ func (r *unconfinedRootReaderWriter) Mkdir(p Path, perm os.FileMode) error {
 	}
 
 	return applyMode(p.abs, perm, true)
+}
+
+// CreateTemp creates a uniquely named file under `dir`.
+//
+// Parameters:
+//   - `dir`: the directory to create the file under; use `NewPath(".")` for the root directory itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `*os.File`: the open file, owned by the caller.
+//   - `Path`: the created file's path.
+//   - `error`: any error from [createTempIn].
+func (r *unconfinedRootReaderWriter) CreateTemp(dir Path, pattern string) (*os.File, Path, error) {
+	return createTempIn(r, dir, pattern)
+}
+
+// MkdirTemp creates a uniquely named directory under `dir`.
+//
+// Parameters:
+//   - `dir`: the directory to create the directory under; use `NewPath(".")` for the root directory itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `Path`: the created directory's path.
+//   - `error`: any error from [mkdirTempIn].
+func (r *unconfinedRootReaderWriter) MkdirTemp(dir Path, pattern string) (Path, error) {
+	return mkdirTempIn(r, dir, pattern)
 }
 
 // MkdirAll creates the directory at the path along with any necessary parents.
@@ -1241,6 +1329,116 @@ func makePath(rootName, path string) Path {
 		rel:  filepath.ToSlash(filepath.Clean(path)),
 		abs:  filepath.Join(rootName, path),
 	}
+}
+
+// createTempIn creates a uniquely named file under `dir`, mirroring [os.CreateTemp] inside a root.
+//
+// The file is created through `r`'s own [Root.OpenFile] with `O_CREATE|O_EXCL`, so confinement and the Windows
+// enforcement pass both apply exactly as they do to any other create. Mode 0600 matches [os.CreateTemp] and is
+// private, which means a temporary file receives a protected DACL on Windows without the caller asking.
+//
+// Parameters:
+//   - `r`: the root the file is created in.
+//   - `dir`: the directory within `r` to create the file under; use `r.NewPath(".")` for the root itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `*os.File`: the open file, positioned at offset zero and owned by the caller.
+//   - `Path`: the created file's path, for the rename or removal the caller owes it.
+//   - `error`: [errTempPatternSeparator] when the pattern contains a path separator, [fs.ErrExist] when a unique
+//     name could not be found, or any error from [Root.OpenFile].
+func createTempIn(r Root, dir Path, pattern string) (*os.File, Path, error) {
+
+	prefix, suffix, err := tempNameParts(pattern)
+	if err != nil {
+		return nil, Path{}, err
+	}
+
+	for range maxTempAttempts {
+
+		candidate := r.NewPath(filepath.Join(dir.Rel(), prefix+nextTempName()+suffix))
+
+		file, openErr := r.OpenFile(candidate, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if openErr == nil {
+			return file, candidate, nil
+		}
+		if !errors.Is(openErr, fs.ErrExist) {
+			return nil, Path{}, openErr
+		}
+	}
+
+	return nil, Path{}, fmt.Errorf("fsroot.CreateTemp %s: %w", filepath.Join(dir.Rel(), prefix+"*"+suffix), fs.ErrExist)
+}
+
+// mkdirTempIn creates a uniquely named directory under `dir`, mirroring [os.MkdirTemp] inside a root.
+//
+// The directory is created through `r`'s own [Root.Mkdir], so confinement and the Windows enforcement pass apply.
+// Mode 0700 matches [os.MkdirTemp] and is private, so the directory is DACL-protected on Windows.
+//
+// Parameters:
+//   - `r`: the root the directory is created in.
+//   - `dir`: the directory within `r` to create the new directory under; use `r.NewPath(".")` for the root itself.
+//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
+//
+// Returns:
+//   - `Path`: the created directory's path, for the removal the caller owes it.
+//   - `error`: [errTempPatternSeparator] when the pattern contains a path separator, [fs.ErrExist] when a unique
+//     name could not be found, or any error from [Root.Mkdir].
+func mkdirTempIn(r Root, dir Path, pattern string) (Path, error) {
+
+	prefix, suffix, err := tempNameParts(pattern)
+	if err != nil {
+		return Path{}, err
+	}
+
+	for range maxTempAttempts {
+
+		candidate := r.NewPath(filepath.Join(dir.Rel(), prefix+nextTempName()+suffix))
+
+		mkdirErr := r.Mkdir(candidate, 0o700)
+		if mkdirErr == nil {
+			return candidate, nil
+		}
+		if !errors.Is(mkdirErr, fs.ErrExist) {
+			return Path{}, mkdirErr
+		}
+	}
+
+	return Path{}, fmt.Errorf("fsroot.MkdirTemp %s: %w", filepath.Join(dir.Rel(), prefix+"*"+suffix), fs.ErrExist)
+}
+
+// nextTempName returns a random component for a temporary name.
+//
+// Uniqueness is not this function's job: both callers create with O_EXCL and retry on collision, exactly as
+// [os.CreateTemp] does, so a repeat costs an attempt rather than a wrong result. The source is [rand.Text] rather
+// than a pseudo-random generator because a predictable temporary name in a directory an attacker can also write
+// to invites a symlink race, and the cost of the strong source here is nothing.
+//
+// Returns:
+//   - `string`: the random component.
+func nextTempName() string { return rand.Text() }
+
+// tempNameParts splits a temporary-name pattern around its last `*`.
+//
+// Parameters:
+//   - `pattern`: the name pattern.
+//
+// Returns:
+//   - `string`: the part before the `*`, or the whole pattern when it has none.
+//   - `string`: the part after the `*`, or empty.
+//   - `error`: [errTempPatternSeparator] when the pattern contains a path separator, which would let a caller
+//     escape `dir` through the name rather than the path.
+func tempNameParts(pattern string) (prefix, suffix string, err error) {
+
+	if strings.ContainsAny(pattern, `/\`) {
+		return "", "", fmt.Errorf("fsroot: pattern %q: %w", pattern, errTempPatternSeparator)
+	}
+
+	if position := strings.LastIndex(pattern, "*"); position >= 0 {
+		return pattern[:position], pattern[position+1:], nil
+	}
+
+	return pattern, "", nil
 }
 
 // endregion

--- a/pkg/fsroot/root_test.go
+++ b/pkg/fsroot/root_test.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -723,6 +725,127 @@ func TestParity_WritableRootsImplementEveryMutation(t *testing.T) {
 	}
 }
 
+// TestCreateTemp_UniqueNamesHonorThePatternAndStayInTheDirectory proves the two temp constructors behave like
+// [os.CreateTemp] and [os.MkdirTemp] while staying inside the root: distinct names under the same pattern, the
+// prefix and suffix around the random component, and the private modes that carry Windows enforcement.
+func TestCreateTemp_UniqueNamesHonorThePatternAndStayInTheDirectory(t *testing.T) {
+
+	dir := t.TempDir()
+
+	for _, tc := range writableRoots(t, dir) {
+		t.Run(tc.name, func(t *testing.T) {
+
+			under := tc.root.NewPath(tc.name)
+			if err := tc.root.Mkdir(under, 0o750); err != nil {
+				t.Fatalf("Mkdir: %v", err)
+			}
+
+			first, firstPath, err := tc.root.CreateTemp(under, "spool-*.zip")
+			if err != nil {
+				t.Fatalf("CreateTemp: %v", err)
+			}
+			t.Cleanup(func() { _ = first.Close() })
+
+			second, secondPath, err := tc.root.CreateTemp(under, "spool-*.zip")
+			if err != nil {
+				t.Fatalf("CreateTemp (second): %v", err)
+			}
+			t.Cleanup(func() { _ = second.Close() })
+
+			if firstPath.Rel() == secondPath.Rel() {
+				t.Fatalf("both CreateTemp calls returned %q; concurrent callers would collide", firstPath.Rel())
+			}
+
+			for _, p := range []fsroot.Path{firstPath, secondPath} {
+				base := path.Base(p.Rel())
+				if !strings.HasPrefix(base, "spool-") || !strings.HasSuffix(base, ".zip") {
+					t.Errorf("name %q does not wrap the random part in the pattern's prefix and suffix", base)
+				}
+				if parent := path.Dir(p.Rel()); parent != under.Rel() {
+					t.Errorf("created under %q, want %q", parent, under.Rel())
+				}
+				if _, err := tc.root.Stat(p); err != nil {
+					t.Errorf("Stat(%s): %v", p.Rel(), err)
+				}
+			}
+
+			// 0600/0700 match os.CreateTemp/os.MkdirTemp, and are private — which is what makes a temporary
+			// file DACL-protected on Windows without the caller asking. Mode bits are a Unix subject.
+			if runtime.GOOS != "windows" {
+				info, statErr := tc.root.Stat(firstPath)
+				if statErr != nil {
+					t.Fatalf("Stat: %v", statErr)
+				}
+				if got := info.Mode().Perm(); got != 0o600 {
+					t.Errorf("CreateTemp mode = %v, want 0600", got)
+				}
+			}
+
+			tempDir, err := tc.root.MkdirTemp(under, "stage-*")
+			if err != nil {
+				t.Fatalf("MkdirTemp: %v", err)
+			}
+			info, err := tc.root.Stat(tempDir)
+			if err != nil {
+				t.Fatalf("Stat(MkdirTemp): %v", err)
+			}
+			if !info.IsDir() {
+				t.Error("MkdirTemp did not create a directory")
+			}
+			if runtime.GOOS != "windows" {
+				if got := info.Mode().Perm(); got != 0o700 {
+					t.Errorf("MkdirTemp mode = %v, want 0700", got)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateTemp_PatternWithSeparatorIsRefused proves the pattern cannot redirect the created object out of the
+// directory argument — the one way a name could otherwise act as a path.
+func TestCreateTemp_PatternWithSeparatorIsRefused(t *testing.T) {
+
+	root := fsroot.OpenWritableUnconfined(t.TempDir())
+	under := root.NewPath(".")
+
+	if _, _, err := root.CreateTemp(under, "../escape-*"); !errors.Is(err, fs.ErrInvalid) {
+		t.Errorf("CreateTemp with a separator = %v, want fs.ErrInvalid", err)
+	}
+	if _, err := root.MkdirTemp(under, "sub/escape-*"); !errors.Is(err, fs.ErrInvalid) {
+		t.Errorf("MkdirTemp with a separator = %v, want fs.ErrInvalid", err)
+	}
+}
+
+// TestCreateTemp_ScratchRootKeepsItsTempFilesInsideTheTree proves a scratch root's temp files are removed with it,
+// which is the property that makes scratch the default home for transient bytes.
+func TestCreateTemp_ScratchRootKeepsItsTempFilesInsideTheTree(t *testing.T) {
+
+	scratch, err := fsroot.OpenScratch("fsroot-scratch-temp-*")
+	if err != nil {
+		t.Fatalf("fsroot.OpenScratch: %v", err)
+	}
+
+	file, created, err := scratch.CreateTemp(scratch.NewPath("."), "spool-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	absolute := created.Abs()
+	if _, err := os.Stat(absolute); err != nil {
+		t.Fatalf("temp file missing before Close: %v", err)
+	}
+
+	if err := scratch.Close(); err != nil {
+		t.Fatalf("scratch Close: %v", err)
+	}
+	if _, err := os.Stat(absolute); !os.IsNotExist(err) {
+		t.Errorf("Stat after scratch Close = %v, want the file gone with the tree", err)
+	}
+}
+
 func TestParity_ReadOnlyRootRefusesEveryMutation(t *testing.T) {
 
 	dir := t.TempDir()
@@ -734,6 +857,9 @@ func TestParity_ReadOnlyRootRefusesEveryMutation(t *testing.T) {
 	if _, err := root.Create(p); !errors.Is(err, errors.ErrUnsupported) {
 		t.Errorf("Create = %v, want ErrUnsupported", err)
 	}
+	if _, _, err := root.CreateTemp(root.NewPath("."), "temp-*"); !errors.Is(err, errors.ErrUnsupported) {
+		t.Errorf("CreateTemp = %v, want ErrUnsupported", err)
+	}
 
 	for name, err := range map[string]error{
 		"Chmod":     root.Chmod(p, 0o600),
@@ -742,6 +868,7 @@ func TestParity_ReadOnlyRootRefusesEveryMutation(t *testing.T) {
 		"Lchown":    root.Lchown(p, -1, -1),
 		"Link":      root.Link(p, root.NewPath("link.txt")),
 		"Mkdir":     root.Mkdir(root.NewPath("sub"), 0o750),
+		"MkdirTemp": mkdirTempError(root),
 		"RemoveAll": root.RemoveAll(p),
 	} {
 		if !errors.Is(err, errors.ErrUnsupported) {
@@ -819,6 +946,14 @@ func allRoots(t *testing.T, dir string) []rootCase {
 }
 
 // writableRoots returns Root implementations that support write operations.
+// mkdirTempError returns only MkdirTemp's error, so the read-only refusal table can hold it beside the
+// single-value mutations.
+func mkdirTempError(root fsroot.Root) error {
+
+	_, err := root.MkdirTemp(root.NewPath("."), "temp-*")
+	return err
+}
+
 func writableRoots(t *testing.T, dir string) []rootCase {
 
 	t.Helper()
@@ -838,11 +973,11 @@ func writableRoots(t *testing.T, dir string) []rootCase {
 func writeFixture(t *testing.T, dir, name, content string) {
 
 	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	absolute := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(absolute, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2b, the **first half of PR 2b.2** of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)), split out so a **sealed-interface
addition** is reviewed on its own rather than inside the accessor change's 82-site diff. The design
is exactly as ruled; only the delivery splits.

## Why these methods exist

`os.Root` has neither, and `os.CreateTemp` cannot be confined to a root. A shared per-session
scratch directory therefore had no way to give concurrent callers unique names — and `gather`
dispatches bodies concurrently **by design**, so two spools would pick the same name and silently
corrupt each other.

## How they are built

Both delegate to `createTempIn` / `mkdirTempIn`, which create through the root's **own** `OpenFile`
and `Mkdir` rather than the inner `*os.Root`. Confinement and the phase-2 Windows enforcement pass
apply for free: **0600** files and **0700** directories are private, so each gets a protected DACL
on Windows without the caller asking.

`CreateTemp(dir Path, pattern string) (*os.File, Path, error)` takes a directory because a
stage-then-rename is only atomic within the target's own directory — a tree can span mounts — and
returns the created `Path` so callers need not rebuild one from `f.Name()`. The root itself is
`NewPath(".")`.

Names come from **`crypto/rand.Text`**: a predictable temporary name in a directory an attacker can
also write to invites a symlink race, and the strong source costs nothing here. Collisions are still
handled by `O_EXCL` with bounded retries, as `os.CreateTemp` does. A pattern containing a path
separator is refused with `fs.ErrInvalid` — the one way a *name* could act as a *path*.

## Verification

`make test` zero failures; `make lint-all` zero issues on linux, darwin, and windows. `lint-all`
also caught a weak-RNG finding — fixed by `crypto/rand`, not a suppression — and an `importShadow`
where the new `path` import collided with a local variable in an existing fixture helper.

`test (windows-latest)` is expected to hold at its known 28 failures.

Assisted-by: Claude
