### PR TITLE
docs(plans): update the 28's cluster names after the ownership rename

### DIFF
--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -179,7 +179,8 @@ reasoning is still a miss; inherited estimates get their own enumeration.
 **The 28 that remain** are the phase-3e grind, one failing package each across twelve packages:
 file-provider write/permission semantics (`TestWrite_*`, `TestCopy_WritesNewFile`,
 `TestWriteBytes_*`), path semantics (`TestName_*`, `TestParent_*`, `TestCommonAncestor`,
-`TestSourcePath_ShardedLayout`), chown (`TestApplyChown_*`, `TestParseChown_*`), git argv
+`TestSourcePath_ShardedLayout`), ownership (`TestApplyOwnership_*`, `TestResolveOwnership_*` — renamed from `TestApplyChown_*` /
+`TestParseChown_*` in #514; same tests, same failures), git argv
 (`TestCheckout_BuildsArgv`, `TestPull_BuildsArgv`), 2 CLI error-text expectations
 (`TestCLI_ConfigPath`, `TestCLI_RunMissingFile`), and singles including
 `TestSourceFile_StarlarkIntegration` (#376). Two survivors — `TestGatherFailureUnwind_ViaPublicAPI`


### PR DESCRIPTION
## Summary

Documentation only, and a direct consequence of #514.

`platform-test-matrix.md` describes the 28 known Windows failures by cluster, using wildcards. One cluster
reads `TestApplyChown_*`, `TestParseChown_*` — names #514 renamed to `TestApplyOwnership_*` /
`TestResolveOwnership_*`. The wildcards now match nothing.

## Why this is worth its own commit

The 28 is verified **name for name** against `develop` on every PR, and #514 is the first time that check
produced a non-empty delta:

```
NEW:     TestApplyOwnership_CurrentUserIsNoOp    TestResolveOwnership_LooksUpNamedUser
CLEARED: TestApplyChown_CurrentUserIsNoOp        TestParseChown_LooksUpNamedUser
```

Two "new" failures and two "cleared" ones — from a rename. The count never moved, and a bare count would
have reported "28, fine" without surfacing anything. The name comparison forced a look, and the look showed
the delta was self-inflicted.

Leaving the document as-is would make the *next* comparison read the same rename as one regression and one
fix, which is precisely the ambiguity the discipline exists to prevent.

## Verified

Documentation only; no code paths touched.
