### PR TITLE
docs(plans): close the phase-8 ledger

### DIFF
--- a/docs/plans/extract-starlark-from-op/phase-8.md
+++ b/docs/plans/extract-starlark-from-op/phase-8.md
@@ -2,11 +2,22 @@
 title: "Phase 8: Plan-time scope and grouping combinators"
 parent: "docs/plans/extract-starlark-from-op.md"
 issue: 275
-status: in-progress
+status: closed
+closed: 2026-08-18
 created: 2026-04-17
-updated: 2026-06-18
+updated: 2026-08-18
 ---
 
+> **CLOSED 2026-08-18.** Every incomplete item in this ledger has a tracking issue, so nothing is lost by
+> never reading it again. The nine open steps: **38 → #520**, **50 → #449**, **53 → #439**, **55 → #518**,
+> **56 → #451**, **57 → #517**, **58 → #392**, **59 → #437**, **60 → #438**. The six remainders that sat
+> behind steps marked complete: **12 → #535**, **13 → #282**, **19 → #536**, **22 → #537**, **25 → #538**,
+> **49 → #495**.
+>
+> The supporting documents under `phase-8/` stay **live** — their disposition waits on the architecture and
+> design sweep, which decides what is a record and what is still a plan. Nothing here is archived or deleted
+> in the meantime.
+>
 > **How work is tracked now (2026-08-18).** This ledger is **historical**. Work items live on GitHub as
 > **epics → features → {tasks | bugs}**, and plans cite **issue numbers**, not step numbers. The scheme —
 > four kinds across three tiers, triage by `Severity:` / `Priority:` labels, and the classification audit


### PR DESCRIPTION
## Summary

Closes the phase-8 ledger. Documentation only.

## Why it is safe to close

**Every incomplete item has a tracking issue.** Verified item by item, not asserted:

| Open steps | | Remainders behind "complete" steps |
|---|---|---|
| 38 → #520 · 50 → #449 · 53 → #439 | | 12 → #535 · 13 → #282 · 19 → #536 |
| 55 → #518 · 56 → #451 · 57 → #517 | | 22 → #537 · 25 → #538 · 49 → #495 |
| 58 → #392 · 59 → #437 · 60 → #438 | | |

The six on the right are the ones that made this worth checking: they were **open work hiding behind steps
the ledger marked complete**, listed only in its own closure-pass paragraph. Closing without filing them
would have lost them — the ledger was the single place they were written down.

## What is not decided here

The **supporting documents under `phase-8/` stay live** — 24 of them, alongside 60 step documents. Their
disposition waits on the architecture and design sweep, which is the pass that can tell a record from a
plan. Nothing is archived or deleted in the meantime.

Four of them gained owners as a side effect of filing the remainders: `platform-unification.md` (#536),
`13.0-n.md` and `13.0-n-phase-6.md` (#537), and `function-resource-slots-and-transport.md` (#538).

## Verified

Documentation only; no code paths touched.
