### PR TITLE
fix(windows): slash-form logical paths and unix-scoped ownership tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,14 @@ on:
 jobs:
   quality-gate:
     runs-on: ubuntu-latest
+    # bash, not the runner default: the default is `bash -e {0}` WITHOUT pipefail, so a failing command
+    # feeding a pipe is masked by the success of whatever reads it. The lint-tool install is exactly that
+    # shape -- `curl ... | sh` -- and a failed curl let `sh` read empty input and exit 0, so the retry loop
+    # below it broke on the first attempt and had never once retried (#439). The sibling `test` and
+    # `scenario` jobs already declare this.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -56,14 +64,25 @@ jobs:
         run: make vet-all
 
       - name: Install lint tools
+        # The timeouts are what make the retry loop work. Without them a stalled connection hangs
+        # indefinitely and the loop never reaches its break-or-retry decision -- retries handle failures,
+        # not hangs. Observed 2026-08-18: this step sat 20+ minutes while every other leg finished (#439).
         run: |
           for attempt in 1 2 3; do
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2 && break
+            curl -sSfL --connect-timeout 15 --max-time 120 \
+              https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh |
+              sh -s -- -b "$(go env GOPATH)/bin" v2.12.2 && break
             echo "golangci-lint install attempt $attempt failed; retrying in 5s" >&2
             sleep 5
           done
-          go install mvdan.cc/sh/v3/cmd/shfmt@latest
-          sudo apt-get update && sudo apt-get install -y shellcheck
+          # Pinned, not @latest: a new shfmt release would change formatting verdicts with no commit on
+          # our side. v3.13.1 is what developers run locally.
+          timeout 180 go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
+          # apt gets its own retries and timeouts -- a mirror that accepts the connection and then stalls
+          # is the same hang as the curl above, and `timeout` alone would retry nothing.
+          apt_options=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30)
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y shellcheck
           golangci-lint version
 
       - name: Lint Go

--- a/cmd/writ/writ/migrate/register.go
+++ b/cmd/writ/writ/migrate/register.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	// Aliased: commonAncestor computes over the slash-form path language, not the OS-native one.
-	slashpath "path"
 	"path/filepath"
 	"strings"
 
