### PR TITLE
fix(signing): write the private key through a root, so 0600 means it

### DIFF
--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -320,6 +320,38 @@ This fails closed. A caller asking for `0600` gets a private file whether or not
 able to swap the path between the write and the DACL call could redirect it. Closing that needs
 handle-based `SetSecurityInfo` at every creation site; tracked on #405 rather than solved here.
 
+#### Correction 2026-08-15 — enforcement was missing from the unconfined writable root
+
+Phase 2 recorded `applyMode` as "wired into `WriteFile`, `OpenFile` (on `O_CREATE`), `Mkdir`, `MkdirAll`, and
+`Chmod` **on both writable implementations**". That was true of every method **except `WriteFile` on
+`unconfinedRootReaderWriter`**, which returned `os.WriteFile` directly and applied nothing.
+
+**Impact, had it not been caught:** the campaign rules that CLI-side roots are `ModeWritableUnconfined`, so
+*every* remaining phase-3 site — state home, run index, user config, self-install manifest,
+`internal/document`'s writes — would have gone through the one unenforced path. The migration would have
+completed, the code would have looked right, and nothing would have been protected.
+
+**Why the tests missed it.** Every DACL test in `applymode_windows_test.go` used `testConfinedRoot`. The
+confined implementation was the one already enforcing; the tests proved the safe path and never touched the
+one production actually uses outside an execution.
+
+**What found it.** `pkg/signing`'s own read-back, on a real Windows runner, printing the descriptor:
+
+```
+D:AI(A;ID;FA;;;LA)(A;ID;FA;;;SY)(A;ID;FA;;;BA)
+```
+
+`AI` rather than `P`, and every ACE tagged `ID` — purely inherited. The key was private only because its
+parent directory happened to be protected, which is a weaker guarantee that any later change to the parent
+would quietly erode.
+
+**Fixed**, with `TestApplyMode_BothWritableRootsProtect` running the same assertions across both writable
+implementations so the asymmetry cannot return. `Create` remains unenforced on both **by design** — phase 1
+ruled it produces an unrestricted `0666` file that must never carry sensitive content.
+
+**The general lesson, for phases 4 and 5:** a test that exercises the safest implementation proves the least.
+These assertions belong on the implementation production actually uses.
+
 ### Phase 2b: session-owned filesystem access — branch per PR below — status: in progress (2b.1 complete; 2b.2 next)
 
 **Inserted before the migration, 2026-08-13, after phase 3's first call site exposed a wrong

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -768,12 +768,33 @@ read an unmoved 28 after phase 3 as a failed migration.**
       - **install-prefix root** — the bulk of `selfinstall.go` (bin dir, cache, layers, manifest
         `0600`, the `0750` binary `Chmod`).
       - `man.go`'s `os.CreateTemp` becomes `fsroot.OpenScratch` — CLI-side, no session.
