### PR TITLE
feat(scripts): bug as a peer kind, with a debt view

### DIFF
--- a/docs/architecture/2.8-eventing-infrastructure.status.md
+++ b/docs/architecture/2.8-eventing-infrastructure.status.md
@@ -20,14 +20,25 @@ metrics; hook reconciliation). Implementation deferred to a post-PR step. Implem
 
 ## Document Discrepancies
 
-None.
+None in the architecture document. **This companion carried one until 2026-08-17**: its "Outstanding / open
+questions" section still listed all five decisions as open, verbatim in the *"was X"* framings the 2026-07-23
+rulings replaced — contradicting this file's own State line. Swept below.
 
-## Outstanding / open questions
+## Settled — the five decisions
 
-1. `status.Narrator` / `result.Pipeline` vs. `slog` — handlers, above, or parallel.
-2. Canonical stream taxonomy + attribute names — (operational logs, narrations, results) vs. (narrations, operational
-   events, diagnostics).
-3. Eventing *is* OpenTelemetry vs. *wraps* it.
-4. Metrics derivation — in-app OTel Metrics API vs. Collector connector.
-5. Hook-interface reconciliation (`OnSubgraph*` vs. spec `OnPhase*`; the missing run-status-transition callback) —
-   tracked in [step 50](../plans/extract-starlark-from-op/phase-8/steps/50-eventstream-narration-integration.md).
+Each is recorded in full in
+[§ Design decisions](2.8-eventing-infrastructure.md#design-decisions); the framing each replaced is kept there.
+
+| # | Ruled 2026-07-23 |
+|---|---|
+| 1 | **`slog` is the primary logging API.** `status.Narrator` / `result.Pipeline` sit above it as a tee handler. |
+| 2 | **Narrations / diagnostics / operational events**, on OTel-native attributes — category carried by signal and severity, never a custom attribute. Attribute names frozen against semconv 1.43.0. |
+| 3 | **Eventing *is* OpenTelemetry; the Collector is the router.** No hand-built sink registry; a bounded in-process tap serves the two consumers OTel does not. |
+| 4 | **Metrics derive at the Collector connector**, from the `event.name` record. |
+| 5 | **Hook reconciliation** — keep `OnNode*` / `OnSubgraph*`, add `OnRunStatusChanged`, do not revive `OnPhase*`. |
+
+## Outstanding
+
+Implementation only — the design is settled. Tracked by
+[step 50](../plans/extract-starlark-from-op/phase-8/steps/50-eventstream-narration-integration.md), whose scope
+includes unwinding step 36's fused first cut so the control plane becomes one sink rather than the event owner.

--- a/scripts/Get-EpicReport
+++ b/scripts/Get-EpicReport
@@ -5,17 +5,21 @@
 
 # Get-EpicReport - render the epic / feature / task tree as markdown
 #
-# GitHub is the index: epics carry the `epic` label plus a per-epic `Epic:<Name>` label, features carry
-# `feature`, tasks carry `task`, and every child repeats its epic's `Epic:<Name>` label. A task states its
-# parent feature in its body as `**Feature:** #<number>`; tasks without that marker are reported under
-# "Unfiled" rather than silently attached to something.
+# GitHub is the index. Four kinds across three tiers: `epic` -> `feature` -> {`task` | `bug`}. A task
+# implements part of a feature; a bug repairs one. They are peers and mutually exclusive. Every issue also
+# carries its epic's `Epic:<Name>` label, and every tier-three issue states its parent in its body as
+# `**Feature:** #<number>`; those without the marker are reported under "Unfiled" rather than silently
+# attached to something.
+#
+# Triage adds attributes, never a kind: `Severity:<level>` (impact if it fires) and `Priority:<Pn>` (when we
+# act), plus the feature that places it in the hierarchy.
 #
 # Every run opens with a classification audit. An issue is well classified when it carries exactly one kind
 # label and exactly one `Epic:<Name>` label; anything else is named up front, because an issue the scheme
 # cannot place is invisible to every other view. Only open issues are audited -- closed ones predate the
 # scheme and cannot be reclassified.
 
-source "Declare-BashScript" "$0" "audit,epic:,limit:,state:,help" "h" "$@"
+source "Declare-BashScript" "$0" "audit,debt,epic:,limit:,state:,help" "h" "$@"
 require_nix
 
 command -v gh >/dev/null 2>&1 || error $EX_UNAVAILABLE "The 'gh' command is required but not found. Please install the GitHub CLI."
@@ -25,9 +29,10 @@ command -v jq >/dev/null 2>&1 || error $EX_UNAVAILABLE "The 'jq' command is requ
 # Arguments
 ###########
 
-declare -r synopsis="Get-EpicReport [--state open|closed|all] [--epic <Name>] [--audit] [--limit <n>]"
+declare -r synopsis="Get-EpicReport [--state open|closed|all] [--epic <Name>] [--audit|--debt] [--limit <n>]"
 
 audit_only=false
+debt_only=false
 epic=""
 limit=500
 state=open
@@ -39,6 +44,10 @@ while :; do
     case "$1" in
         --audit)
             audit_only=true
