### PR TITLE
docs(architecture): correct the encryption provider spec and its companion

### DIFF
--- a/docs/architecture/3.5.13-encryption-provider.md
+++ b/docs/architecture/3.5.13-encryption-provider.md
@@ -74,6 +74,10 @@ writ state, the layers registry included.
 
 ## Status
 
-Implemented in full; the seam bypass is the recorded open item (step 49). The `writ
-secret` family (init, encrypt, decrypt, rekey, list, recover) is chartered, not yet
-implemented.
+The provider is implemented in full; the seam bypass is the recorded open item (step 49).
+
+Of the `writ secret` family, **`encrypt` is implemented** (`cmd/writ/writ/secret/encrypt.go`); `init`,
+`decrypt`, `rekey`, `list` and `recover` are chartered and unbuilt. Deploy-time consumption — the
+`<name>.sops` → `<name>` pipeline that `writ deploy` runs natively — is **not described here**, and is
+specified nowhere: the grammar, its outside-in ordering, and the link-versus-copy fork live only in a doc
+comment on `ProcessingPipeline` (`cmd/writ/writ/tree/node.go`).

--- a/docs/architecture/3.5.13-encryption-provider.status.md
+++ b/docs/architecture/3.5.13-encryption-provider.status.md
@@ -2,8 +2,8 @@
 
 **Architecture document:** [3.5.13-encryption-provider.md](3.5.13-encryption-provider.md)
 **State:** implemented; first design doc written 2026-07-22 (phase-8 step 39); document
-extended 2026-08-10 with § Key custody and break-glass recovery and the four-member
-`writ secret` family (chartered, not yet implemented). Matrix greped, not asserted.
+extended 2026-08-10 with § Key custody and break-glass recovery and the **six**-member
+`writ secret` family, of which `encrypt` has since shipped. Matrix greped, not asserted.
 
 ## Completion
 
@@ -12,19 +12,29 @@ extended 2026-08-10 with § Key custody and break-glass recovery and the four-me
 | `DecryptSopsFile` / `CompensateDecryptSopsFile` | Landed |
 | `EncryptFile` / `CompensateEncryptFile` | Landed |
 | `Receipt.RestoreEncoded` via the catalog | Landed (step 44) |
+| `writ secret encrypt` | Landed (`cmd/writ/writ/secret/encrypt.go`) |
 
 ## Chartered, not yet implemented (2026-08-10)
 
 | Piece | Plan |
 |---|---|
 | `writ secret init` (BYOK ceremony) | [writ-secret-init](../plans/writ-secret-init.md) |
-| `writ secret encrypt` | [writ-secret-encrypt](../plans/writ-secret-encrypt.md) |
+| `writ secret decrypt` (stdout only) | [writ-secret-decrypt](../plans/writ-secret-decrypt.md) |
 | `writ secret rekey` (+ purge preflight) | [writ-secret-rekey](../plans/writ-secret-rekey.md) |
+| `writ secret list` (recipient-drift audit) | [writ-secret-list](../plans/writ-secret-list.md) |
 | `writ secret recover` (pipeline-free) | [writ-secret-recover](../plans/writ-secret-recover.md) |
 
 ## Document Discrepancies
 
-None known — refreshed 2026-08-10 against the tree.
+**Deploy-time consumption is undocumented (found 2026-08-17).** The architecture document covers the
+authoring half — the provider and the `writ secret` family — and says nothing about how `writ deploy`
+consumes a secret, which is where decrypted plaintext reaches disk. The transform-suffix pipeline
+(`<name>.sops` → `<name>`), its outside-in ordering, and the fact that a transformed file is **copied**
+where a plain file is **linked** exist only as a doc comment on `ProcessingPipeline`
+(`cmd/writ/writ/tree/node.go`). Chartered under the Secrets epic.
+
+Two staleness fixes applied the same day: this document had called the family four-member (it is six, and
+its table omitted `decrypt` and `list`), and listed `encrypt` as unimplemented after it shipped.
 
 ## Test matrix (verified 2026-07-22)
 


### PR DESCRIPTION
## Summary

Documentation only. Found while decomposing the Secrets epic (#448), which needed the spec read closely.

## The spec claimed work was unbuilt that had shipped

`3.5.13-encryption-provider.md`'s Status section said the `writ secret` family was *"chartered, not yet
implemented"*. **`writ secret encrypt` is implemented** — `cmd/writ/writ/secret/encrypt.go`, with its plan
marked complete.

The status companion was stale in three further ways:

1. It called it a **four-member** family; the spec names **six**.
2. Its chartered table omitted **`decrypt`** and **`list`** entirely.
3. It listed `encrypt` as unbuilt, and asserted **"Document Discrepancies: None known"**.

The third is the one worth flagging: a companion that asserts no discrepancies tells a reader the check
was performed. Silence would have been more honest.

## And the half the spec never covered

Secrets are **authored** by `writ secret` and **consumed** by `writ deploy`. The document covers only the
first. Deploy-time decryption is `writ deploy`'s native behavior — `<name>.sops` deploys as `<name>` — and
the whole grammar lives in a doc comment on `ProcessingPipeline` (`cmd/writ/writ/tree/node.go`):

```
"foo"                → "foo",  ["file.link"]
"foo.template"       → "foo",  ["template.render_bytes", "file.copy"]
"foo.sops"           → "foo",  ["encryption.decrypt", "file.copy"]
"foo.template.sops"  → "foo",  ["encryption.decrypt", "template.render_bytes", "file.copy"]
```

Two consequences nothing states: suffixes resolve **outside-in**, so `.sops` decrypts before `.template`
renders — the reverse order would silently render ciphertext — and a transformed file is **copied** where
a plain file is **linked**, so **decrypted plaintext lands as a real file in the target**. That is the
write #433 calls the second most security-relevant in the codebase after the private key.

Both documents now say so rather than implying full coverage. The work is chartered as #494 (specify the
pipeline, including how transform suffixes compose with scope segments — which needs a ruling, given #369
already reports the segment grammar as order-unvalidated) and #495 (the conflict-seam bypass).

## Verified

Documentation only; no code paths touched.