-- [ ] **3.2 — `pkg/signing` receives a root** and its 3 sites move: `MkdirAll(…, 0700)`,
-      `WriteFile(key, 0600)`, `WriteFile(key.pub, 0644)`. **Open decision, needs a ruling** — this
-      changes a shared package's signature: `DefaultSigner(configRoot fsroot.Root)` (recommended:
-      one production caller, so the blast radius is one line) versus a `signing.Options` struct
-      carrying the root (more ceremony, same effect) versus a second entry point (rejected on the
-      greenfield no-two-doors rule). Removes the `TODO(#405)`.
+- [x] **3.2 — `pkg/signing` receives a root — COMPLETE 2026-08-15.** `DefaultSigner(configRoot
+      fsroot.Root)`, one production caller updated (`internal/cli/store.go`). All three sites now
+      write through the root: the `0700` directory, the `0600` key, the `0644` public half.
+      `pkg/signing` has **zero** `os.*` mutations left and the `TODO(#405)` is gone.
+
+      **It needed almost none of the groundwork it appeared to.** No `Session` type, no `internal/cli`
+      xdg migration, no `internal/` sweep, no curation — the CLI opens a writable-unconfined root at
+      the existing `DevloreConfigHome()` and hands it over. Writable-unconfined because the config
+      tree may not exist on first run and a confined root requires its anchor to exist.
+
+      **The suite name left `pkg/signing` as a side effect:** the root arrives anchored at
+      `<config>/devlore`, so signing joins `signing/ed25519` and no longer knows the string
+      `"devlore"`.
+
+      **`DefaultSigner`'s first branch keeps reading `~/.ssh/id_ed25519` directly**, with a
+      `// Confinement:` comment: the user's SSH directory is not ours to confine, and a root anchored
+      at our config tree cannot address it.
+
+      **Proof is a DACL read-back, not a mode assertion** (`signing_windows_test.go`): mode bits
+      report 0666 on Windows however private the object is (ruling 5), so the tests read the security
+      descriptor off the key and assert `SE_DACL_PROTECTED` plus exactly three trustees — owner,
+      SYSTEM, Administrators. A fourth allow ACE would leave the DACL "protected" while granting
+      someone else read access to a signing key, so the count is as load-bearing as the flag. A third
+      test pins the deliberate asymmetry: the `.pub` half must **not** be protected, since it exists
+      to be copied into someone else's `allowed_signers`.
+
+      **The 28 does not move.** No existing test asserts the key's mode, so these are additive.
 - [ ] **3.3 — `internal/document`** (2 sites: `0750` dir, `cfg.perm` write) — the package behind
       three of the seven tests above.
 - [ ] **3.4 — the writ deploy/sops output path** — behind `TestExecute_SopsChains`, and the one

--- a/internal/cli/store.go
+++ b/internal/cli/store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/internal/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/signing"
 )
