### PR TITLE
refactor(file): name the write surface mode, user and group; floor the encryption mode

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_backup.star
+++ b/cmd/devlore-test/devloretest/data/test_backup.star
@@ -10,7 +10,7 @@
 
 src = t.tmp("backup_src.txt")
 
-written     = plan.file.write_text(destination_path=src, content="backup me", chmod=0o644)
+written     = plan.file.write_text(destination_path=src, content="backup me", mode=0o644)
 backed_up   = plan.file.backup(source_path=written, backup_suffix=".bak")
 
 graph = plan.assemble_definition([written, backed_up])

--- a/cmd/devlore-test/devloretest/data/test_choose_exists.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_exists.star
@@ -13,10 +13,10 @@
 dest   = t.tmp("choose_target.txt")
 status = t.tmp("choose_status.txt")
 
-written    = plan.file.write_text(destination_path=dest, content="here", chmod=0o644)
+written    = plan.file.write_text(destination_path=dest, content="here", mode=0o644)
 exists_inv = plan.file.exists(path=dest)
 choice     = plan.choose(plan.case(when=exists_inv, then=lambda: "found"), default=lambda: "missing")
-status_inv = plan.file.write_text(destination_path=status, content=choice, chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content=choice, mode=0o644)
 
 graph = plan.assemble_definition([written, choice, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_choose_in_gather.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_in_gather.star
@@ -8,7 +8,7 @@
 probe_hit = t.tmp("probe_present.txt")
 probe_miss = t.tmp("probe_missing.txt")
 
-pre = plan.file.write_text(destination_path=probe_hit, content="here", chmod=0o644)
+pre = plan.file.write_text(destination_path=probe_hit, content="here", mode=0o644)
 
 items = [
     {"probe": probe_hit, "hit": t.tmp("cig0_hit.txt"), "miss": t.tmp("cig0_miss.txt")},
@@ -18,9 +18,9 @@ items = [
 c = plan.choose(
     plan.case(
         when=plan.file.exists(path=plan.item("probe")),
-        then=plan.file.write_text(destination_path=plan.item("hit"), content="hit", chmod=0o644),
+        then=plan.file.write_text(destination_path=plan.item("hit"), content="hit", mode=0o644),
     ),
-    default=plan.file.write_text(destination_path=plan.item("miss"), content="miss", chmod=0o644),
+    default=plan.file.write_text(destination_path=plan.item("miss"), content="miss", mode=0o644),
 )
 
 g = plan.gather(items=items, limit=1, body=[c])

--- a/cmd/devlore-test/devloretest/data/test_choose_lambdas.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_lambdas.star
@@ -40,15 +40,15 @@ c_lambda_then = plan.choose(
     default=lambda: "default",
 )
 
-w_lambda_true    = plan.file.write_text(destination_path=t.tmp("lambda_true.txt"),      content=c_lambda_true,    chmod=0o644)
-w_lambda_false   = plan.file.write_text(destination_path=t.tmp("lambda_false.txt"),     content=c_lambda_false,   chmod=0o644)
-w_lambda_one     = plan.file.write_text(destination_path=t.tmp("lambda_one.txt"),       content=c_lambda_one,     chmod=0o644)
-w_lambda_zero    = plan.file.write_text(destination_path=t.tmp("lambda_zero.txt"),      content=c_lambda_zero,    chmod=0o644)
-w_lambda_str_x   = plan.file.write_text(destination_path=t.tmp("lambda_str_x.txt"),     content=c_lambda_str_x,   chmod=0o644)
-w_lambda_str_emp = plan.file.write_text(destination_path=t.tmp("lambda_str_empty.txt"), content=c_lambda_str_emp, chmod=0o644)
-w_lambda_none    = plan.file.write_text(destination_path=t.tmp("lambda_none.txt"),      content=c_lambda_none,    chmod=0o644)
-w_lambda_second  = plan.file.write_text(destination_path=t.tmp("lambda_second.txt"),    content=c_lambda_second,  chmod=0o644)
-w_lambda_then    = plan.file.write_text(destination_path=t.tmp("lambda_then.txt"),      content=c_lambda_then,    chmod=0o644)
+w_lambda_true    = plan.file.write_text(destination_path=t.tmp("lambda_true.txt"),      content=c_lambda_true,    mode=0o644)
+w_lambda_false   = plan.file.write_text(destination_path=t.tmp("lambda_false.txt"),     content=c_lambda_false,   mode=0o644)
+w_lambda_one     = plan.file.write_text(destination_path=t.tmp("lambda_one.txt"),       content=c_lambda_one,     mode=0o644)
+w_lambda_zero    = plan.file.write_text(destination_path=t.tmp("lambda_zero.txt"),      content=c_lambda_zero,    mode=0o644)
+w_lambda_str_x   = plan.file.write_text(destination_path=t.tmp("lambda_str_x.txt"),     content=c_lambda_str_x,   mode=0o644)
+w_lambda_str_emp = plan.file.write_text(destination_path=t.tmp("lambda_str_empty.txt"), content=c_lambda_str_emp, mode=0o644)
+w_lambda_none    = plan.file.write_text(destination_path=t.tmp("lambda_none.txt"),      content=c_lambda_none,    mode=0o644)
+w_lambda_second  = plan.file.write_text(destination_path=t.tmp("lambda_second.txt"),    content=c_lambda_second,  mode=0o644)
+w_lambda_then    = plan.file.write_text(destination_path=t.tmp("lambda_then.txt"),      content=c_lambda_then,    mode=0o644)
 
 graph = plan.assemble_definition([
     c_lambda_true, c_lambda_false, c_lambda_one, c_lambda_zero,

--- a/cmd/devlore-test/devloretest/data/test_choose_literals.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_literals.star
@@ -54,17 +54,17 @@ c_no_match = plan.choose(
     default=lambda: "default",
 )
 
-w_bool_true   = plan.file.write_text(destination_path=t.tmp("bool_true.txt"),   content=c_bool_true,   chmod=0o644)
-w_bool_false  = plan.file.write_text(destination_path=t.tmp("bool_false.txt"),  content=c_bool_false,  chmod=0o644)
-w_int_one     = plan.file.write_text(destination_path=t.tmp("int_one.txt"),     content=c_int_one,     chmod=0o644)
-w_int_zero    = plan.file.write_text(destination_path=t.tmp("int_zero.txt"),    content=c_int_zero,    chmod=0o644)
-w_str_x       = plan.file.write_text(destination_path=t.tmp("str_x.txt"),       content=c_str_x,       chmod=0o644)
-w_str_empty   = plan.file.write_text(destination_path=t.tmp("str_empty.txt"),   content=c_str_empty,   chmod=0o644)
-w_none        = plan.file.write_text(destination_path=t.tmp("none.txt"),        content=c_none,        chmod=0o644)
-w_zero_cases  = plan.file.write_text(destination_path=t.tmp("zero_cases.txt"),  content=c_zero_cases,  chmod=0o644)
-w_second      = plan.file.write_text(destination_path=t.tmp("second.txt"),      content=c_second,      chmod=0o644)
-w_first_match = plan.file.write_text(destination_path=t.tmp("first_match.txt"), content=c_first_match, chmod=0o644)
-w_no_match    = plan.file.write_text(destination_path=t.tmp("no_match.txt"),    content=c_no_match,    chmod=0o644)
+w_bool_true   = plan.file.write_text(destination_path=t.tmp("bool_true.txt"),   content=c_bool_true,   mode=0o644)
+w_bool_false  = plan.file.write_text(destination_path=t.tmp("bool_false.txt"),  content=c_bool_false,  mode=0o644)
+w_int_one     = plan.file.write_text(destination_path=t.tmp("int_one.txt"),     content=c_int_one,     mode=0o644)
+w_int_zero    = plan.file.write_text(destination_path=t.tmp("int_zero.txt"),    content=c_int_zero,    mode=0o644)
+w_str_x       = plan.file.write_text(destination_path=t.tmp("str_x.txt"),       content=c_str_x,       mode=0o644)
+w_str_empty   = plan.file.write_text(destination_path=t.tmp("str_empty.txt"),   content=c_str_empty,   mode=0o644)
+w_none        = plan.file.write_text(destination_path=t.tmp("none.txt"),        content=c_none,        mode=0o644)
+w_zero_cases  = plan.file.write_text(destination_path=t.tmp("zero_cases.txt"),  content=c_zero_cases,  mode=0o644)
+w_second      = plan.file.write_text(destination_path=t.tmp("second.txt"),      content=c_second,      mode=0o644)
+w_first_match = plan.file.write_text(destination_path=t.tmp("first_match.txt"), content=c_first_match, mode=0o644)
+w_no_match    = plan.file.write_text(destination_path=t.tmp("no_match.txt"),    content=c_no_match,    mode=0o644)
 
 graph = plan.assemble_definition([
     c_bool_true, c_bool_false, c_int_one, c_int_zero,

--- a/cmd/devlore-test/devloretest/data/test_choose_not_exists.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_not_exists.star
@@ -11,7 +11,7 @@ status  = t.tmp("choose_status.txt")
 
 exists_inv = plan.file.exists(path=phantom)
 choice     = plan.choose(plan.case(when=exists_inv, then=lambda: "found"), default=lambda: "missing")
-status_inv = plan.file.write_text(destination_path=status, content=choice, chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content=choice, mode=0o644)
 
 graph = plan.assemble_definition([choice, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_choose_predicates.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_predicates.star
@@ -21,9 +21,9 @@ missing_path = t.tmp("missing.txt")
 dir_path     = t.tmp("a_directory")
 file_path    = t.tmp("a_file.txt")
 
-write_present = plan.file.write_text(destination_path=present_path, content="here", chmod=0o644)
-make_dir      = plan.file.mkdir(path=dir_path, chmod=0o755)
-write_file    = plan.file.write_text(destination_path=file_path, content="x", chmod=0o644)
+write_present = plan.file.write_text(destination_path=present_path, content="here", mode=0o644)
+make_dir      = plan.file.mkdir(path=dir_path, mode=0o755)
+write_file    = plan.file.write_text(destination_path=file_path, content="x", mode=0o644)
 
 c_exists_present = plan.choose(
     plan.case(when=plan.file.exists(path=present_path), then=lambda: "exists-present"),
@@ -51,11 +51,11 @@ c_mixed = plan.choose(
     default=lambda: "default",
 )
 
-w_exists_present = plan.file.write_text(destination_path=t.tmp("exists_present.txt"), content=c_exists_present, chmod=0o644)
-w_exists_missing = plan.file.write_text(destination_path=t.tmp("exists_missing.txt"), content=c_exists_missing, chmod=0o644)
-w_is_dir         = plan.file.write_text(destination_path=t.tmp("is_dir.txt"),         content=c_is_dir,         chmod=0o644)
-w_is_file        = plan.file.write_text(destination_path=t.tmp("is_file.txt"),        content=c_is_file,        chmod=0o644)
-w_mixed          = plan.file.write_text(destination_path=t.tmp("mixed.txt"),          content=c_mixed,          chmod=0o644)
+w_exists_present = plan.file.write_text(destination_path=t.tmp("exists_present.txt"), content=c_exists_present, mode=0o644)
+w_exists_missing = plan.file.write_text(destination_path=t.tmp("exists_missing.txt"), content=c_exists_missing, mode=0o644)
+w_is_dir         = plan.file.write_text(destination_path=t.tmp("is_dir.txt"),         content=c_is_dir,         mode=0o644)
+w_is_file        = plan.file.write_text(destination_path=t.tmp("is_file.txt"),        content=c_is_file,        mode=0o644)
+w_mixed          = plan.file.write_text(destination_path=t.tmp("mixed.txt"),          content=c_mixed,          mode=0o644)
 
 graph = plan.assemble_definition([
     write_present, make_dir, write_file,

--- a/cmd/devlore-test/devloretest/data/test_choose_unchosen_branch.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_unchosen_branch.star
@@ -24,22 +24,22 @@ status            = t.tmp("status.txt")
 choice = plan.choose(
     plan.case(
         when=[
-            plan.file.write_text(destination_path=case1_when_canary, content="ran", chmod=0o644),
+            plan.file.write_text(destination_path=case1_when_canary, content="ran", mode=0o644),
             plan.file.exists(path=t.tmp("never_created.txt")),
         ],
-        then=plan.file.write_text(destination_path=case1_then_canary, content="must-not-run", chmod=0o644),
+        then=plan.file.write_text(destination_path=case1_then_canary, content="must-not-run", mode=0o644),
     ),
     plan.case(
         when=lambda: True,
-        then=plan.file.write_text(destination_path=case2_then_result, content="chosen", chmod=0o644),
+        then=plan.file.write_text(destination_path=case2_then_result, content="chosen", mode=0o644),
     ),
     plan.case(
-        when=plan.file.write_text(destination_path=case3_when_canary, content="must-not-run", chmod=0o644),
-        then=plan.file.write_text(destination_path=case3_then_canary, content="must-not-run", chmod=0o644),
+        when=plan.file.write_text(destination_path=case3_when_canary, content="must-not-run", mode=0o644),
+        then=plan.file.write_text(destination_path=case3_then_canary, content="must-not-run", mode=0o644),
     ),
-    default=plan.file.write_text(destination_path=default_canary, content="must-not-run", chmod=0o644),
+    default=plan.file.write_text(destination_path=default_canary, content="must-not-run", mode=0o644),
 )
-status_inv = plan.file.write_text(destination_path=status, content="done", chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content="done", mode=0o644)
 
 graph = plan.assemble_definition([choice, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_compensation.star
+++ b/cmd/devlore-test/devloretest/data/test_compensation.star
@@ -6,11 +6,11 @@
 
 dest = t.tmp("compensated.txt")
 
-written = plan.file.write_text(destination_path=dest, content="should be undone", chmod=0o644)
+written = plan.file.write_text(destination_path=dest, content="should be undone", mode=0o644)
 
 # Copy using the write output as source (creates an edge for ordering),
 # but target a read-only path that will fail.
-copied = plan.file.copy(source=written, destination_path="/dev/null/impossible/path.txt", chmod=0o644)
+copied = plan.file.copy(source=written, destination_path="/dev/null/impossible/path.txt", mode=0o644)
 
 graph = plan.assemble_definition([written, copied])
 

--- a/cmd/devlore-test/devloretest/data/test_copy.star
+++ b/cmd/devlore-test/devloretest/data/test_copy.star
@@ -8,8 +8,8 @@
 src = t.tmp("source.txt")
 dst = t.tmp("destination.txt")
 
-written = plan.file.write_text(destination_path=src, content="copy me", chmod=0o644)
-copied  = plan.file.copy(source=written, destination_path=dst, chmod=0o644)
+written = plan.file.write_text(destination_path=src, content="copy me", mode=0o644)
+copied  = plan.file.copy(source=written, destination_path=dst, mode=0o644)
 
 graph = plan.assemble_definition([written, copied])
 

--- a/cmd/devlore-test/devloretest/data/test_file_find.star
+++ b/cmd/devlore-test/devloretest/data/test_file_find.star
@@ -7,9 +7,9 @@
 
 dir = t.tmp("finddir")
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=dir, chmod=0o755),
-    plan.file.write_text(destination_path=t.tmp("finddir/a.txt"), content="a", chmod=0o644),
-    plan.file.write_text(destination_path=t.tmp("finddir/b.txt"), content="b", chmod=0o644),
+    plan.file.mkdir(path=dir, mode=0o755),
+    plan.file.write_text(destination_path=t.tmp("finddir/a.txt"), content="a", mode=0o644),
+    plan.file.write_text(destination_path=t.tmp("finddir/b.txt"), content="b", mode=0o644),
     plan.file.find(pattern=t.tmp("finddir/*.txt"), include_gitignored=True),
 ])
 

--- a/cmd/devlore-test/devloretest/data/test_file_glob.star
+++ b/cmd/devlore-test/devloretest/data/test_file_glob.star
@@ -7,9 +7,9 @@
 
 dir = t.tmp("globdir")
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=dir, chmod=0o755),
-    plan.file.write_text(destination_path=t.tmp("globdir/a.txt"), content="a", chmod=0o644),
-    plan.file.write_text(destination_path=t.tmp("globdir/b.txt"), content="b", chmod=0o644),
+    plan.file.mkdir(path=dir, mode=0o755),
+    plan.file.write_text(destination_path=t.tmp("globdir/a.txt"), content="a", mode=0o644),
+    plan.file.write_text(destination_path=t.tmp("globdir/b.txt"), content="b", mode=0o644),
     plan.file.glob(pattern=t.tmp("globdir/*.txt"), include_gitignored=True),
 ])
 

--- a/cmd/devlore-test/devloretest/data/test_file_lifecycle.star
+++ b/cmd/devlore-test/devloretest/data/test_file_lifecycle.star
@@ -12,8 +12,8 @@
 src = t.tmp("lifecycle_src.txt")
 dst = t.tmp("lifecycle_dst.txt")
 
-written = plan.file.write_text(destination_path=src, content="lifecycle test", chmod=0o644)
-copied  = plan.file.copy(source=written, destination_path=dst, chmod=0o644)
+written = plan.file.write_text(destination_path=src, content="lifecycle test", mode=0o644)
+copied  = plan.file.copy(source=written, destination_path=dst, mode=0o644)
 read    = plan.file.read_text(resource=copied)
 
 graph = plan.assemble_definition([written, copied, read])

--- a/cmd/devlore-test/devloretest/data/test_file_unlink.star
+++ b/cmd/devlore-test/devloretest/data/test_file_unlink.star
@@ -8,7 +8,7 @@
 target = t.tmp("unlink_target.txt")
 link   = t.tmp("unlink_link.txt")
 
-written  = plan.file.write_text(destination_path=target, content="keep me", chmod=0o644)
+written  = plan.file.write_text(destination_path=target, content="keep me", mode=0o644)
 linked   = plan.file.link(source_path=written, target_path=link)
 unlinked = plan.file.unlink(path=linked, prune=False, boundary="")
 

--- a/cmd/devlore-test/devloretest/data/test_flow_degraded_template.star
+++ b/cmd/devlore-test/devloretest/data/test_flow_degraded_template.star
@@ -5,7 +5,7 @@
 # The write_text result flows into the degraded template via a promise.
 # Graph should still complete successfully.
 
-written  = plan.file.write_text(destination_path=t.tmp("d.txt"), content="ok", chmod=0o644)
+written  = plan.file.write_text(destination_path=t.tmp("d.txt"), content="ok", mode=0o644)
 degraded = plan.degraded("wrote {{ .path }}", path=written)
 
 graph = plan.assemble_definition([written, degraded])

--- a/cmd/devlore-test/devloretest/data/test_flow_fatal_recovery.star
+++ b/cmd/devlore-test/devloretest/data/test_flow_fatal_recovery.star
@@ -6,7 +6,7 @@
 
 dest = t.tmp("to-be-undone.txt")
 
-written = plan.file.write_text(destination_path=dest, content="temporary", chmod=0o644)
+written = plan.file.write_text(destination_path=dest, content="temporary", mode=0o644)
 fatal   = plan.failed("abort after write")
 
 graph = plan.assemble_definition([written, fatal])

--- a/cmd/devlore-test/devloretest/data/test_flow_fatal_template.star
+++ b/cmd/devlore-test/devloretest/data/test_flow_fatal_template.star
@@ -6,7 +6,7 @@
 
 t.expect_error("fatal:.*startup failed")
 
-svc   = plan.file.write_text(destination_path=t.tmp("svc.txt"), content="myapp", chmod=0o644)
+svc   = plan.file.write_text(destination_path=t.tmp("svc.txt"), content="myapp", mode=0o644)
 fatal = plan.failed("{{ .service }} startup failed", service=svc)
 
 graph = plan.assemble_definition([svc, fatal])

--- a/cmd/devlore-test/devloretest/data/test_gather_advanced.star
+++ b/cmd/devlore-test/devloretest/data/test_gather_advanced.star
@@ -20,7 +20,7 @@ a1_paths = [t.tmp("a1_%d.txt" % i) for i in range(3)]
 a1_inv = plan.file.write_text(
     destination_path=plan.variable("item", default_value=None),
     content=plan.variable("greeting", default_value=None),
-    chmod=0o644,
+    mode=0o644,
 )
 a1 = plan.gather(items=a1_paths, limit=2, body=[a1_inv])
 
@@ -32,7 +32,7 @@ a2_path = t.tmp("a2.txt")
 a2_inv = plan.file.write_text(
     destination_path=a2_path,
     content=plan.variable("items", default_value=""),
-    chmod=0o644,
+    mode=0o644,
 )
 a2 = plan.gather(items=["sentinel"], limit=1, body=[a2_inv])
 
@@ -49,7 +49,7 @@ a4_paths = [t.tmp("a4_%d.txt" % i) for i in range(2)]
 a4_write_inv = plan.file.write_text(
     destination_path=plan.variable("item", default_value=None),
     content="data",
-    chmod=0o644,
+    mode=0o644,
 )
 a4_shell_inv = plan.shell.exec(command="true")
 a4 = plan.gather(items=a4_paths, limit=2, body=[a4_write_inv, a4_shell_inv])
@@ -59,13 +59,13 @@ a4 = plan.gather(items=a4_paths, limit=2, body=[a4_write_inv, a4_shell_inv])
 # region A5: gather composed with leaf nodes — pre-write completes, gather inherits parent frame
 
 a5_pre = t.tmp("a5_pre.txt")
-a5_pre_inv = plan.file.write_text(destination_path=a5_pre, content="before-gather", chmod=0o644)
+a5_pre_inv = plan.file.write_text(destination_path=a5_pre, content="before-gather", mode=0o644)
 
 a5_paths = [t.tmp("a5_%d.txt" % i) for i in range(2)]
 a5_inv = plan.file.write_text(
     destination_path=plan.variable("item", default_value=None),
     content=plan.variable("greeting", default_value=None),
-    chmod=0o644,
+    mode=0o644,
 )
 a5 = plan.gather(items=a5_paths, limit=2, body=[a5_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_gather_basic.star
+++ b/cmd/devlore-test/devloretest/data/test_gather_basic.star
@@ -19,7 +19,7 @@
 # region B1: single-item gather — body runs exactly once
 
 b1_out = t.tmp("b1.txt")
-b1_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="alpha", chmod=0o644)
+b1_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="alpha", mode=0o644)
 b1 = plan.gather(items=[b1_out], limit=1, body=[b1_inv])
 
 # endregion
@@ -29,7 +29,7 @@ b1 = plan.gather(items=[b1_out], limit=1, body=[b1_inv])
 b2_a = t.tmp("b2_a.txt")
 b2_b = t.tmp("b2_b.txt")
 b2_c = t.tmp("b2_c.txt")
-b2_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="bravo", chmod=0o644)
+b2_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="bravo", mode=0o644)
 b2 = plan.gather(items=[b2_a, b2_b, b2_c], limit=2, body=[b2_inv])
 
 # endregion
@@ -37,24 +37,24 @@ b2 = plan.gather(items=[b2_a, b2_b, b2_c], limit=2, body=[b2_inv])
 # region B3: many-items gather — items > limit, all dispatched eventually
 
 b3_paths = [t.tmp("b3_%d.txt" % i) for i in range(5)]
-b3_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="charlie", chmod=0o644)
+b3_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="charlie", mode=0o644)
 b3 = plan.gather(items=b3_paths, limit=3, body=[b3_inv])
 
 # endregion
 
 # region B4: empty items — body runs zero times, no error
 
-b4_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="never", chmod=0o644)
+b4_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="never", mode=0o644)
 b4 = plan.gather(items=[], limit=4, body=[b4_inv])
 b4_canary = t.tmp("b4_canary.txt")
-b4_canary_inv = plan.file.write_text(destination_path=b4_canary, content="reached", chmod=0o644)
+b4_canary_inv = plan.file.write_text(destination_path=b4_canary, content="reached", mode=0o644)
 
 # endregion
 
 # region B5: item binding — plan.variable("item") resolves per iteration
 
 b5_paths = [t.tmp("b5_%s.txt" % name) for name in ["alpha", "bravo", "charlie"]]
-b5_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="delta", chmod=0o644)
+b5_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="delta", mode=0o644)
 b5 = plan.gather(items=b5_paths, limit=2, body=[b5_inv])
 
 # endregion
@@ -63,7 +63,7 @@ b5 = plan.gather(items=b5_paths, limit=2, body=[b5_inv])
 
 b6 = plan.gather(items=["ignored-1", "ignored-2"], limit=2, body=[])
 b6_canary = t.tmp("b6_canary.txt")
-b6_canary_inv = plan.file.write_text(destination_path=b6_canary, content="reached", chmod=0o644)
+b6_canary_inv = plan.file.write_text(destination_path=b6_canary, content="reached", mode=0o644)
 
 # endregion
 

--- a/cmd/devlore-test/devloretest/data/test_gather_concurrency.star
+++ b/cmd/devlore-test/devloretest/data/test_gather_concurrency.star
@@ -18,7 +18,7 @@
 # region C1: limit=1 — serial execution
 
 c1_paths = [t.tmp("c1_%d.txt" % i) for i in range(3)]
-c1_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="serial", chmod=0o644)
+c1_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="serial", mode=0o644)
 c1 = plan.gather(items=c1_paths, limit=1, body=[c1_inv])
 
 # endregion