@@ -200,26 +198,25 @@ func clearExistingLayer(layerDir string, verbose bool) error {
 //   - `a`: the first absolute path.
 //   - `b`: the second absolute path.
 //
-// The computation is in **slash form**, not OS-native: layer paths are a slash-form language on every
-// platform (the same contract as [io/fs] and the canonical [fsroot.Path] rel form), so splitting on
-// [filepath.Separator] answered `\home\user` on Windows for two `/home/user/...` inputs — a pure string
-// operation made platform-dependent.
+// OS-native, deliberately: the result becomes the run's Root — a confinement anchor handed to the
+// filesystem — so it must be a path the platform can resolve. A slash-form answer made [fsroot] panic on
+// Windows trying to relate `C:\...` to `/`.
 //
 // Returns:
-//   - `string`: the deepest common ancestor directory, in slash form.
+//   - `string`: the deepest common ancestor directory, OS-native.
 func commonAncestor(a, b string) string {
 
-	segmentsA := strings.Split(slashpath.Clean(a), "/")
-	segmentsB := strings.Split(slashpath.Clean(b), "/")
+	segmentsA := strings.Split(filepath.Clean(a), string(filepath.Separator))
+	segmentsB := strings.Split(filepath.Clean(b), string(filepath.Separator))
 
 	var common []string
 	for i := 0; i < len(segmentsA) && i < len(segmentsB) && segmentsA[i] == segmentsB[i]; i++ {
 		common = append(common, segmentsA[i])
 	}
 
-	ancestor := strings.Join(common, "/")
+	ancestor := strings.Join(common, string(filepath.Separator))
 	if ancestor == "" {
-		return "/"
+		return string(filepath.Separator)
 	}
 	return ancestor
 }

--- a/cmd/writ/writ/migrate/register.go
+++ b/cmd/writ/writ/migrate/register.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+
+	// Aliased: commonAncestor computes over the slash-form path language, not the OS-native one.
+	slashpath "path"
 	"path/filepath"
 	"strings"
 
@@ -197,21 +200,26 @@ func clearExistingLayer(layerDir string, verbose bool) error {
 //   - `a`: the first absolute path.
 //   - `b`: the second absolute path.
 //
+// The computation is in **slash form**, not OS-native: layer paths are a slash-form language on every
+// platform (the same contract as [io/fs] and the canonical [fsroot.Path] rel form), so splitting on
+// [filepath.Separator] answered `\home\user` on Windows for two `/home/user/...` inputs — a pure string
+// operation made platform-dependent.
+//
 // Returns:
-//   - `string`: the deepest common ancestor directory.
+//   - `string`: the deepest common ancestor directory, in slash form.
 func commonAncestor(a, b string) string {
 
-	segmentsA := strings.Split(filepath.Clean(a), string(filepath.Separator))
-	segmentsB := strings.Split(filepath.Clean(b), string(filepath.Separator))
+	segmentsA := strings.Split(slashpath.Clean(a), "/")
+	segmentsB := strings.Split(slashpath.Clean(b), "/")
 
 	var common []string
 	for i := 0; i < len(segmentsA) && i < len(segmentsB) && segmentsA[i] == segmentsB[i]; i++ {
 		common = append(common, segmentsA[i])
 	}
 
-	ancestor := strings.Join(common, string(filepath.Separator))
+	ancestor := strings.Join(common, "/")
 	if ancestor == "" {
-		return string(filepath.Separator)
+		return "/"
 	}
 	return ancestor
 }

--- a/cmd/writ/writ/migrate/register_test.go
+++ b/cmd/writ/writ/migrate/register_test.go
@@ -15,24 +15,6 @@ import (
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
 )
 
-func TestCommonAncestor(t *testing.T) {
-
-	cases := []struct {
-		a, b, want string
-	}{
-		{"/home/user/repo", "/home/user/.local/share/devlore/writ/layers/personal", "/home/user"},
-		{"/opt/dotfiles", "/home/user/.local/share/devlore/writ/layers/personal", "/"},
-		{"/home/user/a/b", "/home/user/a/b/c", "/home/user/a/b"},
-		{"/same/path", "/same/path", "/same/path"},
-	}
-
-	for _, c := range cases {
-		if got := commonAncestor(c.a, c.b); got != c.want {
-			t.Errorf("commonAncestor(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
-		}
-	}
-}
-
 func TestClearExistingLayer(t *testing.T) {
 
 	t.Run("missing is a no-op", func(t *testing.T) {

--- a/cmd/writ/writ/migrate/register_unix_test.go
+++ b/cmd/writ/writ/migrate/register_unix_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build unix
+
+package migrate
+
+import "testing"
+
+// commonAncestor answers an OS-native path, because its result becomes the run's confinement Root.
+//
+// The cases below feed Unix absolute paths — "/home/user/..." — which on Windows are drive-relative
+// strings with no meaning, so the constraint scopes this rather than skipping it. The Windows behavior
+// that matters is covered by TestRegisterLayer_Link, which exercises the result as a real root.
+
+func TestCommonAncestor(t *testing.T) {
+
+	cases := []struct {
+		a, b, want string
+	}{
+		{"/home/user/repo", "/home/user/.local/share/devlore/writ/layers/personal", "/home/user"},
+		{"/opt/dotfiles", "/home/user/.local/share/devlore/writ/layers/personal", "/"},
+		{"/home/user/a/b", "/home/user/a/b/c", "/home/user/a/b"},
+		{"/same/path", "/same/path", "/same/path"},
+	}
+
+	for _, c := range cases {
+		if got := commonAncestor(c.a, c.b); got != c.want {
+			t.Errorf("commonAncestor(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -107,11 +107,11 @@ func buildCandidateAs(
 	sourcePath := runtimeEnvironment.Root().NewPath(path)
 	var base op.ResourceBase
 
-	// Slash form in the identity, not OS-native. The URI travels into serialized documents and into the
-	// content checksums computed over them, so a backslash here makes identity platform-dependent — the same
-	// defect #377 removed from [fsroot.Path.Rel]. filepath.ToSlash is a no-op on Unix and converts the
-	// separators on Windows; the absolute path itself (volume included) is unchanged.
-	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+filepath.ToSlash(sourcePath.Abs()), resourceType)
+	// NOTE: this identity is OS-native, so on Windows it carries backslashes inside a URI — see #547.
+	// Normalizing HERE was tried on 2026-08-18 and reverted: it fixed the identity string and broke four
+	// consumers that key on the native form, because the transform belongs at resource construction with
+	// the resource owning both forms, not at one site along the way.
+	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), resourceType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -107,7 +107,11 @@ func buildCandidateAs(
 	sourcePath := runtimeEnvironment.Root().NewPath(path)
 	var base op.ResourceBase
 
-	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), resourceType)
+	// Slash form in the identity, not OS-native. The URI travels into serialized documents and into the
+	// content checksums computed over them, so a backslash here makes identity platform-dependent — the same
+	// defect #377 removed from [fsroot.Path.Rel]. filepath.ToSlash is a no-op on Unix and converts the
+	// separators on Windows; the absolute path itself (volume included) is unchanged.
+	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+filepath.ToSlash(sourcePath.Abs()), resourceType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/op/provider/file/helpers_test.go
+++ b/pkg/op/provider/file/helpers_test.go
@@ -6,7 +6,6 @@ package file
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -67,24 +66,6 @@ func TestResolveOwnership_RejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestResolveOwnership_LooksUpNamedUser(t *testing.T) {
-
-	// Looking up the current user by name should always succeed and return the same uid as os.Getuid.
-	currentUID := os.Getuid()
-	currentName := strconv.Itoa(currentUID)
-
-	gotUID, gotGID, err := resolveOwnership(currentName, "")
-	if err != nil {
-		t.Fatalf("resolveOwnership(%q, \"\"): %v", currentName, err)
-	}
-	if gotUID != currentUID {
-		t.Errorf("uid: got %d, want %d", gotUID, currentUID)
-	}
-	if gotGID != -1 {
-		t.Errorf("gid: got %d, want -1 (group side absent)", gotGID)
-	}
-}
-
 // --- applyOwnership ---
 
 func TestApplyOwnership_BothSidesEmptyIsNoOp(t *testing.T) {
@@ -99,22 +80,6 @@ func TestApplyOwnership_BothSidesEmptyIsNoOp(t *testing.T) {
 	// Both sides empty must short-circuit to nil error without invoking any syscall.
 	if err := applyOwnership(target, "", ""); err != nil {
 		t.Errorf("applyOwnership(empty, empty): %v", err)
-	}
-}
-
-func TestApplyOwnership_CurrentUserIsNoOp(t *testing.T) {
-
-	// Setting ownership to the current uid and gid is a no-op-ish operation that needs no CAP_CHOWN.
-	tmp := t.TempDir()
-	target := filepath.Join(tmp, "test.txt")
-
-	if err := os.WriteFile(target, []byte("test"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	user, group := strconv.Itoa(os.Getuid()), strconv.Itoa(os.Getgid())
-	if err := applyOwnership(target, user, group); err != nil {
-		t.Errorf("applyOwnership(%q, %q): %v", user, group, err)
 	}
 }
 

--- a/pkg/op/provider/file/helpers_unix_test.go
+++ b/pkg/op/provider/file/helpers_unix_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build unix
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// Ownership resolution is Unix-only, and the constraint scopes these rather than skipping them.
+//
+// os.Getuid and os.Getgid return **-1** on Windows, so a test that formats them builds the string "-1" —
+// which resolveOwnership reads as a numeric id, then rejects because both sides land on the -1 "leave
+// unchanged" sentinel. The failure is the platform having no such concept, not the code being wrong.
+
+func TestResolveOwnership_LooksUpNamedUser(t *testing.T) {
+
+	// Looking up the current user by name should always succeed and return the same uid as os.Getuid.
+	currentUID := os.Getuid()
+	currentName := strconv.Itoa(currentUID)
+
+	gotUID, gotGID, err := resolveOwnership(currentName, "")
+	if err != nil {
+		t.Fatalf("resolveOwnership(%q, \"\"): %v", currentName, err)
+	}
+	if gotUID != currentUID {
+		t.Errorf("uid: got %d, want %d", gotUID, currentUID)
+	}
+	if gotGID != -1 {
+		t.Errorf("gid: got %d, want -1 (group side absent)", gotGID)
+	}
+}
+
+func TestApplyOwnership_CurrentUserIsNoOp(t *testing.T) {
+
+	// Setting ownership to the current uid and gid is a no-op-ish operation that needs no CAP_CHOWN.
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "test.txt")
+
+	if err := os.WriteFile(target, []byte("test"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	user, group := strconv.Itoa(os.Getuid()), strconv.Itoa(os.Getgid())
+	if err := applyOwnership(target, user, group); err != nil {
+		t.Errorf("applyOwnership(%q, %q): %v", user, group, err)
+	}
+}

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -11,6 +11,10 @@ import (
 	"io"
 	"io/fs"
 	"os"
+
+	// Aliased: these Starlark-facing path helpers speak the slash-form language (the same contract as
+	// io/fs and the canonical fsroot.Path rel form), not the OS-native one.
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -1349,31 +1353,37 @@ func (p *Provider) ReadText(resource *Regular) (product string, err error) {
 //   - `parts`: the path components to join.
 //
 // Returns:
-//   - `string`: the joined path.
+//   - `string`: the joined path, in slash form.
 func (p *Provider) Join(parts ...string) string {
-	return filepath.Join(parts...)
+	return slashpath.Join(parts...)
 }
 
-// Name returns the last element of `path` (a file or directory name) via [filepath.Base].
+// Name returns the last element of `path` (a file or directory name) via [slashpath.Base].
+//
+// Slash form, not OS-native: these helpers are a projected Starlark surface, and a path is a slash-form
+// language on every platform — the same contract as io/fs and the canonical [fsroot.Path] rel form.
+// [filepath.Base] would answer `\` for `/` on Windows, making a pure string operation platform-dependent.
 //
 // Parameters:
 //   - `path`: the path whose last element is returned.
 //
 // Returns:
-//   - `string`: the last path element.
+//   - `string`: the last path element, in slash form.
 func (p *Provider) Name(path string) string {
-	return filepath.Base(path)
+	return slashpath.Base(path)
 }
 
-// Parent returns the directory containing the file at `path` via [filepath.Dir].
+// Parent returns the directory containing the file at `path` via [slashpath.Dir].
+//
+// Slash form, not OS-native — see [Provider.Name] for why.
 //
 // Parameters:
 //   - `path`: the path whose containing directory is returned.
 //
 // Returns:
-//   - `string`: the parent directory path.
+//   - `string`: the parent directory path, in slash form.
 func (p *Provider) Parent(path string) string {
-	return filepath.Dir(path)
+	return slashpath.Dir(path)
 }
 
 // endregion

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -1353,9 +1353,12 @@ func (p *Provider) ReadText(resource *Regular) (product string, err error) {
 //   - `parts`: the path components to join.
 //
 // Returns:
-//   - `string`: the joined path, in slash form.
+//   - `string`: the joined path, OS-native.
+//
+// Native, unlike [Provider.Name] and [Provider.Parent]: those answer questions ABOUT a path as a value,
+// while Join builds one FOR USE — its result is handed to the filesystem.
 func (p *Provider) Join(parts ...string) string {
-	return slashpath.Join(parts...)
+	return filepath.Join(parts...)
 }
 
 // Name returns the last element of `path` (a file or directory name) via [slashpath.Base].

--- a/pkg/op/provider/file/provider_backfill_test.go
+++ b/pkg/op/provider/file/provider_backfill_test.go
@@ -170,9 +170,12 @@ func TestWalkTree_ReducerError_StackHoldsCompletedReceipts(t *testing.T) {
 		t.Fatalf("stack holds %d receipts, want 2 (the completed entries a.txt, b.txt)", len(receipts))
 	}
 
+	// filepath.Base, not p.Name: Abs() is OS-native, and p.Name speaks the slash-form language of the
+	// projected Starlark surface. Feeding it a native path finds no separator on Windows and returns the
+	// whole path — the mismatch #547 exists to remove, here in a test that only wants a file name.
 	got := map[string]bool{}
 	for _, receipt := range receipts {
-		got[p.Name(receipt.Result().(Entry).Path().Abs())] = true
+		got[filepath.Base(receipt.Result().(Entry).Path().Abs())] = true
 	}
 	if !got["a.txt"] || !got["b.txt"] {
 		t.Errorf("stack receipts name %v, want a.txt and b.txt", got)

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -76,7 +76,11 @@ func TestCheckout_BuildsArgv(t *testing.T) {
 	}
 
 	out := buf.String()
-	want := "git -C " + repo.SourcePath.Abs() + " checkout release-1.2"
+	// The argv, not the binary: exec.Cmd.String() renders the LookPath-RESOLVED executable, so the line reads
+	// "/usr/bin/git -C ..." on Unix and "C:\...\git.exe -C ..." on Windows. Asserting a leading "git " only
+	// ever worked because "/usr/bin/git" ends with "git"; ".exe" breaks the same substring. Assert the part
+	// this test is actually about.
+	want := "-C " + repo.SourcePath.Abs() + " checkout release-1.2"
 	if !strings.Contains(out, want) {
 		t.Errorf("narrated command =\n  %q\nwant it to contain\n  %q", out, want)
 	}
@@ -141,7 +145,11 @@ func TestPull_BuildsArgv(t *testing.T) {
 	}
 
 	out := buf.String()
-	want := "git -C " + repo.SourcePath.Abs() + " pull"
+	// The argv, not the binary: exec.Cmd.String() renders the LookPath-RESOLVED executable, so the line reads
+	// "/usr/bin/git -C ..." on Unix and "C:\...\git.exe -C ..." on Windows. Asserting a leading "git " only
+	// ever worked because "/usr/bin/git" ends with "git"; ".exe" breaks the same substring. Assert the part
+	// this test is actually about.
+	want := "-C " + repo.SourcePath.Abs() + " pull"
 	if !strings.Contains(out, want) {
 		t.Errorf("narrated command =\n  %q\nwant it to contain\n  %q", out, want)
 	}

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"path/filepath"
+	slashpath "path"
 	"reflect"
 	"strings"
 	"testing"
@@ -256,6 +256,12 @@ func TestNewResource_DifferentBytesDifferentURI(t *testing.T) {
 
 // --- SourcePath sharding ---
 
+// TestSourcePath_ShardedLayout pins the store layout AND its separator: [fsroot.Path.Rel] is canonically
+// slash-form on every platform, so the expectation is built with the slash-form joiner.
+//
+// Building it with [filepath.Join] made the test assert backslashes on Windows against a Rel that
+// deliberately does not produce them — the platform-dependence #377 removed from Rel, reintroduced in the
+// assertion.
 func TestSourcePath_ShardedLayout(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 
@@ -264,7 +270,7 @@ func TestSourcePath_ShardedLayout(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	want := filepath.Join(".devlore", "mem", "resource", "sha256", r.Hash[0:2], r.Hash)
+	want := slashpath.Join(".devlore", "mem", "resource", "sha256", r.Hash[0:2], r.Hash)
 	if got := r.SourcePath().Rel(); got != want {
 		t.Errorf("SourcePath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Windows baseline reduction, plus the CI fix this PR's own verification needed. **The first pass
over-reached and CI caught it**; this carries the fixes that held, the reverts of the ones that did not, and
a workflow repair.

## What CI said about the first attempt

**Nine cleared, six regressed** — net 28 → 25. Three changes were wrong, all the same way: **slash form
applied to access rather than identity.**

| Over-reach | How it broke |
|---|---|
| `Join` → slash | builds a path **for use**; `Join(a,b,c)` gave `a/b/c` where the platform wants `a\b\c` |
| `commonAncestor` → slash | its result becomes the run's confinement **Root**; `fsroot` panicked relating `C:\…` to `/` |
| identity URI → slash | **four consumers key on the native form**, including drift detection, which stopped seeing a stale file |

The third did not merely fail a comparison — it **silently changed behavior**. That is the "along the way"
fix **#547** exists to prevent: the transform belongs at resource construction, with the resource owning
both forms.

## What stands

| Fix | Why it is identity, not access |
|---|---|
| `Provider.Name` / `Parent` → slash | they answer questions **about** a path as a value, on a projected Starlark surface |
| `mem` `SourcePath` test → `slashpath` | asserted backslashes against a `Rel()` that is canonically slash-form **by design** |
| ownership tests → `//go:build unix` | `os.Getuid()` returns **-1** on Windows; the platform has no such concept |
| `commonAncestor` test → `//go:build unix` | it feeds `/home/user`, a drive-relative string with no meaning on Windows |
| git argv assertions | `exec.Cmd.String()` renders the **resolved** binary; a leading `"git "` matched only because `/usr/bin/git` ends with `git`, and `.exe` breaks it |

## And the CI repair (#439)

`quality-gate` hung **20+ minutes** installing lint tools, blocking this PR's own measurement. Two defects:

1. **No timeouts on the curl** — a stalled connection hangs forever. Retries handle *failures*, not *hangs*.
   Now `--connect-timeout 15 --max-time 120`.
2. **The retry loop had never retried.** `quality-gate` declared no shell, so it ran `bash -e {0}` **without
   pipefail**. In `curl … | sh`, a failed curl left `sh` reading empty input and exiting **0** — the
   pipeline succeeded and `&& break` fired on attempt one. The job now declares `shell: bash` like its
   `test` and `scenario` siblings.
3. **The other two network operations had neither.** `shfmt` is pinned to **v3.13.1** — `@latest` would
   change formatting verdicts with no commit on our side, and 3.13.1 is what developers run locally — and
   wrapped in `timeout 180`. `apt` gets `Acquire::Retries=3` with 30s http/https timeouts, because a mirror
   that accepts the connection then stalls is the same hang, and a bare `timeout` would retry nothing.

The curl is the only pipeline in that job, so `pipefail` changes nothing else. Validated with `actionlint`,
which also shellchecks the `run` blocks.

## Expected windows result

**28 → 18**, no regressions. Held loosely — the last confident number was wrong by six.

## Verified

`make check` and `make lint-all` (linux, darwin, windows) both exit 0; the workflow validates under
`actionlint`.
