### PR TITLE
feat(xdg): one place for XDG locations, one way to find home

### DIFF
--- a/docs/architecture/2.8-eventing-infrastructure.md
+++ b/docs/architecture/2.8-eventing-infrastructure.md
@@ -107,6 +107,28 @@ suppression, linking back to this spec:
 log call. When the diagnostics API lands, the sweep converts each site to a real diagnostics call and deletes the
 suppression; the marker count reaching zero is the done signal.
 
+### Discarded values owe the same debt
+
+An intentionally discarded *input* — a malformed environment variable, a configuration entry rejected as invalid —
+is a pending diagnostic on exactly the same terms as a discarded error. The user set something and the program
+declined to use it; saying nothing leaves them to discover the difference by its absence.
+
+Such a site has no `err` to suppress and therefore no `//nolint` comment for the marker to live in, so **the marker
+goes in a plain comment at the site**:
+
+```go
+// diagnose-ignored-error: <what was discarded and why>; see docs/architecture/2.8-eventing-infrastructure.md
+```
+
+One search string, one done signal: a discarded value that hides from `grep diagnose-ignored-error` is invisible to
+the sweep that closes this out.
+
+The first instance is `pkg/xdg`, where a relative `XDG_*` variable is discarded. That one is not merely our
+convention — the XDG Base Directory Specification requires it: an implementation encountering a relative path
+"should consider the path invalid and ignore it", and the specification separately instructs applications to
+"print a warning message" when `XDG_RUNTIME_DIR` is absent. External requirements to warn are the strongest case
+for this stream existing at all.
+
 ## Is eventing OpenTelemetry?
 
 OpenTelemetry's collectors support many forms of logging and export, so its collector / exporter pipeline already **is**

--- a/docs/plans/extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md
+++ b/docs/plans/extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md
@@ -216,6 +216,10 @@ under `%USERPROFILE%` never raises the question.
 - [ ] All 30 route through the one package: no other package resolves home or names an XDG location.
 - [ ] `cmd/writ`'s `TargetRoot` and `~` expansion fixed — the most severe sites, and the reason this
       step is no longer just about `xdg.go`.