@@ -26,7 +26,7 @@ c1 = plan.gather(items=c1_paths, limit=1, body=[c1_inv])
 # region C2: limit=N (N>1) — parallel up to N
 
 c2_paths = [t.tmp("c2_%d.txt" % i) for i in range(4)]
-c2_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="par_n", chmod=0o644)
+c2_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="par_n", mode=0o644)
 c2 = plan.gather(items=c2_paths, limit=2, body=[c2_inv])
 
 # endregion
@@ -34,7 +34,7 @@ c2 = plan.gather(items=c2_paths, limit=2, body=[c2_inv])
 # region C3: limit > items count — caps at items.len
 
 c3_paths = [t.tmp("c3_%d.txt" % i) for i in range(2)]
-c3_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="over_lim", chmod=0o644)
+c3_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="over_lim", mode=0o644)
 c3 = plan.gather(items=c3_paths, limit=100, body=[c3_inv])
 
 # endregion
@@ -42,7 +42,7 @@ c3 = plan.gather(items=c3_paths, limit=100, body=[c3_inv])
 # region C4: limit=0 — falls through to platform default
 
 c4_paths = [t.tmp("c4_%d.txt" % i) for i in range(3)]
-c4_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="dflt", chmod=0o644)
+c4_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="dflt", mode=0o644)
 c4 = plan.gather(items=c4_paths, limit=0, body=[c4_inv])
 
 # endregion
@@ -50,7 +50,7 @@ c4 = plan.gather(items=c4_paths, limit=0, body=[c4_inv])
 # region C5: items > limit × 2 — multiple parallel batches
 
 c5_paths = [t.tmp("c5_%d.txt" % i) for i in range(10)]
-c5_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="batches", chmod=0o644)
+c5_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="batches", mode=0o644)
 c5 = plan.gather(items=c5_paths, limit=3, body=[c5_inv])
 
 # endregion
@@ -58,7 +58,7 @@ c5 = plan.gather(items=c5_paths, limit=3, body=[c5_inv])
 # region C6: per-iteration isolation — each iteration writes its own item value
 
 c6_paths = [t.tmp("c6_%d.txt" % i) for i in range(6)]
-c6_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="isolated", chmod=0o644)
+c6_inv = plan.file.write_text(destination_path=plan.variable("item", default_value=None), content="isolated", mode=0o644)
 c6 = plan.gather(items=c6_paths, limit=4, body=[c6_inv])
 
 # endregion

