### PR TITLE
fix(application): stamp the version where the linker can actually find it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,16 @@ jobs:
         with:
           go-version: "1.26"
 
+      # The Makefile requires GNU make 3.82+ for `.ONESHELL:`, and macOS ships 3.81 — the last
+      # GPLv2 release, so it will never advance. Without this the multi-line recipes are split into
+      # one shell per line and die as `syntax error: unexpected end of file`. The runner is being
+      # brought up to the same prerequisite developers hold; ubuntu and windows already satisfy it.
+      - name: GNU make 3.82+ (macOS ships 3.81)
+        if: runner.os == 'macOS'
+        run: |
+          brew install make
+          echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+
       - name: Build
         run: make build
 
@@ -100,6 +110,16 @@ jobs:
         with:
           go-version: "1.26"
 
+      # The Makefile requires GNU make 3.82+ for `.ONESHELL:`, and macOS ships 3.81 — the last
+      # GPLv2 release, so it will never advance. Without this the multi-line recipes are split into
+      # one shell per line and die as `syntax error: unexpected end of file`. The runner is being
+      # brought up to the same prerequisite developers hold; ubuntu and windows already satisfy it.
+      - name: GNU make 3.82+ (macOS ships 3.81)
+        if: runner.os == 'macOS'
+        run: |
+          brew install make
+          echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+
       # -race requires cgo and a C toolchain. Set explicitly rather than relying on the default,
       # which varies by platform and by whether a compiler is discoverable; the windows runner
       # ships mingw-w64. `make test-race` depends on `generate`, a chain the scenario job below
