### PR TITLE
refactor(archive,devlore-test): retire the hand-rolled temp lifecycles

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -227,17 +227,22 @@ func NewRunner(script string, opts ...Option) *Runner {
 //   - `error`: non-nil if script loading or graph execution fails unexpectedly.
 func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 
-	// 1. Create a temp directory
+	// 1. Create the workspace — a scratch root, so the tree is removed by the same Close that releases it.
 
-	tmpDir, err := os.MkdirTemp("", "devlore-test-*")
+	workspace, err := fsroot.OpenScratch("devlore-test-*")
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
+		return nil, fmt.Errorf("creating test workspace: %w", err)
 	}
-	defer func() { _ = os.RemoveAll(tmpDir) }() //nolint:errcheck // best-effort cleanup
+	defer iox.Close(&err, workspace)
+
+	tmpDir := workspace.Name()
 
 	// 2. Create ReceiverRegistry and Spec
 
 	receiverRegistry := op.ReceiverRegistry()
+
+	// The test context writes through an unconfined root over the same tree: scripts under test address absolute
+	// paths, which a confined root refuses by design. The workspace above owns the tree's lifetime either way.
 	root := fsroot.OpenWritableUnconfined(tmpDir)
 	defer iox.Close(&err, root)
 

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -375,7 +375,7 @@ test constructor must land **first** or nothing is actually split.
 | **2b.1b** | Remaining **26 sites / 12 files** — branch `test-env-constructor-remainder` | ✅ **complete 2026-08-14** |
 | **2b.2a** | `Dir.CreateTemp` + `Dir.MkdirTemp` on the interface — branch `fsroot-temp-methods` | ✅ **merged 2026-08-14 (#413)** |
 | **2b.2b** | Field → private, `HasRoot()` / `Root()` / `Scratch()`, preflight, lazy allocation, **105 rewrites / 25 files** | ✅ **complete 2026-08-14** |
-| **2b.3** | Move `archive`'s spool and `devlore-test`'s runner onto `Scratch()` (optional; may fold into 2b.2) | pending |
+| **2b.3** | Move `archive`'s spool and `devlore-test`'s runner off hand-rolled temp lifecycles | ✅ **complete 2026-08-14** |
 
 **A codegen PR was planned and proved unnecessary.** The `receiver_type.gen_test.go` template emits
 `Application` / `Context` / `Status` and **never `Root`**, so no generated file breaks. Verified by
@@ -513,6 +513,30 @@ in the root's tree atomically; if the operation ends in a rename into that tree,
 `Root().CreateTemp` so the rename cannot cross a device boundary.* Applied to the known consumers:
 the archive spool gives random access to a streamed zip whose bytes never enter the user's tree →
 **scratch**; a file provider writing a target file atomically → **`Root().CreateTemp` + `Rename`**.
+
+#### 2b.3 as delivered (2026-08-14) — and one correction to this plan
+
+**`archive`'s spool** now lands in the session's scratch through `Scratch().CreateTemp`, threaded
+down via `openArchiveStream`. Three consequences: **both `//nolint:gosec` suppressions disappear**
+(no `os.Remove` of a variable path is left to justify), the spool is `0600` and therefore
+DACL-protected on Windows instead of a bare temp file, and a crashed run leaks nothing — scratch is
+swept at session close even if the reader never closes. The reader still removes its own file on
+close, because an archive's bytes should not outlive the read that needed them and a long session
+extracting many archives would otherwise accumulate them.
+
+**`devlore-test`'s runner** collapses `os.MkdirTemp` + `defer os.RemoveAll` + its
+`//nolint:errcheck` best-effort cleanup into a single `fsroot.OpenScratch("devlore-test-*")`, where
+one `Close` both releases the handle and removes the tree.
+
+**Correction to this plan's wording:** the runner cannot use `RuntimeEnvironment.Scratch()`. It
+builds its `TestContext` *before* any session exists — the workspace is the tree the session is then
+anchored at — so the correct tool is `fsroot.OpenScratch`, which is exactly what phase 1 built it
+for. "Onto `Scratch()`" was the right idea named for the wrong API.
+
+**Deliberately not changed:** `TestContext` keeps an **unconfined** writable root over that tree.
+Scripts under test address absolute paths, which a confined root refuses by design, so handing it
+the scratch root would smuggle a behavior change into a cleanup — and the Windows leg already has
+`devlore-test` failures that would then be unattributable.
 
 #### 2b.2 as delivered (2026-08-14)
 

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider"
@@ -122,7 +123,7 @@ func (p *Provider) ExtractStream(
 	prefixPath string,
 ) (products []file.Entry, stack *op.RecoveryStack, err error) {
 
-	reader, err := openArchiveStream(src)
+	reader, err := openArchiveStream(activationRecord.RuntimeEnvironment.Scratch(), src)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -305,12 +306,13 @@ func (p *Provider) openArchive(source string) (archiveReader, error) {
 // closes.
 //
 // Parameters:
+//   - `scratch`: the session's scratch directory, where a zip stream spools.
 //   - `src`: the archive bytes, consumed exactly once from the current position.
 //
 // Returns:
 //   - `archiveReader`: an entry iterator over the stream; the caller closes it.
 //   - `error`: an undetectable format, or any sniff/spool/decompress failure.
-func openArchiveStream(src io.Reader) (archiveReader, error) {
+func openArchiveStream(scratch fsroot.Root, src io.Reader) (archiveReader, error) {
 
 	header := make([]byte, headerSniffLen)
 	n, err := io.ReadFull(src, header)
@@ -325,7 +327,7 @@ func openArchiveStream(src io.Reader) (archiveReader, error) {
 	case formatGzip, formatBzip2, formatXz, formatZstd, formatTar:
 		return tarReaderFor(format, stitched, nil)
 	case formatZip:
-		return spoolZipStream(stitched)
+		return spoolZipStream(scratch, stitched)
 	default:
 		return nil, fmt.Errorf("unsupported archive format on stream")
 	}
@@ -455,33 +457,38 @@ func copyHardlinkEntry(
 	return product, receipt, nil
 }
 
-// spoolZipStream drains `stream` to a temporary file and opens it as a zip, removing the file on close.
+// spoolZipStream drains `stream` into the session's scratch directory and opens it as a zip.
+//
+// The spool lands in scratch rather than the target tree: its bytes never belong to the user's tree, and scratch is
+// private (0700, DACL-protected on Windows) and swept when the session closes — so a crashed run leaks nothing into
+// a deploy target. The reader still removes its own file on close, because an archive's bytes should not outlive
+// the read that needed them.
 //
 // Parameters:
+//   - `scratch`: the session's scratch directory.
 //   - `stream`: the complete zip bytes.
 //
 // Returns:
 //   - `archiveReader`: the zip entry iterator over the spooled file; closing it also removes the file.
 //   - `error`: any spool or zip-open failure (the temporary file is removed on failure).
-func spoolZipStream(stream io.Reader) (archiveReader, error) {
+func spoolZipStream(scratch fsroot.Root, stream io.Reader) (archiveReader, error) {
 
-	// Confinement: the spool is process scratch in the system temp dir, not target-tree I/O (§10 ruling 5).
-	spool, err := os.CreateTemp("", "devlore-archive-*.zip")
+	spool, spoolPath, err := scratch.CreateTemp(scratch.NewPath("."), "archive-*.zip")
 	if err != nil {
 		return nil, fmt.Errorf("archive: spool zip stream: %w", err)
 	}
 
 	if _, err = io.Copy(spool, stream); err != nil {
-		//nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
-		return nil, errors.Join(fmt.Errorf("archive: spool zip stream: %w", err), spool.Close(), os.Remove(spool.Name()))
-	}
-	inner, err := newZipArchiveReader(spool)
-	if err != nil {
-		//nolint:gosec // G703: the path is os.CreateTemp's own name, not external input.
-		return nil, errors.Join(err, os.Remove(spool.Name()))
+		return nil, errors.Join(
+			fmt.Errorf("archive: spool zip stream: %w", err), spool.Close(), scratch.Remove(spoolPath))
 	}
 
-	return &spooledZipReader{zipArchiveReader: inner, spoolPath: spool.Name()}, nil
+	inner, err := newZipArchiveReader(spool)
+	if err != nil {
+		return nil, errors.Join(err, scratch.Remove(spoolPath))
+	}
+
+	return &spooledZipReader{zipArchiveReader: inner, scratch: scratch, spoolPath: spoolPath}, nil
 }
 
 // endregion
@@ -897,7 +904,12 @@ func (r *zipArchiveReader) Close() error {
 // spooledZipReader wraps a [zipArchiveReader] over a spooled temporary file, removing the file on close.
 type spooledZipReader struct {
 	*zipArchiveReader
-	spoolPath string
+
+	// scratch is the session's scratch directory, the root the spool file was created in and is removed through.
+	scratch fsroot.Root
+
+	// spoolPath is the spooled file inside scratch, removed by Close.
+	spoolPath fsroot.Path
 }
 
 // Close closes the underlying zip reader and removes the spooled temporary file, joining any errors.
@@ -905,7 +917,7 @@ type spooledZipReader struct {
 // Returns:
 //   - `error`: the joined close/remove errors, or nil.
 func (r *spooledZipReader) Close() error {
-	return errors.Join(r.zipArchiveReader.Close(), os.Remove(r.spoolPath))
+	return errors.Join(r.zipArchiveReader.Close(), r.scratch.Remove(r.spoolPath))
 }
 
 // region HELPER FUNCTIONS


### PR DESCRIPTION
## Summary

Phase 2b, **PR 2b.3** of [`windows-native-permissions.md`](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/windows-native-permissions.md)
([#405](https://github.com/NobleFactor/devlore-cli/issues/405)) — the first code to **consume** the
session scratch that 2b.2 introduced, which makes it the first real test of whether the API reads
well at a call site.

## `archive`

The zip spool moves onto `Scratch().CreateTemp`, threaded down through `openArchiveStream`. Three
things follow:

- **Both `//nolint:gosec` suppressions disappear** — there is no longer an `os.Remove` of a variable
  path to justify.
- The spool is created **0600**, so on Windows it carries a protected DACL instead of being a bare
  temp file.
- A crashed run leaks nothing: scratch is swept at session close even if the reader never closes.

The reader still removes its own file on close — an archive's bytes should not outlive the read that
needed them, and a long session extracting many archives would otherwise accumulate them.

## `devlore-test`

`os.MkdirTemp` + `defer os.RemoveAll` + a `//nolint:errcheck` best-effort cleanup collapse into one
`fsroot.OpenScratch("devlore-test-*")`, where a single `Close` both releases the handle and removes
the tree.

## A plan correction, and one deliberate non-change

**The runner cannot use `RuntimeEnvironment.Scratch()`.** It builds its `TestContext` *before* any
session exists — the workspace is the tree the session is then anchored at — so `fsroot.OpenScratch`
is the right tool, which is what phase 1 built it for. "Onto `Scratch()`" was the right idea named
for the wrong API; the plan now says so.

**`TestContext` keeps an unconfined writable root** over that tree. Scripts under test address
absolute paths, which a confined root refuses by design, so handing it the scratch root would
smuggle a behavior change into a cleanup — and the Windows leg already has `devlore-test` failures
that would then be unattributable.

## Verification

`make test` zero failures; `make lint-all` zero issues on linux, darwin, and windows.
`test (windows-latest)` is expected to hold at its known 28.

Assisted-by: Claude
