### PR TITLE
feat(op): graphs and traces save themselves (windows campaign 3.3a)

### DIFF
--- a/cmd/internal/cli/store.go
+++ b/cmd/internal/cli/store.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
-	"github.com/NobleFactor/devlore-cli/internal/document"
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -65,15 +64,23 @@ func WriteGraph(graph *op.Graph) (path string, err error) {
 	}
 
 	// One root for the whole store write. The CLI is the session owner for CLI-side work, so it opens the
-	// tree's authority once and every mutation within it — today the index line, and the document itself once
-	// phase 3.3 converts internal/document — is anchored by the same root (#405, phase 2b).
+	// tree's authority once and every mutation within it — the document, the index line, and for a trace the
+	// `latest` symlink — is anchored by the same root (#405, phase 2b).
 	stateRoot := fsroot.OpenWritableUnconfined(devlore.StateHome())
 	defer iox.Close(&err, stateRoot)
 
+	// The store owns its layout, so the store creates it. op.SaveGraph deliberately does not: a save that
+	// invents directory structure would be making store decisions on the caller's behalf.
+	if err := stateRoot.MkdirAll(stateRoot.NewPath(GraphsDir()), 0o750); err != nil {
+		return "", fmt.Errorf("create graphs directory: %w", err)
+	}
+
 	signArtifact(graph.Signature() == nil, signing.NamespaceGraph, graph.SignWith)
 