@@ -127,6 +147,16 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"
+
+      # The Makefile requires GNU make 3.82+ for `.ONESHELL:`, and macOS ships 3.81 — the last
+      # GPLv2 release, so it will never advance. Without this the multi-line recipes are split into
+      # one shell per line and die as `syntax error: unexpected end of file`. The runner is being
+      # brought up to the same prerequisite developers hold; ubuntu and windows already satisfy it.
+      - name: GNU make 3.82+ (macOS ships 3.81)
+        if: runner.os == 'macOS'
+        run: |
+          brew install make
+          echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
 
       - name: Writ-deploy scenario
         run: make test-scenario

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,9 +31,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Version={{.Version}}
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Commit={{.ShortCommit}}
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.BuildDate={{.Date}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Version={{.Version}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Commit={{.ShortCommit}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate={{.Date}}
 
   - id: lore
     binary: lore
@@ -49,9 +49,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Version={{.Version}}
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Commit={{.ShortCommit}}
-      - -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.BuildDate={{.Date}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Version={{.Version}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Commit={{.ShortCommit}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate={{.Date}}
 
 archives:
   - id: default

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,20 @@
 SHELL := bash
 .SHELLFLAGS := -o errexit -o nounset -o pipefail -c
 .ONESHELL:
+
+# GNU make 3.82+ is a prerequisite, declared here so a wrong version says so.
+#
+# `.ONESHELL:` arrived in 3.82. Older make ignores the directive SILENTLY and runs each recipe line
+# in its own shell, which splits multi-line `if` and `for` blocks mid-statement — the failure reads
+# `bash: -c: line 1: syntax error: unexpected end of file` and names nothing useful. macOS ships
+# 3.81 and always will (it is the last GPLv2 release), so `brew install make` is required there;
+# `$(brew --prefix)/opt/make/libexec/gnubin` on PATH makes plain `make` the right one.
+#
+# The comparison is lexical, which is exact for 3.x/4.x and would misjudge a hypothetical make 10.
+ifneq ($(firstword $(sort 3.82 $(MAKE_VERSION))),3.82)
+$(error GNU make 3.82+ required, found $(MAKE_VERSION). On macOS: brew install make, then put \
+$$(brew --prefix)/opt/make/libexec/gnubin on PATH — or invoke gmake)
+endif
 .SILENT:
 
 ## PARAMETERS
@@ -23,7 +37,27 @@ VERSION ?= $(DEVLORE_VERSION)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS := -ldflags "-X github.com/NobleFactor/devlore-cli/pkg/application.Version=$(VERSION) -X github.com/NobleFactor/devlore-cli/pkg/application.Commit=$(COMMIT) -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate=$(BUILD_DATE)"
+# Freeze the three, and keep them frozen. `?=` defines RECURSIVELY expanded variables, so every
+# $(shell …) above re-runs at every single reference — a different `git describe`, a different
+# `date`, each time the variable is named. LDFLAGS is `:=` and captures one set; a recipe naming
+# $(VERSION) again gets another.
+#
+# That is not hypothetical: on the windows runner the stamp check compared `8a62b17-dirty` against a
+# binary reporting `8a62b17`, because codegen rewrites tracked *.gen.go files mid-build (line
+# endings) and `--dirty` changed its answer between the link and the check. Simply-expanded means
+# one evaluation per make run, so the stamp and everything compared against it cannot disagree.
+#
+# `?=` above still honors an override from the environment or the command line; those win over these
+# assignments and carry no $(shell) to re-run.
+VERSION := $(VERSION)
+COMMIT := $(COMMIT)
+BUILD_DATE := $(BUILD_DATE)
+
+# The package holding the stamped variables. Named once: `verify-ldflags` asserts that every other
+# build definition in the repository names the same one.
+VERSION_PACKAGE := github.com/NobleFactor/devlore-cli/pkg/application
+
+LDFLAGS := -ldflags "-X $(VERSION_PACKAGE).Version=$(VERSION) -X $(VERSION_PACKAGE).Commit=$(COMMIT) -X $(VERSION_PACKAGE).BuildDate=$(BUILD_DATE)"
 
 ### PREFIX
 
@@ -76,7 +110,7 @@ SP := cmd/star/provider
 
 ## TARGETS
 
-.PHONY: all build install clean test test-race cover vet vet-all lint lint-all build-all shell-lint complexity check dev docs dist dist-all star star-lkg generate inventory help
+.PHONY: all build install clean test test-race cover vet vet-all lint lint-all build-all shell-lint complexity verify-ldflags check dev docs dist dist-all star star-lkg generate inventory help
 
 ##@ Help
 
@@ -110,12 +144,13 @@ build: generate ## Build all binaries
 	# the linker ignores it and the binary reports its compiled-in default. Every release before
 	# 2026-08-16 shipped that way, unnoticed, because nothing compared the two. See
 	# docs/plans/version-stamping.md.
+	#
 	stamped="$$(build/writ$(GOEXE) version --short)"
 	if [ "$$stamped" != "$(VERSION)" ]; then
 		echo "ERROR: version stamp did not bind."
 		echo "  build computed: $(VERSION)"
 		echo "  binary reports: $$stamped"
-		echo "  The -X paths in LDFLAGS name symbols that do not exist — check pkg/application."
+		echo "  The -X paths in LDFLAGS name symbols that do not exist — check $(VERSION_PACKAGE)."
 		exit 1
 	fi
 
@@ -202,7 +237,21 @@ complexity: ## Check cyclomatic complexity (max 20)
 	fi
 	echo "All functions below complexity threshold."
 
-check: vet lint shell-lint complexity test ## Run all quality checks
+verify-ldflags: ## Assert every build definition stamps the same package
+	# .goreleaser.yaml carries its own -X flags and is NOT the release path — nothing runs it today
+	# (release.yaml runs `make dist`). It is kept correct anyway: whoever adopts goreleaser inherits
+	# whatever is in that file, and a wrong symbol path there fails the way this whole defect failed,
+	# silently. Agreement is the check, because the Makefile's own paths are proved to bind by `build`.
+	for symbol in Version Commit BuildDate; do
+		if ! grep -q -- "-X $(VERSION_PACKAGE).$$symbol=" .goreleaser.yaml; then
+			echo "ERROR: .goreleaser.yaml does not stamp $(VERSION_PACKAGE).$$symbol"
+			echo "  Both build definitions must name the same package, or one of them stamps nothing."
+			exit 1
+		fi
+	done
+	echo "Build definitions agree on $(VERSION_PACKAGE)."
+
+check: vet lint shell-lint complexity verify-ldflags test ## Run all quality checks
 
 ##@ Development
 
@@ -217,7 +266,12 @@ docs: build ## Generate CLI documentation
 
 dist: dist-all checksums ## Build distribution archives with checksums
 
-dist-all: ## Build distribution archives for all platforms
+dist-all: build ## Build distribution archives for all platforms
+	# Depends on `build` for its stamp check, not for its binaries. This is the path that ships
+	# (.github/workflows/release.yaml runs `make dist`), it cross-compiles with the same LDFLAGS and
+	# the same VERSION, and it cannot run what it produces for other platforms. `build` proves on the
+	# host that those flags bind to real symbols — which is the failure that shipped unnoticed until
+	# 2026-08-16. See docs/plans/version-stamping.md.
 	mkdir -p dist
 	for platform in $(PLATFORMS); do
 		os=$${platform%/*}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ VERSION ?= $(DEVLORE_VERSION)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS := -ldflags "-X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Version=$(VERSION) -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.Commit=$(COMMIT) -X github.com/NobleFactor/devlore-cli/cmd/internal/cli.BuildDate=$(BUILD_DATE)"
+LDFLAGS := -ldflags "-X github.com/NobleFactor/devlore-cli/pkg/application.Version=$(VERSION) -X github.com/NobleFactor/devlore-cli/pkg/application.Commit=$(COMMIT) -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate=$(BUILD_DATE)"
 
 ### PREFIX
 
@@ -106,6 +106,18 @@ build: generate ## Build all binaries
 	go build $(LDFLAGS) -o build/devlore-docs$(GOEXE) ./cmd/devlore-docs
 	go build $(LDFLAGS) -o build/devlore-index$(GOEXE) ./cmd/devlore-index
 	go build $(LDFLAGS) -o build/devlore-inventory$(GOEXE) ./cmd/devlore-inventory
+	# The stamp must reach the binary. `-X` against a symbol that does not exist is NOT an error —
+	# the linker ignores it and the binary reports its compiled-in default. Every release before
+	# 2026-08-16 shipped that way, unnoticed, because nothing compared the two. See
+	# docs/plans/version-stamping.md.
+	stamped="$$(build/writ$(GOEXE) version --short)"
+	if [ "$$stamped" != "$(VERSION)" ]; then
+		echo "ERROR: version stamp did not bind."
+		echo "  build computed: $(VERSION)"
+		echo "  binary reports: $$stamped"
+		echo "  The -X paths in LDFLAGS name symbols that do not exist — check pkg/application."
+		exit 1
+	fi
 
 install: build ## Install lore, star, and writ via self install (PREFIX=~/.local)
 	build/lore$(GOEXE) self install $(PREFIX)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ validate packages. Content is served from GitHub today; OCI distribution
 
 ## Building
 
+**Prerequisites:** Go 1.26+ and **GNU make 3.82+**.
+
+macOS ships GNU make 3.81 — the last GPLv2 release, so it will never advance — and the build uses
+`.ONESHELL:`, which 3.82 introduced. Older make ignores that directive silently and fails with
+`syntax error: unexpected end of file`, so the Makefile refuses to run on it and says why:
+
+```bash
+brew install make
+export PATH="$(brew --prefix)/opt/make/libexec/gnubin:$PATH"   # or invoke gmake
+```
+
 ```bash
 make build   # Build binaries to bin/
 make test    # Run the test suite

--- a/cmd/devlore-test/devloretest/root.go
+++ b/cmd/devlore-test/devloretest/root.go
@@ -12,17 +12,18 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
 	"github.com/NobleFactor/devlore-cli/pkg/status"
 	"github.com/NobleFactor/devlore-cli/schema"
 )
 
-// Version information, set at build time via ldflags.
+// Version information, stamped once for every command in [application].
 var (
-	version   = "dev"
-	commit    = "none"
-	buildDate = "unknown"
+	version   = application.Version
+	commit    = application.Commit
+	buildDate = application.BuildDate
 )
 
 // NewRootCmd creates the root devlore-test command with all subcommands.
@@ -88,12 +89,15 @@ Use --output to route streams to files or %[1]s:
 	}
 
 	// Add shared commands from cli
-	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(cli.NewVersionCmd(cli.VersionInfo{
+	versionInfo := cli.VersionInfo{
 		Version:   version,
 		Commit:    commit,
 		BuildDate: buildDate,
-	}))
+	}
+
+	rootCmd.SetHelpCommand(cli.NewHelpCmd(rootCmd, manHeader))
+	cli.AddVersionFlag(rootCmd, versionInfo)
+	rootCmd.AddCommand(cli.NewVersionCmd(versionInfo))
 	rootCmd.AddCommand(cli.NewManCmd(rootCmd, manHeader))
 	rootCmd.AddCommand(cli.NewConfigCmd(configInfo))
 	rootCmd.AddCommand(cli.NewSelfCmd(rootCmd, cli.SelfInstallInfo{

--- a/cmd/internal/cli/root.go
+++ b/cmd/internal/cli/root.go
@@ -99,12 +99,15 @@ func NewRootCmd(cfg RootConfig) *cobra.Command {
 		DefaultConfig: cfg.DefaultConfig,
 	}
 
-	rootCmd.SetHelpCommand(NewHelpCmd(rootCmd, manHeader))
-	rootCmd.AddCommand(NewVersionCmd(VersionInfo{
+	versionInfo := VersionInfo{
 		Version:   cfg.Version,
 		Commit:    cfg.Commit,
 		BuildDate: cfg.BuildDate,
-	}))
+	}
+
+	rootCmd.SetHelpCommand(NewHelpCmd(rootCmd, manHeader))
+	AddVersionFlag(rootCmd, versionInfo)
+	rootCmd.AddCommand(NewVersionCmd(versionInfo))
 	rootCmd.AddCommand(NewManCmd(rootCmd, manHeader))
 	rootCmd.AddCommand(NewConfigCmd(configInfo))
 	rootCmd.AddCommand(NewSelfCmd(rootCmd, SelfInstallInfo{

--- a/cmd/internal/cli/version.go
+++ b/cmd/internal/cli/version.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// The two version surfaces, split the way docker splits them: `--version` answers in one line and
+// `version` prints the detail. `version --short` is the scriptable form of the first, which is why all three
+// are built here rather than drifting apart in separate files.
+
 // VersionInfo contains version metadata set at build time.
 type VersionInfo struct {
 	Version   string // Semantic version (e.g., "0.1.0")
@@ -17,23 +21,53 @@ type VersionInfo struct {
 	BuildDate string // Build timestamp
 }
 
-// NewVersionCmd creates the version command.
+// AddVersionFlag installs `--version` on a root command, answering in one line.
+//
+// Cobra generates the flag as soon as [cobra.Command.Version] is set; the template fixes the wording to
+// docker's — `writ version 0.4.0, build ed6f468` — a single line that contacts nothing and exits. `-v` is
+// deliberately not a shorthand for it: this repository's commands already use `-v` for verbose output, and
+// the collision would be worse than the missing convenience.
+//
+// Parameters:
+//   - `rootCmd`: the root command the flag is installed on.
+//   - `info`: the build-time metadata; `Version` and `Commit` appear in the line.
+func AddVersionFlag(rootCmd *cobra.Command, info VersionInfo) {
+
+	rootCmd.Version = info.Version
+
+	// The template is rendered by text/template, so it must carry no action delimiters of its own. Every
+	// value here is a build stamp, and a stamp containing "{{" is not a case worth defending against.
+	rootCmd.SetVersionTemplate(fmt.Sprintf("%s version %s, build %s\n", rootCmd.Name(), info.Version, info.Commit))
+}
+
+// NewVersionCmd creates the version command, which prints the full build detail.
+//
+// Output goes through [cobra.Command.OutOrStdout] rather than to [os.Stdout] directly, so a caller that
+// redirects the command's output captures this like any other command's.
+//
+// Parameters:
+//   - `info`: the build-time metadata to report.
+//
+// Returns:
+//   - `*cobra.Command`: the `version` command, carrying its `--short` flag.
 func NewVersionCmd(info VersionInfo) *cobra.Command {
 	var short bool
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
+
+			out := cmd.OutOrStdout()
+
 			if short {
-				fmt.Println(info.Version)
+				_, _ = fmt.Fprintln(out, info.Version) //nolint:errcheck // diagnose-ignored-error: a failed write to the command's own output has nowhere left to report; see docs/architecture/2.8-eventing-infrastructure.md
 				return
 			}
-			fmt.Printf("Version:    %s\n", info.Version)
-			fmt.Printf("Commit:     %s\n", info.Commit)
-			fmt.Printf("Built:      %s\n", info.BuildDate)
-			fmt.Printf("Go version: %s\n", runtime.Version())
-			fmt.Printf("OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+			//nolint:errcheck // diagnose-ignored-error: as above; see docs/architecture/2.8-eventing-infrastructure.md
+			_, _ = fmt.Fprintf(out, "Version:    %s\nCommit:     %s\nBuilt:      %s\nGo version: %s\nOS/Arch:    %s/%s\n",
+				info.Version, info.Commit, info.BuildDate, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 

--- a/cmd/internal/cli/version_test.go
+++ b/cmd/internal/cli/version_test.go
@@ -4,10 +4,68 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
+
+// --- AddVersionFlag ---
+
+// TestAddVersionFlag_AnswersInOneLine pins the `--version` surface: docker's shape, one line, and nothing
+// from the detail block.
+//
+// The one-line property is the whole point of the flag's existence beside the `version` command, so it is
+// asserted directly rather than inferred from the text matching.
+func TestAddVersionFlag_AnswersInOneLine(t *testing.T) {
+
+	rootCmd := &cobra.Command{Use: "writ"}
+	AddVersionFlag(rootCmd, VersionInfo{Version: "1.2.3", Commit: "abc1234", BuildDate: "2026-03-17T00:00:00Z"})
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetArgs([]string{"--version"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if want := "writ version 1.2.3, build abc1234\n"; out.String() != want {
+		t.Errorf("--version = %q, want %q", out.String(), want)
+	}
+
+	if lines := strings.Count(strings.TrimSuffix(out.String(), "\n"), "\n"); lines != 0 {
+		t.Errorf("--version printed %d extra lines; the flag answers in one", lines)
+	}
+
+	// The build date belongs to `version`, not to `--version` — docker's split is the reason both exist.
+	if strings.Contains(out.String(), "2026-03-17") {
+		t.Error("--version reported the build date; that detail belongs to the version command")
+	}
+}
+
+// TestAddVersionFlag_IsNotBoundToShorthandV pins the deliberate omission: `-v` is verbose output across this
+// repository's commands, and cobra would happily take it for --version.
+func TestAddVersionFlag_IsNotBoundToShorthandV(t *testing.T) {
+
+	rootCmd := &cobra.Command{Use: "writ"}
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
+	AddVersionFlag(rootCmd, VersionInfo{Version: "1.2.3", Commit: "abc1234"})
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetArgs([]string{"-v"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if strings.Contains(out.String(), "version") {
+		t.Errorf("-v printed the version %q; it is the verbose flag", out.String())
+	}
+}
 
 // captureStdout runs fn and returns what it wrote to os.Stdout.
 func captureStdout(t *testing.T, fn func()) string {

--- a/cmd/lore/lore/root.go
+++ b/cmd/lore/lore/root.go
@@ -8,14 +8,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/schema"
 )
 
-// Version information, set at build time via ldflags.
+// Version information, stamped once for every command in [application].
 var (
-	version   = "dev"
-	commit    = "none"
-	buildDate = "unknown"
+	version   = application.Version
+	commit    = application.Commit
+	buildDate = application.BuildDate
 )
 
 // NewRootCmd creates the root lore command with all subcommands.

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	starruntime "github.com/NobleFactor/devlore-cli/cmd/star/star"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
@@ -26,10 +27,11 @@ import (
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
 )
 
+// Version information, stamped once for every command in [application].
 var (
-	version   = "dev"
-	commit    = "none"
-	buildDate = "unknown"
+	version   = application.Version
+	commit    = application.Commit
+	buildDate = application.BuildDate
 )
 
 const starlarkDocs = `WRITING STARLARK OPERATIONS
@@ -212,15 +214,11 @@ Generate shell completions with:
 		runtime.Environment().Status = narrator
 	})
 
-	// Version command
+	// Version surfaces — the same two every devlore command carries, rather than star's own spelling.
 
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "version",
-		Short: "Print version information",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("star %s (%s) built %s\n", version, commit, buildDate)
-		},
-	})
+	versionInfo := cli.VersionInfo{Version: version, Commit: commit, BuildDate: buildDate}
+	cli.AddVersionFlag(rootCmd, versionInfo)
+	rootCmd.AddCommand(cli.NewVersionCmd(versionInfo))
 
 	// Key management commands.
 

--- a/cmd/writ/writ/root.go
+++ b/cmd/writ/writ/root.go
@@ -8,14 +8,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/schema"
 )
 
-// Version information, set at build time via ldflags.
+// Version information, stamped once for every command in [application].
 var (
-	version   = "dev"
-	commit    = "none"
-	buildDate = "unknown"
+	version   = application.Version
+	commit    = application.Commit
+	buildDate = application.BuildDate
 )
 
 // NewRootCmd creates the root writ command with all subcommands.

--- a/docs/plans/version-stamping.md
+++ b/docs/plans/version-stamping.md
@@ -1,7 +1,7 @@
 ---
 title: "Version stamping: one stamped location, two reporting surfaces"
 issue: TBD — created after review
-status: in-progress — all three phases landed 2026-08-16; `--version` tests and the release-path guard remain
+status: complete — all three phases landed 2026-08-16, both surfaces tested, both build paths guarded
 created: 2026-08-15
 updated: 2026-08-15
 ---
@@ -130,7 +130,9 @@ every release artifact — reported `dev` / `none` / `unknown`, because the stan
 - [x] `cli.AddVersionFlag` sets `rootCmd.Version` and the one-line template; installed on all four
       root commands
 - [x] `version` writes through `cmd.OutOrStdout()`
-- [ ] Tests covering all three forms — **not written**; see Remaining below
+- [x] Tests covering all three forms. `--version` gets two: that it answers in **one line** carrying
+      no build date (the property that distinguishes it from `version`), and that `-v` still means
+      verbose — cobra would take `-v` for `--version` given the chance
 
 ```console
 $ build/writ --version
@@ -148,7 +150,7 @@ the old format, checked before changing it.
 
 - [x] `make build` compares what the build stamped against what the binary prints, and fails with the
       cause named
-- [ ] The release path is **not** covered — see Remaining
+- [x] The release path is covered — **and it is not goreleaser**
 
 **Proved by watching it refuse**, not by watching it pass. Building with a deliberately wrong symbol
 path:
@@ -162,17 +164,75 @@ ERROR: version stamp did not bind.
 make: *** [Makefile:102: build] Error 1
 ```
 
-## Remaining
+**This plan named the wrong release path.** It asserted that `.goreleaser.yaml` "carries its own
+build stanza, and it is the one that ships." It does not ship anything.
+[`release.yaml:65`](../../.github/workflows/release.yaml) runs **`make dist`**, and `.goreleaser.yaml`
+is referenced by nothing but its own header comment and two forward-looking lines in
+`wiki/Releasing.md`. The published asset names match `dist-all`'s own pattern, not goreleaser's.
 
-Two items, both deliberate rather than forgotten:
+So the release path is guarded where it actually is:
 
-1. **Tests for the three surfaces.** `version` and `version --short` have tests that predate this
-   work and still pass; `--version` has none. The template is built with `fmt.Sprintf` and rendered
-   by cobra, so the case worth pinning is that the flag exists and prints one line.
-2. **The release path is unguarded.** `.goreleaser.yaml` carries its own build stanza with its own
-   `-X` flags, and `make build`'s check cannot see it. A goreleaser build with the paths wrong would
-   ship silently — exactly the failure this plan exists to end, in the one place that reaches users.
-   `goreleaser build --snapshot` plus the same comparison would close it.
+- **`dist-all` now depends on `build`** — not for its binaries, which it cross-compiles itself, but
+  for the stamp check. It uses the same `LDFLAGS` and the same `VERSION`, and it cannot run what it
+  produces for other platforms; `build` proves on the host that those flags bind to real symbols.
+- **`verify-ldflags`, in `make check`**, asserts `.goreleaser.yaml` names the same package. That file
+  is dormant, not dead: whoever adopts goreleaser inherits whatever is in it, and a wrong path there
+  would fail exactly the way this whole defect failed. Agreement is a sufficient check precisely
+  because the Makefile's own paths are proved to bind by `build`.
+
+## Two platform failures, two different causes
+
+The guard's first CI run failed on macOS and Windows. They looked like one problem and were not —
+which is why each got read rather than assumed.
+
+### macOS — GNU make 3.82+ is now a declared prerequisite
+
+`bash: -c: line 1: syntax error: unexpected end of file`. `.ONESHELL:` is a GNU make **3.82**
+feature; macOS ships **3.81** — the last GPLv2 release, so it will never advance — and older make
+ignores the directive *silently*, running each recipe line in its own shell and splitting a
+multi-line `if` mid-statement.
+
+The repository already had multi-line recipes in `complexity`, `dist-all`, `lint-all` and
+`build-all`. All of them had only ever run on ubuntu, so the dependency had been invisible;
+`build` runs everywhere, so it was the first to meet 3.81. A developer on a stock Mac running
+`make dist` would have hit the same wall.
+
+**Ruled 2026-08-16: 3.82+ is a prerequisite, not a constraint to write around.** So, rather than
+keeping the accommodating one-liners:
+
+- The Makefile **declares it** — an `ifneq` on `MAKE_VERSION` that refuses to run with the fix in the
+  message, instead of a shell error naming nothing.
+- CI **conforms** — the macOS legs of all three jobs install GNU make and put it first on `PATH`.
+  ubuntu and windows already satisfy it.
+- `README.md` states it under Building, with the `brew install make` line.
+- The two new recipes are back in their readable multi-line form.
+
+Team tooling — GNU make included — is headed for a lore package list for devlore engineers, which is
+where the prerequisite will eventually be installed rather than merely documented.
+
+### Windows — the guard caught a real defect, in the Makefile's own variables
+
+Windows make handled the multi-line recipe fine. The guard fired, and it was right to:
+
+```
+ERROR: version stamp did not bind.
+  build computed: 8a62b17-dirty
+  binary reports: 8a62b17
+```
+
+`?=` defines **recursively expanded** variables, so `$(shell git describe …)` and `$(shell date …)`
+re-run at *every reference*. `LDFLAGS :=` captured one set of answers at parse time; the check
+named `$(VERSION)` again and got another. On Windows the two differed because codegen rewrites
+tracked `*.gen.go` files mid-build (line endings), so `--dirty` changed its answer between the link
+and the check.
+
+`VERSION`, `COMMIT` and `BUILD_DATE` are now flattened to simply-expanded after their `?=`
+definitions: one evaluation per make run, so the stamped value and anything compared against it
+cannot disagree. Overrides from the environment or command line still win — verified with
+`make build VERSION=v9.9.9-test`.
+
+**This is the guard earning its place on its first run.** The variables have behaved this way since
+long before this plan; nothing compared two evaluations, so nothing noticed.
 
 ## Files to Create/Modify
 

--- a/docs/plans/version-stamping.md
+++ b/docs/plans/version-stamping.md
@@ -1,7 +1,7 @@
 ---
 title: "Version stamping: one stamped location, two reporting surfaces"
 issue: TBD — created after review
-status: draft
+status: in-progress — all three phases landed 2026-08-16; `--version` tests and the release-path guard remain
 created: 2026-08-15
 updated: 2026-08-15
 ---
@@ -106,23 +106,73 @@ the reporting substitutes the default.
 
 ## Implementation Phases
 
-### Phase 1: centralize
+### Phase 1: centralize — **complete 2026-08-16**
 
-- [ ] Create the owning package with the three variables and their defaults
-- [ ] Commands stop declaring their own triples; `RootConfig` takes its values from the one package
-- [ ] `Makefile` and `.goreleaser.yaml` name the new symbol path — one `-X` per value, not per binary
+- [x] `pkg/application/version.go` holds `Version`, `Commit` and `BuildDate` with their defaults
+- [x] All four commands (`writ`, `lore`, `star`, `devlore-test`) stop declaring their own triples
+- [x] `Makefile` and `.goreleaser.yaml` name `pkg/application` — one `-X` per value, not per binary
 
-### Phase 2: the two surfaces
+**Proved by the binaries, not by the build succeeding.** After `make build`, all four report the same
+stamp:
 
-- [ ] `rootCmd.Version` set, with `SetVersionTemplate` producing the one-line form
-- [ ] `version` writes through `cmd.OutOrStdout()`
-- [ ] Tests cover all three forms: `--version`, `version`, `version --short`
+```
+Version:    v0.1.0-dev.20260815050413-1-gf980693b-dirty
+Commit:     f980693b
+Built:      2026-08-16T18:24:33Z
+```
 
-### Phase 3: the guard
+That is the first time these flags have bound to anything. Before this, every binary — including
+every release artifact — reported `dev` / `none` / `unknown`, because the stanzas named
+`internal/cli.Version`, where `Version` was only ever a struct field.
 
-- [ ] The build asserts the built binary reports the version the build computed
-- [ ] Verify the release path too — `.goreleaser.yaml` carries its own build stanza, and it is the
-      one that ships
+### Phase 2: the two surfaces — **complete 2026-08-16**
+
+- [x] `cli.AddVersionFlag` sets `rootCmd.Version` and the one-line template; installed on all four
+      root commands
+- [x] `version` writes through `cmd.OutOrStdout()`
+- [ ] Tests covering all three forms — **not written**; see Remaining below
+
+```console
+$ build/writ --version
+writ version v0.1.0-dev.20260815050413-1-gf980693b-dirty, build f980693b
+```
+
+`lore`, `star` and `devlore-test` print the same shape.
+
+**`star` lost its own spelling.** It carried a hand-rolled `version` command printing
+`star <version> (<commit>) built <date>` — one tool reporting a different shape is the drift
+centralizing exists to end, so it now uses `cli.NewVersionCmd` like the others. Nothing asserted on
+the old format, checked before changing it.
+
+### Phase 3: the guard — **complete 2026-08-16**
+
+- [x] `make build` compares what the build stamped against what the binary prints, and fails with the
+      cause named
+- [ ] The release path is **not** covered — see Remaining
+
+**Proved by watching it refuse**, not by watching it pass. Building with a deliberately wrong symbol
+path:
+
+```console
+$ make build LDFLAGS='-ldflags "-X …/pkg/application.NoSuchSymbol=x"'
+ERROR: version stamp did not bind.
+  build computed: v0.1.0-dev.20260815050413-1-gf980693b-dirty
+  binary reports: dev
+  The -X paths in LDFLAGS name symbols that do not exist — check pkg/application.
+make: *** [Makefile:102: build] Error 1
+```
+
+## Remaining
+
+Two items, both deliberate rather than forgotten:
+
+1. **Tests for the three surfaces.** `version` and `version --short` have tests that predate this
+   work and still pass; `--version` has none. The template is built with `fmt.Sprintf` and rendered
+   by cobra, so the case worth pinning is that the flag exists and prints one line.
+2. **The release path is unguarded.** `.goreleaser.yaml` carries its own build stanza with its own
+   `-X` flags, and `make build`'s check cannot see it. A goreleaser build with the paths wrong would
+   ship silently — exactly the failure this plan exists to end, in the one place that reaches users.
+   `goreleaser build --snapshot` plus the same comparison would close it.
 
 ## Files to Create/Modify
 
@@ -139,17 +189,17 @@ the reporting substitutes the default.
 
 ## Open Questions
 
-1. **Which package owns the values?** Three candidates:
-   - **`pkg/application`** — a public package for what an application-shaped program needs. Fits if
-     more than version metadata will live there; a package created to hold three strings is thin, and
-     `pkg/` is public API surface for a build concern that is not.
-   - **`cmd/internal/devlore`** — already imported by everything CLI-side, so no new package. But it
-     was just chartered to hold *only* what the commands share about locations, and version metadata
-     is not a location. Adding it re-mixes the concern that charter separates.
-   - **`cmd/internal/version`** (unproposed) — a new CLI-internal package named for exactly what it
-     holds. No public surface, no mixing, one import. Costs one more package.
-   **Recommendation: `cmd/internal/version`**, unless `pkg/application` is already planned to carry
-   more, in which case it wins on not multiplying packages.
+1. ~~**Which package owns the values?**~~ **Answered 2026-08-16: `pkg/application`.**
+
+   My recommendation of a new `cmd/internal/version` rested on a false premise — that
+   `pkg/application` would be a package created to hold three strings. It already exists and already
+   holds the tool's identity: the program name plus the variable resolver's flag, config, and
+   override maps, constructed by each command from its own CLI plumbing and read by the framework
+   through the runtime environment. A program's version belongs beside its program name, and no new
+   package is needed.
+
+   The `cmd/internal/devlore` option stays rejected for the reason given: that package was chartered
+   to hold only what the commands share about *locations*, and a version is not a location.
 2. **Does `devlore-test`, `devlore-docs`, `devlore-index` or `devlore-inventory` need the surfaces?**
    All four are stamped by the same `LDFLAGS` today. Whether they get `--version` too, or only the
    three user-facing commands do, is a decision about what those tools are.

--- a/pkg/application/version.go
+++ b/pkg/application/version.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package application
+
+// Build-time identity, stamped by the linker and shared by every command.
+//
+// These are the `-X` targets, and they live here — beside the program name and the tool's other identity —
+// because a build stamps the product once, not once per binary. The build stanzas name exactly these three
+// symbols:
+//
+//	-X github.com/NobleFactor/devlore-cli/pkg/application.Version=$(VERSION)
+//	-X github.com/NobleFactor/devlore-cli/pkg/application.Commit=$(COMMIT)
+//	-X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate=$(BUILD_DATE)
+//
+// **The path is load-bearing and silently so.** `-X` against a symbol that does not exist is not an error —
+// the linker ignores it and the binary reports its compiled-in default. Every release built before
+// 2026-08-16 shipped that way, because the stanzas named `internal/cli.Version`, where `Version` was only ever
+// a struct field. A package move that leaves these paths behind produces working, testable, correct-looking
+// binaries that report `dev`; only a build-time check comparing what was stamped against what the binary
+// prints can catch it (docs/plans/version-stamping.md).
+//
+// The defaults are what an unstamped build honestly reports — `go run`, an IDE build, `go build` without the
+// Makefile — and they are deliberately not empty strings.
+var (
+	// Version is the semantic version, e.g. "v0.4.0"; "dev" in an unstamped build.
+	Version = "dev"
+
+	// Commit is the short git commit hash; "none" in an unstamped build or outside a repository.
+	Commit = "none"
+
+	// BuildDate is the RFC 3339 UTC build timestamp; "unknown" in an unstamped build.
+	BuildDate = "unknown"
+)


### PR DESCRIPTION
## Summary

**Version stamping has never worked.** `Makefile` and `.goreleaser.yaml` named their `-X` targets in
`internal/cli`, where `Version`, `Commit` and `BuildDate` exist only as **struct fields** — on
`RootConfig` and `VersionInfo`. `-X` against a symbol that does not exist is not an error: the linker
ignores it silently. Every binary this repository has ever built, release artifacts included,
reported its compiled-in `dev` / `none` / `unknown`.

`pkg/application` now owns the three variables. It already carries the tool's identity — the program
name plus the variable resolver's flag, config and override maps — so a program's version belongs
beside its program name. One `-X` path serves every binary, replacing four commands that each
declared an identical triple.

## Two surfaces, docker's split

```console
$ build/writ --version
writ version v0.1.0-dev.20260815050413-1-gf980693b-dirty, build f980693b

$ build/writ version
Version:    v0.1.0-dev.20260815050413-1-gf980693b-dirty
Commit:     f980693b
Built:      2026-08-16T18:42:17Z
Go version: go1.26.6
OS/Arch:    darwin/arm64
```

`--version` answers in one line and exits; `version` prints the detail; `version --short` is the
scriptable form. All four commands — `writ`, `lore`, `star`, `devlore-test` — report identically.

**`star` lost its own spelling.** It carried a hand-rolled `version` printing
`star <version> (<commit>) built <date>`. One tool reporting a different shape is the drift that
centralizing exists to end, so it now uses the shared command. Nothing asserted on the old format;
that was checked before changing it.

`-v` is deliberately **not** a shorthand for `--version` — this repository's commands already use
`-v` for verbose output, and the collision would be worse than the missing convenience.

## The guard, proved by watching it refuse

`make build` now compares what it stamped against what the binary prints. A gate nobody has watched
refuse anything is a claim, not a gate — so, with a deliberately wrong symbol path:

```console
$ make build LDFLAGS='-ldflags "-X …/pkg/application.NoSuchSymbol=x"'
ERROR: version stamp did not bind.
  build computed: v0.1.0-dev.20260815050413-1-gf980693b-dirty
  binary reports: dev
  The -X paths in LDFLAGS name symbols that do not exist — check pkg/application.
make: *** [Makefile:102: build] Error 1
```

This check is the reason the defect survived every release: nothing compared the two, so a silent
mis-target looked exactly like a working build.

## Two gaps, recorded rather than implied

1. **`--version` has no test.** `version` and `version --short` have tests that predate this work and
   still pass.
2. **The release path is unguarded.** `.goreleaser.yaml` carries its own build stanza with its own
   `-X` flags, which `make build`'s check cannot see. A goreleaser build with those paths wrong would
   ship silently — the same failure, in the one place that reaches users. `goreleaser build
   --snapshot` plus the same comparison would close it.

Both are in [docs/plans/version-stamping.md](docs/plans/version-stamping.md).

## Verified

- `make check`
- `make lint-all` — 0 issues under linux, darwin and windows
- `make test-scenario`
- All four binaries reporting the same stamp through both surfaces


---

## The first CI run failed on two platforms, for two different reasons

### macOS — GNU make 3.82+ is now a declared prerequisite

`bash: -c: line 1: syntax error: unexpected end of file`. `.ONESHELL:` is a GNU make **3.82**
feature; macOS ships **3.81** — the last GPLv2 release — and older make ignores the directive
*silently*, running each recipe line in its own shell and splitting a multi-line `if` mid-statement.

`complexity`, `dist-all`, `lint-all` and `build-all` have carried multi-line recipes for a while.
All of them run only on ubuntu, so the dependency was invisible until `build` — which runs
everywhere — met 3.81. A developer on a stock Mac running `make dist` would have hit the same wall.

**Ruled: 3.82+ is a prerequisite, not something to write around.**

- The Makefile **declares it** and refuses to run otherwise, with the fix in the message.
- CI **conforms** — the macOS legs of all three jobs install GNU make and put it first on `PATH`.
- `README.md` states it under Building.
- The one-liners written to accommodate 3.81 are back in readable multi-line form.

### Windows — the guard caught a real defect in the Makefile's own variables

Windows make handled the recipe fine. The guard fired, and it was right to:

```
ERROR: version stamp did not bind.
  build computed: 8a62b17-dirty
  binary reports: 8a62b17
```

`?=` defines **recursively expanded** variables, so `$(shell git describe …)` and `$(shell date …)`
re-run at *every reference*. `LDFLAGS :=` captured one set of answers; the check named `$(VERSION)`
again and got another. On Windows the two differed because codegen rewrites tracked `*.gen.go` files
mid-build (line endings), so `--dirty` flipped between the link and the check.

`VERSION`, `COMMIT` and `BUILD_DATE` are now flattened to simply-expanded after their `?=`
definitions — one evaluation per make run. Overrides still win, verified with
`make build VERSION=v9.9.9-test`.

These variables have behaved this way since long before this PR. Nothing ever compared two
evaluations, so nothing noticed — the guard earning its place on its first run.

**Verified:** `make check`, `make lint-all` (0 issues, three platforms), `make test-scenario`, and
the version guard refusing `/usr/bin/make` 3.81 with its message while passing on 4.4.1.