+- [ ] Discarded relative `XDG_*` values carry the `diagnose-ignored-error` marker, so they enumerate with
+      every other pending diagnostic (2.8 §"Ignored errors are diagnostics" → "Discarded values owe the same
+      debt"). The specification requires the warning; the stream does not exist yet, so the debt is recorded
+      rather than paid.
 - [ ] No anchor can resolve to a relative path — proved by a test that controls **both** `HOME` and
       `USERPROFILE`, including the case where neither is set.
 - [x] The failure mode is decided: the four-rung ladder above, with an assert only at rung 4.

--- a/pkg/xdg/xdg.go
+++ b/pkg/xdg/xdg.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+// Package xdg resolves the XDG base directories, rooted at the user's home directory on every platform.
+//
+// This is the single place to ask where user-scoped files belong, and the single way to resolve the home
+// directory. No other package resolves home for itself: naming `HOME` — or `USERPROFILE` — anywhere else is
+// what made the same logical location resolve to two different places on Windows.
+//
+// # Layout
+//
+// The standard XDG directory names, rooted at home, on every platform: `~/.config`, `~/.local/share`,
+// `~/.local/state`, `~/.cache`, plus `~/.local/bin` for the de-facto XDG_BIN_HOME extension. The `XDG_*`
+// variables override, as the specification requires. Windows gets no special case — it receives
+// `%USERPROFILE%\.config` and friends rather than `%LOCALAPPDATA%`.
+//
+// That is a deliberate divergence from the cross-platform directory libraries (Go's `adrg/xdg`, Python's
+// `platformdirs`, Rust's `dirs`), which map the XDG roles onto Windows Known Folders. It follows git,
+// Microsoft's own OpenSSH port, Docker, kubectl, cargo, Starship and WezTerm instead, so that people working
+// across platforms meet one layout rather than three.
+//
+// # Resolving home
+//
+// A ladder, because no single source always answers:
+//
+//  1. The role's `XDG_*` variable, when it names an **absolute** path. A relative value is invalid and
+//     ignored, per the specification, so resolution continues as though it were unset.
+//  2. [os.UserHomeDir] — the environment's answer, under whichever variable name the platform uses. It is a
+//     switch on GOOS, so it reads exactly one name per platform and never the others.
+//  3. [user.Current] — the operating system's answer: the process token's profile directory on Windows, the
+//     passwd entry on Unix. Reached when the environment is silent, which happens to services and scheduled
+//     tasks on Windows.
+//  4. Nothing left. That is an environment in which no anchor can be honored, so it asserts rather than
+//     returning a path no caller could use.
+//
+// A fully configured environment never reaches rung 2: set every `XDG_*` variable absolutely and home is
+// never consulted at all.
+//
+// # No runtime directory
+//
+// `XDG_RUNTIME_DIR` is deliberately absent. The specification gives it no default and tells applications
+// without it to "fall back to a replacement directory with similar capabilities" — user-owned, 0700, lifetime
+// bound to the session. That is precisely the session scratch directory (`op.RuntimeEnvironment.Scratch`),
+// which exists on every platform and is removed when the session closes. An accessor here would report
+// "unset" on macOS and Windows while the correct answer sat one call away under a better name.
+package xdg
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
+)
+
+// Environment variable names read by this package.
+//
+// They appear here and nowhere else: a home-directory variable is never named outside this file, because
+// [os.UserHomeDir] already knows which one each platform uses.
+const (
+	envBinHome    = "XDG_BIN_HOME"
+	envCacheHome  = "XDG_CACHE_HOME"
+	envConfigDirs = "XDG_CONFIG_DIRS"
+	envConfigHome = "XDG_CONFIG_HOME"
+	envDataDirs   = "XDG_DATA_DIRS"
+	envDataHome   = "XDG_DATA_HOME"
+	envStateHome  = "XDG_STATE_HOME"
+)
+
+// region EXPORTED FUNCTIONS
+
+// BinHome returns the base directory for user-specific executables.
+//
+// `XDG_BIN_HOME` is a de-facto extension rather than part of the base specification, but `~/.local/bin` is
+// where self-installation puts binaries and where shells expect to find them.
+//
+// Returns:
+//   - `string`: the value of `XDG_BIN_HOME` when absolute, else `~/.local/bin`.
+func BinHome() string { return base(envBinHome, ".local", "bin") }
+
+// BinPath joins `elem` onto [BinHome].
+//
+// Parameters:
+//   - `elem`: path elements below the base directory; the application name is simply the first of them.
+//
+// Returns:
+//   - `string`: the joined path.
+func BinPath(elem ...string) string { return join(BinHome(), elem) }
+
+// CacheHome returns the base directory for user-specific non-essential data.
+//
+// Returns:
+//   - `string`: the value of `XDG_CACHE_HOME` when absolute, else `~/.cache`.
+func CacheHome() string { return base(envCacheHome, ".cache") }
+
+// CachePath joins `elem` onto [CacheHome].
+//
+// Parameters:
+//   - `elem`: path elements below the base directory; the application name is simply the first of them.
+//
+// Returns:
+//   - `string`: the joined path.
+func CachePath(elem ...string) string { return join(CacheHome(), elem) }
+
+// ConfigDirs returns the preference-ordered directories to search for configuration, after [ConfigHome].
+//
+// Returns:
+//   - `[]string`: the absolute entries of `XDG_CONFIG_DIRS`, else the specification's default of `/etc/xdg`.
+func ConfigDirs() []string { return dirs(envConfigDirs, "/etc/xdg") }
+
+// ConfigHome returns the base directory for user-specific configuration.
+//
+// Returns:
+//   - `string`: the value of `XDG_CONFIG_HOME` when absolute, else `~/.config`.
+func ConfigHome() string { return base(envConfigHome, ".config") }
+
+// ConfigPath joins `elem` onto [ConfigHome].
+//
+// Parameters:
+//   - `elem`: path elements below the base directory; the application name is simply the first of them.
+//
+// Returns:
+//   - `string`: the joined path.
+func ConfigPath(elem ...string) string { return join(ConfigHome(), elem) }
+
+// DataDirs returns the preference-ordered directories to search for data files, after [DataHome].
+//
+// Returns:
+//   - `[]string`: the absolute entries of `XDG_DATA_DIRS`, else the specification's defaults.
+func DataDirs() []string { return dirs(envDataDirs, "/usr/local/share", "/usr/share") }
+
+// DataHome returns the base directory for user-specific data files.
+//
+// Returns:
+//   - `string`: the value of `XDG_DATA_HOME` when absolute, else `~/.local/share`.
+func DataHome() string { return base(envDataHome, ".local", "share") }
+
+// DataPath joins `elem` onto [DataHome].
+//
+// Parameters:
+//   - `elem`: path elements below the base directory; the application name is simply the first of them.
+//
+// Returns:
+//   - `string`: the joined path.
+func DataPath(elem ...string) string { return join(DataHome(), elem) }
+
+// StateHome returns the base directory for state that should persist between restarts but is not portable.
+//
+// Logs, history, and recently-used lists live here rather than in [DataHome].
+//
+// Returns:
+//   - `string`: the value of `XDG_STATE_HOME` when absolute, else `~/.local/state`.
+func StateHome() string { return base(envStateHome, ".local", "state") }
+
+// StatePath joins `elem` onto [StateHome].
+//
+// Parameters:
+//   - `elem`: path elements below the base directory; the application name is simply the first of them.
+//
+// Returns:
+//   - `string`: the joined path.
+func StatePath(elem ...string) string { return join(StateHome(), elem) }
+
+// UserHomeDir returns the user's home directory, asking the operating system when the environment is silent.
+//
+// Rungs 2 through 4 of the ladder described in the package documentation. Callers wanting a standard location
+// should use the base accessors instead; this exists for the cases that genuinely mean *the home directory* —
+// a deploy target, or expanding a leading `~` in user input.
+//
+// Panics when neither the environment nor the user account yields a home directory, which requires the
+// platform's home variable to be unset, the user account to be unreadable, and — on Unix built without cgo —
+// no matching `/etc/passwd` entry. No anchor of any kind can be honored in that environment.
+//
+// Returns:
+//   - `string`: the home directory, never empty and never relative.
+func UserHomeDir() string {
+
+	if home, err := os.UserHomeDir(); err == nil && filepath.IsAbs(home) {
+		return home
+	}
+
+	if account, err := user.Current(); err == nil && filepath.IsAbs(account.HomeDir) {
+		return account.HomeDir
+	}
+
+	assert.Failf("xdg.UserHomeDir: no home directory from the environment or the user account")
+	return ""
+}
+
+// endregion
+
+// region HELPER FUNCTIONS
+
+// base returns the XDG base directory for one role.
+//
+// The variable wins when it names an absolute path. An empty or relative value is invalid and ignored per the
+// specification — [filepath.IsAbs] is false for both, so one test covers unset and invalid alike, and a
+// relative anchor becomes structurally impossible rather than merely guarded against.
+//
+// diagnose-ignored-error: a relative XDG_* value is discarded here, and the user is told nothing until the
+// diagnostics stream exists; see docs/architecture/2.8-eventing-infrastructure.md. The specification itself
+// tells implementations to warn, and this package must not take a dependency on a narrator to say so.
+//
+// Parameters:
+//   - `variable`: the `XDG_*` environment variable name.
+//   - `elem`: the default's path elements below the home directory.
+//
+// Returns:
+//   - `string`: the resolved base directory, always absolute.
+func base(variable string, elem ...string) string {
+
+	if dir := os.Getenv(variable); filepath.IsAbs(dir) {
+		return filepath.Clean(dir)
+	}
+
+	return join(UserHomeDir(), elem)
+}
+
+// dirs returns the absolute entries of a search-path variable, or the supplied defaults.
+//
+// Relative entries are dropped rather than resolved, for the reason [base] gives. An entirely relative or
+// empty variable therefore yields the defaults, not an empty list.
+//
+// Parameters:
+//   - `variable`: the `XDG_*_DIRS` environment variable name.
+//   - `fallback`: the specification's defaults, used when the variable contributes no absolute entry.
+//
+// Returns:
+//   - `[]string`: the search path in preference order.
+func dirs(variable string, fallback ...string) []string {
+
+	var found []string
+
+	for _, dir := range filepath.SplitList(os.Getenv(variable)) {
+		if filepath.IsAbs(dir) {
+			found = append(found, filepath.Clean(dir))
+		}
+	}
+
+	if len(found) == 0 {
+		return fallback
+	}
+
+	return found
+}
+
+// join appends path elements to a base directory.
+//
+// Parameters:
+//   - `dir`: the base directory.
+//   - `elem`: the elements to append; none yields the base directory itself.
+//
+// Returns:
+//   - `string`: the joined path.
+func join(dir string, elem []string) string {
+
+	if len(elem) == 0 {
+		return dir
+	}
+
+	return filepath.Join(append([]string{dir}, elem...)...)
+}
+
+// endregion