@@ -194,7 +195,14 @@ func signArtifact(unsigned bool, namespace string, signWith func(func([]byte) (*
 		return
 	}
 
-	signer, err := signing.DefaultSigner()
+	// The CLI is the session owner for CLI-side work, so it opens the root and signing receives one —
+	// a leaf never constructs its own filesystem access (#405, phase 2b). Writable-unconfined because the
+	// config tree may not exist yet on first use, and a confined root requires its anchor to exist.
+	configRoot := fsroot.OpenWritableUnconfined(DevloreConfigHome())
+	//nolint:errcheck // diagnose-ignored-error: an unconfined root holds no handle, so Close cannot fail; see docs/architecture/2.8-eventing-infrastructure.md
+	defer configRoot.Close()
+
+	signer, err := signing.DefaultSigner(configRoot)
 	if err != nil {
 		return
 	}

--- a/pkg/fsroot/applymode_windows_test.go
+++ b/pkg/fsroot/applymode_windows_test.go
@@ -34,6 +34,50 @@ const (
 	aceTrusteeEnd = ")"
 )
 
+// TestApplyMode_BothWritableRootsProtect pins the parity that matters most in practice: CLI-side roots are
+// unconfined and writable (the campaign's ruling for code outside an execution), so an implementation that
+// enforces only on the confined root protects the code paths that were already safest and leaves the rest
+// silently exposed.
+//
+// That is exactly what happened. WriteFile on the unconfined writable root reached production without an
+// applyMode call, and no test caught it because every DACL test here used a confined root. The signing key's
+// own read-back found it, on a real Windows runner, printing D:AI(A;ID;…) — purely inherited ACEs.
+func TestApplyMode_BothWritableRootsProtect(t *testing.T) {
+
+	directory := t.TempDir()
+
+	confined, err := OpenConfined(directory)
+	if err != nil {
+		t.Fatalf("OpenConfined: %v", err)
+	}
+	t.Cleanup(func() { _ = confined.Close() })
+
+	for name, root := range map[string]Root{
+		"confinedRoot":               confined,
+		"unconfinedRootReaderWriter": OpenWritableUnconfined(directory),
+	} {
+		t.Run(name, func(t *testing.T) {
+
+			target := root.NewPath(name + ".key")
+			if err := root.WriteFile(target, []byte("private"), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			control, sddl := readSecurity(t, target.Abs())
+
+			if control&windows.SE_DACL_PROTECTED == 0 {
+				t.Errorf("WriteFile at 0600 left the DACL unprotected: %s", sddl)
+			}
+			if !hasTrustee(sddl, systemAlias, systemSID) {
+				t.Errorf("DACL is missing SYSTEM: %s", sddl)
+			}
+			if !hasTrustee(sddl, adminsAlias, adminsSID) {
+				t.Errorf("DACL is missing Administrators: %s", sddl)
+			}
+		})
+	}
+}
+
 func TestApplyMode_PrivateFileGetsProtectedDACL(t *testing.T) {
 
 	root := testConfinedRoot(t)

--- a/pkg/fsroot/root.go
+++ b/pkg/fsroot/root.go
@@ -1097,7 +1097,12 @@ func (r *unconfinedRootReaderWriter) Symlink(target string, link Path) error {
 // Returns:
 //   - `error`: any error from [os.WriteFile], or from the Windows enforcement pass.
 func (r *unconfinedRootReaderWriter) WriteFile(p Path, data []byte, perm os.FileMode) error {
-	return os.WriteFile(p.abs, data, perm)
+
+	if err := os.WriteFile(p.abs, data, perm); err != nil {
+		return err
+	}
+
+	return applyMode(p.abs, perm, false)
 }
 
 // endregion

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -102,15 +103,17 @@ func (k *keyfileSigner) Sign(namespace string, canonical []byte) (*op.Signature,
 // Returns:
 //   - `Signer`: the resolved signer.
 //   - `error`: non-nil when no key can be loaded or generated.
-func DefaultSigner() (Signer, error) {
+func DefaultSigner(configRoot fsroot.Root) (Signer, error) {
 
+	// Confinement: the user's own SSH directory is not ours to confine — we read a key they placed there,
+	// under their own permissions, and a root anchored at our config tree cannot address it.
 	if home, err := os.UserHomeDir(); err == nil {
 		if signer, err := loadSSHKeyfile(filepath.Join(home, ".ssh", "id_ed25519")); err == nil {
 			return signer, nil
 		}
 	}
 
-	return localSigner()
+	return localSigner(configRoot)
 }
 
 // region HELPER FUNCTIONS
@@ -149,54 +152,50 @@ func loadSSHKeyfile(path string) (Signer, error) {
 // Returns:
 //   - `Signer`: the local-keyfile signer.
 //   - `error`: non-nil when the key can neither be loaded nor generated.
-func localSigner() (Signer, error) {
+func localSigner(configRoot fsroot.Root) (Signer, error) {
 
-	configDir, err := configHome()
-	if err != nil {
-		return nil, err
-	}
+	keyPath := configRoot.NewPath(filepath.Join("signing", "ed25519"))
 
-	keyPath := filepath.Join(configDir, "devlore", "signing", "ed25519")
-
-	if data, err := os.ReadFile(keyPath); err == nil {
+	if data, err := configRoot.ReadFile(keyPath); err == nil {
 		parsed, parseErr := ssh.ParseRawPrivateKey(data)
 		if parseErr != nil {
-			return nil, fmt.Errorf("parse %s: %w", keyPath, parseErr)
+			return nil, fmt.Errorf("parse %s: %w", keyPath.Abs(), parseErr)
 		}
 		private, ok := parsed.(*ed25519.PrivateKey)
 		if !ok {
-			return nil, fmt.Errorf("%s is not an ed25519 key (%T)", keyPath, parsed)
+			return nil, fmt.Errorf("%s is not an ed25519 key (%T)", keyPath.Abs(), parsed)
 		}
 		return newKeyfileSigner(*private)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 
-	return generateLocalKey(keyPath)
+	return generateLocalKey(configRoot, keyPath)
 }
 
 // generateLocalKey mints the local Ed25519 keypair at `keyPath` (private, OpenSSH PEM, 0600) with its `.pub`
 // (authorized_keys format — one copy-paste from an `allowed_signers` line).
 //
-// TODO(#405): these writes still go through os.*, so the private key's 0600 is NOT enforced on Windows. The
-// migration onto [fsroot] is blocked on deciding who owns the root for CLI-side work — this function is reached
-// from internal/cli, outside any execution, so there is no session to receive a root from, and a leaf must never
-// construct its own. See docs/plans/windows-native-permissions.md, phase 2b.
+// Every write goes through the caller's root, so the 0700 directory and the 0600 key are enforced on Windows
+// by a protected DACL rather than being silently ignored (#405). The `.pub` half stays 0644 deliberately: it is
+// public trust material, and ruling 4's boundary leaves anything granting `other` on its parent's inherited
+// DACL. Only the private half is protected, which is the point.
 //
 // Parameters:
-//   - `keyPath`: the private-key destination.
+//   - `configRoot`: the root the key tree is created under, supplied by the caller that owns it.
+//   - `keyPath`: the private-key destination within that root.
 //
 // Returns:
 //   - `Signer`: the freshly generated signer.
 //   - `error`: non-nil when generation or persistence fails.
-func generateLocalKey(keyPath string) (Signer, error) {
+func generateLocalKey(configRoot fsroot.Root, keyPath fsroot.Path) (Signer, error) {
 
 	public, private, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		return nil, fmt.Errorf("generate ed25519 key: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+	if err := configRoot.MkdirAll(configRoot.NewPath(filepath.Dir(keyPath.Rel())), 0o700); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +203,7 @@ func generateLocalKey(keyPath string) (Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal private key: %w", err)
 	}
-	if err := os.WriteFile(keyPath, pem.EncodeToMemory(pemBlock), 0o600); err != nil {
+	if err := configRoot.WriteFile(keyPath, pem.EncodeToMemory(pemBlock), 0o600); err != nil {
 		return nil, err
 	}
 
@@ -213,7 +212,8 @@ func generateLocalKey(keyPath string) (Signer, error) {
 		return nil, fmt.Errorf("wrap public key: %w", err)
 	}
 	//nolint:gosec // G306: the .pub half is public trust material, deliberately world-readable (0o644).
-	if err := os.WriteFile(keyPath+".pub", ssh.MarshalAuthorizedKey(sshPublic), 0o644); err != nil {
+	if err := configRoot.WriteFile(configRoot.NewPath(keyPath.Rel()+".pub"),
+		ssh.MarshalAuthorizedKey(sshPublic), 0o644); err != nil {
 		return nil, err
 	}
 

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -23,7 +24,11 @@ func isolate(t *testing.T) (signer Signer, allowedSigners string) {
 	t.Setenv("HOME", root)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
 
-	signer, err := DefaultSigner()
+	// The caller owns the root, exactly as internal/cli does in production; signing receives it.
+	configRoot := fsroot.OpenWritableUnconfined(filepath.Join(root, "config", "devlore"))
+	t.Cleanup(func() { _ = configRoot.Close() })
+
+	signer, err := DefaultSigner(configRoot)
 	if err != nil {
 		t.Fatalf("DefaultSigner: %v", err)
 	}

--- a/pkg/signing/signing_windows_test.go
+++ b/pkg/signing/signing_windows_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package signing
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+)
+
+// The proof for the defect that opened issue #405: a generated private key written at 0600 into a 0700
+// directory, both silently unenforced on Windows because os.Chmod there toggles only the read-only attribute.
+//
+// Asserting the mode bits would prove nothing — Mode().Perm() reports 0666 on Windows however private the
+// object actually is (ruling 5) — so these tests read the access-control list back off the key and inspect
+// it. A subtly wrong DACL fails OPEN: the key stays readable while every "did the call return nil" assertion
+// passes.
+//
+// The two well-known trustees ruling 4 keeps alongside the owner buy real safety and cost nothing:
+// restricting SYSTEM and Administrators is theater, since an administrator takes ownership at will.
+const (
+	systemAlias = "SY"
+	systemSID   = "S-1-5-18"
+	adminsAlias = "BA"
+	adminsSID   = "S-1-5-32-544"
+)
+
+// TestGenerateLocalKey_PrivateKeyIsProtectedOnWindows is the assertion this campaign exists to make.
+func TestGenerateLocalKey_PrivateKeyIsProtectedOnWindows(t *testing.T) {
+
+	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	t.Cleanup(func() { _ = configRoot.Close() })
+
+	if _, err := localSigner(configRoot); err != nil {
+		t.Fatalf("localSigner: %v", err)
+	}
+
+	keyPath := configRoot.NewPath(filepath.Join("signing", "ed25519"))
+
+	control, sddl := readSecurity(t, keyPath.Abs())
+
+	// Inheritance broken is the load-bearing part. Without SE_DACL_PROTECTED the config directory's
+	// inherited ACEs survive on the key and it is private in name only.
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("private key's DACL is not protected; inherited ACEs survive: %s", sddl)
+	}
+
+	if !hasTrustee(sddl, systemAlias, systemSID) {
+		t.Errorf("private key's DACL is missing SYSTEM: %s", sddl)
+	}
+	if !hasTrustee(sddl, adminsAlias, adminsSID) {
+		t.Errorf("private key's DACL is missing Administrators: %s", sddl)
+	}
+
+	// Exactly three trustees. A fourth allow ACE would leave the DACL "protected" while granting someone
+	// else read access to a signing key, so the count is as load-bearing as the flag.
+	if got := strings.Count(sddl, "(A;"); got != 3 {
+		t.Errorf("private key's DACL has %d allow ACEs, want 3 (owner, SYSTEM, Administrators): %s", got, sddl)
+	}
+}
+
+// TestGenerateLocalKey_SigningDirectoryIsProtectedOnWindows covers the 0700 directory holding the key: a
+// protected key inside a world-traversable directory is a weaker guarantee than it looks.
+func TestGenerateLocalKey_SigningDirectoryIsProtectedOnWindows(t *testing.T) {
+
+	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	t.Cleanup(func() { _ = configRoot.Close() })
+
+	if _, err := localSigner(configRoot); err != nil {
+		t.Fatalf("localSigner: %v", err)
+	}
+
+	control, sddl := readSecurity(t, configRoot.NewPath("signing").Abs())
+
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("signing directory's DACL is not protected: %s", sddl)
+	}
+}
+
+// TestGenerateLocalKey_PublicHalfIsNotProtected pins the deliberate asymmetry. The .pub half is public trust
+// material at 0644, which grants `other`, so ruling 4's boundary leaves it inheriting its parent's DACL. A
+// future reader who "fixes" this to match the private half would be locking up a file whose whole purpose is
+// to be copied into someone else's allowed_signers.
+func TestGenerateLocalKey_PublicHalfIsNotProtected(t *testing.T) {
+
+	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	t.Cleanup(func() { _ = configRoot.Close() })
+
+	if _, err := localSigner(configRoot); err != nil {
+		t.Fatalf("localSigner: %v", err)
+	}
+
+	control, sddl := readSecurity(t, configRoot.NewPath(filepath.Join("signing", "ed25519.pub")).Abs())
+
+	if control&windows.SE_DACL_PROTECTED != 0 {
+		t.Errorf("public key's DACL is protected; the .pub half is meant to be readable: %s", sddl)
+	}
+}
+
+// region HELPER FUNCTIONS
+
+// hasTrustee reports whether an SDDL string grants a trustee, in either the alias or numeric rendering.
+//
+// SDDL renders well-known accounts as two-letter aliases rather than SIDs, and which form appears varies by
+// host — matching only the numeric form is what made phase 2's first CI run fail against a correct DACL. The
+// match is anchored on the ACE's trustee field so an alias cannot match inside an unrelated SID.
+func hasTrustee(sddl, alias, sid string) bool {
+
+	return strings.Contains(sddl, ";;;"+alias+")") || strings.Contains(sddl, ";;;"+sid+")")
+}
+
+// readSecurity reads an object's DACL back off the filesystem.
+//
+// Parameters:
+//   - `t`: the test harness.
+//   - `path`: the absolute path of the object to inspect.
+//
+// Returns:
+//   - `windows.SECURITY_DESCRIPTOR_CONTROL`: the descriptor's control flags, carrying SE_DACL_PROTECTED.
+//   - `string`: the descriptor's SDDL form, printed on failure so the actual ACL is visible.
+func readSecurity(
+	t *testing.T, path string,
+) (control windows.SECURITY_DESCRIPTOR_CONTROL, sddl string) {
+
+	t.Helper()
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%s): %v", path, err)
+	}
+
+	control, _, err = descriptor.Control()
+	if err != nil {
+		t.Fatalf("Control(%s): %v", path, err)
+	}
+
+	return control, descriptor.String()
+}
+
+// endregion


### PR DESCRIPTION
## Summary

**The defect that opened [#405](https://github.com/NobleFactor/devlore-cli/issues/405).**
`generateLocalKey` wrote an Ed25519 **private key** at `0600` into a `0700` directory through
`os.MkdirAll` and `os.WriteFile`. On Windows `os.Chmod` toggles only the read-only attribute, so neither
mode was enforced — the key landed readable by anyone with directory access, and the code carried a
`TODO(#405)` saying exactly that.

Every write now goes through a root the caller supplies. `DefaultSigner` takes an `fsroot.Root`;
`internal/cli/store.go` opens one, because **the CLI is the session owner for CLI-side work and a leaf never
constructs its own filesystem access** — phase 2b's invariant, applied to its first real consumer.

`pkg/signing` now has **zero** `os.*` mutations and no TODO.

## It needed almost none of the groundwork it appeared to

No `Session` type, no `internal/cli` xdg migration, no `internal/` sweep, no curation verdicts. The existing
`DevloreConfigHome()` anchor was enough. Writable-unconfined rather than confined, because the config tree may
not exist on first run and a confined root requires its anchor to exist.

The suite name left `pkg/signing` as a side effect: the root arrives anchored at `<config>/devlore`, so signing
joins `signing/ed25519` and no longer knows the string `"devlore"`.

`DefaultSigner`'s first branch still reads `~/.ssh/id_ed25519` directly, now with a `// Confinement:` comment —
the user's SSH directory is not ours to confine, and a root anchored at our config tree cannot address it.

## Proof is a DACL read-back, not a mode assertion

`Mode().Perm()` reports `0666` on Windows however private an object actually is (ruling 5), so asserting
`0600` there would prove nothing. `signing_windows_test.go` reads the **security descriptor** off the generated
key and asserts `SE_DACL_PROTECTED` plus **exactly three trustees** — owner, SYSTEM, Administrators.

The count is as load-bearing as the flag: a fourth allow ACE would leave the DACL "protected" while granting
someone else read access to a signing key. Trustees are matched in both SDDL renderings — alias and numeric
SID — which is the lesson from phase 2's first CI run failing against a DACL that was already correct.

A third test pins the deliberate asymmetry: **the `.pub` half must not be protected.** It is `0644` public
trust material whose purpose is to be copied into someone else's `allowed_signers`, and ruling 4's boundary
leaves anything granting `other` on its parent's inherited DACL.

## Verification

`make test` zero failures; `make lint-all` zero issues on linux, darwin, windows.
`test (windows-latest)` holds at its known **28** — no existing test asserts the key's mode, so the new ones
are additive.

Assisted-by: Claude
