### PR TITLE
docs(architecture): 6.2 — the process pool

### DIFF
--- a/docs/architecture/6.2-process-pool.md
+++ b/docs/architecture/6.2-process-pool.md
@@ -1,0 +1,297 @@
+# The Process Pool
+
+> **Status:** design (draft, 2026-08-17; revised the same day onto prior art and the PowerShell runspace model).
+> Answers the first of the two questions [`6.1-privilege-elevation.md`](6.1-privilege-elevation.md) poses about the
+> command-execution substrate — *"three scattered one-shot spawns … how do we manage the processes these providers
+> rely on?"* — and gives the second question (*how do we elevate*) its mechanism. Companion:
+> [`6.2-process-pool.status.md`](6.2-process-pool.status.md).
+>
+> **Relationship to the neighbours.** [`6-execution-topology.md`](6-execution-topology.md) owns the elevation
+> **policy** and describes a persistent privileged child as the elevation mechanism. [`6.1`](6.1-privilege-elevation.md)
+> owns the **provider** that fulfills that policy. **This document owns the execution hosts themselves** — how they
+> are identified, allocated, reused, and reclaimed, whether or not they are elevated.
+
+## Thesis
+
+**An execution host is a resource with an acquisition cost and a privilege identity, and devlore currently treats it
+as neither.** Every command builds a fresh `*exec.Cmd`, so an acquisition that is expensive exactly once — a sudo
+credential, a UAC consent dialog, a PowerShell module import — is paid again on every command, or not paid at all
+because the code fails fast instead of asking.
+
+Nothing here is novel, and the design is assembled from named prior art rather than invented (§2). Three ideas carry
+it:
+
+1. **Two kinds of persistence, deliberately separated.** *Persistent privilege* is an elevated parent that forks a
+   fresh child per request — the credential survives, no execution state does. *Persistent interpreter state* is a
+   live shell where variables and imported modules survive. They have opposite isolation properties and must not
+   share a mechanism. §3.
+2. **Identity, not instance.** Callers ask for a host *of a given identity*, never for a specific one. The pool
+   decides whether that means starting one or handing back a running one, and **lazily to the point of never** — a
+   run that does not take its elevated branch never elevates.
+3. **Concurrency comes from multiplexing, not from more processes.** One host serves many in-flight requests when
+   requests carry ids. This is what keeps a concurrent `gather` concurrent while an elevated identity is acquired
+   exactly once.
+
+## 1. The problem, as the code stands
+
+Three spawn paths exist today, and they do not agree on anything — not narration, not dry-run, not cancellation.
+
+| Path | Site | Feeds | Context |
+|---|---|---|---|
+| Runtime runner | [`runtime_environment.go:726`](../../pkg/op/runtime_environment.go) — `re.runner()` builds a fresh `process.Runner` per call | `Capture` ([:390](../../pkg/op/runtime_environment.go)), `Emit` ([:428](../../pkg/op/runtime_environment.go)), `Run` ([:564](../../pkg/op/runtime_environment.go)); the `shell` and `powershell` providers | run-bound — cancellation kills the child |
+| Platform shell | [`helpers_unix.go:56`](../../pkg/platform/helpers_unix.go) — `runShellCommand(command, sudo)`, a package var so tests can fake it | the `pkg` and `service` providers, through the manager backends | **`context.Background()`** with a fixed timeout |
+| Windows managers | the winget leaves, driving their own path | Windows package operations | per-leaf |
+
+Three defects follow, and the pool is the shape that resolves all three at once:
+
+1. **`pkg/process` is not the single bridge it declares itself to be.** Its package doc states that *every* provider
+   which shells out goes through `Runner`, so line-splitting, dry-run, cancellation and error wrapping live in one
+   place. The platform path does none of that. This is the same class of finding that retired `internal/pwsh`,
+   except this one is live and load-bearing.
+2. **Run cancellation does not reach package installs.** `Runner`'s contract is that a cancelled context kills the
+   subprocess. `runShellCommand` uses `context.Background()`, so cancelling a run leaves `apt-get install` running to
+   completion. A pool that owns host lifetime owns cancellation with it.
+3. **`sudo -n` fails rather than elevates.** The flag is deliberate — fail fast instead of prompting on a tty — but
+   the consequence is that an operator without cached credentials gets a hard failure and no path forward. That is
+   the standing TODO at [`helpers_unix.go:64`](../../pkg/platform/helpers_unix.go): *"centralize this. Route
+   privileged execution through the ElevationOffer/Elevator — one credential-cached, policy-governed, audited sudo
+   session — instead of every command inlining `sudo -n`."*
+
+The *sometimes-privileged* character is already modelled: `NeedsSudo()` is true for systemd
+([`linux_managers.go:147`](../../pkg/platform/linux_managers.go)), SysVinit
+([:167](../../pkg/platform/linux_managers.go)) and the Windows Service Control Manager
+([`windows_managers.go:36`](../../pkg/platform/windows_managers.go)), and false for a launchd **user** agent
+([`darwin_managers.go:73`](../../pkg/platform/darwin_managers.go)). What is missing is somewhere for that answer to
+go other than a boolean parameter.
+
+## 2. Prior art — this is a solved problem
+
+| Precedent | What to take |
+|---|---|
+| **Bazel persistent workers** | The closest analogue. Long-lived workers keyed by a `WorkerKey` (mnemonic + startup flags + tool-input hash + sandboxing mode), speaking **length-delimited messages carrying a `request_id`**, so one *multiplex* worker serves concurrent requests. Also the cautionary tale: state leakage between requests produced nondeterministic builds, which is why worker sandboxing exists. |
+| **PgBouncer pooling modes** | The vocabulary for the state question — *session*, *transaction*, *statement* pooling — and the honest rule that the aggressive modes **forbid** session state rather than pretending to reset it. |
+| **`database/sql`** | The Go-idiomatic API: `MaxOpenConns` / `MaxIdleConns` / `ConnMaxIdleTime` / `ConnMaxLifetime`, acquisition that blocks at the cap, `sql.Conn` for pinned exclusive use, and the two driver hooks this design needs — `driver.SessionResetter.ResetSession` and `driver.Validator.IsValid`. |
+| **PHP-FPM** (`pm = ondemand`, `pm.max_requests`) | Lazy allocation as a first-class mode, and **retirement** as the answer to state that cannot be fully reset: don't reset it, replace the host after N requests. Python's `ProcessPoolExecutor` carries the same idea as `maxtasksperchild`, plus an `initializer` hook — per-host setup paid once. |
+| **SSH `ControlMaster`** | Authenticate once, run many **concurrent** channels over one connection. The direct precedent for "one credential acquisition, full concurrency," and already cited by [`6`](6-execution-topology.md) for remote execution. |
+| **Nailgun / Gradle daemon** | Amortizing interpreter startup is a decades-old pattern with known failure modes (stale daemons, version skew). |
+
+The tuning lesson these share: **the cap should match real concurrency, and queueing beats spawning.**
+
+## 3. Two kinds of persistence
+
+Merging these is the mistake this document was revised to remove.
+
+**Persistent privilege.** An elevated parent that **forks a fresh child per request**. What survives is the
+credential; no execution state does. Isolation is total — each request gets a new process — so there is no state
+bleed, and concurrency is limited only by the parent's willingness to fork. This is what elevation needs, and it is
+why an elevated identity capped at one host does **not** serialize the work it hosts.
+
+**Persistent interpreter state.** A live shell in which variables, functions and imported modules survive across
+requests. This is what the retired `internal/pwsh` wanted, for reasons that remain valid: PowerShell modules (Az,
+ActiveDirectory) authenticate on import, COM/.NET objects (WMI, Registry, IIS) are expensive to instantiate, and DSC
+requires compile→test→apply in one session. It is also the only case with a state-bleed problem.
+
+A pool serving both must know which it is providing. They differ in isolation, in concurrency, and in whether a
+reset is even possible.
+
+## 4. Host identity — the pool key
+
+Two requests share a host when they share an identity, modelled on Bazel's `WorkerKey`:
+
+- **Interpreter** — `bash`, `pwsh`, or the worker binary.
+- **Privilege** — unelevated, or a resolved elevation identity (the *outcome* of an `elevation.Policy` evaluation,
+  not the policy: two units arriving at the same identity by different routes still share).
+- **Pooling mode** — §5. A session-mode acquisition is never interchangeable with a statement-mode one.
+- **Session** — the owning `RuntimeEnvironment`. The pool is a **session service**, never a process singleton,
+  following the `Invoker` precedent: two graphs running concurrently in one process share nothing.
+
+Deliberately **not** in the key: working directory and environment variables. They travel with the request, because
+folding them into the identity fragments the pool toward one host per call site and defeats it.
+
+## 5. Pooling modes
+
+Adopted from PgBouncer, whose taxonomy answers what three home-grown options could not:
+
+| Mode | Host returned to the pool | State guarantee | For |
+|---|---|---|---|
+| **Statement** | after every request | none — session state is **forbidden**, not reset | the default; `shell.exec`, `pkg.install`, `service.start` |
+| **Session** | when the acquirer releases it | full — the acquirer owns the host exclusively | Az login → deploy → verify; DSC compile→test→apply |
+| **Transaction** | at a declared boundary | state survives within the bracket only | reserved; no consumer today |
+
+The rule that makes this honest is PgBouncer's: **statement mode does not promise a reset — it promises that state
+was never allowed.** Where an interpreter cannot enforce that (PowerShell module imports cannot be un-imported), the
+answer is retirement, not reset: replace the host after N requests, as PHP-FPM does. `IsValid` decides whether a
+returned host is fit to reuse; `ResetSession` does what cleanup is possible; `max_requests` bounds what neither can.
+
+## 6. Concurrency
+
+**Multiplexing, not more processes.** Each request carries an id, and a host may have several in flight. This is
+Bazel's multiplex worker and SSH's channel model, and it is what keeps a concurrent `gather` concurrent:
+
+- **Unelevated, statement mode** — per-identity cap above one; requests spread across hosts *and* multiplex within
+  them.
+- **Elevated** — cap of **one host**, with many concurrent requests multiplexed over it. The single host forks a
+  child per request (§3), so concurrency is preserved while the credential is acquired exactly once. Raising the
+  host cap would repeat the human interaction for no throughput gain.
+- **Session mode** — one acquirer, no multiplexing. That is the point of the mode.
+
+Requests beyond the caps queue rather than spawn, and queueing is narrated: a gather that waits on an elevated
+identity should say so rather than merely run slowly.
+
+## 7. Framing
+
+Length-prefixed messages carrying a **request id**, `(id, command, args, env, cwd)` in and
+`(id, stdout, stderr, exit_code)` out. [`6`](6-execution-topology.md) proposes ndjson; **request ids are the
+addition that matters**, because without them a host can only serve one request at a time and §6 collapses.
+
+**Do not adopt the marker protocol from the prior art.** The retired `internal/pwsh` framed output by writing a
+sentinel line and reading until it appeared, which breaks the moment a command's own output begins with that
+sentinel.
+
+## 8. Host kind is chosen by the interpreter, not the platform
+
+The pool has **two host kinds**, and which one serves a request is decided by the interpreter in its identity (§4) —
+never by the operating system it happens to be running on:
+
+| Host kind | Unit of execution | Interpreters | Isolation |
+|---|---|---|---|
+| **Process-per-request** | an OS process | `bash`, and the elevated forking parent (§3) | by construction — every request is a new process |
+| **Runspace pool** | a runspace: a thread-level context with its own session state | `pwsh`, on **every** platform | per-runspace; a fresh runspace is statement mode, a pinned one is session mode |
+
+A POSIX shell's unit of execution is a **process**. PowerShell's is a **runspace**, and `pwsh` already ships the pool
+this document is designing: `RunspacePool`, with a min/max and asynchronous `BeginInvoke`. Pooling `pwsh`
+*processes* would ignore the runtime's own answer and pay process cost for what it does with threads.
+
+**This is a property of PowerShell, not of Windows.** `pwsh` is cross-platform, so `powershell.exec` on Linux or
+macOS gets the runspace host, session mode, amortized module imports and object fidelity exactly as Windows does.
+The platform selects the *elevation* mechanism (§10); the interpreter selects the *host kind*.
+
+**The shape this implies.** The PowerShell host is not a Go-spawned command loop but a **PowerShell-side host script**
+that owns a `RunspacePool`, reads framed requests, dispatches each to a runspace, and writes framed responses. Go
+speaks the protocol; PowerShell owns the execution. That yields, natively and without invention:
+
+- **Concurrency inside one process** — N runspaces on threads, not N `pwsh` processes.
+- **Both pooling modes for free** — a fresh runspace per request *is* statement mode; a runspace pinned to an
+  acquirer *is* session mode. §5 maps onto the platform primitive exactly.
+- **Module import amortized** — the `initializer` idea, as a runspace-pool `InitialSessionState`.
+
+**The object boundary is the real design question.** PowerShell pipelines carry live .NET objects; `pwsh -Command`
+flattens them to formatted text, which is lossy and unstable — today's `powershell.exec` returns `Stdout string`, so
+every structured result is already being destroyed at the boundary. Crossing into Go requires a serialization
+choice: `ConvertTo-Json` (readable, depth-limited, lossy for types) or CLIXML via `PSSerializer` (PowerShell
+remoting's own format, higher fidelity, produces property-bag "deserialized" objects that lose methods). Neither is
+free, and choosing is a prerequisite to any of this.
+
+**PSSession may also answer elevation on Windows, which nothing else does.** PowerShell's session configurations —
+JEA endpoints registered with `RunAsVirtualAccount` — let an unprivileged caller connect to an endpoint that
+executes under a privileged virtual account. Because it is service-hosted rather than desktop-elevated, it plausibly
+works **headless**, where UAC categorically cannot. It moves the one-time elevated act to endpoint registration
+(install time), which is the right place for it. PowerShell 7 also carries PSSession over SSH on Linux and macOS,
+tying into [`6`](6-execution-topology.md)'s multiplexing section.
+
+This is the most promising unverified claim in this document and is called out as such: it needs a spike on a real
+Windows host before anything is built on it (open question 6).
+
+### Why `pwsh` is not promoted to the universal host
+
+Since `pwsh` runs everywhere and brings runspaces with it, the obvious question is whether it should simply *be* the
+host on Unix too, collapsing the two host kinds into one. **It should not**, and the reason is specific rather than
+sentimental:
+
+**PowerShell's object model exists for cmdlets, and there are no cmdlets on the Unix path.** The work devlore does
+there is `apt-get install -y`, `systemctl start`, `brew install`, `port -N install` — external POSIX programs.
+Invoking them from `pwsh` returns exactly what invoking them from `bash` returns: text on stdout and an exit code.
+The single largest advantage would be paid for and not received.
+
+What remains does not carry the decision:
+
+- **Concurrency is not a reason.** §3's elevated parent forking per request already gives one host and N concurrent
+  requests without a second runtime.
+- **The dependency is severe.** `sh`/`bash` is present on every Linux and macOS host; `pwsh` must be installed from
+  Microsoft's repository or a package manager. Today the hard `pwsh` requirement is scoped to one provider a user
+  opts into; making it the universal host makes it mandatory for every run — including the bootstrapping paradox of
+  needing `pwsh` present to run the tool that installs it.
+- **Cost.** Cold start is hundreds of milliseconds against `bash`'s few, and roughly 60–100 MB resident against ~3 MB.
+  Pooling amortizes the former only when the pool is warm, which a one-shot CLI invocation may never be.
+- **It would not remove `bash` anyway.** `shell.exec` bodies are POSIX text with POSIX quoting, so a POSIX shell is
+  still required; `pwsh`-as-universal-host adds a layer rather than replacing one.
+- **Native-command argument passing differs enough to bite** — the reason PowerShell carries `--%` and later
+  `$PSNativeCommandArgumentPassing`. Existing manifests and `.star` snippets assume POSIX rules.
+
+So `pwsh` is a first-class host kind wherever `pwsh` is the interpreter asked for, and never the default.
+
+## 9. Lazy allocation and lifetime
+
+No host starts until a request needs one of that identity. A dry run allocates **nothing** — `Runner` already
+narrates without executing, so the pool's acquire returns a narrating stub and a dry run of an elevated graph never
+prompts for credentials. Today's platform path does not honor dry-run at all, which this fixes as a side effect.
+
+The pool is **per-run**, owned by the session, and must **outlive the forward pass**: compensation runs after
+failure, and an undo that needs an elevated host must not be what re-prompts for credentials. It drains after
+compensation, not after the last forward unit. Idle hosts are reclaimed on a timer; an elevated host's idle timeout
+is the run itself, because reclaiming it discards a credential that costs a human interaction to replace.
+
+## 10. Platform divergence — elevation only
+
+Host kind is the interpreter's business (§8). What the **platform** decides is how an elevated identity is acquired:
+
+| Platform | Spawn | IPC | Elevation cost |
+|---|---|---|---|
+| Linux / macOS | `sudo` the worker | stdin/stdout pipe | one prompt per elevated identity per run |
+| Windows (desktop) | `runas` / ShellExecute with the `runas` verb | **named pipe** — the native IPC | one UAC dialog; UAC is per-process and **cannot be cached**, so pooling is the only mechanism that yields one dialog |
+| Windows (headless) | JEA session configuration, `RunAsVirtualAccount` — §8, unverified | PowerShell remoting | one-time elevated registration at install; none per run |
+
+The rows are orthogonal to host kind: a runspace-pool host on Linux is acquired unelevated in-process and elevated
+through `sudo` exactly as a `bash` host is, and the JEA row is the one place the two intersect — because there the
+elevation mechanism *is* a PowerShell session.
+
+Absent the JEA path, **headless Windows has no elevation mechanism at all**, and an elevated acquire there must fail
+as a named policy failure routed through the elevation failure contract — never block on a dialog nobody can see.
+
+## 11. Relationship to elevation
+
+The pool is the **mechanism**; [`6.1`](6.1-privilege-elevation.md) owns the **policy** and the provider:
+
+- **`ProcessSpawn`** becomes "acquire from the pool with an elevated identity." The strategy stops needing a
+  privileged-worker design of its own — the worker *is* a pooled host whose identity happens to be elevated.
+- **`IdentityAssumption`** does not touch the pool: it mints a token and bridges it down an edge.
+- **`InteractiveChallenge`** / **`MandatedApproval`** ride pause/resume, so acquire must tolerate suspending and
+  resuming — including across a process restart, where nothing pooled survives.
+
+## 12. Hermeticity
+
+[`2.4-hermeticity-guarantees.md`](2.4-hermeticity-guarantees.md) is the constraint a pool most obviously strains: a
+reused host is a channel between units that the graph does not model as an edge. §5 is the answer — statement mode
+forbids the state rather than promising to clean it, and session mode makes the sharing explicit and exclusive — but
+`2.4` must say so too, and today it does not.
+
+## Open questions
+
+1. **Serialization at the PowerShell boundary** — JSON with a depth limit, or CLIXML with remoting fidelity? Gates
+   §8 entirely, and is worth answering even if the runspace host is deferred, because `powershell.exec` is lossy
+   today.
+2. **Who acquires?** Providers reach the runtime environment already; `pkg/platform`'s manager backends do not —
+   they call a package var. Either they gain a runtime-environment parameter, or the pool is reached another way.
+   Same question the filesystem roots answered with "caller owns, leaf receives"
+   ([#405 phase 2b](../plans/windows-native-permissions.md)), and it should be answered the same way.
+3. **Retirement thresholds** — what N, and per interpreter or global?
+4. **Does the pool subsume `runShellCommand`'s knobs?** It carries `DEBIAN_FRONTEND=noninteractive` and a stdin of
+   repeated `y\n` — package-manager-specific behavior a general pool should not know, but which has to live
+   somewhere.
+5. **Worker binary** — the same binary behind a `--worker` flag, or a separate `devlore-worker`?
+   ([`6`](6-execution-topology.md) Q2, still open.) Note the PowerShell host is a *script*, not this binary.
+6. **Spike JEA** on a real Windows host: does an unprivileged caller reach a `RunAsVirtualAccount` endpoint headless,
+   and what does registration cost at install time? The answer decides whether headless Windows elevation exists.
+7. **Pause/resume across restart** — a resumed run re-acquires, meaning a second credential prompt for an elevated
+   identity. Whether that is acceptable is unanswered.
+
+## Related Documents
+
+- [6-execution-topology.md](6-execution-topology.md) — elevation policy, the privileged-child approach, remote
+  execution, the telemetry pipeline
+- [6.1-privilege-elevation.md](6.1-privilege-elevation.md) — the elevation provider, both strategies, the token
+  bridge; poses the process-management question this document answers
+- [2.4-hermeticity-guarantees.md](2.4-hermeticity-guarantees.md) — the isolation constraint a pool strains
+- [2.6-execution-policies.md](2.6-execution-policies.md) — where elevation sits among retry and error-action
+- [3.5.8-shell-provider.md](3.5.8-shell-provider.md), [3.5.9-powershell-provider.md](3.5.9-powershell-provider.md) —
+  the two providers that acquire most often; the latter is where §8 lands

--- a/docs/architecture/6.2-process-pool.status.md
+++ b/docs/architecture/6.2-process-pool.status.md
@@ -1,0 +1,76 @@
+# The Process Pool — Status
+
+**Document:** [6.2-process-pool.md](6.2-process-pool.md)
+**State:** Design draft (2026-08-17), revised the same day onto prior art and the PowerShell runspace model. Answers
+[`6.1`](6.1-privilege-elevation.md)'s process-management question with a lazily-allocated, identity-keyed pool whose
+privilege is an axis of the identity. No implementation.
+
+## Completion
+
+- [x] The problem enumerated against the code: three spawn paths, with the two that bypass `pkg/process` named.
+- [x] Three defects the current shape carries — `pkg/process` is not the single bridge it declares itself to be; run
+  cancellation does not reach package installs (`context.Background()`); `sudo -n` fails rather than elevates.
+- [x] **Prior art surveyed** — Bazel persistent workers (`WorkerKey`, request ids, multiplexing, the state-leakage
+  cautionary tale), PgBouncer pooling modes, `database/sql` (caps, `ResetSession`, `IsValid`, pinned `Conn`), PHP-FPM
+  (`ondemand`, `max_requests`), SSH `ControlMaster`, Nailgun / Gradle daemon.
+- [x] **Two kinds of persistence separated** — persistent *privilege* (elevated parent forking per request, no state,
+  full concurrency) versus persistent *interpreter state* (the only case with a bleed problem).
+- [x] Host identity defined on Bazel's `WorkerKey` shape — interpreter × privilege × pooling mode × session — with
+  working directory and environment deliberately excluded.
+- [x] Pooling modes adopted from PgBouncer, replacing three home-grown options; retirement (`max_requests`) named as
+  the answer where reset is impossible.
+- [x] Concurrency corrected — multiplexing with request ids, not more processes. An elevated identity is capped at
+  one host and still runs concurrently.
+- [x] Lazy allocation, dry-run allocating nothing, per-run lifetime draining after compensation.
+- [x] **PowerShell modelled on runspaces, not processes** — a PowerShell-side host owning a `RunspacePool`, with §5's
+  two modes falling out natively; the object-serialization boundary raised as the gating question.
+- [x] **Host kind is interpreter-determined, not platform-determined** — two kinds (process-per-request, runspace
+  pool); `powershell.exec` on Linux and macOS gets the runspace host and its benefits too. The platform decides only
+  how elevation is acquired (§10).
+- [x] **`pwsh` ruled out as the universal host**, with the reason recorded: its object model serves cmdlets, and the
+  Unix path is external POSIX programs (apt, systemd, brew) that return text either way — the largest advantage is
+  paid for and not received. Supporting costs: a mandatory Microsoft runtime with a bootstrapping paradox, cold-start
+  and footprint, `bash` still required for `shell.exec` bodies, and native-command argument-passing differences.
+- [x] Mapped onto [`6.1`](6.1-privilege-elevation.md)'s strategies.
+- [ ] **Settle the PowerShell serialization boundary** (JSON depth-limited vs CLIXML). Gates §8.
+- [ ] **Spike JEA** — decides whether headless Windows elevation exists at all.
+- [ ] **Settle acquisition** — how `pkg/platform`'s manager backends reach the pool.
+- [ ] Retirement thresholds; whether the elevated host cap of one survives a long privileged gather.
+- [ ] Reconcile with [`2.4`](2.4-hermeticity-guarantees.md) — a reused host is an unmodelled channel between units.
+- [ ] Worker binary packaging (`--worker` vs separate) — inherited from [`6`](6-execution-topology.md).
+
+## Corrections made in revision
+
+- **Multiplexing was conflated with serialization.** The first draft capped elevated identities at one host and then
+  concluded that elevated sections serialize. They do not: request ids let one host serve many in-flight requests,
+  and an elevated parent forks a fresh child per request. Bazel multiplex workers and SSH `ControlMaster` are the
+  precedents.
+- **Two kinds of persistence were merged**, which is what produced that error — interpreter-state constraints were
+  applied to the privilege case, which has none.
+- **The state question was posed as three invented options.** Replaced with PgBouncer's established taxonomy and its
+  honest rule: aggressive modes forbid state rather than pretending to reset it.
+- **Runspaces were presented as the Windows answer.** They are the *PowerShell* answer; `pwsh` is cross-platform, so
+  the runspace host serves Linux and macOS too. Host kind follows the interpreter; only elevation follows the
+  platform.
+
+## Outstanding / open questions
+
+- Whether the pool subsumes `runShellCommand`'s package-manager knobs (`DEBIAN_FRONTEND=noninteractive`, the
+  repeated-`y` stdin) or they stay with the callers that need them.
+- Pause/resume across a process restart: nothing pooled survives, so a resumed run re-acquires — a second credential
+  prompt for an elevated identity.
+
+## Discrepancies (design vs. current code)
+
+- No pool exists. `RuntimeEnvironment.runner()` ([`runtime_environment.go:726`](../../pkg/op/runtime_environment.go))
+  constructs a fresh `process.Runner` per call.
+- `pkg/platform.runShellCommand` ([`helpers_unix.go:56`](../../pkg/platform/helpers_unix.go)) is a second spawner
+  that bypasses `pkg/process` entirely — no narration, no dry-run, no result pipeline — and uses
+  `context.Background()`, so run cancellation does not reach it.
+- The `sudo -n` inline it carries is under a standing TODO ([:64](../../pkg/platform/helpers_unix.go)) to route
+  through the elevation model; this design is where that route lands.
+- `NeedsSudo()` is modelled per backend but has nowhere to go except a boolean parameter.
+- `powershell.exec` returns `Stdout string` — PowerShell's object pipeline is already being flattened to text at the
+  boundary, so open question 1 is a live defect, not only a future design choice.
+- [`6.1`](6.1-privilege-elevation.md)'s citations of `runShellCommand` in `pkg/platform/helpers.go` are **stale** —
+  the function lives in `helpers_unix.go` and is a package var, not a func. Correct when 6.1 is next revised.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -70,6 +70,7 @@ Each architecture document has a companion `*.status.md` file tracking completio
 
 - [Execution Topology](6-execution-topology.md) ([status](6-execution-topology.status.md)) — Elevation, remote execution, telemetry (planned)
   - [Privilege Elevation: The Elevator Provider](6.1-privilege-elevation.md) ([status](6.1-privilege-elevation.status.md)) — The elevator provider: graph/config/runtime split, the two strategies (ProcessSpawn / IdentityAssumption), the token-provider mechanism, the config outline, and failure routing
+  - [The Process Pool](6.2-process-pool.md) ([status](6.2-process-pool.status.md)) — Lazily-allocated execution hosts keyed by interpreter × privilege × pooling mode × session; persistent privilege vs persistent interpreter state; multiplexing with request ids; PgBouncer pooling modes; the PowerShell runspace host and why `pwsh` is not the universal one
 
 ### 7. Knowledge and LLM
 


### PR DESCRIPTION
## Summary

New design document: [`6.2-process-pool.md`](docs/architecture/6.2-process-pool.md), plus its status
companion and an `index.md` entry. Design only -- no code.

It answers the first of the two questions [`6.1`](docs/architecture/6.1-privilege-elevation.md) poses
about the command-execution substrate: *"three scattered one-shot spawns … how do we manage the processes
these providers rely on?"* -- and gives the second (*how do we elevate*) its mechanism.

## Three live defects it documents

1. **`pkg/process` is not the single bridge it declares itself to be.** Its package doc says every
   provider that shells out goes through `Runner`. `pkg/platform.runShellCommand` does not -- no
   narration, no dry-run, no result pipeline.
2. **Run cancellation does not reach package installs.** That path uses `context.Background()` with a
   fixed timeout, so cancelling a run leaves `apt-get install` running to completion.
3. **`sudo -n` fails rather than elevates**, leaving an operator without cached credentials with no path
   forward -- the standing TODO at `helpers_unix.go:64`.

## The design

- **Two kinds of persistence, separated.** Persistent *privilege* (an elevated parent forking a fresh
  child per request -- no state, full concurrency) versus persistent *interpreter state* (the only case
  with a bleed problem).
- **Identity, not instance** -- interpreter × privilege × pooling mode × session, a session service and
  never a process singleton.
- **Concurrency by multiplexing.** Request ids let one host serve many in-flight requests, so an elevated
  identity is acquired exactly once and still runs a `gather` concurrently.
- **Pooling modes from PgBouncer** -- statement / session / transaction, with the honest rule that the
  aggressive modes *forbid* state rather than pretending to reset it, and retirement (`max_requests`)
  where reset is impossible.

## Host kind follows the interpreter, not the platform

PowerShell's unit of execution is a **runspace**, not a process, and `pwsh` ships the pool this document
designs (`RunspacePool`). Because `pwsh` is cross-platform, `powershell.exec` on Linux and macOS gets the
runspace host, session mode and module amortization too.

`pwsh` is **not** promoted to the universal host, and the reason is recorded: its object model serves
cmdlets, and the Unix path is `apt-get`, `systemctl`, `brew`, `port` -- external POSIX programs that
return text from either shell. The largest advantage would be paid for and not received. Supporting
costs: a mandatory Microsoft runtime (with the bootstrapping paradox of needing `pwsh` to install `pwsh`),
cold start and footprint, `bash` still required for `shell.exec` bodies, and native-command
argument-passing differences.

## One unverified claim, flagged as such

JEA session configurations (`RunAsVirtualAccount`) may give **headless Windows elevation**, which UAC
categorically cannot. It needs a spike on a real Windows host before anything is built on it; open
question 6.

## Verified

Documentation only; no code paths touched.