--- a/pkg/xdg/xdg_test.go
+++ b/pkg/xdg/xdg_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package xdg
+
+import (
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// homeVariable returns the environment variable [os.UserHomeDir] reads on this platform.
+//
+// This is the one place in the repository that names a home-directory variable outside the package
+// documentation: a test that proves the fallback ladder has to be able to silence the rung above it.
+//
+// Returns:
+//   - `string`: "USERPROFILE" on Windows, "home" on plan9, "HOME" elsewhere.
+func homeVariable() string {
+
+	switch runtime.GOOS {
+	case "windows":
+		return "USERPROFILE"
+	case "plan9":
+		return "home"
+	default:
+		return "HOME"
+	}
+}
+
+// clearEnvironment blanks every variable this package reads, so a test sees pristine defaults.
+//
+// Parameters:
+//   - `t`: the test harness; [testing.T.Setenv] restores each value at test end.
+func clearEnvironment(t *testing.T) {
+
+	t.Helper()
+
+	for _, variable := range []string{
+		envBinHome, envCacheHome, envConfigDirs, envConfigHome, envDataDirs, envDataHome, envStateHome,
+	} {
+		t.Setenv(variable, "")
+	}
+}
+
+// --- UserHomeDir ---
+
+// TestUserHomeDir_UsesTheEnvironmentWhenItAnswers pins rung 2: the platform's own variable, whatever it is
+// called here.
+func TestUserHomeDir_UsesTheEnvironmentWhenItAnswers(t *testing.T) {
+
+	want := t.TempDir()
+	t.Setenv(homeVariable(), want)
+
+	if got := UserHomeDir(); got != want {
+		t.Errorf("UserHomeDir() = %q, want %q", got, want)
+	}
+}
+
+// TestUserHomeDir_FallsBackToTheUserAccount pins rung 3 — the rung that exists for Windows services and
+// scheduled tasks, where the environment carries no home at all.
+//
+// Rung 4 (the assert) is deliberately not exercised: reaching it requires the user account lookup to fail
+// too, which no in-process seam can force. The invariant that stands in for it is asserted by
+// [TestNoAnchorIsEverRelative] — whatever rung answers, the result is absolute.
+func TestUserHomeDir_FallsBackToTheUserAccount(t *testing.T) {
+
+	t.Setenv(homeVariable(), "")
+
+	account, err := user.Current()
+	if err != nil || account.HomeDir == "" {
+		t.Skipf("no user-account home available on this host: %v", err)
+	}
+
+	if got := UserHomeDir(); got != account.HomeDir {
+		t.Errorf("UserHomeDir() = %q, want the account home %q", got, account.HomeDir)
+	}
+}
+
+// --- Base directories ---
+
+// TestBases_DefaultBeneathHome proves each base lands at its standard XDG name under home — the same layout
+// on every platform, which is the whole point of the ruling.
+func TestBases_DefaultBeneathHome(t *testing.T) {
+
+	clearEnvironment(t)
+
+	home := t.TempDir()
+	t.Setenv(homeVariable(), home)
+
+	for _, tc := range []struct {
+		name     string
+		resolve  func() string
+		expected string
+	}{
+		{"BinHome", BinHome, filepath.Join(home, ".local", "bin")},
+		{"CacheHome", CacheHome, filepath.Join(home, ".cache")},
+		{"ConfigHome", ConfigHome, filepath.Join(home, ".config")},
+		{"DataHome", DataHome, filepath.Join(home, ".local", "share")},
+		{"StateHome", StateHome, filepath.Join(home, ".local", "state")},
+	} {
+		if got := tc.resolve(); got != tc.expected {
+			t.Errorf("%s() = %q, want %q", tc.name, got, tc.expected)
+		}
+	}
+}
+
+// TestBases_AbsoluteVariableWins proves the environment overrides the default on every platform, including
+// Windows — the specification's first rule.
+func TestBases_AbsoluteVariableWins(t *testing.T) {
+
+	clearEnvironment(t)
+	t.Setenv(homeVariable(), t.TempDir())
+
+	override := t.TempDir()
+
+	for _, tc := range []struct {
+		name     string
+		variable string
+		resolve  func() string
+	}{
+		{"BinHome", envBinHome, BinHome},
+		{"CacheHome", envCacheHome, CacheHome},
+		{"ConfigHome", envConfigHome, ConfigHome},
+		{"DataHome", envDataHome, DataHome},
+		{"StateHome", envStateHome, StateHome},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.variable, override)
+			if got := tc.resolve(); got != override {
+				t.Errorf("%s() = %q, want the override %q", tc.name, got, override)
+			}
+		})
+	}
+}
+
+// TestBases_RelativeVariableIsIgnored is the defect this package exists to make impossible.
+//
+// The specification: "If an implementation encounters a relative path in any of these variables it should
+// consider the path invalid and ignore it." A relative value must therefore resolve to the home-rooted
+// default, never to something the working directory decides.
+func TestBases_RelativeVariableIsIgnored(t *testing.T) {
+
+	clearEnvironment(t)
+
+	home := t.TempDir()
+	t.Setenv(homeVariable(), home)
+
+	for _, tc := range []struct {
+		name     string
+		variable string
+		resolve  func() string
+		expected string
+	}{
+		{"BinHome", envBinHome, BinHome, filepath.Join(home, ".local", "bin")},
+		{"CacheHome", envCacheHome, CacheHome, filepath.Join(home, ".cache")},
+		{"ConfigHome", envConfigHome, ConfigHome, filepath.Join(home, ".config")},
+		{"DataHome", envDataHome, DataHome, filepath.Join(home, ".local", "share")},
+		{"StateHome", envStateHome, StateHome, filepath.Join(home, ".local", "state")},
+	} {
+		for _, relative := range []string{".local/state", "devlore", filepath.Join("..", "escape")} {
+			t.Run(tc.name+"/"+relative, func(t *testing.T) {
+				t.Setenv(tc.variable, relative)
+				if got := tc.resolve(); got != tc.expected {
+					t.Errorf("%s() = %q with %s=%q; a relative value must be ignored, want %q",
+						tc.name, got, tc.variable, relative, tc.expected)
+				}
+			})
+		}
+	}
+}
+
+// TestNoAnchorIsEverRelative is the invariant that outranks every individual case: no combination of a
+// missing home variable and junk in the XDG variables may yield a path resolved against the working
+// directory. On Windows before this package, `filepath.Join("", ".local", "state")` did exactly that.
+func TestNoAnchorIsEverRelative(t *testing.T) {
+
+	t.Setenv(homeVariable(), "")
+
+	if _, err := user.Current(); err != nil {
+		t.Skipf("no user-account home available on this host: %v", err)
+	}
+
+	for _, variable := range []string{envBinHome, envCacheHome, envConfigHome, envDataHome, envStateHome} {
+		t.Setenv(variable, filepath.Join("relative", "nonsense"))
+	}
+
+	for name, got := range map[string]string{
+		"BinHome":    BinHome(),
+		"CacheHome":  CacheHome(),
+		"ConfigHome": ConfigHome(),
+		"DataHome":   DataHome(),
+		"StateHome":  StateHome(),
+		"home":       UserHomeDir(),
+	} {
+		if !filepath.IsAbs(got) {
+			t.Errorf("%s = %q, which is relative to the working directory", name, got)
+		}
+	}
+}
+
+// --- Path builders ---
+
+// TestPaths_JoinElementsBeneathTheBase covers the option-D surface: the application name is simply the first
+// element, and no elements yields the base directory itself.
+func TestPaths_JoinElementsBeneathTheBase(t *testing.T) {
+
+	clearEnvironment(t)
+
+	home := t.TempDir()
+	t.Setenv(homeVariable(), home)
+
+	for _, tc := range []struct {
+		name     string
+		resolve  func(...string) string
+		expected string
+	}{
+		{"BinPath", BinPath, filepath.Join(home, ".local", "bin", "devlore")},
+		{"CachePath", CachePath, filepath.Join(home, ".cache", "devlore")},
+		{"ConfigPath", ConfigPath, filepath.Join(home, ".config", "devlore")},
+		{"DataPath", DataPath, filepath.Join(home, ".local", "share", "devlore")},
+		{"StatePath", StatePath, filepath.Join(home, ".local", "state", "devlore")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := tc.resolve("devlore"); got != tc.expected {
+				t.Errorf("%s(\"devlore\") = %q, want %q", tc.name, got, tc.expected)
+			}
+
+			deep := tc.resolve("devlore", "signing", "ed25519")
+			if want := filepath.Join(tc.expected, "signing", "ed25519"); deep != want {
+				t.Errorf("%s(deep) = %q, want %q", tc.name, deep, want)
+			}
+		})
+	}
+
+	if got, want := StatePath(), StateHome(); got != want {
+		t.Errorf("StatePath() = %q with no elements, want the base %q", got, want)
+	}
+}
+
+// --- Search lists ---
+
+// TestDirs_KeepsAbsoluteEntriesAndDropsRelativeOnes proves the search lists apply the same absolute-only rule
+// as the base variables, entry by entry rather than all-or-nothing.
+func TestDirs_KeepsAbsoluteEntriesAndDropsRelativeOnes(t *testing.T) {
+
+	first, second := t.TempDir(), t.TempDir()
+	mixed := strings.Join([]string{first, "relative/entry", second}, string(filepath.ListSeparator))
+
+	t.Setenv(envConfigDirs, mixed)
+
+	got := ConfigDirs()
+	want := []string{first, second}
+
+	if len(got) != len(want) {
+		t.Fatalf("ConfigDirs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ConfigDirs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDirs_FallsBackWhenNoAbsoluteEntrySurvives proves an unset — or entirely relative — variable yields the
+// specification's defaults rather than an empty search path.
+func TestDirs_FallsBackWhenNoAbsoluteEntrySurvives(t *testing.T) {
+
+	for _, value := range []string{"", "relative/only"} {
+		t.Run("value="+value, func(t *testing.T) {
+
+			t.Setenv(envConfigDirs, value)
+			t.Setenv(envDataDirs, value)
+
+			if got := ConfigDirs(); len(got) != 1 || got[0] != "/etc/xdg" {
+				t.Errorf("ConfigDirs() = %v, want the specification default [/etc/xdg]", got)
+			}
+			if got := DataDirs(); len(got) != 2 {
+				t.Errorf("DataDirs() = %v, want the two specification defaults", got)
+			}
+		})
+	}
+}
+
+// --- Helpers ---
+
+// TestJoin_NoElementsReturnsTheBase pins the zero-element contract [join] gives every *Path accessor.
+func TestJoin_NoElementsReturnsTheBase(t *testing.T) {
+
+	base := filepath.Join(string(filepath.Separator), "anchor")
+
+	if got := join(base, nil); got != base {
+		t.Errorf("join(base, nil) = %q, want %q", got, base)
+	}
+	if got, want := join(base, []string{"a", "b"}), filepath.Join(base, "a", "b"); got != want {
+		t.Errorf("join(base, [a b]) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pkg/xdg` — [step 54](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md),
which blocks phase 3.1 of [#405](https://github.com/NobleFactor/devlore-cli/issues/405). **The package
only**; migrating the 30 existing resolutions follows.

`internal/cli/xdg.go` resolves every anchor from `os.Getenv("HOME")`, which Windows does not define, so
with `XDG_*` unset `StateHome()` yields the **relative** `.local\state` and user state lands under
whatever directory the process was started from. Phase 3.1 would have anchored **writable roots**
there.

## Finding home is a ladder

| Rung | Source |
| --- | --- |
| 1 | the role's `XDG_*` variable, **when absolute** — a relative value is invalid and ignored, per the spec |
| 2 | `os.UserHomeDir` — the environment, under whichever variable name the platform uses |
| 3 | `user.Current` — the OS: process token profile on Windows, passwd on Unix |
| 4 | assert |

**This package never names a home variable.** `os.UserHomeDir` is a switch on `GOOS`, so it already
knows the right one — and naming one is what every defective site in the repository has in common.
Rung 3 is the rung that saves Windows services and scheduled tasks, where the environment carries no
home. Every rung requires an absolute result, so `filepath.IsAbs` covers unset and invalid alike and
**a relative anchor becomes structurally impossible rather than guarded against**.

## Layout and shape

Standard XDG names rooted at home on **every** platform — `~/.config`, `~/.local/share`,
`~/.local/state`, `~/.cache`, plus `~/.local/bin`. A base accessor and a variadic path builder per
role, so the application name is just the first element:

```go
xdg.StatePath(devlore.Name, "index.ndjson")
xdg.ConfigPath(devlore.Name, "signing", "ed25519")
```

`XDG_RUNTIME_DIR` is **deliberately absent**: the spec gives it no default and directs applications
to "a replacement directory with similar capabilities" — user-owned, `0700`, session-scoped — which
is exactly phase 2b's session scratch, available on every platform.

## Diagnostics debt, recorded

`2.8-eventing-infrastructure.md` gains a subsection under *Ignored errors are diagnostics*: a
discarded **value** owes the diagnostics stream the same debt as a discarded **error**, and where
there is no lint suppression to host the marker, it goes in a plain comment. `pkg/xdg` carries the
first one, so it enumerates with the other 41 under `grep diagnose-ignored-error`. The XDG spec
independently requires the warning, which is the strongest case yet for that stream.

## Verification

`make test` zero failures; `make lint-all` zero issues on linux, darwin, windows; **93.5%** statement
coverage. The uncovered remainder is rung 4's assert — no in-process seam can make the user-account
lookup fail, and the test says so rather than faking it.

Assisted-by: Claude