+            shift 1
+            ;;
+        --debt)
+            debt_only=true
             shift 1
             ;;
         --epic)
@@ -75,7 +84,10 @@ esac
 
 [[ "$limit" =~ ^[1-9][0-9]*$ ]] || error $EX_USAGE "--limit must be a positive integer (got '$limit')."
 
-readonly audit_only epic limit state
+[[ "$audit_only" == "true" && "$debt_only" == "true" ]] &&
+    error $EX_USAGE "--audit and --debt are mutually exclusive."
+
+readonly audit_only debt_only epic limit state
 
 ###########
 # Variables
@@ -90,21 +102,41 @@ declare -r exempt='[65]'
 # Main
 ###########
 
-note "state=${state} epic=${epic:-<all>} audit-only=${audit_only}"
+note "state=${state} epic=${epic:-<all>} audit-only=${audit_only} debt-only=${debt_only}"
 
 gh issue list \
     --state "$state" \
     --limit "$limit" \
     --json number,title,state,labels,body,url |
     jq -r --arg epicFilter "$epic" --arg state "$state" --arg auditOnly "$audit_only" \
-        --argjson exempt "$exempt" '
+        --arg debtOnly "$debt_only" --argjson exempt "$exempt" '
     def names: [.labels[].name];
     def tagged($l): (names | index($l)) != null;
-    def kinds: (names | map(select(. == "epic" or . == "feature" or . == "task")));
+    def kinds: (names | map(select(. == "epic" or . == "feature" or . == "task" or . == "bug")));
     def epicTags: (names | map(select(startswith("Epic:"))));
     def epicTag: (epicTags | first // "");
     def mark: if .state == "CLOSED" then "~~" else "" end;
     def line: "\(mark)\(.title)\(mark) [#\(.number)](\(.url))";
+
+    # Triage attributes. Orthogonal to the epic hierarchy: a bug reaches its epic through its feature.
+    def isBug: tagged("bug");
+    def severity: (names | map(select(startswith("Severity:"))) | first // "");
+    def priority: (names | map(select(startswith("Priority:"))) | first // "");
+    def severityRank:
+      severity
+      | if . == "Severity:Critical" then 0
+        elif . == "Severity:High" then 1
+        elif . == "Severity:Medium" then 2
+        elif . == "Severity:Low" then 3
+        else 4 end;
+    def triage:
+      [ (if isBug then "bug" else empty end),
+        (if severity != "" then severity else empty end),
+        (if priority != "" then priority else empty end) ]
+      | if length == 0 then "" else " — **" + join("** · **") + "**" end;
+
+    # A tier-three issue is a task or a bug; they are peers under a feature.
+    def isChild: tagged("task") or isBug;
 
     # A tasks parent feature, stated in its body as **Feature:** #123.
     def parentFeature:
@@ -112,17 +144,23 @@ gh issue list \
       | capture("Feature:\\*\\* #(?<n>[0-9]+)") // null
       | if . then (.n | tonumber) else null end;
 
+    # A bug awaiting triage has no feature yet, so it has no epic. That is the triage queue, not a fault.
+    def awaitingTriage: isBug and (epicTags | length) == 0;
+
     def faults:
-      [ (if (kinds | length) == 0 then "no kind label (epic/feature/task)" else empty end),
+      if awaitingTriage then [] else
+      [ (if (kinds | length) == 0 then "no kind label (epic/feature/task/bug)" else empty end),
         (if (kinds | length) > 1 then "multiple kind labels: \(kinds | join(", "))" else empty end),
         (if (epicTags | length) == 0 then "no Epic:<Name> label" else empty end),
-        (if (epicTags | length) > 1 then "multiple epics: \(epicTags | join(", "))" else empty end) ];
+        (if (epicTags | length) > 1 then "multiple epics: \(epicTags | join(", "))" else empty end) ] end;
 
     . as $all
     # Only open work can be reclassified; closed issues predate the scheme and are left as history.
     | [ $all[] | select(.state == "OPEN") | select((.number | IN($exempt[])) | not)
         | select((faults | length) > 0) ] as $bad
     | [ $all[] | select(.state == "OPEN") | select(.number | IN($exempt[])) ] as $exempted
+    | [ $all[] | select(.state == "OPEN") | select(isBug) ] as $bugs
+    | [ $bugs[] | select(awaitingTriage) ] as $untriaged
     | (
         "# Epic report\n",
         "State filter: **\($state)**.",
@@ -137,7 +175,27 @@ gh issue list \
           else ( "\nDeliberately outside the scheme, by decision:\n",
                  ( $exempted | sort_by(.number) | .[] | "- \(line)" ) )
           end ),
-        ( if $auditOnly == "true" then empty else
+        ( if ($untriaged | length) == 0 then empty
+          else ( "\n**\($untriaged | length) bug(s) awaiting triage** — no feature, so no epic. Not a fault; this is the queue.\n",
+                 ( $untriaged | sort_by(.number) | .[] | "- \(line)" ) )
+          end ),
+        ( if $debtOnly == "true" then
+            ( "\n## Bug debt\n",
+              ( if ($bugs | length) == 0 then "No open bugs."
+                else
+                  ( "_\($bugs | length) open bug(s)._",
+                    ( $bugs
+                      | sort_by([severityRank, .number])
+                      | group_by(severityRank)
+                      | .[]
+                      | ( "\n### \(.[0] | severity | if . == "" then "Untriaged — no severity" else . end)",
+                          ( .[]
+                            | "\n- \(line)"
+                              + ( (epicTag | if . == "" then "" else " — **" + ltrimstr("Epic:") + "**" end) )
+                              + ( parentFeature | if . == null then " · _no feature_" else " · feature #\(.)" end )
+                              + ( priority | if . == "" then " · _no priority_" else " · **" + . + "**" end ) ) ) ) )
+                end ) )
+          elif $auditOnly == "true" then empty else
           ( [ $all[] | select(tagged("epic")) ]
             | map(select($epicFilter == "" or epicTag == "Epic:" + $epicFilter))
             | sort_by(.number)
@@ -147,11 +205,11 @@ gh issue list \
                   ( .[] as $e
                     | ($e | epicTag) as $tag
                     | [ $all[] | select(tagged("feature") and epicTag == $tag) ] as $features
-                    | [ $all[] | select(tagged("task")    and epicTag == $tag) ] as $tasks
+                    | [ $all[] | select(isChild          and epicTag == $tag) ] as $tasks
                     | ([ $features[].number ]) as $featureNumbers
                     | (
                         "\n# \($e | line)",
-                        "\n_\($features | length) feature(s), \($tasks | length) task(s)._",
+                        "\n_\($features | length) feature(s), \([$tasks[] | select(isBug | not)] | length) task(s), \([$tasks[] | select(isBug)] | length) bug(s)._",
                         ( $features
                           | sort_by(.number)
                           | .[] as $f
@@ -159,14 +217,14 @@ gh issue list \
                               ( [ $tasks[] | select(parentFeature == $f.number) ]
                                 | sort_by(.number)
                                 | if length == 0 then "\n_No tasks filed._"
-                                  else (.[] | "\n### \(line)") end ) ) ),
+                                  else (.[] | "\n### \(line)\(triage)") end ) ) ),
                         ( [ $tasks[]
                             | select(parentFeature == null
                                      or (parentFeature as $p | $featureNumbers | index($p) | not)) ]
                           | sort_by(.number)
                           | if length == 0 then empty
                             else ( "\n## Unfiled — no parent feature stated",
-                                   (.[] | "\n### \(line)") ) end )
+                                   (.[] | "\n### \(line)\(triage)") ) end )
                       ) ) )
               end )
         end )


