### PR TITLE
fix(writ): resolve home through pkg/xdg, not a bare HOME read

### DIFF
--- a/cmd/writ/writ/adopt/batch.go
+++ b/cmd/writ/writ/adopt/batch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
 // Config carries the adopt run's inputs from the cobra layer.
@@ -302,10 +303,10 @@ func inferScope(filePath, homeDir string) string {
 func expandPath(path string) string {
 
 	if strings.HasPrefix(path, "~/") {
-		return os.Getenv("HOME") + path[1:]
+		return xdg.UserHomeDir() + path[1:]
 	}
 	if path == "~" {
-		return os.Getenv("HOME")
+		return xdg.UserHomeDir()
 	}
 
 	return path

--- a/cmd/writ/writ/commands.go
+++ b/cmd/writ/writ/commands.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/NobleFactor/devlore-cli/cmd/lore/lore"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/decommission"
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/deploy"
@@ -86,10 +87,10 @@ func runDeployV2(cmd *cobra.Command, args []string) error {
 func expandPath(path string) string {
 
 	if strings.HasPrefix(path, "~/") {
-		return os.Getenv("HOME") + path[1:]
+		return xdg.UserHomeDir() + path[1:]
 	}
 	if path == "~" {
-		return os.Getenv("HOME")
+		return xdg.UserHomeDir()
 	}
 
 	return path
@@ -125,10 +126,7 @@ Signature-gated safety (refusing unsigned state) arrives with graph signing (ste
 // runDecommission implements the decommission command on the decommission package (phase-8 step 47 slice 2).
 func runDecommission(cmd *cobra.Command, args []string) error {
 
-	cfg, err := parseDecommissionConfig(cmd, args)
-	if err != nil {
-		return err
-	}
+	cfg := parseDecommissionConfig(cmd, args)
 
 	return decommission.Execute(cmd.Context(), &decommission.Config{
 		Projects: cfg.Projects,
@@ -170,10 +168,7 @@ entries cannot be compared without decrypting and follow the same --force rule.`
 // runUpgrade implements the upgrade command on the upgrade package (phase-8 step 47 slice 2).
 func runUpgrade(cmd *cobra.Command, args []string) error {
 
-	cfg, err := parseUpgradeConfig(cmd, args)
-	if err != nil {
-		return err
-	}
+	cfg := parseUpgradeConfig(cmd, args)
 
 	return upgrade.Execute(cmd.Context(), &upgrade.Config{
 		Projects: cfg.Projects,

--- a/cmd/writ/writ/config.go
+++ b/cmd/writ/writ/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
 // parseDeployConfig resolves all settings for a deploy operation.
@@ -75,10 +76,7 @@ func parseDeployConfig(cmd *cobra.Command, args []string) (*DeployConfig, error)
 	}
 
 	// Target root
-	cfg.TargetRoot = os.Getenv("HOME")
-	if cfg.TargetRoot == "" {
-		return nil, fmt.Errorf("HOME environment variable not set")
-	}
+	cfg.TargetRoot = xdg.UserHomeDir()
 
 	// Segments
 	cfg.Segments = segment.DetectSegments().LoadFromEnv()
@@ -110,7 +108,7 @@ func parseDeployConfig(cmd *cobra.Command, args []string) (*DeployConfig, error)
 }
 
 // parseUpgradeConfig resolves all settings for an upgrade operation.
-func parseUpgradeConfig(cmd *cobra.Command, args []string) (*UpgradeConfig, error) {
+func parseUpgradeConfig(cmd *cobra.Command, args []string) *UpgradeConfig {
 	cfg := &UpgradeConfig{}
 	cfg.Tool = "writ"
 	cfg.Projects = withCommonProject(args)
@@ -127,10 +125,7 @@ func parseUpgradeConfig(cmd *cobra.Command, args []string) (*UpgradeConfig, erro
 	}
 
 	// Target root
-	cfg.TargetRoot = os.Getenv("HOME")
-	if cfg.TargetRoot == "" {
-		return nil, fmt.Errorf("HOME environment variable not set")
-	}
+	cfg.TargetRoot = xdg.UserHomeDir()
 
 	// Segments
 	cfg.Segments = segment.DetectSegments().LoadFromEnv()
@@ -150,7 +145,7 @@ func parseUpgradeConfig(cmd *cobra.Command, args []string) (*UpgradeConfig, erro
 		cfg.SigningKey = findSigningKey(identities)
 	}
 
-	return cfg, nil
+	return cfg
 }
 
 // parseReconcileConfig resolves all settings for a reconcile operation.
@@ -177,7 +172,7 @@ func parseStatusConfig(cmd *cobra.Command, args []string) *StatusConfig {
 }
 
 // parseDecommissionConfig resolves all settings for a decommission operation.
-func parseDecommissionConfig(cmd *cobra.Command, args []string) (*DecommissionConfig, error) {
+func parseDecommissionConfig(cmd *cobra.Command, args []string) *DecommissionConfig {
 	cfg := &DecommissionConfig{}
 	cfg.Tool = "writ"
 	cfg.Projects = args
@@ -188,15 +183,12 @@ func parseDecommissionConfig(cmd *cobra.Command, args []string) (*DecommissionCo
 	cfg.Prune = assert.Must(cmd.Flags().GetBool("prune"))
 
 	// Target root
-	cfg.TargetRoot = os.Getenv("HOME")
-	if cfg.TargetRoot == "" {
-		return nil, fmt.Errorf("HOME environment variable not set")
-	}
+	cfg.TargetRoot = xdg.UserHomeDir()
 
 	// Initialize template data (prune settings added in runDecommission if --prune)
 	cfg.TemplateData = make(map[string]any)
 
-	return cfg, nil
+	return cfg
 }
 
 // parseAdoptConfig resolves all settings for an adopt operation.
@@ -239,10 +231,7 @@ func parseAdoptConfig(cmd *cobra.Command, args []string) (*AdoptConfig, error) {
 	}
 
 	// Target root (HOME)
-	cfg.TargetRoot = os.Getenv("HOME")
-	if cfg.TargetRoot == "" {
-		return nil, fmt.Errorf("HOME environment variable not set")
-	}
+	cfg.TargetRoot = xdg.UserHomeDir()
 
 	return cfg, nil
 }

--- a/cmd/writ/writ/deploy/templatedata.go
+++ b/cmd/writ/writ/deploy/templatedata.go
@@ -6,10 +6,10 @@ package deploy
 import (
 	"os"
 	"os/user"
-	"path/filepath"
 	"runtime"
 
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/segment"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
 // RenderData assembles the render-chain data map: the builtin platform/user/XDG values overlaid with the
@@ -84,7 +84,7 @@ func builtinTemplateData(segMap map[string]string) map[string]any {
 	}
 	data["Hostname"] = hostname
 
-	data["Home"] = os.Getenv("HOME")
+	data["Home"] = xdg.UserHomeDir()
 	if u, err := user.Current(); err == nil {
 		data["Username"] = u.Username
 	} else {
@@ -93,27 +93,10 @@ func builtinTemplateData(segMap map[string]string) map[string]any {
 
 	data["Segments"] = segMap
 
-	home := os.Getenv("HOME")
-	data["ConfigHome"] = xdgPath("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	data["DataHome"] = xdgPath("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
-	data["StateHome"] = xdgPath("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	data["CacheHome"] = xdgPath("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	data["ConfigHome"] = xdg.ConfigHome()
+	data["DataHome"] = xdg.DataHome()
+	data["StateHome"] = xdg.StateHome()
+	data["CacheHome"] = xdg.CacheHome()
 
 	return data
-}
-
-// xdgPath returns the XDG directory from the environment variable, or the default path.
-//
-// Parameters:
-//   - `envVar`: the XDG environment variable name.
-//   - `defaultPath`: the fallback when the variable is unset.
-//
-// Returns:
-//   - `string`: the resolved directory.
-func xdgPath(envVar, defaultPath string) string {
-
-	if v := os.Getenv(envVar); v != "" {
-		return v
-	}
-	return defaultPath
 }

--- a/cmd/writ/writ/layer.go
+++ b/cmd/writ/writ/layer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/tree"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
 // LayerOrder defines the processing order for repository layers.
@@ -23,7 +24,7 @@ type TargetSpec struct {
 // TargetOrder defines the processing order for targets within each repo.
 // System files are deployed before Home files.
 func TargetOrder() []TargetSpec {
-	home := os.Getenv("HOME")
+	home := xdg.UserHomeDir()
 	return []TargetSpec{
 		{SourceDir: "System", TargetRoot: "/"},
 		{SourceDir: "Home", TargetRoot: home},

--- a/docs/plans/extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md
+++ b/docs/plans/extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md
@@ -77,6 +77,17 @@ unpacking someone's dotfiles into whatever directory they happened to be standin
 `cmd/writ/writ/commands.go` and `adopt/batch.go` additionally implement `~` expansion off the same
 bare read, so a tilde in user input expands to nothing rather than to a home directory.
 
+### It was three implementations, not two
+
+Migrating `cmd/writ` (2026-08-14) found a **third**: `cmd/writ/writ/deploy/templatedata.go` carried its own
+`xdgPath(envVar, defaultPath)` helper feeding `{{.ConfigHome}}`, `{{.DataHome}}`, `{{.StateHome}}` and
+`{{.CacheHome}}` to **user templates**. It was the weakest of the three — it accepted any non-empty value,
+relative included, and built its defaults on the bare `HOME` — so a relative `XDG_*` would have been rendered
+straight into a user's generated dotfiles. Deleted; those four now read `xdg.ConfigHome()` and friends.
+
+Worth recording as method: the original "two packages disagree" came from reading imports. The third had no
+import to find — it was a local helper. Only migrating the code surfaced it.
+
 ## Why CI cannot see it
 
 Every path that would expose this is masked:


### PR DESCRIPTION
## Summary

Step 54's **most severe sites**. `cmd/writ/writ/config.go` set `cfg.TargetRoot = os.Getenv("HOME")` at four
separate sites — and `writ` **deploys dotfiles into that root**. Windows does not define `HOME` for a native
process, so on a Windows host without it `TargetRoot` was `""` and **a deploy targeted the working directory**.

All ten of `cmd/writ`'s bare reads now go through `xdg.UserHomeDir()`, which cannot return empty: it falls back
to the OS user account and asserts only when neither the environment nor the account has an answer. The
`"HOME environment variable not set"` error branches go with them — there is no such state any more.

`layer.go`'s `TargetOrder` and the duplicated `expandPath` in `commands.go` and `adopt/batch.go` move the same
way, so a leading `~` expands to a home directory rather than to nothing.

## A third XDG implementation, found only by migrating

`deploy/templatedata.go` carried its own `xdgPath(envVar, defaultPath)` feeding `{{.ConfigHome}}`,
`{{.DataHome}}`, `{{.StateHome}}` and `{{.CacheHome}}` to **user templates** — and it was the weakest of the
three: any non-empty value accepted, relative included, defaults built on the bare `HOME`. A relative `XDG_*`
would have been rendered straight into a user's generated dotfiles. Deleted.

Worth the note in the step doc: the original "two packages disagree" came from reading **imports**. This one
was a local helper with no import to find. Only migrating the code surfaced it.

## What lint caught

With the `HOME` error branches gone, `parseUpgradeConfig` and `parseDecommissionConfig` returned an error that
is always nil. One caller each, so both signatures drop it rather than keeping an error the caller must write
dead code against.

`make test` zero failures; `make lint-all` zero issues on linux, darwin, windows.

Assisted-by: Claude