-	if err := document.Write(path, graph); err != nil {
-		return "", fmt.Errorf("write graph %s: %w", path, err)
+	// The artifact renders itself: op owns the encoding and the format is stated, not inferred from the
+	// ".yaml" on the end of the path (phase-8 step 46 / the single-codec direction).
+	if err := op.SaveGraph(stateRoot, stateRoot.NewPath(path), graph, "yaml"); err != nil {
+		return "", err
 	}
 
 	entry := IndexEntry{At: time.Now().UTC(), Event: IndexEventGraph, GraphChecksum: graph.Checksum()}
@@ -103,8 +110,7 @@ func WriteGraph(graph *op.Graph) (path string, err error) {
 //   - `error`: non-nil if the directory cannot be created or the trace/symlink cannot be written.
 func WriteTrace(trace *op.Trace) (path string, err error) {
 
-	// One root for the whole store write — see [WriteGraph]. Here it covers two mutations directly, the
-	// `latest` symlink and the index line, plus the document once phase 3.3 converts internal/document.
+	// One root for the whole store write — see [WriteGraph].
 	stateRoot := fsroot.OpenWritableUnconfined(devlore.StateHome())
 	defer iox.Close(&err, stateRoot)
 
@@ -114,14 +120,17 @@ func WriteTrace(trace *op.Trace) (path string, err error) {
 	filename := time.Now().UTC().Format("20060102T150405.000000000Z") + ".yaml"
 	path = filepath.Join(directory, filename)
 
-	if err := trace.StampChecksum(); err != nil {
-		return "", fmt.Errorf("stamp trace checksum: %w", err)
+	// The per-graph subdirectory is store layout, so the store creates it — see [WriteGraph].
+	if err := stateRoot.MkdirAll(stateRoot.NewPath(directory), 0o750); err != nil {
+		return "", fmt.Errorf("create traces directory: %w", err)
 	}
 
 	signArtifact(trace.Signature == nil, signing.NamespaceTrace, trace.SignWith)
 
-	if err := document.Write(path, trace); err != nil {
-		return "", fmt.Errorf("write trace %s: %w", path, err)
+	// SaveTrace stamps the checksum itself — LoadTrace refuses a document without one, so the pair is total
+	// rather than relying on the caller to remember. Signing stays here: the key is the publisher's.
+	if err := op.SaveTrace(stateRoot, stateRoot.NewPath(path), trace); err != nil {
+		return "", err
 	}
 
 	// NewPath rebases an absolute path onto the root, so the display string and the root-relative path stay

--- a/docs/architecture/1-system-model.md
+++ b/docs/architecture/1-system-model.md
@@ -254,7 +254,7 @@ The trace ([2](2-execution-graph.md), [5.2](5.2-recovery-serialization.md)) reco
 - **Checksum and signature** — the graph document's checksum covers canonical content; signing is
   `pkg/signing` + `writ verify` ([5](5-graph-trace-integrity.md)).
 
-The run index (`internal/cli`) folds records over time — `writ status` reads it today; the fleet-level record graph
+The run index (`cmd/internal/cli`) folds records over time — `writ status` reads it today; the fleet-level record graph
 above is the same idea at distributed scale.
 
 ### 7.3 Drift Detection
@@ -365,7 +365,7 @@ walk catches drift even without a new deployment.
 | Providers (18 in the catalog) | Implemented | `pkg/op/provider/` ([3.5](3.5-provider-catalog.md)) |
 | Plan bindings (the Starlark planning API) | Implemented | `pkg/op/provider/plan/`, `pkg/op/starlarkbridge/` |
 | Record integrity (checksum, ssh-ed25519 signing, `writ verify`) | Implemented | `pkg/signing/` (step 46) |
-| Trace store + run index + drift attribution | Implemented | `internal/cli/` (steps 47–48) |
+| Trace store + run index + drift attribution | Implemented | `cmd/internal/cli/` (steps 47–48) |
 | Package planner (ref counting, SemVer intersection) | Not started | — (§5 vision) |
 | Distributed coordinator / interface nodes / cross-node promises | Not started | — (§6 vision) |
 | Global record graph | Not started | — (§7 vision) |

--- a/docs/architecture/1-system-model.status.md
+++ b/docs/architecture/1-system-model.status.md
@@ -7,7 +7,7 @@ vision content (dependency taxonomy, package planner, distributed orchestration,
 preserved and explicitly marked *vision*; every current-system claim now describes the landed model — units + saga
 receipts instead of runtime phases, the sealed `Binding` set instead of `Proxy`/`Context.Data`, retained
 receipts/journal instead of Tombstones, the trace/run-index instead of the receipt-YAML sketch, and a corrected §12
-status table (`pkg/op`, `pkg/signing`, `internal/cli`; the landed drift attribution of steps 47–48). The pre-rewrite
+status table (`pkg/op`, `pkg/signing`, `cmd/internal/cli`; the landed drift attribution of steps 47–48). The pre-rewrite
 discrepancy list (Sidecar cross-reference, `internal/execution` paths, provider count, `actions_gen.go`) is obsolete
 with the body it described.
 

--- a/docs/architecture/2-execution-graph.md
+++ b/docs/architecture/2-execution-graph.md
@@ -125,7 +125,7 @@ Two documents, two roles:
    compensation), the catalog snapshot with content identity (Etag + Digest), and the transition journal
    ([5.2 recovery serialization](5.2-recovery-serialization.md)).
 
-The store lives behind `internal/cli`: `WriteGraph` persists the plan once, `WriteTrace` persists every run's trace —
+The store lives behind `cmd/internal/cli`: `WriteGraph` persists the plan once, `WriteTrace` persists every run's trace —
 win or lose — and both append to the NDJSON **run index** that `writ status` and the deploy family fold over.
 
 ## The command layer
@@ -155,5 +155,5 @@ the graph.
 | per-`Node` status strings mutated by `Run` | immutable graph; outcomes recorded as receipts in the trace |
 | `graph.Run()` (graph executes itself) | `op.GraphExecutor.Run` (one executor per run; child executors per subgraph) |
 | one structure serialized before/after `Run` | two documents: the graph (plan) and the trace (record) |
-| `receipts/` directory + `state.yaml` | the `internal/cli` store: graph + trace documents + the NDJSON run index |
+| `receipts/` directory + `state.yaml` | the `cmd/internal/cli` store: graph + trace documents + the NDJSON run index |
 | checksum + optional age signing inline | `CanonicalContent` checksum at seal; `pkg/signing` via `SignWith` |

--- a/docs/architecture/2-execution-graph.status.md
+++ b/docs/architecture/2-execution-graph.status.md
@@ -6,7 +6,7 @@
 pre-`op` `internal/graph` design (`ExecutionGraph`, `GraphBuilder`, `SlotValue`, `GraphState`, `graph.Run()`) — is
 replaced; its old→new mapping is preserved in the document's closing table. Every code claim in the rewritten document
 was verified against the tree on 2026-07-21 (`pkg/op/graph.go`, `binding.go`, `validate.go`, `graph_executor.go`,
-`internal/cli/receipts.go`, `cmd/writ/writ/deploy/deploy.go`).
+`cmd/internal/cli/receipts.go`, `cmd/writ/writ/deploy/deploy.go`).
 
 ## Completion
 

--- a/docs/architecture/2.5-lifecycle-pipeline-construction.md
+++ b/docs/architecture/2.5-lifecycle-pipeline-construction.md
@@ -11,7 +11,7 @@ relies on the immutable graph seal (phase-8 [graph-immutability.md](../plans/ext
 It is lore's job to **construct lifecycle pipelines**. A package declares a lifecycle composed of **pipelines**
 — one per `Action`. A pipeline is an **ordered sequence of phase subgraphs executed in order; the outputs of
 one phase are the inputs to the next.** The phase order is canonical, defined in
-`internal/lorepackage/lifecycle.go` (`PhaseOrder(action)`):
+`cmd/internal/lorepackage/lifecycle.go` (`PhaseOrder(action)`):
 
 | Pipeline (`Action`) | Phase order |
 |---|---|
@@ -42,7 +42,7 @@ graph (Origin{Tool, Scope, Annotations})
 
 Phase scripts are laid out as a **platform taxonomy** under `<package>/<platform-layer>/<Action>/<phase>.star`.
 A target platform selects an ordered **cascade** of layers — most-general → most-specific — via
-`PlatformResolutionOrder` (`internal/lorepackage/lifecycle.go`):
+`PlatformResolutionOrder` (`cmd/internal/lorepackage/lifecycle.go`):
 
 | Target platform | Resolution cascade |
 |---|---|

--- a/docs/architecture/3.4-platform-package-managers.status.md
+++ b/docs/architecture/3.4-platform-package-managers.status.md
@@ -9,7 +9,7 @@ The design is settled (2026-06-04) and was **reversed to an op-free `pkg/platfor
 routing with construction-time normalization, the native driver catalog, per-leaf state-query verification, named
 `*Spec` factories) is **implemented and style-compliant**. The `pkg/platform` test rewrites and the `pkg.Provider`
 veneer migration (#6 — `provider/pkg` + `provider/service`) are **done**; the consumer migration completed 2026-07-04
-(`internal/lorepackage` was the last old-surface consumer — `cmd/lore` and `cmd/devlore-test` were already on
+(`cmd/internal/lorepackage` was the last old-surface consumer — `cmd/lore` and `cmd/devlore-test` were already on
 `platform.Detect`/`platform.New`; `cmd/writ` stays broken on unrelated sealed-graph drift, phase-8 step 33) and the
 `pkg/op` duplicate surface (`op.Platform`, `op.PURL`, the string-based managers) is **deleted** (phase-8 step 19).
 It supersedes the stale "Darwin Package Manager Idempotence" treatment formerly in

--- a/docs/architecture/3.5.3-plan-provider.md
+++ b/docs/architecture/3.5.3-plan-provider.md
@@ -164,5 +164,10 @@ Both doors converge on the same invocation registry, the same assembly pipeline,
 
 1. **Graph signing at assembly.** `AssembleDefinition` leaves sub-graphs unsigned (no signing client propagated);
    `cli.WriteGraph` signs at persist instead. Whether assembly should accept a signer is open (step 46 follow-on).
+   **Narrowed 2026-08-17** by the `op.SaveGraph` / `op.SaveTrace` split: the *checksum* moved to the artifact,
+   because `LoadTrace` refuses a document without one and the pair has to be total. The *signature* deliberately
+   did not, because the key is the publisher's — the artifact cannot know which identity is publishing it. So
+   the open question is no longer "where does signing happen" but "who supplies the signer, and when": today the
+   store does, at persist; assembly could, if a signing client were propagated.
 2. **`plan.case` collision surface.** `Case` lives on the plan provider but constructs a `flow.Case` — the one
    tier-3 method whose type belongs to another provider; kept here so the construction surface is uniform.

--- a/docs/architecture/5-graph-trace-integrity.md
+++ b/docs/architecture/5-graph-trace-integrity.md
@@ -26,7 +26,14 @@ Settled 2026-07-26/27. Every persisted run document carries a tier-1 checksum co
 | Document | Checksum | Stamped | Verified |
 |---|---|---|---|
 | Graph | `GitStyleChecksum("graph", canonical)` | at build (`op.NewGraph`) | `op.LoadGraph` recomputes and compares |
-| Trace | `GitStyleChecksum("trace", canonical)` | at persist (`cli.WriteTrace`) | `op.LoadTrace` recomputes and compares |
+| Trace | `GitStyleChecksum("trace", canonical)` | at persist (`op.SaveTrace`) | `op.LoadTrace` recomputes and compares |
+
+**The stamp is unskippable, and that is the point (2026-08-17).** `op.SaveTrace` stamps rather than trusting
+its caller to, because `op.LoadTrace` refuses a document carrying no checksum: a save that left stamping to the
+caller could write a document nothing can read, and the failure would surface at the next load rather than at
+the write. Stamping is idempotent — the canonical bytes exclude the checksum field — so `SaveTrace` stamps
+unconditionally. Signing is not folded in for the same reason it is not skippable: the checksum belongs to the
+artifact, the key belongs to whoever publishes it, so the caller signs and `SaveTrace` persists.
 
 `GitStyleChecksum` is the git-object construction — `SHA256("<type> <len>\0" ‖ content)`, rendered
 `"sha256:<hex>"` (`pkg/op/helpers.go`). The type word is fixed per document kind; the filename is never
@@ -76,14 +83,14 @@ The signing model is publisher identity with verifier-side trust (`pkg/signing`,
 - The default custody tier is the developer's SSH key (`~/.ssh/id_ed25519`), with a generated local
   Ed25519 keyfile as the fallback. The ssh-agent, cloud-KMS, and keyless tiers are chartered follow-ons.
 
-Signing at persist time is **best effort** (`signArtifact`, `internal/cli/store.go`): when no signer
+Signing at persist time is **best effort** (`signArtifact`, `cmd/internal/cli/store.go`): when no signer
 resolves, the document writes unsigned and verification reports the fact — persistence never fails on
 signing. `writ verify` performs signature verification against the verifier's trust file.
 
 ## The Execution Store
 
 Graphs and traces are distinct artifacts with one-graph-to-many-traces cardinality
-(`internal/cli/store.go`):
+(`cmd/internal/cli/store.go`):
 
 ```
 ${XDG_STATE_HOME:-~/.local/state}/devlore/

--- a/docs/architecture/5.2-recovery-serialization.md
+++ b/docs/architecture/5.2-recovery-serialization.md
@@ -50,9 +50,15 @@ cleared by hand while fixing the blocker (observe, don't assume). A clean resume
 
 The `FailedCompensation` response splits along the framework/client boundary. **The framework reports what it
 knows — the source of the problem and the compensation diagnostics — durably on the `Trace`.** **The client owns
-persistence and presentation:** `internal/cli.WriteTrace` writes the `Trace` under the receipts directory, and
-rendering restart instructions (troubleshooting text, the resume command) is the consumer's surface. So the
-framework never calls `WriteTrace` and never formats operator prose; its whole job is to make the trace faithful.
+persistence and presentation:** `cmd/internal/cli.WriteTrace` decides *where* the `Trace` goes and what points at
+it, and rendering restart instructions (troubleshooting text, the resume command) is the consumer's surface. So
+the framework never decides a path and never formats operator prose; its whole job is to make the trace faithful.
+
+**Persistence splits along that same seam (2026-08-17).** `op.SaveTrace` owns the *artifact*: it stamps the
+checksum, renders the document, and writes it through a root the caller supplies. `cli.WriteTrace` owns the
+*store*: the per-graph subdirectory, the `latest` symlink, the run-index line, and the signing key. The
+framework still never chooses a location — it is handed one — which is what keeps `op` free of store policy
+while the artifact's integrity rules travel with the artifact.
 
 Reporting durably has one hard requirement the executor did not meet before this landed: **the journal must survive the
 unwind.**

--- a/docs/architecture/7.1-llm-integration.md
+++ b/docs/architecture/7.1-llm-integration.md
@@ -4,7 +4,7 @@
 > 33/47). The load-bearing correction: **the LLM never returns an execution graph.** It returns analysis plus a
 > flat operation list; the sealed `*op.Graph` is built Go-side through the plan provider — the pre-rewrite
 > `LLMAnalysisResult{ExecutionGraph execution.Graph}` unmarshal is gone. Provider-abstraction and prompt sections
-> verified current against `internal/model` and the registry-loaded prompts.
+> verified current against `cmd/internal/model` and the registry-loaded prompts.
 
 This document describes how devlore-cli integrates with Large Language Models (LLMs)
 for intelligent analysis tasks in `writ migrate` and `lore onboard`.
@@ -33,7 +33,7 @@ for intelligent analysis tasks in `writ migrate` and `lore onboard`.
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                     model.Provider Interface                     │
-│                   (internal/model/provider.go)                   │
+│                   (cmd/internal/model/provider.go)                   │
 ├─────────────────────────────────────────────────────────────────┤
 │  Chat(ctx, ChatRequest) → (*ChatResponse, error)                 │
 │  Name() → string          // provider name (keystore account)    │
@@ -64,7 +64,7 @@ for intelligent analysis tasks in `writ migrate` and `lore onboard`.
 ### Provider Selection
 
 ```go
-// The standard resolution chain (model.EnsureProvider, internal/model/config.go):
+// The standard resolution chain (model.EnsureProvider, cmd/internal/model/config.go):
 // CLI flags → environment variables → config → keystore credentials → auto-detect → Ollama fallback.
 provider, err := model.EnsureProvider(ctx, false, model.CLIFlags{})
 ```

--- a/docs/architecture/7.1-llm-integration.status.md
+++ b/docs/architecture/7.1-llm-integration.status.md
@@ -7,7 +7,7 @@ response-parsing example (the LLM proposes analysis + a flat operation list; the
 through `planBuilder` and `plan.Provider.AssembleDefinition` — the pre-rewrite unmarshal of an
 `execution.Graph` field is dead), the provider-selection example (the live `model.EnsureProvider` resolution
 chain), and the testing example's graph assertion. Provider table, prompt design, and the remaining sections
-verified against `internal/model` and the registry-loaded prompts.
+verified against `cmd/internal/model` and the registry-loaded prompts.
 
 ## Completion
 

--- a/docs/architecture/7.2-e2e-testing.md
+++ b/docs/architecture/7.2-e2e-testing.md
@@ -2,7 +2,7 @@
 
 > **Status:** re-grounded 2026-07-22 (phase-8 step 51, slice 6) on the rewritten `writ migrate`: correctness
 > evaluation takes the analysis **and the sealed `*op.Graph` separately** (the LLM never returns a graph —
-> [7.1](7.1-llm-integration.md)); the live harness is `internal/e2e` (`GetTestProvider` resolves through
+> [7.1](7.1-llm-integration.md)); the live harness is `cmd/internal/e2e` (`GetTestProvider` resolves through
 > `model.EnsureProvider`'s standard chain).
 
 This document describes the end-to-end testing strategy for LLM-integrated
@@ -20,7 +20,7 @@ performance metrics, and correctness evaluation.
 ## Test Infrastructure
 
 ```
-internal/e2e/
+cmd/internal/e2e/
 ├── harness.go          # Test harness, metrics, reporting
 ├── migrate_test.go     # writ migrate E2E tests
 ├── onboard_test.go     # lore onboard E2E tests
@@ -229,7 +229,7 @@ installation:
 The evaluator takes the analysis and the **sealed graph** as separate inputs — the graph is Go-built through the
 plan provider, never LLM-emitted ([7.1](7.1-llm-integration.md)) — and extracts the proposed operations from the
 graph's units (the live shape: `evaluateMigrateCorrectness(analysis *migrate.MigrationAnalysis, graph *op.Graph,
-expected MigrateExpected)` in `internal/e2e/migrate_test.go`):
+expected MigrateExpected)` in `cmd/internal/e2e/migrate_test.go`):
 
 ```go
 func evaluateMigrateCorrectness(analysis *migrate.MigrationAnalysis,
@@ -310,17 +310,17 @@ func EvaluateOnboardingCorrectness(actual *OnboardResult,
 
 ```bash
 # Run with default providers (Ollama only if running)
-go test ./internal/e2e/... -v
+go test ./cmd/internal/e2e/... -v
 
 # Run with specific provider
-ANTHROPIC_API_KEY=sk-... go test ./internal/e2e/... -v -run TestMigrate
+ANTHROPIC_API_KEY=sk-... go test ./cmd/internal/e2e/... -v -run TestMigrate
 
 # Run with all available providers
 ANTHROPIC_API_KEY=sk-... GITHUB_TOKEN=$(gh auth token) \
-    go test ./internal/e2e/... -v
+    go test ./cmd/internal/e2e/... -v
 
 # Generate report
-go test ./internal/e2e/... -v -json | go run ./cmd/e2e-report > report.md
+go test ./cmd/internal/e2e/... -v -json | go run ./cmd/e2e-report > report.md
 ```
 
 ### Test Functions
@@ -452,7 +452,7 @@ jobs:
         run: ollama pull llama3.2
 
       - name: Run E2E tests
-        run: go test ./internal/e2e/... -v -timeout 30m
+        run: go test ./cmd/internal/e2e/... -v -timeout 30m
 
   e2e-cloud:
     runs-on: ubuntu-latest
@@ -465,7 +465,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: go test ./internal/e2e/... -v -timeout 30m
+        run: go test ./cmd/internal/e2e/... -v -timeout 30m
 ```
 
 ### Fork Safety

--- a/docs/architecture/7.2-e2e-testing.status.md
+++ b/docs/architecture/7.2-e2e-testing.status.md
@@ -4,8 +4,8 @@
 
 **State:** re-grounded 2026-07-22 (phase-8 step 51, slice 6). Corrected: the migration-correctness evaluator to
 the live shape (`evaluateMigrateCorrectness(analysis, graph *op.Graph, expected)` in
-`internal/e2e/migrate_test.go` — the analysis and the Go-built sealed graph are separate inputs; the pre-rewrite
-`actual.ExecutionGraph` field is dead). Harness sections verified against `internal/e2e/harness.go`
+`cmd/internal/e2e/migrate_test.go` — the analysis and the Go-built sealed graph are separate inputs; the pre-rewrite
+`actual.ExecutionGraph` field is dead). Harness sections verified against `cmd/internal/e2e/harness.go`
 (`GetTestProvider` over `model.EnsureProvider`'s chain).
 
 ## Completion

--- a/docs/architecture/8-rust-migration.md
+++ b/docs/architecture/8-rust-migration.md
@@ -565,10 +565,10 @@ different execution host:
 | `pkg/op/provider/` (20 providers) | ~5,292 | ~9,000 | 1,150 |
 | `internal/execution/` | 2,914 | 6,891 | — |
 | `internal/writ/` | 6,676 | 3,154 | — |
-| `internal/cli/` | 2,346 | 1,320 | — |
-| `internal/lorepackage/` | 2,114 | 994 | — |
+| `cmd/internal/cli/` | 2,346 | 1,320 | — |
+| `cmd/internal/lorepackage/` | 2,114 | 994 | — |
 | `internal/lore/` | 1,781 | 882 | — |
-| `internal/model/` | 1,245 | 97 | — |
+| `cmd/internal/model/` | 1,245 | 97 | — |
 | `internal/signing/` | 1,146 | 329 | — |
 | Other internal packages | 4,791 | 3,159 | — |
 | `cmd/` binaries | ~2,100 | — | — |

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -18,7 +18,7 @@ systems*: independent participants that register themselves into a shared, versi
 resolution rules. This document applies that lens to configuration.
 
 The foundation package is **`pkg/devconfig`** (named `devconfig`, not `config`, because the bare name is already
-contended — `internal/config`, `cmd/star/config`, and the AWS SDK's `config` all coexist).
+contended — `cmd/internal/config`, `cmd/star/config`, and the AWS SDK's `config` all coexist).
 
 ## The model
 
@@ -657,9 +657,9 @@ The sections that must exist, each at its owner (the working ledger; sequencing 
    flat sources.
 2. **`policies`** (`pkg/op`, announced) — `Retry` + `Transition`; the executor's floor fallback becomes the
    resolved-config read once `Application.Config` exists.
-3. **`writ`** (`cmd/writ`) and **`lore`** (`cmd/lore`) — the app sections, dissolving `internal/config` and the
+3. **`writ`** (`cmd/writ`) and **`lore`** (`cmd/lore`) — the app sections, dissolving `cmd/internal/config` and the
    viper keys (`writ.repo`, `writ.vars`, `*.dry-run`, `*.verbose`).
-4. **`model`** (absorbing `internal/config/model.go`) — provider/endpoint/model/api_key, unifying the viper,
+4. **`model`** (absorbing `cmd/internal/config/model.go`) — provider/endpoint/model/api_key, unifying the viper,
    `DEVLORE_MODEL_*`, and `--model-*` sources into the loader overlay.
 5. **The registry section** (`pkg/devregistry` extraction) — lore's package-registry location.
 6. **`signing`** (`pkg/signing`, lands with phase-8 step 46).
@@ -907,7 +907,7 @@ From the comparison, the concrete refinements layered onto star's proven registr
 
 - **`op.ReceiverRegistry`** — the in-house precedent for distributed, reflect.Type-keyed, import-time registration;
   `devconfig`'s registry mirrors it (and a provider may announce its config section as part of its announcement).
-- **`internal/config`** — the established typed model (`Config`, `LoreConfig`, `WritConfig`, `ModelConfig`,
+- **`cmd/internal/config`** — the established typed model (`Config`, `LoreConfig`, `WritConfig`, `ModelConfig`,
   `RegistryConfig`) being moved to `pkg/devconfig` and reshaped into the registry.
 - **`cmd/star/config`** — the extension-config system being **unified onto** `devconfig` rather than bolted alongside
   it; "provider as extension" makes the config-participant abstraction the same for both.

--- a/docs/architecture/configuration.status.md
+++ b/docs/architecture/configuration.status.md
@@ -33,7 +33,7 @@ per-scope `dev`/`test`/`stage`/`prod` variants, scope-dominant); per-key overlay
 - [ ] Owner-located sections — `op` runtime **landed** (`RuntimeEnvironmentConfig`); `signing`
   (`pkg/signing`, not yet created), model, registry pending.
 - [ ] Unify `cmd/star/config` onto `devconfig`.
-- [ ] Retire `internal/config` and the package-global `viper` reads.
+- [ ] Retire `cmd/internal/config` and the package-global `viper` reads.
 
 ## Outstanding / open questions
 
@@ -46,7 +46,7 @@ per-scope `dev`/`test`/`stage`/`prod` variants, scope-dominant); per-key overlay
 
 ## Discrepancies (design vs. current code)
 
-- `internal/config` is today's model — flat and centralized; this design moves it to `pkg/devconfig` and reshapes it
+- `cmd/internal/config` is today's model — flat and centralized; this design moves it to `pkg/devconfig` and reshapes it
   into the registry.
 - `cmd/star/config` is today's registration system — data-driven and star-only; this design generalizes it to cover
   Go participants and unifies the two.

--- a/docs/plans/architecture-doc-refresh.md
+++ b/docs/plans/architecture-doc-refresh.md
@@ -1,0 +1,149 @@
+---
+title: "Architecture docs: the four undescribed decisions"
+issue: TBD — created after review
+status: draft
+created: 2026-08-17
+updated: 2026-08-17
+---
+
+# Plan: architecture docs — the four undescribed decisions
+
+## Summary
+
+The 2026-08-16/17 sessions settled four things that no architecture document describes. Each is a rule
+other work will be measured against — where files live, who owns filesystem authority, where a
+machine-wide install goes, and what a scenario is for — and each currently survives only in a plan
+document, a step charter, or a package doc comment. A rule that lives only in the plan that produced
+it is a rule the next reader re-litigates.
+
+This plan is **only** the four gaps. Corrections already applied on the `cli-save-artifacts` branch —
+the trace-stamp owner, the persistence seam, the signing open question, and a mechanical
+`internal/…` → `cmd/internal/…` path sweep across fifteen documents — are not repeated here.
+
+## Goals
+
+1. **Every rule has one home**, and the plan documents point at it rather than holding it.
+2. **The reasoning travels with the rule.** These four were each chosen against a rejected
+   alternative; a doc that states only the outcome invites the alternative back.
+3. **No new document unless the subject has no owner.** Three of the four have an obvious home.
+
+## Current State
+
+| Decision | Lives today in | Architecture home |
+| --- | --- | --- |
+| The home-resolution ladder | `pkg/xdg`'s package doc, step 54 | ❌ none |
+| Root ownership (caller owns, leaf receives) | windows-native-permissions phase 2b/3.1 | ❌ none — 2.4 is the near miss |
+| Machine-wide install location + `--all-users` | windows-native-permissions 3.1b | ❌ none — `configuration.md` is the home |
+| The scenario tier | this plan, `cmd/scenario`'s package doc | ❌ none — `7.2-e2e-testing.md` predates it |
+
+## Requirements
+
+### R1 — The home-resolution ladder and the XDG layout
+
+**Where:** a new `2.9-filesystem-locations.md`. There is no document about where anything lives on
+disk, which is why this rule had nowhere to go; `configuration.md` is about the config *model*, not
+about locations, and the execution store's layout currently sits inside
+`5-graph-trace-integrity.md` because that document needed it.
+
+Must state:
+
+- The four-rung ladder — absolute `XDG_<ROLE>_HOME`, then `user.Current`, then `os.UserHomeDir`, then
+  an assert — and that **rung 2 outranks rung 3 deliberately**, following OpenSSH, which expands `~`
+  from the account database and never consults `HOME`.
+- Why rung 3 survives anyway: releases build `CGO_ENABLED=0`, so `user.Current` parses `/etc/passwd`
+  and nothing else, and an LDAP/SSSD/systemd-homed user resolves through the environment or not at
+  all. This is the one place our resolution is *weaker* than ssh's, and it should be written down.
+- The consequence, which is the part people trip on: **home is resolved, never injected.** Setting
+  `HOME` moves nothing for any user the account database can see. Redirecting a home-rooted location
+  means setting the role's `XDG_*` variable or passing the path in.
+- The layout — `~/.config`, `~/.local/share`, `~/.local/state`, `~/.cache`, `~/.local/bin` on **every**
+  platform including Windows — and the evidence for diverging from the Windows Known Folders that
+  `adrg/xdg`, `platformdirs` and `dirs` use: git, Microsoft's own OpenSSH port, Docker, kubectl, cargo.
+- That `ConfigDirs`/`DataDirs` are **not** yet platform-correct ([step 59](extract-starlark-from-op/phase-8/steps/59-xdg-search-paths-on-windows.md)).
+
+### R2 — Root ownership: the caller owns, the leaf receives
+
+**Where:** `2.4-hermeticity-guarantees.md`, which already owns confinement but describes it as a
+property of execution rather than as an ownership rule.
+
+Must state:
+
+- **Code receives filesystem access; it does not construct it.** The session owner opens a root; every
+  leaf takes one as a parameter. `pkg/signing` receives its config root *and* its identity path;
+  `appendIndexEntry` receives the state root; `document`'s successor will too.
+- The worked example, because it is what made the rule concrete: `WriteTrace` writes three things into
+  one tree — the document, the `latest` symlink, the index line — and under the old shape its callee
+  opened a fourth root for itself.
+- The counter-rule: a **`// Confinement:`** comment is the sanctioned exception, and it states why the
+  root cannot serve — a source path the operator named, a generator that writes its own files, an SSH
+  directory that is not ours to confine.
+- That a save does **not** create store layout: `op.SaveGraph` writes, `cli.WriteGraph` decides where.
+
+### R3 — Where an installation goes
+
+**Where:** `configuration.md`, under a new section beside "Where sections live".
+
+Must state:
+
+- Per-user default `~/.local`; machine-wide is the **usual directories within `/usr/local`** on Darwin
+  and Linux, `%ProgramFiles%\<Vendor>\<Product>` on Windows.
+- `/opt/local` was **rejected**: not in FHS — which reserves only `/opt/bin`, `/opt/doc`,
+  `/opt/include`, `/opt/info`, `/opt/lib`, `/opt/man` for local use — and its one real-world claimant
+  is MacPorts.
+- `--all-users` selects it and the positional prefix remains the escape hatch, because a prefix
+  argument **cannot express machine-wide on Windows**: `%ProgramFiles%\<Vendor>\<Product>` is not a GNU
+  prefix and carries obligations no path can state (the Uninstall registry key, machine `PATH` in
+  `HKLM`).
+- Not `--system`: writ's layer vocabulary already uses `System` for the `/` target root.
+- `writ.targets.{home,system}` override the deployment roots — distinct from the *install* prefix, and
+  the only way to redirect a deployment now that home is not injectable.
+- The precedent worth recording: Git, Python and Vim install as single prefixes under
+  `%ProgramFiles%` and keep system config **inside the prefix**; only software with machine-wide
+  mutable state (Docker, Chocolatey) uses `%ProgramData%`. writ has none, so it needs no `%ProgramData%`.
+
+### R4 — The scenario tier
+
+**Where:** `7.2-e2e-testing.md`, which describes the AI-model E2E harness and predates scenarios.
+
+Must state:
+
+- The three tiers and what each can prove: unit tests (in process), **scenarios** (the real binaries in
+  a sandbox, `make test-scenario`), and the AI E2E harness (needs API keys).
+- The rule scenarios exist for, stated as the incident that proved it: **an in-process test can encode
+  the same wrong assumption the code makes.** The self-install unit test asserted `bin/<tool>` with no
+  extension, agreeing with a bug that made Windows installs unrunnable; the scenario, driving the
+  shipped binary, disagreed on its first run.
+- What belongs where: `cmd/writ` for writ's own deploy scenario, `cmd/scenario` for scenarios owned by
+  no single command.
+- The sandbox contract — every `XDG_*` redirected, and `writ.targets.home` for a deployment, because
+  `HOME` no longer redirects anything (R1).
+
+## Implementation Phases
+
+### Phase 1: the three that have homes
+
+- [ ] R2 into `2.4-hermeticity-guarantees.md`
+- [ ] R3 into `configuration.md`
+- [ ] R4 into `7.2-e2e-testing.md`
+- [ ] Each plan/step doc that currently holds the rule gains a pointer to its new home
+
+### Phase 2: the one that needs a home
+
+- [ ] `2.9-filesystem-locations.md` (R1), plus its `.status.md` companion per the house pattern
+- [ ] Move the execution-store layout diagram out of `5-graph-trace-integrity.md`, or link it — that
+      document should own integrity, not locations
+
+## Open Questions
+
+- [ ] Does `2.9` also absorb the install locations (R3), leaving `configuration.md` to reference it?
+      One document about where things live is tidier than two, but install locations are configurable
+      and the rest are not.
+- [ ] Do the `.status.md` companions get the same treatment, or are they regenerated?
+
+## Related Documents
+
+- [windows-native-permissions.md](windows-native-permissions.md) — holds R2 and R3 today
+- [step 54](extract-starlark-from-op/phase-8/steps/54-xdg-anchors-on-windows.md) — holds R1's ruling
+- [step 59](extract-starlark-from-op/phase-8/steps/59-xdg-search-paths-on-windows.md) — the search-path
+  defect R1 must mention
+- [version-stamping.md](version-stamping.md) — a fifth candidate if `pkg/application` grows further

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -928,6 +928,41 @@ read an unmoved 28 after phase 3 as a failed migration.**
       **The 28 does not move.** No existing test asserts the key's mode, so these are additive.
 - [ ] **3.3 — `internal/document`** (2 sites: `0750` dir, `cfg.perm` write) — the package behind
       three of the seven tests above.
+
+      **Re-shaped 2026-08-17, by enumeration and then by a design ruling.** Both sites live inside
+      `document.Write`, which owns no root — so converting them changes its signature for **25 call
+      sites**, nine of which hold no root today. The plan already knew this and filed it under
+      phase 4's "shared libraries… each needs one supplied by its caller — the design question of
+      phase 4"; it sized 3.3 as if the two questions were separate.
+
+      Examining the package answered it differently. `document.Write` does three unrelated jobs:
+      choose a rendering from the **file extension**, apply the permission policy, and wrap errors
+      with the path. It never serialized anything — `Graph` has `MarshalJSON`/`MarshalYAML` and
+      `Trace` marshals through its tags. Meanwhile `op` had `LoadGraph` and `LoadTrace` but no
+      `Save*`: deserialization was a trust boundary owned by the artifact, serialization was not.
+
+      **Ruled: the artifacts save themselves.**
+
+- [x] **3.3a — `op.SaveGraph` / `op.SaveTrace` — COMPLETE 2026-08-17.** The write-side complements of
+      `LoadGraph` / `LoadTrace`, taking a root and a path, writing `0600`.
+      - **Format is stated, not inferred from a filename suffix** — `SaveGraph(…, "yaml")` mirrors
+        `LoadGraph(env, data, format)`. `SaveTrace` is YAML-only because `LoadTrace` is.
+      - **`SaveTrace` stamps the checksum itself.** `LoadTrace` refuses a document without one, so
+        leaving the stamp to the caller allowed writing a document nothing could read — a failure
+        that surfaced at the next load rather than at the write. Stamping is idempotent because the
+        canonical bytes exclude the field.
+      - **Signing stays with the caller**: the checksum belongs to the artifact, the key belongs to
+        whoever publishes it.
+      - **`Save*` does not create directories.** A save that invents store layout would decide store
+        policy on the caller's behalf, so `WriteGraph`/`WriteTrace` create their own trees — which is
+        what `document.Write`'s implicit `MkdirAll` had been hiding.
+
+- [ ] **3.3b — `document.Write` takes a root.** Deferred deliberately, per the 2026-08-17 ruling:
+      it lands with the configuration work and the JSON/YAML/protobuf codec, because its remaining
+      **18-19** callers are ordinary config-shaped documents and its extension-sniffing is precisely
+      what the single-codec design replaces. Threading a root through it now would be work done
+      twice. Until then `internal/document` keeps its two `os.*` sites, and the three permission
+      tests behind it stay where they are — they move in phase 5 regardless.
 - [ ] **3.4 — the writ deploy/sops output path** — behind `TestExecute_SopsChains`, and the one
       that writes **decrypted plaintext**, which makes it the second-most security-relevant site in
       the campaign after the private key.

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 const (
@@ -268,6 +270,54 @@ func LoadGraph(env *RuntimeEnvironment, data []byte, format string) (*Graph, err
 	}
 
 	return assembleGraph(env, &p)
+}
+
+// SaveGraph encodes a graph and writes it through `dst`.
+//
+// The write-side complement of [LoadGraph], and the reason the pair exists: a graph knows how to render itself
+// ([Graph.MarshalJSON], [Graph.MarshalYAML]) and [LoadGraph] knows how to rebuild itself, so persistence has no
+// business inferring a rendering from a filename suffix. The format is stated here, as [LoadGraph] states it.
+//
+// The root is received, never constructed (#405, phase 2b): whoever owns the store owns the tree it is written
+// into. Mode 0600 is the artifact policy — a graph is signed material, and its confidentiality does not vary
+// by caller.
+//
+// Parameters:
+//   - `dst`: the tree the document is written into, opened by the caller.
+//   - `path`: the destination within `dst`.
+//   - `graph`: the graph to persist. Must not be nil.
+//   - `format`: "json" or "yaml" (or "yml") — case-insensitive, matching [LoadGraph].
+//
+// Returns:
+//   - `error`: non-nil if the format is unsupported, encoding fails, or the write fails.
+func SaveGraph(dst fsroot.Dir, path fsroot.Path, graph *Graph, format string) error {
+
+	if graph == nil {
+		return fmt.Errorf("op.SaveGraph: nil graph")
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+
+	switch strings.ToLower(format) {
+	case "json":
+		data, err = json.MarshalIndent(graph, "", "  ")
+	case "yaml", "yml":
+		data, err = yaml.Marshal(graph)
+	default:
+		return fmt.Errorf("op.SaveGraph: unsupported format %q (use json, yaml, or yml)", format)
+	}
+	if err != nil {
+		return fmt.Errorf("op.SaveGraph: %s encode: %w", format, err)
+	}
+
+	if err := dst.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("op.SaveGraph: write %s: %w", path.Abs(), err)
+	}
+
+	return nil
 }
 
 // SerializeGraphs serializes the graphs to w as one YAML document stream.

--- a/pkg/op/trace.go
+++ b/pkg/op/trace.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // Trace is the serializable projection of a [*GraphExecutor]'s per-run mutable state.
@@ -52,7 +54,7 @@ type Trace struct {
 	Catalog *ResourceLedgerSnapshot `json:"catalog,omitempty" yaml:"catalog,omitempty"`
 
 	// Checksum is the trace's own tier-1 integrity hash — [GitStyleChecksum]("trace", canonical) over
-	// [Trace.CanonicalContent] — stamped at persist by the store's WriteTrace and recomputed and compared by
+	// [Trace.CanonicalContent] — stamped at persist by [SaveTrace] and recomputed and compared by
 	// [LoadTrace]. Excluded (with Signature) from the canonical bytes, so integrity and authenticity verify
 	// independently. See docs/architecture/5-graph-trace-integrity.md § Document Integrity.
 	Checksum string `json:"checksum,omitempty" yaml:"checksum,omitempty"`
@@ -188,8 +190,9 @@ func (t *Trace) SignWith(sign func(canonical []byte) (*Signature, error)) error 
 
 // StampChecksum computes and sets the trace's tier-1 checksum over its canonical bytes.
 //
-// Idempotent: the canonical bytes exclude the checksum field, so restamping recomputes the same value. The
-// store's WriteTrace stamps at persist; [LoadTrace] recomputes and compares.
+// Idempotent: the canonical bytes exclude the checksum field, so restamping recomputes the same value.
+// [SaveTrace] stamps at persist — which is why it can do so unconditionally — and [LoadTrace] recomputes and
+// compares.
 //
 // Returns:
 //   - `error`: non-nil when canonicalization fails.
@@ -201,6 +204,48 @@ func (t *Trace) StampChecksum() error {
 	}
 
 	t.Checksum = GitStyleChecksum("trace", canonical)
+	return nil
+}
+
+// SaveTrace stamps a trace's checksum, encodes it, and writes it through `dst`.
+//
+// The write-side complement of [LoadTrace], and it stamps deliberately: [LoadTrace] refuses a document
+// carrying no checksum, so a save that left stamping to the caller could write a document nothing can read —
+// a failure that surfaces at the next load rather than at the write. Stamping is idempotent, because
+// [Trace.CanonicalContent] excludes the checksum field.
+//
+// YAML only, matching [LoadTrace]. The root is received, never constructed (#405, phase 2b), and mode 0600 is
+// the artifact policy: a trace is signed material and its confidentiality does not vary by caller.
+//
+// Signing remains the caller's, because the signer is: the checksum belongs to the artifact, the key belongs
+// to whoever is publishing it.
+//
+// Parameters:
+//   - `dst`: the tree the document is written into, opened by the caller.
+//   - `path`: the destination within `dst`.
+//   - `trace`: the trace to persist. Must not be nil.
+//
+// Returns:
+//   - `error`: non-nil if stamping, encoding, or the write fails.
+func SaveTrace(dst fsroot.Dir, path fsroot.Path, trace *Trace) error {
+
+	if trace == nil {
+		return fmt.Errorf("op.SaveTrace: nil trace")
+	}
+
+	if err := trace.StampChecksum(); err != nil {
+		return fmt.Errorf("op.SaveTrace: %w", err)
+	}
+
+	data, err := yaml.Marshal(trace)
+	if err != nil {
+		return fmt.Errorf("op.SaveTrace: yaml encode: %w", err)
+	}
+
+	if err := dst.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("op.SaveTrace: write %s: %w", path.Abs(), err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Phase 3.3 of the [windows campaign](docs/plans/windows-native-permissions.md) was sized as **two**
`os.*` sites in `internal/document`. Both live inside `document.Write`, which owns no root — so
converting them changes its signature for **25 call sites**, nine of which hold no root today. The
plan already knew that and filed it under phase 4's shared-library design question; it sized 3.3 as
if the two questions were separate.

Reading the package answered it differently. `document.Write` does three unrelated jobs: choose a
rendering from the **file extension**, apply the permission policy, and wrap errors with the path. It
never serialized anything — `Graph` has `MarshalJSON`/`MarshalYAML` and `Trace` marshals through its
tags. Meanwhile `op` had `LoadGraph` and `LoadTrace` but **no `Save*`**: deserialization was a trust
boundary owned by the artifact, serialization was not.

## The artifacts save themselves

```go
func SaveGraph(dst fsroot.Dir, path fsroot.Path, graph *Graph, format string) error
func SaveTrace(dst fsroot.Dir, path fsroot.Path, trace *Trace) error
```

- **Format is stated, not inferred from a filename suffix.** `SaveGraph` takes it as `LoadGraph` does;
  `SaveTrace` is YAML-only because `LoadTrace` is.
- **`SaveTrace` stamps the checksum itself.** `LoadTrace` refuses a document without one, so leaving
  the stamp to the caller allowed writing a document nothing could read — a failure that surfaced at
  the next load rather than at the write. Stamping is idempotent, because the canonical bytes exclude
  the field.
- **Signing stays with the caller.** The checksum belongs to the artifact; the key belongs to whoever
  publishes it.
- **`Save*` does not create directories.** A save that invents store layout decides store policy on
  the caller's behalf — so `WriteGraph`/`WriteTrace` create their own trees, which is what
  `document.Write`'s implicit `MkdirAll` had been hiding.

The seam that results: **`op` owns the artifact** (render, stamp, write through a supplied root),
**`cli` owns the store** (paths, the `latest` symlink, the run index, the signing key).

## What is deliberately not in this PR

`document.Write` keeps its signature. Its remaining 18–19 callers are ordinary config-shaped
documents, and its extension-sniffing is precisely what the single-codec design replaces — threading a
root through it now would be work done twice. `internal/document` keeps its two `os.*` sites until the
configuration and codec work; the three permission tests behind it move in phase 5 regardless.

## Three design documents were wrong

Corrected here rather than deferred, because they state mechanics:

1. **`5-graph-trace-integrity.md`** named `cli.WriteTrace` as the stamper, in the table that defines
   the trust boundary.
2. **`5.2-recovery-serialization.md`** described persistence as undivided; it now names the seam.
3. **`3.5.3-plan-provider.md`**'s signing open question is **narrowed, not answered** — the checksum
   moved to the artifact and the signature deliberately did not, so the question is no longer "where
   does signing happen" but "who supplies the signer, and when".

Fifteen documents carried `internal/{cli,config,model,lorepackage,e2e}` paths from the phase-7 move.
Swept mechanically, including the `go test ./internal/e2e/...` command examples.

## And a plan for the rest

[docs/plans/architecture-doc-refresh.md](docs/plans/architecture-doc-refresh.md) charters four
decisions from these sessions that **no architecture document describes at all**: the home-resolution
ladder, root ownership (caller owns, leaf receives), install locations, and the scenario tier. Three
have obvious homes; the fourth needs a new `2.9-filesystem-locations.md`, because nothing owns "where
things live on disk" — which is why the execution-store layout currently sits inside the integrity
document.

## Verified

- `make check`
- `make lint-all` — 0 issues under linux, darwin and windows
- `make test-scenario` — both groups
