### PR TITLE
feat(op): make the session own filesystem access behind accessors

### DIFF
--- a/cmd/star/provider/staranalysis/provider.go
+++ b/cmd/star/provider/staranalysis/provider.go
@@ -51,8 +51,8 @@ type Provider struct {
 // environment's Root when present.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
-	if ctx.Root != nil {
-		p.Root = ctx.Root.Name()
+	if ctx.HasRoot() {
+		p.Root = ctx.Root().Name()
 	}
 	return p
 }

--- a/cmd/star/provider/starcode/provider.go
+++ b/cmd/star/provider/starcode/provider.go
@@ -30,8 +30,8 @@ type Provider struct {
 // environment's Root when present.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
-	if ctx.Root != nil {
-		p.Root = ctx.Root.Name()
+	if ctx.HasRoot() {
+		p.Root = ctx.Root().Name()
 	}
 	return p
 }

--- a/cmd/star/provider/starcomplexity/provider.go
+++ b/cmd/star/provider/starcomplexity/provider.go
@@ -56,8 +56,8 @@ type Provider struct {
 // environment's Root when present.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
-	if ctx.Root != nil {
-		p.Root = ctx.Root.Name()
+	if ctx.HasRoot() {
+		p.Root = ctx.Root().Name()
 	}
 	return p
 }

--- a/cmd/star/provider/starindex/provider.go
+++ b/cmd/star/provider/starindex/provider.go
@@ -71,8 +71,8 @@ type Provider struct {
 // environment's Root when present.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
-	if ctx.Root != nil {
-		p.Root = ctx.Root.Name()
+	if ctx.HasRoot() {
+		p.Root = ctx.Root().Name()
 	}
 	return p
 }

--- a/cmd/star/provider/starstats/provider.go
+++ b/cmd/star/provider/starstats/provider.go
@@ -45,8 +45,8 @@ type Provider struct {
 // environment's Root when present.
 func NewProvider(ctx *op.RuntimeEnvironment) *Provider {
 	p := &Provider{ProviderBase: op.NewProviderBase(ctx)}
-	if ctx.Root != nil {
-		p.Root = ctx.Root.Name()
+	if ctx.HasRoot() {
+		p.Root = ctx.Root().Name()
 	}
 	return p
 }

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -373,7 +373,8 @@ test constructor must land **first** or nothing is actually split.
 | --- | --- | --- |
 | **2b.1a** | First 6 test files onto the real constructor — branch `test-env-constructor` | ✅ **merged 2026-08-14 (#410)** |
 | **2b.1b** | Remaining **26 sites / 12 files** — branch `test-env-constructor-remainder` | ✅ **complete 2026-08-14** |
-| **2b.2** | Field → private, `HasRoot()` / `Root()` / `Scratch()`, `Dir.CreateTemp` + `Dir.MkdirTemp`, lazy allocation, **82 sites / 20 files** (1 write, 81 reads) | ready — design ruled 2026-08-14 |
+| **2b.2a** | `Dir.CreateTemp` + `Dir.MkdirTemp` on the interface — branch `fsroot-temp-methods` | ✅ **merged 2026-08-14 (#413)** |
+| **2b.2b** | Field → private, `HasRoot()` / `Root()` / `Scratch()`, preflight, lazy allocation, **105 rewrites / 25 files** | ✅ **complete 2026-08-14** |
 | **2b.3** | Move `archive`'s spool and `devlore-test`'s runner onto `Scratch()` (optional; may fold into 2b.2) | pending |
 
 **A codegen PR was planned and proved unnecessary.** The `receiver_type.gen_test.go` template emits
@@ -512,6 +513,36 @@ in the root's tree atomically; if the operation ends in a rename into that tree,
 `Root().CreateTemp` so the rename cannot cross a device boundary.* Applied to the known consumers:
 the archive spool gives random access to a streamed zip whose bytes never enter the user's tree →
 **scratch**; a file provider writing a target file atomically → **`Root().CreateTemp` + `Rename`**.
+
+#### 2b.2 as delivered (2026-08-14)
+
+Split in two: **2b.2a** put `CreateTemp` / `MkdirTemp` on the interface (#413), so a sealed-interface
+addition was reviewed on its own rather than inside the migration diff. **2b.2b** is the rest.
+
+**The production count held; the total did not.** 82 production sites was accurate, but the
+migration touched **105 sites across 25 files** once test files were included — `triad_test.go`
+alone held 20. The estimate counted production only, and said so; the lesson is that a migration's
+size is the *repository's* count, not the subset that was enumerated.
+
+**The mechanical rewrite over-matched once, and the compiler caught it.** `pkg/op/triad_test.go`
+defines a local `triadEnv` fixture with its own `Root fsroot.Root` **field**, so `env.Root` there is
+not the session; 20 rewrites were reverted. It compiled loudly because a field is not callable —
+but had that fixture been an interface with a `Root()` method, the same edit would have compiled and
+silently changed meaning. **Phase 6's rename runs the same risk over a far larger surface.**
+
+**One existing test specified the old contract** — `Root() != nil` on a rootless session — and was
+rewritten to specify the new one, with `recover()` proving the panic. A new test pins scratch:
+a private tree inside `os.TempDir()`, the same instance on every call, `0700`, removed on `Close`.
+
+**Implementation notes for the reader:**
+
+- `sync.Once` per resource, not a shared mutex: `gather` dispatches bodies concurrently, so two
+  goroutines can reach `Root()` at the same moment.
+- The assert is the repository's existing `assert.Failf` / `assert.NoError` (typed `AssertionError`,
+  identifiable under `recover`) rather than a newly coined error type.
+- `probeScratchAnchor` carries a `// Confinement:` comment: it is the one call that cannot route
+  through a root, because it exists to prove the anchor a root would need.
+- `Close` releases only what was minted, so a planning-only session closes nothing.
 
 **Review hazard:** `file.Provider` already has `Root() string`
 (`provider/file/provider.go:60`), itself a nil-tolerant wrapper returning `""`. Forty-four of the 82

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -274,7 +274,7 @@ func (p *Provider) CompensateExtractStream(activation *op.ActivationRecord, stac
 //   - `error`: an unsupported or undetectable format, or any open/sniff/decompress failure.
 func (p *Provider) openArchive(source string) (archiveReader, error) {
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 
 	archiveFile, err := root.Open(root.NewPath(source))
 	if err != nil {
@@ -437,7 +437,7 @@ func copyHardlinkEntry(
 		return nil, nil, refErr
 	}
 
-	root := activationRecord.RuntimeEnvironment.Root
+	root := activationRecord.RuntimeEnvironment.Root()
 	referentFile, openErr := root.Open(root.NewPath(referent))
 	if openErr != nil {
 		return nil, nil, fmt.Errorf(

--- a/pkg/op/provider/encryption/provider.go
+++ b/pkg/op/provider/encryption/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) DecryptSopsFile(activationRecord *op.ActivationRecord, source
 		return nil, nil, err
 	}
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 
 	// 1. Read the source file into memory
 	data, err := root.ReadFile(root.NewPath(source.SourcePath.Abs()))
@@ -107,7 +107,7 @@ func (p *Provider) CompensateDecryptSopsFile(activationRecord *op.ActivationReco
 		return fmt.Errorf("compensate decrypt sops file: unexpected resource type %T", receipt.Resource())
 	}
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Remove(root.NewPath(resource.SourcePath.Abs()))
 }
 
@@ -134,7 +134,7 @@ func (p *Provider) EncryptFile(activationRecord *op.ActivationRecord, source *fi
 		return nil, nil, err
 	}
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 
 	// 1. Read the source cleartext into memory
 	data, err := root.ReadFile(root.NewPath(source.SourcePath.Abs()))
@@ -179,7 +179,7 @@ func (p *Provider) CompensateEncryptFile(activationRecord *op.ActivationRecord, 
 		return fmt.Errorf("compensate encrypt file: unexpected resource type %T", receipt.Resource())
 	}
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Remove(root.NewPath(resource.SourcePath.Abs()))
 }
 

--- a/pkg/op/provider/file/directory.go
+++ b/pkg/op/provider/file/directory.go
@@ -104,7 +104,7 @@ func DiscoverDirectory(runtimeEnvironment *op.RuntimeEnvironment, value any) (*D
 //   - `error`: an lstat error, a kind mismatch, an unsupported entry kind, or any read error during the walk.
 func (r *Directory) Digest() (op.Digest, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {
@@ -155,7 +155,7 @@ func (r *Directory) Equal(other any) bool {
 //   - `error`: an lstat error or a kind mismatch.
 func (r *Directory) Etag() (string, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -109,7 +109,7 @@ func buildCandidateAs(
 	// back this provider's own emitted identity specific ("file://" + path) — strip our own prefix and it
 	// is a path again. No URI parsing: the provider decodes only what it mints (readback does the same).
 	path = strings.TrimPrefix(path, "file://")
-	sourcePath := runtimeEnvironment.Root.NewPath(path)
+	sourcePath := runtimeEnvironment.Root().NewPath(path)
 	var base op.ResourceBase
 
 	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), resourceType)

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -56,13 +56,13 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 // Root returns the root path of the file-system scope, or the empty string when no root is set.
 //
 // Returns:
-//   - `string`: the scoped root path, or "" when [RuntimeEnvironment.Root] is nil.
+//   - `string`: the scoped root path, or "" when the session has no root.
 func (p *Provider) Root() string {
 
-	if p.RuntimeEnvironment().Root == nil {
+	if !p.RuntimeEnvironment().HasRoot() {
 		return ""
 	}
-	return p.RuntimeEnvironment().Root.Name()
+	return p.RuntimeEnvironment().Root().Name()
 }
 
 // endregion
@@ -96,7 +96,7 @@ func (p *Provider) Backup(
 		backupSuffix = p.RuntimeEnvironment().BackupSuffix
 	}
 
-	sourceAbs := p.RuntimeEnvironment().Root.NewPath(sourcePath).Abs()
+	sourceAbs := p.RuntimeEnvironment().Root().NewPath(sourcePath).Abs()
 	timestamp := time.Now().Format("20060102-150405")
 	backupPath := sourceAbs + backupSuffix + "." + timestamp
 
@@ -202,7 +202,7 @@ func (p *Provider) Link(
 	verbatim bool,
 ) (product *SymbolicLink, receipt *Receipt, err error) {
 
-	storedName := p.RuntimeEnvironment().Root.NewPath(sourcePath).Abs()
+	storedName := p.RuntimeEnvironment().Root().NewPath(sourcePath).Abs()
 	if verbatim {
 		storedName = sourcePath
 	}
@@ -299,7 +299,7 @@ func (p *Provider) existingLinkMatches(linkPath, storedName string, verbatim boo
 //   - `error`: non-nil when archiving fails.
 func (p *Provider) archiveOccupant(product *SymbolicLink) (*Receipt, error) {
 
-	preDigest := preArchiveDigest(p.RuntimeEnvironment().Root, product.SourcePath.Abs())
+	preDigest := preArchiveDigest(p.RuntimeEnvironment().Root(), product.SourcePath.Abs())
 
 	recoveryID, archiveErr := p.RuntimeEnvironment().RecoverySite.ArchiveFile(product.SourcePath)
 	if archiveErr != nil {
@@ -335,7 +335,7 @@ func (p *Provider) Mkdir(
 	chown string,
 ) (product *Directory, receipt *Receipt, err error) {
 
-	leaf := p.RuntimeEnvironment().Root.NewPath(path).Abs()
+	leaf := p.RuntimeEnvironment().Root().NewPath(path).Abs()
 
 	// Observe before claiming: an occupant of another kind gets the plain refusal rather than the catalog's
 	// cross-kind collision (the claim below would collide with the occupant's discovered entry).
@@ -461,7 +461,7 @@ func (p *Provider) Move(
 	destinationPath string,
 ) (product Entry, receipt *Receipt, err error) {
 
-	sourceAbs := p.RuntimeEnvironment().Root.NewPath(sourcePath).Abs()
+	sourceAbs := p.RuntimeEnvironment().Root().NewPath(sourcePath).Abs()
 
 	sourceInfo, err := p.lstat(sourceAbs)
 	if err != nil {
@@ -549,7 +549,7 @@ func (p *Provider) compensateMove(receipt *Receipt) error {
 		if expected.Algorithm != "" {
 
 			recoveryPath := ".devlore/recovery/" + recoveryID
-			actualStr := checksumFile(p.RuntimeEnvironment().Root, recoveryPath)
+			actualStr := checksumFile(p.RuntimeEnvironment().Root(), recoveryPath)
 
 			if actualStr == "" {
 				return fmt.Errorf("cannot read %s for verification", recoveryID)
@@ -663,7 +663,7 @@ func (p *Provider) Remove(
 	boundary string,
 ) (product Entry, receipt *Receipt, err error) {
 
-	abs := p.RuntimeEnvironment().Root.NewPath(path).Abs()
+	abs := p.RuntimeEnvironment().Root().NewPath(path).Abs()
 
 	nonEmptyDirectory, err := p.isDirAndNotEmpty(abs)
 	if err != nil {
@@ -717,7 +717,7 @@ func (p *Provider) RemoveAll(
 	boundary string,
 ) (product Entry, receipt *Receipt, err error) {
 
-	abs := p.RuntimeEnvironment().Root.NewPath(path).Abs()
+	abs := p.RuntimeEnvironment().Root().NewPath(path).Abs()
 
 	entry, err := p.discoverEntryAt(abs)
 	if errors.Is(err, os.ErrNotExist) {
@@ -762,7 +762,7 @@ func (p *Provider) Unlink(
 	boundary string,
 ) (product Entry, receipt *Receipt, err error) {
 
-	abs := p.RuntimeEnvironment().Root.NewPath(path).Abs()
+	abs := p.RuntimeEnvironment().Root().NewPath(path).Abs()
 
 	info, err := p.lstat(abs)
 	if errors.Is(err, os.ErrNotExist) {
@@ -835,7 +835,7 @@ func (p *Provider) WalkTree(
 		return nil, nil, err
 	}
 
-	osRoot := p.RuntimeEnvironment().Root
+	osRoot := p.RuntimeEnvironment().Root()
 
 	walkFn := func(entryAbs string, d fs.DirEntry, walkDirErr error) error {
 
@@ -1026,7 +1026,7 @@ func (p *Provider) WriteText(
 //   - `error`: non-nil on any stat failure other than not-exist.
 func (p *Provider) Exists(path string) (bool, error) {
 
-	_, err := p.lstat(p.RuntimeEnvironment().Root.NewPath(path).Abs())
+	_, err := p.lstat(p.RuntimeEnvironment().Root().NewPath(path).Abs())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
@@ -1076,7 +1076,7 @@ func (p *Provider) Find(pattern string, includeGitignored bool) (product []Entry
 	matches := make([]string, 0, 8192)
 	walk := p.findWalkFunc(absoluteRoot, matchPattern, tracker, &matches)
 
-	err = p.walkDir(p.RuntimeEnvironment().Root, absoluteRoot, walk)
+	err = p.walkDir(p.RuntimeEnvironment().Root(), absoluteRoot, walk)
 	if err != nil {
 		return nil, fmt.Errorf("find: walk %q: %w", absoluteRoot, err)
 	}
@@ -1220,7 +1220,7 @@ func (p *Provider) Glob(pattern string, includeGitignored bool) ([]Entry, error)
 //   - `error`: non-nil on any stat failure other than not-exist.
 func (p *Provider) IsDir(path string) (bool, error) {
 
-	info, err := p.stat(p.RuntimeEnvironment().Root.NewPath(path).Abs())
+	info, err := p.stat(p.RuntimeEnvironment().Root().NewPath(path).Abs())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
@@ -1244,7 +1244,7 @@ func (p *Provider) IsDir(path string) (bool, error) {
 //   - `error`: non-nil on any stat failure other than not-exist.
 func (p *Provider) IsFile(path string) (bool, error) {
 
-	info, err := p.stat(p.RuntimeEnvironment().Root.NewPath(path).Abs())
+	info, err := p.stat(p.RuntimeEnvironment().Root().NewPath(path).Abs())
 
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -1272,7 +1272,7 @@ func (p *Provider) IsFile(path string) (bool, error) {
 //   - `error`: any stat failure other than not-exist.
 func (p *Provider) Observe(resource Entry) (*Observation, error) {
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	absPath := root.NewPath(resource.Path().Abs())
 
 	info, err := root.Stat(absPath)
@@ -1440,7 +1440,7 @@ func (p *Provider) archiveAndPrune(
 	boundary string,
 ) (recoveryID string, digest op.Digest, err error) {
 
-	digest = preArchiveDigest(p.RuntimeEnvironment().Root, entry.Path().Abs())
+	digest = preArchiveDigest(p.RuntimeEnvironment().Root(), entry.Path().Abs())
 
 	recoveryID, err = p.RuntimeEnvironment().RecoverySite.ArchiveFile(entry.Path())
 	if err != nil {
@@ -1549,7 +1549,7 @@ func (p *Provider) discoverEntries(paths []string) (product []Entry, err error) 
 	for i, path := range paths {
 		// Enumeration discovery — the disk was just walked, so the observed kind is authoritative; no
 		// production claim.
-		entry, derr := p.discoverEntryAt(p.RuntimeEnvironment().Root.NewPath(path).Abs())
+		entry, derr := p.discoverEntryAt(p.RuntimeEnvironment().Root().NewPath(path).Abs())
 		if derr != nil {
 			return nil, derr
 		}
@@ -1734,7 +1734,7 @@ func (p *Provider) isDirAndNotEmpty(abs string) (_ bool, err error) {
 //   - `os.FileInfo`: the stat info for the entry itself (the link, not its target).
 //   - `error`: non-nil on stat failure.
 func (p *Provider) lstat(abs string) (os.FileInfo, error) {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Lstat(root.NewPath(abs))
 }
 
@@ -1747,7 +1747,7 @@ func (p *Provider) lstat(abs string) (os.FileInfo, error) {
 // Returns:
 //   - `error`: non-nil on creation failure.
 func (p *Provider) mkdirAll(abs string, perm os.FileMode) error {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.MkdirAll(root.NewPath(abs), perm)
 }
 
@@ -1776,7 +1776,7 @@ func (p *Provider) newTrackerIfEnabled(rootPath string, honorGitignore bool) (*g
 //   - `*os.File`: the opened file.
 //   - `error`: non-nil on open failure.
 func (p *Provider) open(abs string) (*os.File, error) {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Open(root.NewPath(abs))
 }
 
@@ -1791,7 +1791,7 @@ func (p *Provider) open(abs string) (*os.File, error) {
 //   - `*os.File`: the opened file.
 //   - `error`: non-nil on open failure.
 func (p *Provider) openFile(abs string, flag int, perm os.FileMode) (*os.File, error) {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.OpenFile(root.NewPath(abs), flag, perm)
 }
 
@@ -1897,7 +1897,7 @@ func (p *Provider) stageWrite(product Entry) (spec *ReceiptSpec, err error) {
 //   - `error`: non-nil on read failure.
 func (p *Provider) read(resource *Regular) (*bytes.Buffer, error) {
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	data, err := root.ReadFile(root.NewPath(resource.SourcePath.Abs()))
 
 	if err != nil {
@@ -1930,13 +1930,13 @@ func (p *Provider) read(resource *Regular) (*bytes.Buffer, error) {
 //   - `string`: the raw readlink result.
 //   - `error`: non-nil on readlink failure.
 func (p *Provider) rawReadLink(abs string) (string, error) {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Readlink(root.NewPath(abs))
 }
 
 func (p *Provider) readLink(abs string) (string, error) {
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	target, err := root.Readlink(root.NewPath(abs))
 
 	if err != nil {
@@ -1958,7 +1958,7 @@ func (p *Provider) readLink(abs string) (string, error) {
 // Returns:
 //   - `error`: non-nil on removal failure.
 func (p *Provider) remove(abs string) error {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Remove(root.NewPath(abs))
 }
 
@@ -1971,7 +1971,7 @@ func (p *Provider) remove(abs string) error {
 // Returns:
 //   - `error`: non-nil on rename failure.
 func (p *Provider) rename(oldAbs, newAbs string) error {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Rename(root.NewPath(oldAbs), root.NewPath(newAbs))
 }
 
@@ -1984,7 +1984,7 @@ func (p *Provider) rename(oldAbs, newAbs string) error {
 //   - `os.FileInfo`: the stat info for the entry (or its symlink target).
 //   - `error`: non-nil on stat failure.
 func (p *Provider) stat(abs string) (os.FileInfo, error) {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Stat(root.NewPath(abs))
 }
 
@@ -1998,7 +1998,7 @@ func (p *Provider) stat(abs string) (os.FileInfo, error) {
 //   - `error`: non-nil when the relative target cannot be computed or the link cannot be created.
 func (p *Provider) symlink(targetAbs, linkAbs string) error {
 
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	relTarget, err := filepath.Rel(filepath.Dir(linkAbs), targetAbs)
 
 	if err != nil {
@@ -2020,7 +2020,7 @@ func (p *Provider) symlink(targetAbs, linkAbs string) error {
 // Returns:
 //   - `error`: non-nil on symlink failure.
 func (p *Provider) symlinkRaw(target, linkAbs string) error {
-	root := p.RuntimeEnvironment().Root
+	root := p.RuntimeEnvironment().Root()
 	return root.Symlink(target, root.NewPath(linkAbs))
 }
 
@@ -2152,7 +2152,7 @@ func (p *Provider) pruneEmptyParents(path string, prune bool, boundary string) {
 	boundaryPath := p.Root()
 
 	if boundary != "" {
-		boundaryPath = p.RuntimeEnvironment().Root.NewPath(boundary).Abs()
+		boundaryPath = p.RuntimeEnvironment().Root().NewPath(boundary).Abs()
 	}
 
 	dir := filepath.Dir(path)

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -102,7 +102,7 @@ func mustRegular(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment, path s
 
 	// A catalog-free session anchored at the same directory: the nil catalog is what leaves the returned
 	// *Regular unlinked, and the constructor defaults one.
-	unlinked := testEnvironment(t, runtimeEnvironment.Root.Name())
+	unlinked := testEnvironment(t, runtimeEnvironment.Root().Name())
 	unlinked.ResourceCatalog = nil
 
 	regular, err := DiscoverRegular(unlinked, path)

--- a/pkg/op/provider/file/regular.go
+++ b/pkg/op/provider/file/regular.go
@@ -91,7 +91,7 @@ func DiscoverRegular(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reg
 //   - `error`: an lstat error, a kind mismatch, or any read error.
 func (r *Regular) Digest() (op.Digest, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *Regular) Equal(other any) bool {
 //   - `error`: an lstat error or a kind mismatch.
 func (r *Regular) Etag() (string, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -125,7 +125,7 @@ func (r *Resource) Addressing() op.AddressingMode {
 //   - `error`: a stat error, [op.ErrUnimplemented] for directories, or any read error.
 func (r *Resource) Digest() (digest op.Digest, err error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 	path := root.NewPath(r.SourcePath.Abs())
 
 	var info fs.FileInfo
@@ -190,7 +190,7 @@ func (r *Resource) Equal(other any) bool {
 //   - `error`: any stat error (file gone, permission denied, etc.).
 func (r *Resource) Etag() (string, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Stat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {
@@ -208,7 +208,7 @@ func (r *Resource) Etag() (string, error) {
 // Returns:
 //   - `bool`: true when the file exists; false when the stat returns [os.ErrNotExist] or any other error.
 func (r *Resource) Exists() bool {
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 	_, err := root.Stat(root.NewPath(r.SourcePath.Abs()))
 	return err == nil
 }
@@ -223,7 +223,7 @@ func (r *Resource) Exists() bool {
 //   - `bool`: true when the file exists and is a directory; false otherwise.
 func (r *Resource) IsDir() bool {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 	info, err := root.Stat(root.NewPath(r.SourcePath.Abs()))
 
 	if err != nil {
@@ -344,7 +344,7 @@ func (*Resource) ConvertFrom(value any) (any, error) {
 //   - `error`: any stat error other than not-exist.
 func (r *Resource) Resolve() error {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	r.SourcePath = root.NewPath(r.SourcePath.Abs())
 

--- a/pkg/op/provider/file/symbolic_link.go
+++ b/pkg/op/provider/file/symbolic_link.go
@@ -99,7 +99,7 @@ func DiscoverSymbolicLink(runtimeEnvironment *op.RuntimeEnvironment, value any) 
 //   - `error`: an lstat error, a kind mismatch, or a readlink failure.
 func (r *SymbolicLink) Digest() (op.Digest, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {
@@ -156,7 +156,7 @@ func (r *SymbolicLink) Equal(other any) bool {
 //   - `error`: an lstat error or a kind mismatch.
 func (r *SymbolicLink) Etag() (string, error) {
 
-	root := r.RuntimeEnvironment().Root
+	root := r.RuntimeEnvironment().Root()
 
 	info, err := root.Lstat(root.NewPath(r.SourcePath.Abs()))
 	if err != nil {

--- a/pkg/op/provider/function/resource.go
+++ b/pkg/op/provider/function/resource.go
@@ -354,11 +354,11 @@ func newFromSource(
 	sp := f.SourcePath()
 
 	parentRel := filepath.Dir(sp.Rel())
-	if err := runtimeEnvironment.Root.MkdirAll(runtimeEnvironment.Root.NewPath(parentRel), 0o700); err != nil {
+	if err := runtimeEnvironment.Root().MkdirAll(runtimeEnvironment.Root().NewPath(parentRel), 0o700); err != nil {
 		return nil, fmt.Errorf("function.Resource: create canonical dir: %w", err)
 	}
 
-	if err := runtimeEnvironment.Root.WriteFile(sp, packBuf.Bytes(), 0o600); err != nil {
+	if err := runtimeEnvironment.Root().WriteFile(sp, packBuf.Bytes(), 0o600); err != nil {
 		return nil, fmt.Errorf("function.Resource: write pack %s: %w", f.FuncName, err)
 	}
 

--- a/pkg/op/provider/git/resource.go
+++ b/pkg/op/provider/git/resource.go
@@ -173,7 +173,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 	// The input is a filesystem path; catalog rehydration hands back our own emitted identity specific
 	// ("file://" + path) — strip our own prefix, no URI parsing (the provider decodes only what it mints).
 	path = strings.TrimPrefix(path, "file://")
-	sourcePath := runtimeEnvironment.Root.NewPath(path)
+	sourcePath := runtimeEnvironment.Root().NewPath(path)
 
 	base, err := op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), reflect.TypeFor[*Resource]())
 	if err != nil {

--- a/pkg/op/provider/mem/helpers.go
+++ b/pkg/op/provider/mem/helpers.go
@@ -75,7 +75,7 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 
 	r := &Resource{ResourceBase: base, Hash: hexDigest}
 
-	root := runtimeEnvironment.Root
+	root := runtimeEnvironment.Root()
 	canonical := r.SourcePath()
 
 	if err := root.MkdirAll(root.NewPath(filepath.Dir(canonical.Rel())), 0o700); err != nil {
@@ -114,7 +114,7 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 //     canonical directory creation failure, or rename failure.
 func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*Resource, error) {
 
-	root := runtimeEnvironment.Root
+	root := runtimeEnvironment.Root()
 
 	staging, err := stagingPath(root)
 	if err != nil {

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -334,7 +334,7 @@ func (r *Resource) SourcePath() fsroot.Path {
 
 	runtimeEnvironment := r.RuntimeEnvironment()
 
-	if runtimeEnvironment == nil || runtimeEnvironment.Root == nil {
+	if runtimeEnvironment == nil || !runtimeEnvironment.HasRoot() {
 		return fsroot.Path{}
 	}
 
@@ -350,7 +350,7 @@ func (r *Resource) SourcePath() fsroot.Path {
 	}
 
 	pkg, typeName := splitTypeID(r.ResourceType())
-	return runtimeEnvironment.Root.NewPath(filepath.Join(".devlore", pkg, strings.ToLower(typeName), algo, shard, hexPart))
+	return runtimeEnvironment.Root().NewPath(filepath.Join(".devlore", pkg, strings.ToLower(typeName), algo, shard, hexPart))
 }
 
 // String returns the compact JSON encoding of the Resource for debug output.

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -468,7 +468,7 @@ func (p *Provider) Spec(programName, rootPath string, flags map[string]any) (*op
 		programName = runtimeEnvironment.Application.Name
 	}
 	if rootPath == "" {
-		rootPath = runtimeEnvironment.Root.Name()
+		rootPath = runtimeEnvironment.Root().Name()
 	}
 	if flags == nil {
 		flags = runtimeEnvironment.Application.Flags

--- a/pkg/op/provider/plan/provider_test.go
+++ b/pkg/op/provider/plan/provider_test.go
@@ -350,9 +350,9 @@ func TestProvider_Spec_DefaultsFromPlanningEnvironment(t *testing.T) {
 
 	// The spec carries the anchor, never a handle (issue #393): it must anchor at the planning environment's root
 	// path in confined mode; each Run's executor mints its own Root from it.
-	if spec.RootPath != environment.Root.Name() {
+	if spec.RootPath != environment.Root().Name() {
 		t.Fatalf("spec.RootPath = %q, want the planning environment's root path %q",
-			spec.RootPath, environment.Root.Name())
+			spec.RootPath, environment.Root().Name())
 	}
 	if spec.RootMode != fsroot.ModeConfined {
 		t.Errorf("spec.RootMode = %v, want fsroot.ModeConfined", spec.RootMode)

--- a/pkg/op/recovery_site.go
+++ b/pkg/op/recovery_site.go
@@ -53,14 +53,14 @@ func NewRecoverySite(runtimeEnvironment *RuntimeEnvironment) *RecoverySite {
 //   - error: any write error
 func (s *RecoverySite) ArchiveData(data []byte) (string, error) {
 
-	if err := s.runtimeEnvironment.Root.MkdirAll(s.runtimeEnvironment.Root.NewPath(recoveryDir), 0o700); err != nil {
+	if err := s.runtimeEnvironment.Root().MkdirAll(s.runtimeEnvironment.Root().NewPath(recoveryDir), 0o700); err != nil {
 		return "", fmt.Errorf("create recovery directory: %w", err)
 	}
 
 	id := uuid.Must(uuid.NewV7()).String()
 	recoveryPath := recoveryDir + "/" + id
 
-	if err := s.runtimeEnvironment.Root.WriteFile(s.runtimeEnvironment.Root.NewPath(recoveryPath), data, 0o600); err != nil {
+	if err := s.runtimeEnvironment.Root().WriteFile(s.runtimeEnvironment.Root().NewPath(recoveryPath), data, 0o600); err != nil {
 		return "", err
 	}
 
@@ -82,16 +82,16 @@ func (s *RecoverySite) ArchiveFile(p fsroot.Path) (string, error) {
 
 	// Normalize: ensure the Path has fsroot context for confined I/O. Resources created via coercion
 	// (NewResource → fsroot.NewPath("", abs)) carry fsroot="" and rel=<absolute>, which os.Root rejects.
-	p = s.runtimeEnvironment.Root.NewPath(p.Abs())
+	p = s.runtimeEnvironment.Root().NewPath(p.Abs())
 
-	if err := s.runtimeEnvironment.Root.MkdirAll(s.runtimeEnvironment.Root.NewPath(recoveryDir), 0o700); err != nil {
+	if err := s.runtimeEnvironment.Root().MkdirAll(s.runtimeEnvironment.Root().NewPath(recoveryDir), 0o700); err != nil {
 		return "", fmt.Errorf("create recovery directory: %w", err)
 	}
 
 	id := uuid.Must(uuid.NewV7()).String()
 	recoveryPath := recoveryDir + "/" + id
 
-	if err := s.runtimeEnvironment.Root.Rename(p, s.runtimeEnvironment.Root.NewPath(recoveryPath)); err != nil {
+	if err := s.runtimeEnvironment.Root().Rename(p, s.runtimeEnvironment.Root().NewPath(recoveryPath)); err != nil {
 		return "", err
 	}
 
@@ -113,14 +113,14 @@ func (s *RecoverySite) ArchiveFile(p fsroot.Path) (string, error) {
 //   - error:  any error from recovery-directory creation, file creation, or the copy.
 func (s *RecoverySite) ArchiveStream(r io.Reader) (_ string, err error) {
 
-	if err := s.runtimeEnvironment.Root.MkdirAll(s.runtimeEnvironment.Root.NewPath(recoveryDir), 0o700); err != nil {
+	if err := s.runtimeEnvironment.Root().MkdirAll(s.runtimeEnvironment.Root().NewPath(recoveryDir), 0o700); err != nil {
 		return "", fmt.Errorf("create recovery directory: %w", err)
 	}
 
 	id := uuid.Must(uuid.NewV7()).String()
 	recoveryPath := recoveryDir + "/" + id
 
-	f, err := s.runtimeEnvironment.Root.OpenFile(s.runtimeEnvironment.Root.NewPath(recoveryPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	f, err := s.runtimeEnvironment.Root().OpenFile(s.runtimeEnvironment.Root().NewPath(recoveryPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("create recovery file: %w", err)
 	}
@@ -144,7 +144,7 @@ func (s *RecoverySite) ArchiveStream(r io.Reader) (_ string, err error) {
 func (s *RecoverySite) RestoreData(recoveryID string) ([]byte, error) {
 
 	recoveryPath := recoveryDir + "/" + recoveryID
-	data, err := s.runtimeEnvironment.Root.ReadFile(s.runtimeEnvironment.Root.NewPath(recoveryPath))
+	data, err := s.runtimeEnvironment.Root().ReadFile(s.runtimeEnvironment.Root().NewPath(recoveryPath))
 	if err != nil {
 		return nil, fmt.Errorf("read recovery data: %w", err)
 	}
@@ -166,25 +166,25 @@ func (s *RecoverySite) RestoreData(recoveryID string) ([]byte, error) {
 func (s *RecoverySite) RestoreFile(original fsroot.Path, recoveryID string) error {
 
 	// Normalize: ensure the Path has fsroot context for confined I/O.
-	original = s.runtimeEnvironment.Root.NewPath(original.Abs())
+	original = s.runtimeEnvironment.Root().NewPath(original.Abs())
 
 	if original.Rel() == "" || recoveryID == "" {
 		return fmt.Errorf("invalid recovery state: missing path metadata")
 	}
 
 	recoveryPath := recoveryDir + "/" + recoveryID
-	recPath := s.runtimeEnvironment.Root.NewPath(recoveryPath)
+	recPath := s.runtimeEnvironment.Root().NewPath(recoveryPath)
 
-	if _, err := s.runtimeEnvironment.Root.Lstat(recPath); errors.Is(err, fs.ErrNotExist) {
+	if _, err := s.runtimeEnvironment.Root().Lstat(recPath); errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("%w: %s", ErrRecoverySourceNotFound, recoveryID)
 	}
 
 	parentDir := recoveryParentDir(original.Rel())
-	if err := s.runtimeEnvironment.Root.MkdirAll(s.runtimeEnvironment.Root.NewPath(parentDir), 0o755); err != nil {
+	if err := s.runtimeEnvironment.Root().MkdirAll(s.runtimeEnvironment.Root().NewPath(parentDir), 0o755); err != nil {
 		return fmt.Errorf("recreate parent directory: %w", err)
 	}
 
-	if err := s.runtimeEnvironment.Root.Rename(recPath, original); err != nil {
+	if err := s.runtimeEnvironment.Root().Rename(recPath, original); err != nil {
 		return fmt.Errorf("restore from recovery: %w", err)
 	}
 

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -37,7 +37,7 @@ func newTestRecoverySite(t *testing.T) (*RecoverySite, fsroot.Root) {
 	}
 	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
 
-	return NewRecoverySite(runtimeEnvironment), runtimeEnvironment.Root
+	return NewRecoverySite(runtimeEnvironment), runtimeEnvironment.Root()
 }
 
 func TestArchiveFile_MovesFile(t *testing.T) {

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -6,6 +6,7 @@ package op
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -38,7 +39,7 @@ func init() {
 // runners, daemons, repls) construct a fresh runtime environment per session; one process may produce many runtime
 // environments over its lifetime.
 //
-// The runtime environment owns the [Root] handle and is the single point of Close responsibility. See
+// The runtime environment owns the root handle and the scratch tree, and is the single point of Close responsibility. See
 // [RuntimeEnvironment.Close]. Every other type in this package that holds a *RuntimeEnvironment
 // ([starlarkbridge.Runtime], [GraphExecutor], [Graph]) is a co-user of the session, not an owner; callers construct the
 // runtime environment, defer Close once, and pass it by pointer to whatever needs it.
@@ -70,12 +71,6 @@ type RuntimeEnvironment struct {
 	//
 	// Nil when running in environments where host access is not needed (e.g., pure data transforms).
 	Platform platform.Platform
-
-	// Root provides scoped filesystem operations.
-	//
-	// All provider I/O goes through this interface. Three implementations: confinedRoot (execution), RootReader
-	// (planning), RootReaderWriter (testing). Created by the executor or test runner; closed after execution completes.
-	Root fsroot.Root
 
 	// Result is the primary output pipeline carried from the [RuntimeEnvironmentSpec].
 	//
@@ -131,6 +126,35 @@ type RuntimeEnvironment struct {
 	// application wires its source maps); every read happens at dispatch. Reading a variable in a provider
 	// constructor would silently reintroduce the config-resolution bug — see TestVariableByName_ReadBeforeSourceSet.
 	resolvers sync.Map
+
+	// rootPath is the anchor the session's root is minted at, carried verbatim from the spec.
+	//
+	// Empty means the session has no root at all — a legal, advertised state; see [RuntimeEnvironment.HasRoot].
+	// [NewRuntimeEnvironment] validates a non-empty anchor with an open-and-release probe, and that validation is
+	// what licenses [RuntimeEnvironment.Root] to assert rather than return an error.
+	rootPath string
+
+	// rootMode selects which [fsroot.Root] implementation is minted at rootPath.
+	rootMode fsroot.Mode
+
+	// root is the session's filesystem root, minted on first use and released by Close.
+	//
+	// Allocation is lazy so a planning-only session that never touches the filesystem holds no handle at all.
+	root fsroot.Root
+
+	// rootOnce mints root exactly once, even when concurrent dispatches call [RuntimeEnvironment.Root] together.
+	rootOnce sync.Once
+
+	// scratch is the session's scratch directory — a private tree inside the OS temp directory, minted on first
+	// use, whose Close removes it along with everything in it.
+	//
+	// Never a root over the temp directory itself: this tree is the session's own, created 0700 so it carries a
+	// protected DACL on Windows, which matters because scratch holds the most sensitive transient data in the
+	// system.
+	scratch fsroot.Root
+
+	// scratchOnce mints scratch exactly once, even under concurrent dispatch.
+	scratchOnce sync.Once
 
 	// mutex guards the providers and services maps for concurrent access.
 	mutex sync.Mutex
@@ -199,14 +223,16 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*
 		modules = ReceiverRegistry().Modules()
 	}
 
-	var root fsroot.Root
-
+	// Preflight, not allocation: both anchors are proved usable here and released again, so a bad anchor is
+	// refused before dispatch rather than killing a run halfway through — and so the accessors may assert.
 	if spec.RootPath != "" {
-		minted, err := fsroot.Open(spec.RootPath, spec.RootMode)
-		if err != nil {
-			return nil, fmt.Errorf("op.NewRuntimeEnvironment: open root %s: %w", spec.RootPath, err)
+		if err := probeRootAnchor(spec.RootPath, spec.RootMode); err != nil {
+			return nil, fmt.Errorf("op.NewRuntimeEnvironment: %w", err)
 		}
-		root = minted
+	}
+
+	if err := probeScratchAnchor(); err != nil {
+		return nil, fmt.Errorf("op.NewRuntimeEnvironment: %w", err)
 	}
 
 	runtimeEnvironment := &RuntimeEnvironment{
@@ -215,13 +241,14 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*
 		Modules:          modules,
 		Platform:         platformCapability,
 		ResourceCatalog:  resourceCatalog,
-		Root:             root,
+		rootPath:         spec.RootPath,
+		rootMode:         spec.RootMode,
 		Status:           statusNarrator,
 		Result:           resultPipeline,
 		variableResolver: NewVariableResolver(spec.Application),
 	}
 
-	if root != nil {
+	if runtimeEnvironment.HasRoot() {
 		runtimeEnvironment.RecoverySite = NewRecoverySite(runtimeEnvironment)
 	}
 
@@ -279,6 +306,71 @@ func (re *RuntimeEnvironment) ActionByName(name ActionName) (Action, error) {
 	return newAction(providerReceiverType, method, name), nil
 }
 
+// HasRoot reports whether the session was built with a filesystem root.
+//
+// It answers from the spec's anchor, not from whether the handle has been minted yet, so the answer never changes
+// over a session's life. A session with no anchor is legal and advertised: [NewRuntimeEnvironment] mints no root
+// when [RuntimeEnvironmentSpec.RootPath] is empty, and `cmd/lore` builds exactly such a session for work that
+// touches no files.
+//
+// If HasRoot returns false, [RuntimeEnvironment.Root] panics.
+//
+// Returns:
+//   - `bool`: true when the session has an anchor and [RuntimeEnvironment.Root] may be called.
+func (re *RuntimeEnvironment) HasRoot() bool { return re.rootPath != "" }
+
+// Root returns the session's filesystem root, minting it on first use.
+//
+// Panics when the session has no root ([RuntimeEnvironment.HasRoot] is false), and panics when minting fails
+// despite the anchor having passed validation at construction. Both are invariant violations rather than
+// conditions to handle: the first is a caller that never asked, the second is an environment that changed under a
+// validated session. This mirrors the repository's checksum trust boundary — an error before verification, an
+// assert after it — and keeps the ~75 call sites that structurally have a root as one-liners.
+//
+// Returns:
+//   - `fsroot.Root`: the session's root, the same instance on every call.
+func (re *RuntimeEnvironment) Root() fsroot.Root {
+
+	if !re.HasRoot() {
+		assert.Failf("op.RuntimeEnvironment.Root: session has no root; guard with HasRoot")
+	}
+
+	re.rootOnce.Do(func() {
+		minted, err := fsroot.Open(re.rootPath, re.rootMode)
+		assert.NoError("op.RuntimeEnvironment.Root: mint root after successful preflight", err)
+		re.root = minted
+	})
+
+	return re.root
+}
+
+// Scratch returns the session's scratch directory, minting it on first use.
+//
+// The directory is the session's own private tree inside the OS temp directory, created 0700 — never a root over
+// the temp directory itself, which is shared with every other process, cannot be mode-controlled, and could not
+// be removed on Close. [RuntimeEnvironment.Close] removes the tree and everything left in it.
+//
+// Takes no predicate: unlike the root, scratch has nothing to configure, so there is no session that lacks one and
+// a HasScratch could only ever return true. Panics when minting fails, on the same grounds as
+// [RuntimeEnvironment.Root]: [NewRuntimeEnvironment] proves the OS temp directory usable at construction.
+//
+// Use scratch unless the bytes must end up in the root's tree atomically — a rename out of scratch can cross a
+// device boundary and degrade to a copy, so a stage-then-rename stages with [fsroot.Root.CreateTemp] on
+// [RuntimeEnvironment.Root] instead.
+//
+// Returns:
+//   - `fsroot.Root`: the session's scratch directory, the same instance on every call.
+func (re *RuntimeEnvironment) Scratch() fsroot.Root {
+
+	re.scratchOnce.Do(func() {
+		minted, err := fsroot.OpenScratch(re.Application.Name + "-*")
+		assert.NoError("op.RuntimeEnvironment.Scratch: mint scratch after successful preflight", err)
+		re.scratch = minted
+	})
+
+	return re.scratch
+}
+
 // endregion
 
 // region Behaviors
@@ -298,7 +390,7 @@ func (re *RuntimeEnvironment) Capture(cmd *exec.Cmd) ([]byte, error) {
 	return re.runner().Capture(cmd)
 }
 
-// Close releases the session's owned resources — currently the [Root] handle.
+// Close releases the session's owned resources — the root handle, and the scratch tree along with its contents.
 //
 // Idempotent: The close path runs exactly once per runtime environment regardless of how many times Close is called.
 // The first call performs the close and stores any joined error; later calls return the stored error without
@@ -313,7 +405,10 @@ func (re *RuntimeEnvironment) Capture(cmd *exec.Cmd) ([]byte, error) {
 func (re *RuntimeEnvironment) Close() error {
 
 	re.closeOnce.Do(func() {
-		iox.Close(&re.closeErr, re.Root)
+		// Only what was actually minted: a session that never touched the filesystem closes nothing. Closing the
+		// scratch root removes its tree, so a leaked handle inside it surfaces here as an error rather than as a
+		// silently orphaned directory.
+		iox.Close(&re.closeErr, re.root, re.scratch)
 	})
 
 	return re.closeErr
@@ -922,6 +1017,60 @@ func (c *RuntimeEnvironmentSpec) WithStatus(narrator *status.Narrator) *RuntimeE
 
 	c.Status = narrator
 	return c
+}
+
+// endregion
+
+// region HELPER FUNCTIONS
+
+// probeRootAnchor proves a root anchor usable, then releases it.
+//
+// The probe is what turns a bad anchor into a refusal before dispatch rather than a failure halfway through a run,
+// and it is what licenses [RuntimeEnvironment.Root] to assert on a later mint failure. Opening and releasing —
+// rather than holding — keeps allocation lazy, so a session that never touches the filesystem carries no handle.
+//
+// Parameters:
+//   - `path`: the anchor directory.
+//   - `mode`: the [fsroot.Mode] the session will mint with.
+//
+// Returns:
+//   - `error`: a wrapped error when the anchor cannot be opened in the requested mode.
+func probeRootAnchor(path string, mode fsroot.Mode) error {
+
+	probe, err := fsroot.Open(path, mode)
+	if err != nil {
+		return fmt.Errorf("open root %s: %w", path, err)
+	}
+
+	if err := probe.Close(); err != nil {
+		return fmt.Errorf("release root probe %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// probeScratchAnchor proves the OS temporary directory writable, then removes what it created.
+//
+// Scratch has no configurable anchor — [os.MkdirTemp] resolves through [os.TempDir], which already honors TMPDIR
+// on Unix and TMP/TEMP on Windows — so this probes the one location scratch can ever use. Proving it here is what
+// licenses [RuntimeEnvironment.Scratch] to assert instead of returning an error.
+//
+// Returns:
+//   - `error`: a wrapped error when the temporary directory cannot be created or removed.
+func probeScratchAnchor() error {
+
+	// Confinement: this is the probe that proves fsroot's own scratch anchor usable, so it cannot itself run
+	// through a root — there is no root to run it through until it succeeds.
+	dir, err := os.MkdirTemp("", "devlore-scratch-probe-*")
+	if err != nil {
+		return fmt.Errorf("probe scratch anchor %s: %w", os.TempDir(), err)
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("release scratch probe %s: %w", dir, err)
+	}
+
+	return nil
 }
 
 // endregion

--- a/pkg/op/runtime_environment_test.go
+++ b/pkg/op/runtime_environment_test.go
@@ -5,8 +5,11 @@ package op
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
@@ -98,10 +101,10 @@ func TestNewRuntimeEnvironment_MintsRootFromAnchor(t *testing.T) {
 		t.Fatalf("NewRuntimeEnvironment: %v", err)
 	}
 
-	if runtimeEnvironment.Root == nil {
+	if runtimeEnvironment.Root() == nil {
 		t.Fatal("Root = nil, want a minted confined root")
 	}
-	if got := runtimeEnvironment.Root.Name(); got != dir {
+	if got := runtimeEnvironment.Root().Name(); got != dir {
 		t.Errorf("Root.Name() = %q, want %q", got, dir)
 	}
 	if runtimeEnvironment.RecoverySite == nil {
@@ -128,7 +131,9 @@ func TestNewRuntimeEnvironment_BadAnchorFails(t *testing.T) {
 
 // TestNewRuntimeEnvironment_EmptyAnchorMeansNoRoot verifies the no-root semantics.
 //
-// An unset anchor yields a nil Root and no RecoverySite — the pre-#393 nil-Root contract, preserved.
+// An unset anchor is legal and advertised — `cmd/lore` builds such a session in production — and it yields no
+// RecoverySite. HasRoot reports the state, and Root panics rather than handing back a nil interface that would
+// fail later, inside fsroot, with a stack that never names the mistake.
 func TestNewRuntimeEnvironment_EmptyAnchorMeansNoRoot(t *testing.T) {
 
 	app := &application.Application{Name: "test"}
@@ -139,10 +144,66 @@ func TestNewRuntimeEnvironment_EmptyAnchorMeansNoRoot(t *testing.T) {
 		t.Fatalf("NewRuntimeEnvironment: %v", err)
 	}
 
-	if runtimeEnvironment.Root != nil {
-		t.Errorf("Root = %v, want nil (no anchor set)", runtimeEnvironment.Root)
+	if runtimeEnvironment.HasRoot() {
+		t.Error("HasRoot = true, want false (no anchor set)")
 	}
 	if runtimeEnvironment.RecoverySite != nil {
-		t.Error("RecoverySite non-nil, want nil (no root minted)")
+		t.Error("RecoverySite non-nil, want nil (no root)")
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("Root on a rootless session did not panic; the nil interface would fail later, inside fsroot")
+		}
+	}()
+	_ = runtimeEnvironment.Root()
+}
+
+// TestRuntimeEnvironment_ScratchIsAPrivateTreeRemovedOnClose pins the scratch contract: a directory of the
+// session's own inside the OS temp directory, the same instance on every call, gone with its contents on Close.
+func TestRuntimeEnvironment_ScratchIsAPrivateTreeRemovedOnClose(t *testing.T) {
+
+	app := &application.Application{Name: "test"}
+	spec := NewRuntimeEnvironmentSpec(app.Name).WithApplication(app)
+
+	runtimeEnvironment, err := NewRuntimeEnvironment(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewRuntimeEnvironment: %v", err)
+	}
+
+	scratch := runtimeEnvironment.Scratch()
+	if scratch == nil {
+		t.Fatal("Scratch = nil; a session always has one")
+	}
+	if again := runtimeEnvironment.Scratch(); again != scratch {
+		t.Error("Scratch returned a second instance; the session's scratch is one tree, minted once")
+	}
+
+	// A rootless session still has scratch — the two are independent, which is the point of having no HasScratch.
+	if runtimeEnvironment.HasRoot() {
+		t.Error("HasRoot = true, want false")
+	}
+
+	if inside := scratch.Name(); !strings.HasPrefix(inside, os.TempDir()) {
+		t.Errorf("scratch anchored at %q, want a directory inside %q", inside, os.TempDir())
+	}
+
+	// 0700 is what carries the protected DACL on Windows; mode bits are a Unix subject.
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(scratch.Name())
+		if statErr != nil {
+			t.Fatalf("Stat(scratch): %v", statErr)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Errorf("scratch mode = %v, want 0700", got)
+		}
+	}
+
+	tree := scratch.Name()
+	if err := runtimeEnvironment.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(tree); !os.IsNotExist(err) {
+		t.Errorf("Stat after Close = %v, want the scratch tree removed", err)
 	}
 }

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -45,7 +45,7 @@ func newTriad(t *testing.T, mode fsroot.Mode, dir string) triadEnv {
 	}
 	t.Cleanup(func() { _ = runtimeEnvironment.Close() })
 
-	return triadEnv{Root: runtimeEnvironment.Root, Site: op.NewRecoverySite(runtimeEnvironment), Dir: dir}
+	return triadEnv{Root: runtimeEnvironment.Root(), Site: op.NewRecoverySite(runtimeEnvironment), Dir: dir}
 }
 
 func newTriadRW(t *testing.T) triadEnv {


### PR DESCRIPTION
## Summary

Phase 2b, **PR 2b.2b** of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)), completing 2b.2 after
[#413](https://github.com/NobleFactor/devlore-cli/pull/413) added `CreateTemp` / `MkdirTemp`.

`RuntimeEnvironment.Root` is no longer a field anyone can set or read. **The session owns filesystem
access and hands it out** — the invariant this phase exists to establish.

## The accessors

**`HasRoot()`** answers from the spec's anchor, not from whether a handle has been minted, so the
answer cannot change mid-session.

**`Root()` panics when `HasRoot()` is false.** A rootless session is legal and advertised —
`cmd/lore/lore/builder.go` builds one in production — so the panic reports *a caller that never
asked*. A bare `nil` was rejected in design: `fsroot.Root` is an **interface**, so nil doesn't avoid
the panic, it relocates it into `fsroot` with a stack that never names the mistake. Modeled on
`reflect.Value.IsValid`, whose doc states the rule once and whose getters panic.

**`Scratch()`** returns a per-session private directory **inside** the OS temp directory — never a
root over the temp directory itself, which is shared with every process, cannot be mode-controlled,
and could not be removed on `Close`. Created `0700`, so phase 2 gives it a protected DACL on
Windows. **No `HasScratch`**: nothing about scratch is configurable, so it could only return `true`.

## Preflight is what licenses the asserts

`probeRootAnchor` opens and releases the root; `probeScratchAnchor` creates and removes a temp
directory. Validation passes at construction, so a later failure is an invariant violation, not a
condition — the same trust boundary the checksum rule draws. Allocation stays **lazy** behind a
`sync.Once` each, because `gather` dispatches bodies concurrently and two goroutines can reach an
accessor at the same moment. A planning-only session holds no handle and closes nothing.

## Migration

**105 sites across 25 files**, and the **seven** that nil-checked the field became `HasRoot()`
guards. The 82-site estimate counted production only and was accurate there; test files added the
rest.

**The mechanical rewrite over-matched once and the compiler caught it:** `triad_test.go` has a local
`triadEnv` fixture with its own `Root` **field**, so `env.Root` there is not the session — 20
rewrites reverted. It failed loudly only because a field is not callable. An interface with a
`Root()` method would have compiled and silently changed meaning, **which is the risk phase 6's
rename runs over a much larger surface.**

## Tests

One existing test specified the old contract (`Root() != nil` on a rootless session) and now
specifies the new one, with `recover()` proving the panic. A new test pins scratch: private tree
inside `os.TempDir()`, same instance on every call, `0700`, removed on `Close`.

`make test` zero failures; `make lint-all` zero issues on linux, darwin, and windows.
`test (windows-latest)` is expected to hold at its known 28.

Assisted-by: Claude