### PR DESCRIPTION
## Summary

Two commits: the report learns the bug kind, and a stale status companion is swept.

## 1. `bug` is a peer of `task`, not an attribute

Four kinds across three tiers: **`epic` -> `feature` -> {`task` | `bug`}**. A **task** implements part of a
feature; a **bug** repairs one. They are peers, mutually exclusive, and both reach their epic through the
feature that parents them.

Triage adds **attributes** -- `Severity:<level>` (impact if it fires) and `Priority:<Pn>` (when we act) --
plus the feature that places the bug. It never adds a kind.

- **`--debt`** lists open bugs grouped by severity, each showing its epic, feature and priority.
- **The audit gets stricter for free**: carrying both `task` and `bug` is now a multiple-kind fault. That
  check is what caught an earlier version of the sweep, which *added* `bug` alongside `task` rather than
  swapping them.
- **An untriaged bug is no longer reported as a fault.** Filed against no feature, it has no epic -- that
  is the triage queue, and it now says so.
- Feature lines count the two separately: `_2 feature(s), 7 task(s), 0 bug(s)._`

## 2. The eventing status companion contradicted itself

`2.8-eventing-infrastructure.status.md` opened with *"decisions settled 2026-07-23 (all five)"* and then
listed those same five under **Outstanding / open questions** -- verbatim in the *"was X"* framings the
rulings replaced. Its Document Discrepancies section said **"None."**

Outstanding now carries implementation only, the five settled decisions are tabulated with pointers to the
full text, and the discrepancy section records that this file was the one carrying a discrepancy.

## Verified

`shfmt -d -i 4 -ci` and `shellcheck -x --severity=warning` on the script; `--debt`, `--audit` and the tree
exercised against the live board; `--audit --debt` together exits 64.