--- a/cmd/devlore-test/devloretest/data/test_gather_projection.star
+++ b/cmd/devlore-test/devloretest/data/test_gather_projection.star
@@ -15,12 +15,12 @@ items = [
 write_a = plan.file.write_text(
     destination_path=plan.item("path_a"),
     content=plan.item("content"),
-    chmod=0o644,
+    mode=0o644,
 )
 write_b = plan.file.write_text(
     destination_path=plan.variable("item", field="path_b"),
     content=plan.variable("item", field="content"),
-    chmod=0o644,
+    mode=0o644,
 )
 
 g = plan.gather(items=items, limit=2, body=[write_a, write_b])

--- a/cmd/devlore-test/devloretest/data/test_gather_projection_missing_field.star
+++ b/cmd/devlore-test/devloretest/data/test_gather_projection_missing_field.star
@@ -12,7 +12,7 @@ items = [{"path": t.tmp("never.txt")}]
 inv = plan.file.write_text(
     destination_path=plan.item("path"),
     content=plan.item("content"),
-    chmod=0o644,
+    mode=0o644,
 )
 
 plan.gather(items=items, limit=1, body=[inv])

--- a/cmd/devlore-test/devloretest/data/test_imm_file.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_file.star
@@ -17,7 +17,7 @@ t.expect_equal(file.parent(path="/some/dir/file.txt"), "/some/dir")
 
 # Write — returns a Resource (verify callable, not None)
 dest = t.tmp("imm_write.txt")
-written = file.write_text(destination_path=dest, content="immediate write", chmod=0o644)
+written = file.write_text(destination_path=dest, content="immediate write", mode=0o644)
 t.expect_equal(type(written), "struct")
 
 # ReadText — returns the file content as a string
@@ -32,12 +32,12 @@ t.expect_equal(file.exists(path=t.tmp("no_such_file")), False)
 
 # Mkdir and is_dir
 dir = t.tmp("imm_dir")
-file.mkdir(path=dir, chmod=0o755)
+file.mkdir(path=dir, mode=0o755)
 t.expect_equal(file.is_dir(path=dir), True)
 
 # Copy — returns a Resource
 dst = t.tmp("imm_copy.txt")
-copied = file.copy(source=dest, destination_path=dst, chmod=0o644)
+copied = file.copy(source=dest, destination_path=dst, mode=0o644)
 t.expect_equal(type(copied), "struct")
 
 # Move — returns a Resource
@@ -51,8 +51,8 @@ file.remove(path=moved, prune=False, boundary="")
 t.expect_equal(file.exists(path=moved), False)
 
 # Glob — returns a list
-file.write_text(destination_path=t.tmp("imm_dir/a.txt"), content="a", chmod=0o644)
-file.write_text(destination_path=t.tmp("imm_dir/b.txt"), content="b", chmod=0o644)
+file.write_text(destination_path=t.tmp("imm_dir/a.txt"), content="a", mode=0o644)
+file.write_text(destination_path=t.tmp("imm_dir/b.txt"), content="b", mode=0o644)
 matches = file.glob(pattern=t.tmp("imm_dir/*.txt"), include_gitignored=True)
 t.expect_equal(len(matches), 2)
 

--- a/cmd/devlore-test/devloretest/data/test_is_dir.star
+++ b/cmd/devlore-test/devloretest/data/test_is_dir.star
@@ -9,10 +9,10 @@
 dir    = t.tmp("is_dir_test")
 status = t.tmp("is_dir_status.txt")
 
-mkdir_inv  = plan.file.mkdir(path=dir, chmod=0o755)
+mkdir_inv  = plan.file.mkdir(path=dir, mode=0o755)
 dir_check  = plan.file.is_dir(path=dir)
 choice     = plan.choose(plan.case(when=dir_check, then=lambda: "is_dir"), default=lambda: "not_dir")
-status_inv = plan.file.write_text(destination_path=status, content=choice, chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content=choice, mode=0o644)
 
 graph = plan.assemble_definition([mkdir_inv, choice, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_is_file.star
+++ b/cmd/devlore-test/devloretest/data/test_is_file.star
@@ -9,10 +9,10 @@
 src    = t.tmp("is_file_src.txt")
 status = t.tmp("is_file_status.txt")
 
-written    = plan.file.write_text(destination_path=src, content="file check", chmod=0o644)
+written    = plan.file.write_text(destination_path=src, content="file check", mode=0o644)
 file_check = plan.file.is_file(path=src)
 choice     = plan.choose(plan.case(when=file_check, then=lambda: "is_file"), default=lambda: "not_file")
-status_inv = plan.file.write_text(destination_path=status, content=choice, chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content=choice, mode=0o644)
 
 graph = plan.assemble_definition([written, choice, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_link.star
+++ b/cmd/devlore-test/devloretest/data/test_link.star
@@ -8,7 +8,7 @@
 target = t.tmp("link_target.txt")
 link   = t.tmp("link_pointer.txt")
 
-written = plan.file.write_text(destination_path=target, content="linked content", chmod=0o644)
+written = plan.file.write_text(destination_path=target, content="linked content", mode=0o644)
 linked  = plan.file.link(source_path=written, target_path=link)
 
 graph = plan.assemble_definition([written, linked])

--- a/cmd/devlore-test/devloretest/data/test_mkdir_and_remove_all.star
+++ b/cmd/devlore-test/devloretest/data/test_mkdir_and_remove_all.star
@@ -13,8 +13,8 @@ dir  = t.tmp("mydir")
 file = t.tmp("mydir/nested.txt")
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=dir, chmod=0o755),
-    plan.file.write_text(destination_path=file, content="nested content", chmod=0o644),
+    plan.file.mkdir(path=dir, mode=0o755),
+    plan.file.write_text(destination_path=file, content="nested content", mode=0o644),
     plan.file.remove_all(path=dir, prune=False, boundary=""),
 ])
 

--- a/cmd/devlore-test/devloretest/data/test_move.star
+++ b/cmd/devlore-test/devloretest/data/test_move.star
@@ -8,7 +8,7 @@
 src = t.tmp("move_src.txt")
 dst = t.tmp("move_dst.txt")
 
-written = plan.file.write_text(destination_path=src, content="moving data", chmod=0o644)
+written = plan.file.write_text(destination_path=src, content="moving data", mode=0o644)
 moved   = plan.file.move(source_path=written, destination_path=dst)
 
 graph = plan.assemble_definition([written, moved])

--- a/cmd/devlore-test/devloretest/data/test_orphan_unattached.star
+++ b/cmd/devlore-test/devloretest/data/test_orphan_unattached.star
@@ -8,8 +8,8 @@
 
 t.expect_error("orphan invocation")
 
-attached = plan.file.mkdir(path=t.tmp("made"), chmod=0o755)
-orphan   = plan.file.mkdir(path=t.tmp("stray"), chmod=0o755)
+attached = plan.file.mkdir(path=t.tmp("made"), mode=0o755)
+orphan   = plan.file.mkdir(path=t.tmp("stray"), mode=0o755)
 
 # `orphan` is deliberately absent from the root set — never rooted by any container.
 plan.assemble_definition([attached])

--- a/cmd/devlore-test/devloretest/data/test_promise_type_mismatch.star
+++ b/cmd/devlore-test/devloretest/data/test_promise_type_mismatch.star
@@ -3,13 +3,13 @@
 
 # test_promise_type_mismatch.star — Verify the plan-time promise type-check fires end-to-end (phase-8 step 16).
 #
-# plan.file.mkdir produces a *file.Resource; binding its promise to write_text's os.FileMode chmod slot has no
+# plan.file.mkdir produces a *file.Resource; binding its promise to write_text's os.FileMode mode slot has no
 # conversion path, so plan.assemble_definition fails with checkPromiseTypes' "cannot bind" violation.
 # Plan-time validation only: the script never calls t.run.
 
 t.expect_error("cannot bind")
 
-made = plan.file.mkdir(path=t.tmp("made"), chmod=0o755)
-bad  = plan.file.write_text(destination_path=t.tmp("out.txt"), content="x", chmod=made)
+made = plan.file.mkdir(path=t.tmp("made"), mode=0o755)
+bad  = plan.file.write_text(destination_path=t.tmp("out.txt"), content="x", mode=made)
 
 plan.assemble_definition([made, bad])

--- a/cmd/devlore-test/devloretest/data/test_round_trip_writ_adopt.star
+++ b/cmd/devlore-test/devloretest/data/test_round_trip_writ_adopt.star
@@ -26,7 +26,7 @@ t.set_flags({
 })
 
 plan.subgraph(body=[
-    plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755),
+    plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
     plan.file.move(source_path=plan.variable("source_path"), destination_path=plan.variable("dest_path")),
     plan.file.link(source_path=plan.variable("dest_path"), target_path=plan.variable("source_path")),
 ])

--- a/cmd/devlore-test/devloretest/data/test_wait_until.star
+++ b/cmd/devlore-test/devloretest/data/test_wait_until.star
@@ -14,10 +14,10 @@
 ready  = t.tmp("ready.txt")
 status = t.tmp("wait_status.txt")
 
-writer     = plan.file.write_text(destination_path=ready, content="up", chmod=0o644)
+writer     = plan.file.write_text(destination_path=ready, content="up", mode=0o644)
 wait_ready = plan.wait_until(body=plan.file.exists(path=ready), timeout="10s", interval="1s")
 wait_value = plan.wait_until(body=lambda: "ready", timeout="10s", interval="1s")
-status_inv = plan.file.write_text(destination_path=status, content=wait_value, chmod=0o644)
+status_inv = plan.file.write_text(destination_path=status, content=wait_value, mode=0o644)
 
 graph = plan.assemble_definition([writer, wait_ready, wait_value, status_inv])
 

--- a/cmd/devlore-test/devloretest/data/test_walk_tree.star
+++ b/cmd/devlore-test/devloretest/data/test_walk_tree.star
@@ -5,13 +5,13 @@
 
 # Set up temp directory with files.
 dir = t.tmp("walk_root")
-file.mkdir(path=dir, chmod=0o755)
-file.write_text(destination_path=t.tmp("walk_root/a.txt"), content="a", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_root/b.txt"), content="b", chmod=0o644)
+file.mkdir(path=dir, mode=0o755)
+file.write_text(destination_path=t.tmp("walk_root/a.txt"), content="a", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_root/b.txt"), content="b", mode=0o644)
 
 sub = t.tmp("walk_root/sub")
-file.mkdir(path=sub, chmod=0o755)
-file.write_text(destination_path=t.tmp("walk_root/sub/c.txt"), content="c", chmod=0o644)
+file.mkdir(path=sub, mode=0o755)
+file.write_text(destination_path=t.tmp("walk_root/sub/c.txt"), content="c", mode=0o644)
 
 # Walk and collect relative paths.
 def collector(initial, resource, path, stack):

--- a/cmd/devlore-test/devloretest/data/test_walk_tree_closure.star
+++ b/cmd/devlore-test/devloretest/data/test_walk_tree_closure.star
@@ -7,11 +7,11 @@
 # passed as the fn parameter.
 
 dir = t.tmp("walk_closure")
-file.mkdir(path=dir, chmod=0o755)
-file.write_text(destination_path=t.tmp("walk_closure/hello.py"), content="print", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_closure/readme.md"), content="docs", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_closure/main.py"), content="main", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_closure/notes.txt"), content="notes", chmod=0o644)
+file.mkdir(path=dir, mode=0o755)
+file.write_text(destination_path=t.tmp("walk_closure/hello.py"), content="print", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_closure/readme.md"), content="docs", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_closure/main.py"), content="main", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_closure/notes.txt"), content="notes", mode=0o644)
 
 # Closure variable: filter by extension.
 ext = ".py"

--- a/cmd/devlore-test/devloretest/data/test_walk_tree_gitignore.star
+++ b/cmd/devlore-test/devloretest/data/test_walk_tree_gitignore.star
@@ -7,15 +7,15 @@
 # then walks with include_gitignored=False to verify filtering.
 
 dir = t.tmp("walk_gi")
-file.mkdir(path=dir, chmod=0o755)
+file.mkdir(path=dir, mode=0o755)
 
 # Write .gitignore that excludes .log files.
-file.write_text(destination_path=t.tmp("walk_gi/.gitignore"), content="*.log\n", chmod=0o644)
+file.write_text(destination_path=t.tmp("walk_gi/.gitignore"), content="*.log\n", mode=0o644)
 
 # Write a mix of included and excluded files.
-file.write_text(destination_path=t.tmp("walk_gi/keep.txt"), content="keep", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_gi/skip.log"), content="skip", chmod=0o644)
-file.write_text(destination_path=t.tmp("walk_gi/also_keep.md"), content="md", chmod=0o644)
+file.write_text(destination_path=t.tmp("walk_gi/keep.txt"), content="keep", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_gi/skip.log"), content="skip", mode=0o644)
+file.write_text(destination_path=t.tmp("walk_gi/also_keep.md"), content="md", mode=0o644)
 
 # Walk with gitignore filtering.
 def collector(initial, resource, path, stack):

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt.star
@@ -24,7 +24,7 @@ t.set_flags({
     "dest_path":   dest_path,
 })
 
-mkdir = plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755)
+mkdir = plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755)
 move  = plan.file.move(source_path=plan.variable("source_path"), destination_path=plan.variable("dest_path"))
 link  = plan.file.link(source_path=plan.variable("dest_path"), target_path=plan.variable("source_path"))
 

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_missing_required.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_missing_required.star
@@ -15,7 +15,7 @@ dest_dir = t.tmp("adopt-dest-missing")
 # No t.set_flags / t.set_overrides — "dest_dir" is unresolvable.
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755),
+    plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
 ])
 
 t.expect_error("dest_dir.*is required but no source supplied a value")

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_origin_full.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_origin_full.star
@@ -15,7 +15,7 @@ t.set_env_prefix("DEVLORE_TEST")
 t.set_env({"DEVLORE_TEST_DEST_DIR": dest_dir})
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755),
+    plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
 ])
 
 t.expect_variable("dest_dir", origin="env:DEVLORE_TEST_DEST_DIR")

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_origin_namespace.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_origin_namespace.star
@@ -14,7 +14,7 @@ dest_dir = t.tmp("adopt-dest-origin-ns")
 t.set_flags({"dest_dir": dest_dir})
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755),
+    plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
 ])
 
 # Phase 4+ assertions:

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_precedence.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_precedence.star
@@ -17,7 +17,7 @@ t.set_config({"layer": "config-value"})
 _ = plan.variable("layer", default_value="default-value")  # declare the parameter; reference unused except for binding
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=t.tmp("precedence-dest"), chmod=0o755),
+    plan.file.mkdir(path=t.tmp("precedence-dest"), mode=0o755),
 ])
 
 # Phase 4+ assertion:

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_subgraph.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_subgraph.star
@@ -27,7 +27,7 @@ t.set_flags({
 # Phase 8 (writ adopt migration) will use this exact subgraph shape inside the writ-side helper. The
 # Phase 1 plan-doc captures the intent here so the bubble-up contract is exercised at the .star level.
 sg = plan.subgraph(body=[
-    plan.file.mkdir(path=plan.variable("dest_dir"), chmod=0o755),
+    plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
     plan.file.move(source_path=plan.variable("source_path"), destination_path=plan.variable("dest_path")),
     plan.file.link(source_path=plan.variable("dest_path"), target_path=plan.variable("source_path")),
 ])

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_type_mismatch.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_type_mismatch.star
@@ -3,7 +3,7 @@
 
 # test_writ_adopt_type_mismatch.star — Variable binding: type mismatch at preflight.
 #
-# Supplies an override of the wrong Go type for a parameter (chmod expects an int mode; flag gives a string).
+# Supplies an override of the wrong Go type for a parameter (mode expects an int mode; flag gives a string).
 # Phase 4 (preflight validation) should detect the mismatch during the bindVariables pass and aggregate it
 # into the D5 envelope.
 #
@@ -11,13 +11,13 @@
 # expected discoverable error in Phase 4).
 
 t.set_flags({
-    "chmod": "not_an_int",  # plan.file.mkdir.chmod is os.FileMode; string is the wrong type
+    "mode": "not_an_int",  # plan.file.mkdir.mode is os.FileMode; string is the wrong type
 })
 
 graph = plan.assemble_definition([
-    plan.file.mkdir(path=t.tmp("type-mismatch-dest"), chmod=plan.variable("chmod")),
+    plan.file.mkdir(path=t.tmp("type-mismatch-dest"), mode=plan.variable("mode")),
 ])
 
-t.expect_error("chmod.*not assignable to declared type")
+t.expect_error("mode.*not assignable to declared type")
 
 t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_write_and_read.star
+++ b/cmd/devlore-test/devloretest/data/test_write_and_read.star
@@ -6,7 +6,7 @@
 # insertion order within the same path depth, so write runs first.
 dest = t.tmp("readback.txt")
 graph = plan.assemble_definition([
-    plan.file.write_text(destination_path=dest, content="read me back", chmod=0o644),
+    plan.file.write_text(destination_path=dest, content="read me back", mode=0o644),
     plan.file.read_text(resource=dest),
 ])
 t.expect_file(dest, content="read me back")

--- a/cmd/devlore-test/devloretest/data/test_write_bytes.star
+++ b/cmd/devlore-test/devloretest/data/test_write_bytes.star
@@ -8,7 +8,7 @@
 dest = t.tmp("bytes_output.bin")
 
 graph = plan.assemble_definition([
-    plan.file.write_bytes(destination_path=dest, content="raw bytes here", chmod=0o644),
+    plan.file.write_bytes(destination_path=dest, content="raw bytes here", mode=0o644),
 ])
 
 t.expect_file(dest, content="raw bytes here")

--- a/cmd/devlore-test/devloretest/data/test_write_text.star
+++ b/cmd/devlore-test/devloretest/data/test_write_text.star
@@ -4,7 +4,7 @@
 # test_write_text.star — Verify plan.file.write_text creates a file with correct content.
 dest = t.tmp("hello.txt")
 graph = plan.assemble_definition([
-    plan.file.write_text(destination_path=dest, content="hello world", chmod=0o644),
+    plan.file.write_text(destination_path=dest, content="hello world", mode=0o644),
 ])
 t.run(graph)
 t.expect_file(dest, content="hello world")

--- a/cmd/internal/cli/store.go
+++ b/cmd/internal/cli/store.go
@@ -133,15 +133,11 @@ func WriteTrace(trace *op.Trace) (path string, err error) {
 		return "", err
 	}
 
-	// NewPath rebases an absolute path onto the root, so the display string and the root-relative path stay
-	// one value rather than two spellings that can drift.
-	latest := stateRoot.NewPath(directory, "latest.yaml")
-	//nolint:errcheck // diagnose-ignored-error: stale link; see docs/architecture/2.8-eventing-infrastructure.md
-	_ = stateRoot.Remove(latest) // best-effort: replace any prior link
-	if err := stateRoot.Symlink(filename, latest); err != nil {
-		return "", fmt.Errorf("link latest trace %s: %w", latest.Abs(), err)
-	}
-
+	// The index is appended BEFORE the convenience link, because the trace is already durable at this point
+	// and the index is what readers enumerate. Linking first meant any link failure discarded the index entry
+	// for a trace sitting on disk — silently, since every caller warns rather than fails. That is not a
+	// Windows-only defect, but Windows is where it fires for ordinary users: creating a symlink there needs
+	// Developer Mode or SeCreateSymbolicLinkPrivilege (#438).
 	entry := IndexEntry{
 		At:            time.Now().UTC(),
 		Event:         IndexEventTrace,
@@ -150,6 +146,15 @@ func WriteTrace(trace *op.Trace) (path string, err error) {
 	}
 	if err := appendIndexEntry(stateRoot, entry); err != nil {
 		return "", err
+	}
+
+	// NewPath rebases an absolute path onto the root, so the display string and the root-relative path stay
+	// one value rather than two spellings that can drift.
+	latest := stateRoot.NewPath(directory, "latest.yaml")
+	//nolint:errcheck // diagnose-ignored-error: stale link; see docs/architecture/2.8-eventing-infrastructure.md
+	_ = stateRoot.Remove(latest) // best-effort: replace any prior link
+	if err := stateRoot.Symlink(filename, latest); err != nil {
+		return "", fmt.Errorf("link latest trace %s: %w", latest.Abs(), err)
 	}
 
 	return path, nil

--- a/cmd/internal/cli/store_test.go
+++ b/cmd/internal/cli/store_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// TestWriteTrace_IndexSurvivesLinkFailure pins the ordering fixed for #438: the run index is appended before
+// the `latest.yaml` convenience link, so a link that cannot be created never costs the index its entry.
+//
+// The failure it guards is silent rather than loud. Every caller of [WriteTrace] warns instead of failing, so
+// before the reorder a machine that cannot create symlinks — an ordinary Windows user, lacking Developer Mode
+// and administrator rights — wrote the trace to disk, lost the index entry, and reported success.
+//
+// The link failure is forced portably by occupying `latest.yaml` with a non-empty directory: the best-effort
+// Remove cannot unlink it, so Symlink fails on every platform rather than only where privileges are short.
+func TestWriteTrace_IndexSurvivesLinkFailure(t *testing.T) {
+
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const checksum = "sha256:5eaf00d5eaf00d5eaf00d5eaf00d5eaf00d5eaf00d5eaf00d5eaf00d5eaf00d5"
+	trace := &op.Trace{GraphChecksum: checksum}
+
+	// Occupy the link name with a directory that cannot be removed.
+	directory := filepath.Join(TracesDir(), safeChecksum(checksum))
+	occupied := filepath.Join(directory, "latest.yaml")
+	if err := os.MkdirAll(filepath.Join(occupied, "occupant"), 0o750); err != nil { //nolint:gosec // G301: test fixture
+		t.Fatalf("preparing the occupied link name: %v", err)
+	}
+
+	path, err := WriteTrace(trace)
+	if err == nil {
+		t.Fatal("WriteTrace succeeded; the occupied link name should have failed the symlink")
+	}
+	if path != "" {
+		t.Errorf("path = %q on failure, want empty", path)
+	}
+
+	// The trace document is durable even though the link failed.
+	written, globErr := filepath.Glob(filepath.Join(directory, "*.yaml"))
+	if globErr != nil {
+		t.Fatalf("globbing the trace directory: %v", globErr)
+	}
+	var traceFiles []string
+	for _, candidate := range written {
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			traceFiles = append(traceFiles, candidate)
+		}
+	}
+	if len(traceFiles) != 1 {
+		t.Fatalf("trace files = %v, want exactly one", traceFiles)
+	}
+
+	// The index recorded it. This is the assertion that fails if the link is ever moved back ahead of the
+	// index append.
+	entries, err := ReadIndex()
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("index entries = %d, want 1 — the index lost a trace that is on disk", len(entries))
+	}
+	if entries[0].GraphChecksum != checksum {
+		t.Errorf("index GraphChecksum = %q, want %q", entries[0].GraphChecksum, checksum)
+	}
+	if entries[0].Event != IndexEventTrace {
+		t.Errorf("index Event = %q, want %q", entries[0].Event, IndexEventTrace)
+	}
+	if got, want := entries[0].TraceFile, filepath.Base(traceFiles[0]); got != want {
+		t.Errorf("index TraceFile = %q, want %q", got, want)
+	}
+}

--- a/cmd/writ/writ/adopt/plan.go
+++ b/cmd/writ/writ/adopt/plan.go
@@ -70,9 +70,9 @@ func BuildGraph(env *op.RuntimeEnvironment, items []Item) (*op.Graph, error) {
 		seenDirs[item.DestDir] = struct{}{}
 
 		mkdir, err := planProvider.Plan(file.Mkdir, nil, map[string]any{
-			"path":  item.DestDir,
-			"chmod": os.FileMode(0o755),
-			"chown": "",
+			"path": item.DestDir,
+			"mode": os.FileMode(0o755),
+			"user": "", "group": "",
 		})
 		if err != nil {
 			return nil, fmt.Errorf("adopt.BuildGraph: plan file.mkdir: %w", err)

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -179,8 +179,8 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 		invocation, err := provider.Plan(file.WriteText, nil, map[string]any{
 			"destination_path": f.Target,
 			"content":          rendered,
-			"chmod":            mode,
-			"chown":            "",
+			"mode":             mode,
+			"user":             "", "group": "",
 		})
 		return invocation, string(file.WriteText), err
 
@@ -206,8 +206,8 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 		invocation, err := provider.Plan(file.WriteText, nil, map[string]any{
 			"destination_path": f.Target,
 			"content":          rendered,
-			"chmod":            os.FileMode(0o600),
-			"chown":            "",
+			"mode":             os.FileMode(0o600),
+			"user":             "", "group": "",
 		})
 		return invocation, string(file.WriteText), err
 
@@ -337,9 +337,9 @@ func planParentDirectories(provider *plan.Provider, files []*tree.FileEntry) err
 
 	for _, directory := range directories {
 		if _, err := provider.Plan(file.Mkdir, nil, map[string]any{
-			"path":  directory,
-			"chmod": os.FileMode(0o755),
-			"chown": "",
+			"path": directory,
+			"mode": os.FileMode(0o755),
+			"user": "", "group": "",
 		}); err != nil {
 			return fmt.Errorf("plan mkdir %s: %w", directory, err)
 		}

--- a/cmd/writ/writ/migrate/plan_builder.go
+++ b/cmd/writ/writ/migrate/plan_builder.go
@@ -55,9 +55,9 @@ func newPlanBuilder(environment *op.RuntimeEnvironment, project string) (*planBu
 // Mkdir plans a directory-creation invocation.
 func (p *planBuilder) Mkdir(path string) *op.Invocation {
 	return p.add(file.Mkdir, map[string]any{
-		"path":  path,
-		"chmod": os.FileMode(0o755),
-		"chown": "",
+		"path": path,
+		"mode": os.FileMode(0o755),
+		"user": "", "group": "",
 	})
 }
 
@@ -66,8 +66,8 @@ func (p *planBuilder) Copy(source, path string) *op.Invocation {
 	return p.add(file.Copy, map[string]any{
 		"source":           source,
 		"destination_path": path,
-		"chmod":            os.FileMode(0o644),
-		"chown":            "",
+		"mode":             os.FileMode(0o644),
+		"user":             "", "group": "",
 	})
 }
 

--- a/cmd/writ/writ/migrate/receipt_integration_test.go
+++ b/cmd/writ/writ/migrate/receipt_integration_test.go
@@ -39,9 +39,9 @@ func TestExecutionTrace_SerializesAsMigrationReceipt(t *testing.T) {
 	planProvider := plan.NewProvider(environment)
 
 	invocation, err := planProvider.Plan(file.Mkdir, nil, map[string]any{
-		"path":  filepath.Join(tmp, "created"),
-		"chmod": os.FileMode(0o755),
-		"chown": "",
+		"path": filepath.Join(tmp, "created"),
+		"mode": os.FileMode(0o755),
+		"user": "", "group": "",
 	})
 	if err != nil {
 		t.Fatalf("Plan(file.mkdir): %v", err)

--- a/cmd/writ/writ/migrate/register.go
+++ b/cmd/writ/writ/migrate/register.go
@@ -100,9 +100,9 @@ func buildRegistrationGraph(
 	planProvider := plan.NewProvider(environment)
 
 	mkdirInvocation, err := planProvider.Plan(file.Mkdir, nil, map[string]any{
-		"path":  filepath.Dir(layerDir),
-		"chmod": os.FileMode(0o755),
-		"chown": "",
+		"path": filepath.Dir(layerDir),
+		"mode": os.FileMode(0o755),
+		"user": "", "group": "",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("migrate.RegisterLayer: plan file.mkdir: %w", err)

--- a/pkg/op/default_func.go
+++ b/pkg/op/default_func.go
@@ -19,7 +19,7 @@ import (
 //   - env:      live runtime environment from the dispatching call. Always non-nil at slot-fill; registered
 //     functions may rely on env.Status, env.Root, env.Catalog, etc. without a nil check.
 //   - siblings: already-filled slot values from the same dispatch, keyed by parameter name. Nil-safe lookups
-//     via the standard `v, ok := siblings[name]` form. Functions that don't consult siblings (umask, chmod,
+//     via the standard `v, ok := siblings[name]` form. Functions that don't consult siblings (umask, mode,
 //     env) ignore this argument.
 //   - args:     argument values produced by recursively evaluating each child node of the CommandNode in
 //     announce-declared order. Functions validate arity and per-argument Kind before extracting concrete

--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -386,7 +386,7 @@ func extractEntry(
 
 	switch entry.Kind {
 	case entryDir:
-		product, receipt, err := fileProvider.Mkdir(activationRecord, target, entry.Mode, "")
+		product, receipt, err := fileProvider.Mkdir(activationRecord, target, entry.Mode, "", "")
 		if err != nil {
 			return nil, nil, fmt.Errorf("archive: mkdir %q: %w", target, err)
 		}

--- a/pkg/op/provider/encryption/gen/provider.gen.go
+++ b/pkg/op/provider/encryption/gen/provider.gen.go
@@ -17,7 +17,7 @@ func init() {
 		op.RoleAction,
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
-			"DecryptSopsFile": {ParameterNames: []string{"source", "destination_path"}},
-			"EncryptFile":     {ParameterNames: []string{"source", "destination_path"}},
+			"DecryptSopsFile": {ParameterNames: []string{"source", "destination_path", "mode?=0o600"}},
+			"EncryptFile":     {ParameterNames: []string{"source", "destination_path", "mode?=0o600"}},
 		})
 }

--- a/pkg/op/provider/encryption/provider.go
+++ b/pkg/op/provider/encryption/provider.go
@@ -6,6 +6,7 @@ package encryption
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
@@ -44,16 +45,27 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 //
 // Identity for the destination is constructed by [file.DiscoverRegular].
 //
+// `mode` is floored: the decrypted product is plaintext whose sensitivity was already declared by the act of
+// encrypting it, so a mode carrying group or other bits is refused rather than honored. 0o600 and 0o400 are the
+// useful values; the default is 0o600.
+//
 // Parameters:
 //   - `activationRecord`: the dispatch activation (the required floor for compensable actions — step 27).
 //   - `source`: [file.Regular] identifying the encrypted SOPS file.
 //   - `destinationPath`: the path where the decrypted content will be written.
+//   - `mode`: the [os.FileMode] applied to the decrypted file; refused if it grants group or other access.
 //
 // Returns:
 //   - `*file.Regular`: the destination resource with populated metadata.
 //   - `*Receipt`: compensation state for removing the decrypted file.
-//   - `error`: any error from reading, decrypting, or writing.
-func (p *Provider) DecryptSopsFile(activationRecord *op.ActivationRecord, source *file.Regular, destinationPath string) (*file.Regular, *Receipt, error) {
+//   - `error`: any error from the mode floor, reading, decrypting, or writing.
+//
+// +devlore:defaults mode=0o600
+func (p *Provider) DecryptSopsFile(activationRecord *op.ActivationRecord, source *file.Regular, destinationPath string, mode os.FileMode) (*file.Regular, *Receipt, error) {
+
+	if err := enforceSecretFloor(mode); err != nil {
+		return nil, nil, err
+	}
 
 	result, err := file.DiscoverRegular(p.RuntimeEnvironment(), destinationPath)
 
@@ -77,7 +89,7 @@ func (p *Provider) DecryptSopsFile(activationRecord *op.ActivationRecord, source
 	}
 
 	// 3. Write cleartext to the destination path
-	if err := root.WriteFile(root.NewPath(result.SourcePath.Abs()), cleartext, 0o600); err != nil {
+	if err := root.WriteFile(root.NewPath(result.SourcePath.Abs()), cleartext, mode); err != nil {
 		return nil, nil, fmt.Errorf("failed to write destination: %w", err)
 	}
 
@@ -117,16 +129,23 @@ func (p *Provider) CompensateDecryptSopsFile(activationRecord *op.ActivationReco
 // [sops.Encrypter] walking up from source to the [RuntimeEnvironment] Root, then the XDG fallback. Identity for the
 // destination is constructed by [file.DiscoverRegular].
 //
+// `mode` is NOT floored here: the product is ciphertext, which is safe at rest by construction and is typically
+// committed to a repository that will store it 0o644 regardless. The default stays 0o600 so behavior is unchanged
+// unless a caller asks otherwise.
+//
 // Parameters:
 //   - `activationRecord`: the dispatch activation (the required floor for compensable actions — step 27).
 //   - `source`: [file.Regular] identifying the cleartext file to encrypt.
 //   - `destinationPath`: the path where the encrypted content will be written.
+//   - `mode`: the [os.FileMode] applied to the encrypted file.
 //
 // Returns:
 //   - `*file.Regular`: the destination resource with populated metadata.
 //   - `*Receipt`: compensation state for removing the encrypted file.
 //   - `error`: any error from reading, encrypting, or writing.
-func (p *Provider) EncryptFile(activationRecord *op.ActivationRecord, source *file.Regular, destinationPath string) (*file.Regular, *Receipt, error) {
+//
+// +devlore:defaults mode=0o600
+func (p *Provider) EncryptFile(activationRecord *op.ActivationRecord, source *file.Regular, destinationPath string, mode os.FileMode) (*file.Regular, *Receipt, error) {
 
 	result, err := file.DiscoverRegular(p.RuntimeEnvironment(), destinationPath)
 
@@ -149,7 +168,7 @@ func (p *Provider) EncryptFile(activationRecord *op.ActivationRecord, source *fi
 	}
 
 	// 3. Write the ciphertext to the destination path
-	if err := root.WriteFile(root.NewPath(result.SourcePath.Abs()), ciphertext, 0o600); err != nil {
+	if err := root.WriteFile(root.NewPath(result.SourcePath.Abs()), ciphertext, mode); err != nil {
 		return nil, nil, fmt.Errorf("failed to write destination: %w", err)
 	}
 
@@ -186,3 +205,28 @@ func (p *Provider) CompensateEncryptFile(activationRecord *op.ActivationRecord, 
 // endregion
 
 // endregion
+
+// ---------------------------------------------------------------------------------------------------- helpers
+
+// enforceSecretFloor rejects a mode that would leave decrypted plaintext readable beyond its owner.
+//
+// Encrypting a file is itself the declaration that its contents are sensitive, so the deployed mode is derived from
+// that declaration rather than re-stated per call site. Taking `mode` as a parameter would reopen that decision to a
+// caller who can get it wrong, and a world-readable secret fails silently — the file is written, the run succeeds, and
+// nothing reports it. The floor keeps the useful variation (0o600 versus a read-only 0o400) and refuses the rest.
+//
+// Parameters:
+//   - `mode`: the caller-supplied mode for a decrypted product.
+//
+// Returns:
+//   - `error`: non-nil when `mode` grants any group or other access.
+func enforceSecretFloor(mode os.FileMode) error {
+
+	if beyondOwner := mode.Perm() & 0o077; beyondOwner != 0 {
+		return fmt.Errorf(
+			"encryption: mode %04o would leave decrypted plaintext readable beyond its owner (offending bits %04o); "+
+				"a decrypted secret must not grant group or other access", mode.Perm(), beyondOwner)
+	}
+
+	return nil
+}

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"filippo.io/age"
@@ -107,6 +108,63 @@ func TestCompensateDecryptSopsFile_MissingFile(t *testing.T) {
 	}
 }
 
+// --- the secret-mode floor ---
+
+// TestEnforceSecretFloor_RefusesAccessBeyondOwner pins the rule that makes the mode parameter safe to expose.
+//
+// Encrypting a file is the declaration that its contents are sensitive, so the decrypted product's mode follows from
+// that declaration. Accepting a mode without a floor would reopen the decision to a caller who can get it wrong, and a
+// world-readable secret fails silently: the file is written, the run succeeds, and nothing reports it.
+func TestEnforceSecretFloor_RefusesAccessBeyondOwner(t *testing.T) {
+
+	cases := []struct {
+		name string
+		mode os.FileMode
+		want bool
+	}{
+		{"owner read-write", 0o600, true},
+		{"owner read-only", 0o400, true},
+		{"owner all", 0o700, true},
+		{"group read", 0o640, false},
+		{"other read", 0o604, false},
+		{"world readable", 0o644, false},
+		{"world writable", 0o666, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforceSecretFloor(tc.mode)
+			if tc.want && err != nil {
+				t.Errorf("enforceSecretFloor(%04o) = %v, want nil", tc.mode, err)
+			}
+			if !tc.want && err == nil {
+				t.Errorf("enforceSecretFloor(%04o) = nil, want an error", tc.mode)
+			}
+		})
+	}
+}
+
+// TestDecryptSopsFile_RefusesReadableMode proves the floor is enforced at the action, not merely available as a helper
+// -- and that it is refused BEFORE any decryption happens, so a rejected call never materializes plaintext.
+func TestDecryptSopsFile_RefusesReadableMode(t *testing.T) {
+
+	tmp := t.TempDir()
+	p := testProviderWithSops(t, tmp)
+	source, _ := file.DiscoverRegular(p.RuntimeEnvironment(), filepath.Join(tmp, "encrypted.yaml"))
+	destination := filepath.Join(tmp, "out.yaml")
+
+	_, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination, 0o644)
+	if err == nil {
+		t.Fatal("DecryptSopsFile with mode 0644: want an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "beyond its owner") {
+		t.Errorf("error = %q, want it to name the floor", err.Error())
+	}
+	if _, statErr := os.Stat(destination); statErr == nil {
+		t.Error("a refused decrypt wrote its destination anyway")
+	}
+}
+
 // --- DecryptSopsFile ---
 
 func TestDecryptSopsFile_SourceReadFailure(t *testing.T) {
@@ -116,7 +174,7 @@ func TestDecryptSopsFile_SourceReadFailure(t *testing.T) {
 	source, _ := file.DiscoverRegular(runtimeEnvironment, "/nonexistent/encrypted.yaml")
 	destination := filepath.Join(tmp, "out.yaml")
 
-	_, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination)
+	_, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination, 0o600)
 	if err == nil {
 		t.Fatal("expected error for unresolvable source")
 	}
@@ -140,7 +198,7 @@ func TestDecryptSopsFile_NilSopsClient(t *testing.T) {
 	}
 	destination := filepath.Join(tmp, "out.yaml")
 
-	_, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination)
+	_, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination, 0o600)
 	if err == nil {
 		t.Fatal("expected error when SopsClient is nil")
 	}
@@ -220,7 +278,7 @@ func TestDecryptSopsFile_RoundTrip(t *testing.T) {
 
 	destination := filepath.Join(tmp, "secret.dec.yaml")
 
-	result, receipt, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination)
+	result, receipt, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination, 0o600)
 	if err != nil {
 		t.Fatalf("DecryptSopsFile: %v", err)
 	}
@@ -270,7 +328,7 @@ func TestDecryptSopsFile_CompensateRoundTrip(t *testing.T) {
 
 	destination := filepath.Join(tmp, "secret.dec.yaml")
 
-	_, receipt, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination)
+	_, receipt, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), source, destination, 0o600)
 	if err != nil {
 		t.Fatalf("DecryptSopsFile: %v", err)
 	}
@@ -370,7 +428,7 @@ func TestEncryptFile_RoundTrip(t *testing.T) {
 
 	destPath := filepath.Join(tmp, "secret.enc.yaml")
 
-	result, receipt, err := p.EncryptFile(testActivation(t, p.RuntimeEnvironment()), source, destPath)
+	result, receipt, err := p.EncryptFile(testActivation(t, p.RuntimeEnvironment()), source, destPath, 0o600)
 	if err != nil {
 		t.Fatalf("EncryptFile: %v", err)
 	}
@@ -396,7 +454,7 @@ func TestEncryptFile_RoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	decPath := filepath.Join(tmp, "secret.dec.yaml")
-	if _, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), encResource, decPath); err != nil {
+	if _, _, err := p.DecryptSopsFile(testActivation(t, p.RuntimeEnvironment()), encResource, decPath, 0o600); err != nil {
 		t.Fatalf("DecryptSopsFile: %v", err)
 	}
 	decrypted, err := os.ReadFile(decPath)

--- a/pkg/op/provider/file/gen/provider.gen.go
+++ b/pkg/op/provider/file/gen/provider.gen.go
@@ -18,7 +18,7 @@ func init() {
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Backup":     {ParameterNames: []string{"source_path", "backup_suffix"}},
-			"Copy":       {ParameterNames: []string{"source", "destination_path", "chmod?={{ umask 0o755 }}", "chown?=\"\""}},
+			"Copy":       {ParameterNames: []string{"source", "destination_path", "mode?={{ umask 0o755 }}", "user?=\"\"", "group?=\"\""}},
 			"Exists":     {ParameterNames: []string{"path"}},
 			"Find":       {ParameterNames: []string{"pattern", "include_gitignored?=false"}},
 			"Glob":       {ParameterNames: []string{"pattern", "include_gitignored?=false"}},
@@ -26,7 +26,7 @@ func init() {
 			"IsFile":     {ParameterNames: []string{"path"}},
 			"Join":       {ParameterNames: []string{"*parts"}},
 			"Link":       {ParameterNames: []string{"source_path", "target_path", "verbatim?=false"}},
-			"Mkdir":      {ParameterNames: []string{"path", "chmod?={{ umask 0o777 }}", "chown?=\"\""}},
+			"Mkdir":      {ParameterNames: []string{"path", "mode?={{ umask 0o777 }}", "user?=\"\"", "group?=\"\""}},
 			"Move":       {ParameterNames: []string{"source_path", "destination_path"}},
 			"Name":       {ParameterNames: []string{"path"}},
 			"Observe":    {ParameterNames: []string{"resource"}},
@@ -38,8 +38,8 @@ func init() {
 			"Root":       {ParameterNames: []string{}},
 			"Unlink":     {ParameterNames: []string{"path", "prune", "boundary"}},
 			"WalkTree":   {ParameterNames: []string{"root", "fn", "include_gitignored?=false"}},
-			"WriteBytes": {ParameterNames: []string{"destination_path", "content", "chmod?={{ umask 0o666 }}", "chown?=\"\""}},
+			"WriteBytes": {ParameterNames: []string{"destination_path", "content", "mode?={{ umask 0o666 }}", "user?=\"\"", "group?=\"\""}},
 			"WriteFile":  {ParameterNames: []string{"target_path", "src", "mode"}},
-			"WriteText":  {ParameterNames: []string{"destination_path", "content", "chmod?={{ umask 0o666 }}", "chown?=\"\""}},
+			"WriteText":  {ParameterNames: []string{"destination_path", "content", "mode?={{ umask 0o666 }}", "user?=\"\"", "group?=\"\""}},
 		})
 }

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
+	osuser "os/user"
 
 	// Aliased: three functions in this file take a `path` parameter, and the slash-form glob
 	// matcher needs the stdlib path package beside them.
@@ -33,44 +33,39 @@ import (
 // errors.Is.
 var errKindMismatch = errors.New("file kind mismatch")
 
-// applyChown changes the owner and/or group of path according to the Dockerfile-style ownership string spec.
+// applyOwnership changes the owner and/or group of path.
 //
-// An empty spec is a no-op — the function returns nil without invoking any system call, which is the contract that lets
-// the four file-provider write methods always call applyChown unconditionally and rely on the empty-string
-// short-circuit.
+// Both sides empty is a no-op — the function returns nil without invoking any system call, which is the contract that
+// lets the file-provider write methods always call applyOwnership unconditionally and rely on the short-circuit.
 //
-// Accepted spec shapes:
-//   - ""             — no change (short-circuit; no syscall)
-//   - "user"         — change owner only; group unchanged
-//   - "user:group"   — change owner and group
-//   - ":group"       — change group only; owner unchanged
-//   - "uid"          — numeric form of "user"
-//   - "uid:gid"      — numeric form of "user:group"
-//   - ":gid"         — numeric form of ":group"
+// Either side accepts a name (resolved via os/user) or a decimal integer (passed to os.Chown directly), and either may
+// be empty to leave that side unchanged. Mixed forms are allowed: `user="alice"`, `group="1000"` resolves alice's uid
+// and uses gid 1000.
 //
-// User and group sides accept either a name (resolved via os/user) or a decimal integer (passed to os.Chown directly).
-//
-// Mixed forms are allowed: `"alice:1000"` resolves alice's uid and uses gid 1000.
+// The two are separate parameters rather than one Dockerfile-style `"user:group"` string because the surface they
+// project into is Starlark, where Python's `shutil.chown(path, user=…, group=…)` is the familiar shape — and because a
+// colon-delimited string makes the caller build a value the callee immediately takes apart.
 //
 // Parameters:
-//   - path: the filesystem path to chown.
-//   - spec: the Dockerfile-style ownership string.
+//   - `path`: the filesystem path whose ownership changes.
+//   - `user`: the owner to set, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group to set, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
-//   - error: non-nil if spec is malformed, a name doesn't resolve, or os.Chown fails.
-func applyChown(path, spec string) error {
+//   - `error`: non-nil if a name does not resolve, or os.Chown fails.
+func applyOwnership(path, user, group string) error {
 
-	if spec == "" {
+	if user == "" && group == "" {
 		return nil
 	}
 
-	uid, gid, err := parseChown(spec)
+	uid, gid, err := resolveOwnership(user, group)
 	if err != nil {
-		return fmt.Errorf("chown %q: %w", path, err)
+		return fmt.Errorf("ownership %q: %w", path, err)
 	}
 
 	if err := os.Chown(path, uid, gid); err != nil {
-		return fmt.Errorf("chown %q: %w", path, err)
+		return fmt.Errorf("ownership %q: %w", path, err)
 	}
 
 	return nil
@@ -364,25 +359,24 @@ func matchDoubleStarSingle(rawPrefix, rawSuffix, relPath string) bool {
 	return false
 }
 
-// parseChown splits a Dockerfile-style ownership string into uid and gid integers suitable for os.Chown.
+// resolveOwnership resolves a user and a group into uid and gid integers suitable for os.Chown.
 //
-// Each side resolves either a name via os/user or a numeric form via strconv. Empty sides produce -1 — the os.Chown
+// Each side resolves either a name via os/user or a numeric form via strconv. An empty side produces -1 — the os.Chown
 // sentinel for "leave this side unchanged."
 //
 // Parameters:
-//   - spec: the ownership string; must be non-empty (callers short-circuit on empty before calling).
+//   - `user`: the owner, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
-//   - int:   resolved uid, or -1 if the user side is empty.
-//   - int:   resolved gid, or -1 if the group side is empty.
-//   - error: non-nil if either side fails to resolve.
-func parseChown(spec string) (uid, gid int, err error) {
-
-	userSide, groupSide, hasColon := strings.Cut(spec, ":")
+//   - `int`: resolved uid, or -1 when `user` is empty.
+//   - `int`: resolved gid, or -1 when `group` is empty.
+//   - `error`: non-nil if either side fails to resolve, or if both are empty.
+func resolveOwnership(user, group string) (uid, gid int, err error) {
 
 	uid = -1
-	if userSide != "" {
-		resolved, err := resolveUser(userSide)
+	if user != "" {
+		resolved, err := resolveUser(user)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -390,8 +384,8 @@ func parseChown(spec string) (uid, gid int, err error) {
 	}
 
 	gid = -1
-	if hasColon && groupSide != "" {
-		resolved, err := resolveGroup(groupSide)
+	if group != "" {
+		resolved, err := resolveGroup(group)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -399,7 +393,7 @@ func parseChown(spec string) (uid, gid int, err error) {
 	}
 
 	if uid == -1 && gid == -1 {
-		return 0, 0, fmt.Errorf("invalid ownership %q: at least one of user or group must be present", spec)
+		return 0, 0, fmt.Errorf("invalid ownership: at least one of user or group must be present")
 	}
 
 	return uid, gid, nil
@@ -465,7 +459,7 @@ func resolveGroup(s string) (int, error) {
 		return gid, nil
 	}
 
-	g, err := user.LookupGroup(s)
+	g, err := osuser.LookupGroup(s)
 	if err != nil {
 		return 0, fmt.Errorf("lookup group %q: %w", s, err)
 	}
@@ -494,7 +488,7 @@ func resolveUser(s string) (int, error) {
 		return uid, nil
 	}
 
-	u, err := user.Lookup(s)
+	u, err := osuser.Lookup(s)
 	if err != nil {
 		return 0, fmt.Errorf("lookup user %q: %w", s, err)
 	}

--- a/pkg/op/provider/file/helpers_test.go
+++ b/pkg/op/provider/file/helpers_test.go
@@ -11,27 +11,27 @@ import (
 	"testing"
 )
 
-// --- parseChown ---
+// --- resolveOwnership ---
 
-func TestParseChown_Forms(t *testing.T) {
+func TestResolveOwnership_Forms(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		spec    string
+		user    string
+		group   string
 		wantUID int
 		wantGID int
 	}{
-		{"numeric user only", "1000", 1000, -1},
-		{"numeric user and group", "1000:2000", 1000, 2000},
-		{"numeric group only", ":2000", -1, 2000},
-		{"trailing colon, no group", "1000:", 1000, -1},
+		{"numeric user only", "1000", "", 1000, -1},
+		{"numeric user and group", "1000", "2000", 1000, 2000},
+		{"numeric group only", "", "2000", -1, 2000},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotUID, gotGID, err := parseChown(tc.spec)
+			gotUID, gotGID, err := resolveOwnership(tc.user, tc.group)
 			if err != nil {
-				t.Fatalf("parseChown(%q): %v", tc.spec, err)
+				t.Fatalf("resolveOwnership(%q, %q): %v", tc.user, tc.group, err)
 			}
 			if gotUID != tc.wantUID {
 				t.Errorf("uid: got %d, want %d", gotUID, tc.wantUID)
@@ -43,19 +43,20 @@ func TestParseChown_Forms(t *testing.T) {
 	}
 }
 
-func TestParseChown_RejectsInvalid(t *testing.T) {
+func TestResolveOwnership_RejectsInvalid(t *testing.T) {
 
 	cases := []struct {
-		name string
-		spec string
-		want string
+		name  string
+		user  string
+		group string
+		want  string
 	}{
-		{"bare colon", ":", "at least one of"},
+		{"both sides empty", "", "", "at least one of"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := parseChown(tc.spec)
+			_, _, err := resolveOwnership(tc.user, tc.group)
 			if err == nil {
 				t.Fatal("want error, got nil")
 			}
@@ -66,15 +67,15 @@ func TestParseChown_RejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestParseChown_LooksUpNamedUser(t *testing.T) {
+func TestResolveOwnership_LooksUpNamedUser(t *testing.T) {
 
 	// Looking up the current user by name should always succeed and return the same uid as os.Getuid.
 	currentUID := os.Getuid()
 	currentName := strconv.Itoa(currentUID)
 
-	gotUID, gotGID, err := parseChown(currentName)
+	gotUID, gotGID, err := resolveOwnership(currentName, "")
 	if err != nil {
-		t.Fatalf("parseChown(%q): %v", currentName, err)
+		t.Fatalf("resolveOwnership(%q, \"\"): %v", currentName, err)
 	}
 	if gotUID != currentUID {
 		t.Errorf("uid: got %d, want %d", gotUID, currentUID)
@@ -84,9 +85,9 @@ func TestParseChown_LooksUpNamedUser(t *testing.T) {
 	}
 }
 
-// --- applyChown ---
+// --- applyOwnership ---
 
-func TestApplyChown_EmptySpecIsNoOp(t *testing.T) {
+func TestApplyOwnership_BothSidesEmptyIsNoOp(t *testing.T) {
 
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "test.txt")
@@ -95,15 +96,15 @@ func TestApplyChown_EmptySpecIsNoOp(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	// Empty spec must short-circuit to nil error without invoking any syscall.
-	if err := applyChown(target, ""); err != nil {
-		t.Errorf("applyChown(empty): %v", err)
+	// Both sides empty must short-circuit to nil error without invoking any syscall.
+	if err := applyOwnership(target, "", ""); err != nil {
+		t.Errorf("applyOwnership(empty, empty): %v", err)
 	}
 }
 
-func TestApplyChown_CurrentUserIsNoOp(t *testing.T) {
+func TestApplyOwnership_CurrentUserIsNoOp(t *testing.T) {
 
-	// Chown'ing to the current uid:gid is a no-op-ish operation that doesn't require CAP_CHOWN.
+	// Setting ownership to the current uid and gid is a no-op-ish operation that needs no CAP_CHOWN.
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "test.txt")
 
@@ -111,15 +112,15 @@ func TestApplyChown_CurrentUserIsNoOp(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	spec := strconv.Itoa(os.Getuid()) + ":" + strconv.Itoa(os.Getgid())
-	if err := applyChown(target, spec); err != nil {
-		t.Errorf("applyChown(%q): %v", spec, err)
+	user, group := strconv.Itoa(os.Getuid()), strconv.Itoa(os.Getgid())
+	if err := applyOwnership(target, user, group); err != nil {
+		t.Errorf("applyOwnership(%q, %q): %v", user, group, err)
 	}
 }
 
-func TestApplyChown_RejectsMalformed(t *testing.T) {
+func TestApplyOwnership_RejectsUnresolvableUser(t *testing.T) {
 
-	if err := applyChown("/tmp/anything", ":"); err == nil {
-		t.Error("bare colon: want error")
+	if err := applyOwnership("/tmp/anything", "no-such-user-exists-here", ""); err == nil {
+		t.Error("unresolvable user: want error")
 	}
 }

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -105,29 +105,31 @@ func (p *Provider) Backup(
 
 // Copy copies `source`'s contents to a new file at `destinationPath` with the given mode and ownership.
 //
-// `chown` is the Dockerfile-style ownership string (`"user[:group]"`, `":group"`, `"uid[:gid]"`, or empty for no
-// change). When non-empty it is parsed and applied via os.Chown after the file is created.
+// `user` and `group` each accept a name or a decimal id, and either may be empty to leave that side unchanged.
+// When either is set they are resolved and applied via os.Chown after the file is created.
 //
 // Parameters:
 //   - `activationRecord`: the dispatch activation; its `Unit` stamps the produced [*Regular]'s producerID.
 //   - `source`: the [*Regular] whose contents are copied — a content read, so the parameter is the resource
 //     (step 23, ruling 2).
 //   - `destinationPath`: the destination path for the new file.
-//   - `chmod`: the [os.FileMode] applied to the created file.
-//   - `chown`: the Dockerfile-style ownership string, or empty for no ownership change.
+//   - `mode`: the [os.FileMode] applied to the created file.
+//   - `user`: the owner, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
 //   - `*Regular`: the created destination resource, resolved against the filesystem.
 //   - `*Receipt`: the compensation receipt for undo.
-//   - `error`: non-nil on resource construction, write preparation, copy, chown, or resolve failure.
+//   - `error`: non-nil on resource construction, write preparation, copy, ownership, or resolve failure.
 //
-// +devlore:defaults chmod={{ umask 0o755 }}, chown=""
+// +devlore:defaults mode={{ umask 0o755 }}, user="", group=""
 func (p *Provider) Copy(
 	activationRecord *op.ActivationRecord,
 	source *Regular,
 	destinationPath string,
-	chmod os.FileMode,
-	chown string,
+	mode os.FileMode,
+	user string,
+	group string,
 ) (product *Regular, receipt *Receipt, err error) {
 
 	product, err = NewRegular(p.RuntimeEnvironment(), activationRecord.CallerID, destinationPath)
@@ -150,7 +152,7 @@ func (p *Provider) Copy(
 	}
 	defer iox.Close(&err, src)
 
-	dst, err := p.openFile(product.SourcePath.Abs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, chmod)
+	dst, err := p.openFile(product.SourcePath.Abs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return product, receipt, err
 	}
@@ -160,7 +162,7 @@ func (p *Provider) Copy(
 		return product, receipt, err
 	}
 
-	if err := applyChown(product.SourcePath.Abs(), chown); err != nil {
+	if err := applyOwnership(product.SourcePath.Abs(), user, group); err != nil {
 		return product, receipt, err
 	}
 
@@ -311,28 +313,31 @@ func (p *Provider) archiveOccupant(product *SymbolicLink) (*Receipt, error) {
 
 // Mkdir creates a directory (and any missing parents) at `path` with the given mode and ownership.
 //
-// `chown` is the Dockerfile-style ownership string (`"user[:group]"`, `":group"`, `"uid[:gid]"`, or empty for
-// "no change"). When non-empty it is applied via os.Chown to the leaf directory only — intermediate parents
-// created by the call are NOT chown'd, since their role is "existed before this call" rather than "created here."
+// `user` and `group` each accept a name or a decimal id, and either may be empty to leave that side unchanged.
+// When either is set they are applied via os.Chown to the leaf directory only — intermediate parents created by
+// the call do NOT have their ownership changed, since their role is "existed before this call" rather than
+// "created here."
 //
 // Parameters:
 //   - `activationRecord`: the dispatch activation; its `Unit` stamps the produced [*Directory]'s producerID.
 //   - `path`: the directory path to create.
-//   - `chmod`: the [os.FileMode] applied to the leaf directory.
-//   - `chown`: the Dockerfile-style ownership string applied to the leaf directory, or empty for no change.
+//   - `mode`: the [os.FileMode] applied to the leaf directory.
+//   - `user`: the owner applied to the leaf directory, by name or decimal uid; empty leaves it unchanged.
+//   - `group`: the group applied to the leaf directory, by name or decimal gid; empty leaves it unchanged.
 //
 // Returns:
 //   - `*Directory`: the created directory resource, resolved; a nil receipt accompanies an already-existing
 //     directory.
 //   - `*Receipt`: the compensation receipt recording the creation boundary for undo.
-//   - `error`: non-nil when `path` exists as a non-directory, or on construction, mkdir, chown, or resolve failure.
+//   - `error`: non-nil when `path` exists as a non-directory, or on construction, mkdir, ownership, or resolve failure.
 //
-// +devlore:defaults chmod={{ umask 0o777 }}, chown=""
+// +devlore:defaults mode={{ umask 0o777 }}, user="", group=""
 func (p *Provider) Mkdir(
 	activationRecord *op.ActivationRecord,
 	path string,
-	chmod os.FileMode,
-	chown string,
+	mode os.FileMode,
+	user string,
+	group string,
 ) (product *Directory, receipt *Receipt, err error) {
 
 	leaf := p.RuntimeEnvironment().Root().NewPath(path).Abs()
@@ -362,11 +367,11 @@ func (p *Provider) Mkdir(
 
 	receipt = NewReceipt(NewReceiptSpec(product, MutationCreateDir).WithBoundary(boundary))
 
-	if err := p.mkdirAll(leaf, chmod); err != nil {
+	if err := p.mkdirAll(leaf, mode); err != nil {
 		return nil, receipt, err
 	}
 
-	if err := applyChown(leaf, chown); err != nil {
+	if err := applyOwnership(leaf, user, group); err != nil {
 		return nil, receipt, err
 	}
 
@@ -898,29 +903,31 @@ func (p *Provider) CompensateWalkTree(activation *op.ActivationRecord, stack *op
 
 // WriteBytes writes inline byte `content` to a file at `destinationPath` with the given mode and ownership.
 //
-// `chown` is the Dockerfile-style ownership string (`"user[:group]"`, `":group"`, `"uid[:gid]"`, or empty for "no
-// change"). When non-empty it is applied via os.Chown after the file is written. Any existing file is archived for
+// `user` and `group` each accept a name or a decimal id, and either may be empty to leave that side unchanged.
+// When either is set they are applied via os.Chown after the file is written. Any existing file is archived for
 // compensation before the write.
 //
 // Parameters:
 //   - `activationRecord`: the dispatch activation; its `Unit` stamps the produced [*Regular]'s producerID.
 //   - `destinationPath`: the path of the file to write.
 //   - `content`: the bytes to write, carried as a string.
-//   - `chmod`: the [os.FileMode] applied to the written file.
-//   - `chown`: the Dockerfile-style ownership string, or empty for no ownership change.
+//   - `mode`: the [os.FileMode] applied to the written file.
+//   - `user`: the owner, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
 //   - `*Regular`: the written resource.
 //   - `*Receipt`: the compensation receipt for undo.
 //   - `error`: non-nil on construction or write failure.
 //
-// +devlore:defaults chmod={{ umask 0o666 }}, chown=""
+// +devlore:defaults mode={{ umask 0o666 }}, user="", group=""
 func (p *Provider) WriteBytes(
 	activationRecord *op.ActivationRecord,
 	destinationPath string,
 	content string,
-	chmod os.FileMode,
-	chown string,
+	mode os.FileMode,
+	user string,
+	group string,
 ) (product *Regular, receipt *Receipt, err error) {
 
 	product, err = NewRegular(p.RuntimeEnvironment(), activationRecord.CallerID, destinationPath)
@@ -928,7 +935,7 @@ func (p *Provider) WriteBytes(
 		return nil, nil, err
 	}
 
-	product, receipt, err = p.write(product, strings.NewReader(content), chmod, chown)
+	product, receipt, err = p.write(product, strings.NewReader(content), mode, user, group)
 	if err != nil {
 		return product, receipt, err
 	}
@@ -943,7 +950,7 @@ func (p *Provider) WriteBytes(
 // kernel copy_file_range/sendfile fast path when `src` is an [*os.File]), and any content already at `targetPath`
 // is archived to [op.RecoverySite] before the overwrite. Takes a path (step 23, ruling 2) and mints the
 // [*Regular] product internally with the activation's producer stamp. WriteFile applies no ownership change
-// (callers needing `chown` use [Provider.WriteText] / [Provider.WriteBytes]). The returned [*Receipt] names
+// (callers needing `user` / `group` use [Provider.WriteText] / [Provider.WriteBytes]). The returned [*Receipt] names
 // [Provider.CompensateFileMutation] as its undo.
 //
 // Parameters:
@@ -968,34 +975,36 @@ func (p *Provider) WriteFile(
 		return nil, nil, err
 	}
 
-	return p.write(product, src, mode, "")
+	return p.write(product, src, mode, "", "")
 }
 
 // WriteText writes inline text `content` to a file at `destinationPath` with the given mode and ownership.
 //
-// `chown` is the Dockerfile-style ownership string (`"user[:group]"`, `":group"`, `"uid[:gid]"`, or empty for "no
-// change"). When non-empty it is applied via os.Chown after the file is written. Any existing file is archived for
+// `user` and `group` each accept a name or a decimal id, and either may be empty to leave that side unchanged.
+// When either is set they are applied via os.Chown after the file is written. Any existing file is archived for
 // compensation before the write.
 //
 // Parameters:
 //   - `activationRecord`: the dispatch activation; its `Unit` stamps the produced [*Regular]'s producerID.
 //   - `destinationPath`: the path of the file to write.
 //   - `content`: the text to write.
-//   - `chmod`: the [os.FileMode] applied to the written file.
-//   - `chown`: the Dockerfile-style ownership string, or empty for no ownership change.
+//   - `mode`: the [os.FileMode] applied to the written file.
+//   - `user`: the owner, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
 //   - `*Regular`: the written resource.
 //   - `*Receipt`: the compensation receipt for undo.
 //   - `error`: non-nil on construction or write failure.
 //
-// +devlore:defaults chmod={{ umask 0o666 }}, chown=""
+// +devlore:defaults mode={{ umask 0o666 }}, user="", group=""
 func (p *Provider) WriteText(
 	activationRecord *op.ActivationRecord,
 	destinationPath string,
 	content string,
-	chmod os.FileMode,
-	chown string,
+	mode os.FileMode,
+	user string,
+	group string,
 ) (product *Regular, receipt *Receipt, err error) {
 
 	product, err = NewRegular(p.RuntimeEnvironment(), activationRecord.CallerID, destinationPath)
@@ -1003,7 +1012,7 @@ func (p *Provider) WriteText(
 		return nil, nil, err
 	}
 
-	product, receipt, err = p.write(product, strings.NewReader(content), chmod, chown)
+	product, receipt, err = p.write(product, strings.NewReader(content), mode, user, group)
 	if err != nil {
 		return product, receipt, err
 	}
@@ -2054,26 +2063,28 @@ func (p *Provider) walkDir(
 // write streams `src` to the staged target with the given mode and ownership.
 //
 // The content is copied with [io.Copy], so it streams in constant memory and engages the kernel
-// copy_file_range/sendfile fast path when `src` is an [*os.File]; no full-content buffer is materialized. `chown`
-// follows the same Dockerfile-style format as the public Write* methods; empty means no ownership change. The chown is
+// copy_file_range/sendfile fast path when `src` is an [*os.File]; no full-content buffer is materialized. `user` and
+// `group` follow the same shape as the public Write* methods; both empty means no ownership change. Ownership is
 // applied after the file is fully written and synced — placing it before the close would risk applying ownership to a
 // file the kernel may yet reject.
 //
 // Parameters:
 //   - `target`: the minted [*Regular] to write.
 //   - `src`: the byte source streamed to the file.
-//   - `chmod`: the [os.FileMode] applied to the written file.
-//   - `chown`: the Dockerfile-style ownership string, or empty for no ownership change.
+//   - `mode`: the [os.FileMode] applied to the written file.
+//   - `user`: the owner, by name or decimal uid; empty leaves the owner unchanged.
+//   - `group`: the group, by name or decimal gid; empty leaves the group unchanged.
 //
 // Returns:
 //   - `*Regular`: the written resource (`target`).
 //   - `*Receipt`: the compensation receipt for undo.
-//   - `error`: non-nil on write preparation, open, write, sync, or chown failure.
+//   - `error`: non-nil on write preparation, open, write, sync, or ownership failure.
 func (p *Provider) write(
 	target *Regular,
 	src io.Reader,
-	chmod os.FileMode,
-	chown string,
+	mode os.FileMode,
+	user string,
+	group string,
 ) (product *Regular, receipt *Receipt, err error) {
 
 	product = target
@@ -2087,7 +2098,7 @@ func (p *Provider) write(
 	}
 	receipt = NewReceipt(spec)
 
-	f, err := p.openFile(product.SourcePath.Abs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, chmod)
+	f, err := p.openFile(product.SourcePath.Abs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return product, receipt, err
 	}
@@ -2101,7 +2112,7 @@ func (p *Provider) write(
 		return product, receipt, err
 	}
 
-	if err := applyChown(product.SourcePath.Abs(), chown); err != nil {
+	if err := applyOwnership(product.SourcePath.Abs(), user, group); err != nil {
 		return product, receipt, err
 	}
 

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -151,7 +151,7 @@ func TestProducerStamp_Mkdir(t *testing.T) {
 	activation := testActivation(t, p.RuntimeEnvironment())
 
 	target := filepath.Join(tmp, "produced")
-	product, _, err := p.Mkdir(activation, target, 0o755, "")
+	product, _, err := p.Mkdir(activation, target, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir: %v", err)
 	}
@@ -379,7 +379,7 @@ func TestCopy_WritesNewFile(t *testing.T) {
 	fileResource := testFileResource(t, []byte("hello world"))
 
 	p := testProvider(t, tmp)
-	result, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), fileResource, path, 0o600, "")
+	result, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), fileResource, path, 0o600, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
@@ -415,7 +415,7 @@ func TestCopy_OverwritesExistingFile(t *testing.T) {
 
 	p := testProvider(t, tmp)
 	blob := testFileResource(t, []byte("replaced"))
-	_, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "")
+	_, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
@@ -759,7 +759,7 @@ func TestWriteText_WritesContentToNewFile(t *testing.T) {
 	path := filepath.Join(tmp, "output.txt")
 
 	p := testProvider(t, tmp)
-	result, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "hello world", 0o644, "")
+	result, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "hello world", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -786,7 +786,7 @@ func TestWriteBytes_WritesContentToNewFile(t *testing.T) {
 	path := filepath.Join(tmp, "output.bin")
 
 	p := testProvider(t, tmp)
-	result, state, err := p.WriteBytes(testActivation(t, p.RuntimeEnvironment()), path, "binary data", 0o600, "")
+	result, state, err := p.WriteBytes(testActivation(t, p.RuntimeEnvironment()), path, "binary data", 0o600, "", "")
 	if err != nil {
 		t.Fatalf("WriteBytes() error = %v", err)
 	}
@@ -1026,7 +1026,7 @@ func TestWriteText_CreatesParentDirectories(t *testing.T) {
 	path := filepath.Join(tmp, "nested", "deep", "file.txt")
 
 	p := testProvider(t, tmp)
-	result, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "nested content", 0o644, "")
+	result, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "nested content", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -1049,7 +1049,7 @@ func TestWriteText_CompensateWriteText_RoundTrip_NewFile(t *testing.T) {
 	path := filepath.Join(tmp, "roundtrip.txt")
 
 	p := testProvider(t, tmp)
-	_, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "to be undone", 0o644, "")
+	_, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "to be undone", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -1075,7 +1075,7 @@ func TestWriteBytes_CompensateWriteBytes_RoundTrip_NewFile(t *testing.T) {
 	path := filepath.Join(tmp, "roundtrip.bin")
 
 	p := testProvider(t, tmp)
-	_, state, err := p.WriteBytes(testActivation(t, p.RuntimeEnvironment()), path, "to be undone", 0o600, "")
+	_, state, err := p.WriteBytes(testActivation(t, p.RuntimeEnvironment()), path, "to be undone", 0o600, "", "")
 	if err != nil {
 		t.Fatalf("WriteBytes() error = %v", err)
 	}
@@ -1369,7 +1369,7 @@ func TestMkdir_CreatesDirectory(t *testing.T) {
 	path := filepath.Join(tmp, "newdir")
 
 	p := testProvider(t, tmp)
-	product, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "")
+	product, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -1392,7 +1392,7 @@ func TestMkdir_CreatesParents(t *testing.T) {
 	path := filepath.Join(tmp, "a", "b", "c")
 
 	p := testProvider(t, tmp)
-	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "")
+	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -1415,7 +1415,7 @@ func TestMkdir_Idempotent(t *testing.T) {
 	}
 
 	p := testProvider(t, tmp)
-	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "")
+	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), path, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() on existing directory error = %v", err)
 	}
@@ -1912,7 +1912,7 @@ func TestWriteText_OverwriteExisting_RoundTrip(t *testing.T) {
 	}
 
 	p := testProvider(t, tmp)
-	_, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "replaced content", 0o644, "")
+	_, state, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "replaced content", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -1994,7 +1994,7 @@ func TestCopy_CompensateCopy_RoundTrip_NewFile(t *testing.T) {
 
 	p := testProvider(t, tmp)
 	blob := testFileResource(t, []byte("new content"))
-	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "")
+	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
@@ -2019,7 +2019,7 @@ func TestCopy_CompensateCopy_RoundTrip_Overwrite(t *testing.T) {
 
 	p := testProvider(t, tmp)
 	blob := testFileResource(t, []byte("replaced"))
-	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "")
+	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
@@ -2218,7 +2218,7 @@ func TestCompensateMkdir_RoundTrip_RemovesCreatedChain(t *testing.T) {
 	target := filepath.Join(tmp, "a", "b", "c")
 	p := testProvider(t, tmp)
 
-	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "")
+	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -2244,7 +2244,7 @@ func TestCompensateMkdir_StopsAtBoundary_PreservesPreExisting(t *testing.T) {
 	target := filepath.Join(tmp, "a", "b", "c", "d")
 	p := testProvider(t, tmp)
 
-	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "")
+	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -2274,7 +2274,7 @@ func TestCompensateMkdir_AlreadyExists_NoOp(t *testing.T) {
 	}
 	p := testProvider(t, tmp)
 
-	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "")
+	_, receipt, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -2297,7 +2297,7 @@ func TestCompensateMkdir_NotADirectory_ReturnsError(t *testing.T) {
 	target := filepath.Join(tmp, "regular")
 	p := testProvider(t, tmp)
 
-	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "")
+	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "", "")
 	if err == nil {
 		t.Fatal("Mkdir() on a regular file should error")
 	}
@@ -2315,7 +2315,7 @@ func TestCompensateMkdir_TamperedBoundary_Errors(t *testing.T) {
 	target := filepath.Join(tmp, "a", "b", "c")
 	p := testProvider(t, tmp)
 
-	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "")
+	_, _, err := p.Mkdir(testActivation(t, p.RuntimeEnvironment()), target, 0o755, "", "")
 	if err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
 	}
@@ -2354,7 +2354,7 @@ func TestCompensateWriteText_RoundTrip_RemovesParentDirectories(t *testing.T) {
 	target := filepath.Join(tmp, "a", "b", "c", "hello.txt")
 	p := testProvider(t, tmp)
 
-	_, receipt, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), target, "hi", 0o644, "")
+	_, receipt, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), target, "hi", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -2380,7 +2380,7 @@ func TestCompensateWriteText_StopsAtBoundary_PreservesPreExisting(t *testing.T) 
 	target := filepath.Join(tmp, "a", "b", "c", "hello.txt")
 	p := testProvider(t, tmp)
 
-	_, receipt, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), target, "hi", 0o644, "")
+	_, receipt, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), target, "hi", 0o644, "", "")
 	if err != nil {
 		t.Fatalf("WriteText() error = %v", err)
 	}
@@ -2450,18 +2450,20 @@ func TestCompensateMove_RoundTrip_RemovesCreatedParents(t *testing.T) {
 
 // TestWriteText_AppliesChownWhenSpecified lives in provider_unix_test.go: uid/gid via syscall.Stat_t is Unix-only.
 
-// TestWriteText_RejectsMalformedChown verifies a malformed chown spec surfaces an error.
+// TestWriteText_RejectsUnresolvableUser verifies an ownership side that does not resolve surfaces an error.
 //
-// The provider method must error rather than silently no-op.
-func TestWriteText_RejectsMalformedChown(t *testing.T) {
+// The provider method must error rather than silently no-op. With `user` and `group` as separate parameters there is
+// no malformed *spec* left to reject — the failure mode that remains is a name the account database cannot resolve.
+func TestWriteText_RejectsUnresolvableUser(t *testing.T) {
 
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "rejected.txt")
 
 	p := testProvider(t, tmp)
 
-	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "rejected", 0o644, ":")
+	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "rejected",
+		0o644, "no-such-user-exists-here", "")
 	if err == nil {
-		t.Fatal("WriteText with bare colon: want error, got nil")
+		t.Fatal("WriteText with an unresolvable user: want error, got nil")
 	}
 }

--- a/pkg/op/provider/file/provider_unix_test.go
+++ b/pkg/op/provider/file/provider_unix_test.go
@@ -15,23 +15,24 @@ import (
 
 // --- Chown ---
 
-// TestWriteText_AppliesChownWhenSpecified verifies the chown parameter drives applyChown through to os.Chown.
+// TestWriteText_AppliesOwnershipWhenSpecified verifies the user and group parameters drive applyOwnership through
+// to os.Chown.
 //
 // The subject — uid/gid ownership read through syscall.Stat_t — exists only on Unix, so the build constraint scopes
 // the test rather than skipping it; Windows compilation of the package's tests failed on Stat_t before this file
-// existed (#373 phase 1b). Uses the current uid:gid as the target spec — the only spec that doesn't require
-// CAP_CHOWN — so the test runs without privilege.
-func TestWriteText_AppliesChownWhenSpecified(t *testing.T) {
+// existed (#373 phase 1b). Uses the current uid and gid — the only pair that doesn't require CAP_CHOWN — so the
+// test runs without privilege.
+func TestWriteText_AppliesOwnershipWhenSpecified(t *testing.T) {
 
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "owned.txt")
 
 	p := testProvider(t, tmp)
 
-	spec := strconv.Itoa(os.Getuid()) + ":" + strconv.Itoa(os.Getgid())
-	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "owned content", 0o644, spec)
+	user, group := strconv.Itoa(os.Getuid()), strconv.Itoa(os.Getgid())
+	_, _, err := p.WriteText(testActivation(t, p.RuntimeEnvironment()), path, "owned content", 0o644, user, group)
 	if err != nil {
-		t.Fatalf("WriteText with chown=%q: %v", spec, err)
+		t.Fatalf("WriteText with user=%q group=%q: %v", user, group, err)
 	}
 
 	info, err := os.Stat(path)

--- a/pkg/op/provider/plan/deferred_default_test.go
+++ b/pkg/op/provider/plan/deferred_default_test.go
@@ -27,7 +27,7 @@ import (
 // The planner stuffs the parsed-but-unresolved [op.DeferredDefault] into the omitted slot; before the fix,
 // dispatch handed it straight to [op.Convert] ("*op.treeDefault value is neither assignable nor convertible to
 // fs.FileMode"). The starlark bridge's direct-invocation path always resolved deferred defaults, and every
-// existing plan-path fixture passed `chmod` explicitly — this is the first planned omission under test.
+// existing plan-path fixture passed `mode` explicitly — this is the first planned omission under test.
 func TestPlannedDeferredDefault_ResolvesAtDispatch(t *testing.T) {
 
 	tmp := t.TempDir()
@@ -41,7 +41,7 @@ func TestPlannedDeferredDefault_ResolvesAtDispatch(t *testing.T) {
 
 	graph, err := op.Plan(context.Background(), spec(), func(environment *op.RuntimeEnvironment) (*op.Graph, error) {
 		planProvider := plan.NewProvider(environment)
-		// chmod and chown deliberately omitted: chmod carries the deferred {{ umask 0o666 }} default, chown a
+		// mode and chown deliberately omitted: mode carries the deferred {{ umask 0o666 }} default, chown a
 		// literal "".
 		if _, err := planProvider.Plan(file.WriteText, nil, map[string]any{
 			"destination_path": destination,

--- a/pkg/op/provider/plan/gather_api_test.go
+++ b/pkg/op/provider/plan/gather_api_test.go
@@ -46,7 +46,7 @@ func TestGatherFailureUnwind_ViaPublicAPI(t *testing.T) {
 	writeInv, err := planProvider.Plan(file.WriteText, nil, map[string]any{
 		"destination_path": itemVar,
 		"content":          "x",
-		"chmod":            os.FileMode(0o644),
+		"mode":             os.FileMode(0o644),
 	})
 	if err != nil {
 		t.Fatalf("Plan(file.write_text): %v", err)

--- a/pkg/op/provider/plan/lifecycle_api_test.go
+++ b/pkg/op/provider/plan/lifecycle_api_test.go
@@ -56,9 +56,9 @@ func TestGraphSaveLoadExecuteTrace_ViaPublicAPI(t *testing.T) {
 	// plan: a one-node graph that creates a directory.
 	target := filepath.Join(tmp, "made")
 	invocation, err := planProvider.Plan(file.Mkdir, nil, map[string]any{
-		"path":  target,
-		"chmod": os.FileMode(0o755),
-		"chown": "",
+		"path": target,
+		"mode": os.FileMode(0o755),
+		"user": "", "group": "",
 	})
 	if err != nil {
 		t.Fatalf("Plan(file.mkdir): %v", err)
@@ -140,12 +140,12 @@ func TestGraphPauseResume_ViaPublicAPI(t *testing.T) {
 	dirA := filepath.Join(tmp, "a")
 	dirB := filepath.Join(tmp, "b")
 	inv1, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirA, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(a): %v", err)
 	}
 	inv2, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}
@@ -222,12 +222,12 @@ func TestGraphPauseResumeNested_ViaPublicAPI(t *testing.T) {
 	dirB := filepath.Join(tmp, "b")
 	dirC := filepath.Join(tmp, "c")
 	invB, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}
 	invC, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirC, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirC, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(c): %v", err)
 	}
@@ -301,12 +301,12 @@ func TestGraphSaveLoadResume_ViaPublicAPI(t *testing.T) {
 	dirA := filepath.Join(tmp, "a")
 	dirB := filepath.Join(tmp, "b")
 	inv1, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirA, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(a): %v", err)
 	}
 	inv2, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}
@@ -411,12 +411,12 @@ func resumeThenFailRollsBack(t *testing.T, format string) {
 	dirA := filepath.Join(tmp, "a")
 	dirB := filepath.Join(tmp, "b")
 	inv1, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirA, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(a): %v", err)
 	}
 	inv2, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}
@@ -511,7 +511,7 @@ func resumePromiseFidelity(t *testing.T, format string) {
 
 	dir := filepath.Join(tmp, "d")
 	producer, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dir, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dir, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(mkdir): %v", err)
 	}
@@ -813,12 +813,12 @@ func TestGraphStop_UnwindsToStopped_ViaPublicAPI(t *testing.T) {
 	dirA := filepath.Join(tmp, "a")
 	dirB := filepath.Join(tmp, "b")
 	inv1, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirA, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(a): %v", err)
 	}
 	inv2, err := planProvider.Plan(file.Mkdir, nil,
-		map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+		map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}

--- a/pkg/op/provider/plan/lifecycle_e2e_test.go
+++ b/pkg/op/provider/plan/lifecycle_e2e_test.go
@@ -179,11 +179,11 @@ func goGraphMaker(t *testing.T, tmp string) (graph *op.Graph, provider *plan.Pro
 	_, provider = newLifecycleEnv(t, tmp)
 	dirA, dirB = filepath.Join(tmp, "a"), filepath.Join(tmp, "b")
 
-	inv1, err := provider.Plan(file.Mkdir, nil, map[string]any{"path": dirA, "chmod": os.FileMode(0o755), "chown": ""})
+	inv1, err := provider.Plan(file.Mkdir, nil, map[string]any{"path": dirA, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(a): %v", err)
 	}
-	inv2, err := provider.Plan(file.Mkdir, nil, map[string]any{"path": dirB, "chmod": os.FileMode(0o755), "chown": ""})
+	inv2, err := provider.Plan(file.Mkdir, nil, map[string]any{"path": dirB, "mode": os.FileMode(0o755), "user": "", "group": ""})
 	if err != nil {
 		t.Fatalf("Plan(b): %v", err)
 	}
@@ -206,8 +206,8 @@ func runStarlarkLifecycle(t *testing.T, tmp, dirA, dirB string) error {
 	graphPath := filepath.Join(tmp, "graph.json")
 
 	script := fmt.Sprintf(`
-a = plan.file.mkdir(path = %q, chmod = 0o755, chown = "")
-b = plan.file.mkdir(path = %q, chmod = 0o755, chown = "")
+a = plan.file.mkdir(path = %q, mode = 0o755, chown = "")
+b = plan.file.mkdir(path = %q, mode = 0o755, chown = "")
 graph = plan.assemble_definition([a, b])
 plan.save_definition(graph, %q)
 loaded = plan.load_definition(%q)

--- a/pkg/op/provider/plan/lifecycle_starlark_test.go
+++ b/pkg/op/provider/plan/lifecycle_starlark_test.go
@@ -37,7 +37,7 @@ func TestGraphSaveLoadExecute_ViaStarlark(t *testing.T) {
 
 	// plan a one-node graph (mkdir), save it, load it back, and run the *loaded* graph.
 	script := fmt.Sprintf(`
-node   = plan.file.mkdir(path = %q, chmod = 0o755, chown = "")
+node   = plan.file.mkdir(path = %q, mode = 0o755, chown = "")
 graph  = plan.assemble_definition([node])
 plan.save_definition(graph, %q)
 loaded = plan.load_definition(%q)

--- a/pkg/op/provider/plan/provider_test.go
+++ b/pkg/op/provider/plan/provider_test.go
@@ -90,9 +90,9 @@ func plannedMkdir(t *testing.T, p *Provider, path string) *op.Invocation {
 	t.Helper()
 
 	invocation, err := p.Plan(file.Mkdir, nil, map[string]any{
-		"path":  path,
-		"chmod": os.FileMode(0o755),
-		"chown": "",
+		"path": path,
+		"mode": os.FileMode(0o755),
+		"user": "", "group": "",
 	})
 	if err != nil {
 		t.Fatalf("Plan(file.mkdir): %v", err)

--- a/pkg/op/provider/plan/provider_units_test.go
+++ b/pkg/op/provider/plan/provider_units_test.go
@@ -47,11 +47,11 @@ func TestPlan_UnknownMethod(t *testing.T) {
 func TestPlan_MalformedKwargs_WrongType(t *testing.T) {
 	p := NewProvider(plannedEnvironmentAt(t, t.TempDir()))
 
-	// file.mkdir's `chmod` parameter is an os.FileMode (numeric); a non-numeric string cannot convert to it.
+	// file.mkdir's `mode` parameter is an os.FileMode (numeric); a non-numeric string cannot convert to it.
 	_, err := p.Plan(file.Mkdir, nil, map[string]any{
-		"path":  "/tmp/backfill",
-		"chmod": "not-a-file-mode",
-		"chown": "",
+		"path": "/tmp/backfill",
+		"mode": "not-a-file-mode",
+		"user": "", "group": "",
 	})
 	if err == nil {
 		t.Fatal("Plan() with a wrong-typed kwarg should error")

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -1472,8 +1472,8 @@ def emit_file(command, template_name, descriptor, filename, label, method_count,
         # without them the slot defaults to FileMode(0) and the written files become inaccessible.
         out_dir = file.parent(out_path)
         if not file.exists(out_dir):
-            file.mkdir(out_dir, chmod = 0o755)
-        file.write_text(out_path, code, chmod = 0o644)
+            file.mkdir(out_dir, mode = 0o755)
+        file.write_text(out_path, code, mode = 0o644)
         ui.succeed("Wrote " + out_path)
     else:
         ui.note("--- " + filename + " ---")


### PR DESCRIPTION
## Summary

Three commits on the file and encryption write surface.

Closes #512
Closes #513

## 1. Append the run index before the `latest` link

`WriteTrace` linked `latest.yaml` and *then* appended the index entry, so any link failure discarded the
index entry for a trace already durable on disk — **silently**, because all nine callers warn rather than
fail.

That ordering is wrong on **every** platform. Windows is only where it fires for ordinary users, who have
neither Developer Mode nor `SeCreateSymbolicLinkPrivilege` and so cannot create a symlink at all.

The regression test forces a link failure portably — occupy `latest.yaml` with a non-empty directory, so the
best-effort `Remove` cannot unlink it — then asserts the trace is both on disk and in the index.

**This advances #438 by one of its six exit criteria and does not close it.** The `latest` disposition still
needs its ruling (and the fact that *nothing reads it* reframes the question), and the Windows proof must
**deny** the privilege rather than run where it happens to be granted.

## 2. `mode`, `user`, `group`

`chmod` is a verb. The Dockerfile-style `chown` string made every caller assemble a value the callee
immediately took apart with `strings.Cut`.

**Python decides it**, because Python is the surface Starlark projects into — `os.chmod(path, mode)`,
`os.mkdir(path, mode=…)`, `pathlib.Path.chmod(mode)`, `shutil.chown(path, user=…, group=…)`. Go is **not**
self-consistent here (`perm` when creating, `mode` in `os.Chmod`), so there was no single stdlib convention
to defer to.

- `applyChown` / `parseChown` → `applyOwnership` / `resolveOwnership`, taking the two sides directly.
- `os/user` aliased `osuser`, because the parameter now legitimately owns the name `user`.
- 46 `.star` fixtures, the `+devlore:defaults` directives, and the generated announce lists all move.
  **No `.star` file ever passed `chown`**, so that side was a pure rename.
- One test changed **meaning**, not shape: with two parameters there is no malformed *spec* left to reject,
  so `RejectsMalformedChown` became `RejectsUnresolvableUser`.
- Incidental fix: `default_func.go` listed the deferred-default functions as `(umask, chmod, env)`; the
  registry has had `"mode"` all along.

## 3. A floored `mode` on the encryption actions

They hardcoded `0o600` — the only writes in the catalog not taking a mode.

**The parameter is floored on decrypt.** Encrypting a file *is* the declaration that its contents are
sensitive, and `tree/builder.go` already derives `0o600` from the pipeline containing `encryption.decrypt`.
A free parameter would reopen that decision to a caller who can get it wrong, and a world-readable secret
fails silently. `enforceSecretFloor` refuses group or other access **before** decrypting, so a rejected call
never materializes plaintext — asserted by the test.

**Encrypt is deliberately not floored**: ciphertext is safe at rest and lands in a repository that stores it
`0o644` regardless. Both default to `0o600`, so behavior is unchanged unless asked.

## Note on the codegen

`AnnounceProvider` panics at init when a generated parameter list disagrees with its signature, so the
generator could not run to fix its own output. The announce lists in the two `gen/provider.gen.go` files were
corrected by hand to break that cycle, then regenerated — the committed files are generator output.

## Verified

`make check` and `make lint-all` both exit 0.
