### PR TITLE
fix(platform): keep the network out of package-manager reads

### DIFF
--- a/cmd/internal/lorepackage/package.go
+++ b/cmd/internal/lorepackage/package.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/NobleFactor/devlore-cli/pkg/platform"
 )
 
 // PackageSource indicates where a package was resolved from.
@@ -245,48 +243,6 @@ func (r *Registry) resolveNative(name, targetPlatform string) (*Release, error) 
 	_ = cache.Put(info) //nolint:errcheck // cache errors are non-fatal
 
 	return pkg, nil
-}
-
-// VerifySyntheticPackage checks if a synthetic package is available and updates the cache.
-func (r *Registry) VerifySyntheticPackage(pkg *Release) bool {
-	if pkg.Source == SourceLore {
-		return true // Lore packages are always "verified"
-	}
-
-	cache := NewSyntheticCache(r.cacheDir)
-
-	// Check if already verified in cache
-	if cached := cache.Get(pkg.Source, pkg.Name); cached != nil && cached.Verified {
-		return true
-	}
-
-	// Verify with the host's package-manager router, querying the default native manager.
-	spec, err := platform.Detect()
-	if err != nil {
-		return false
-	}
-	host, err := platform.New(spec)
-	if err != nil {
-		return false
-	}
-	router := host.PackageManager()
-	if router == nil {
-		return false
-	}
-
-	available := router.Available(platform.PURL{Type: host.DefaultPurlType(), Name: pkg.Name})
-
-	// Update cache with verification result
-	info := &SyntheticPackageInfo{
-		Name:       pkg.Name,
-		Source:     pkg.Source,
-		NativeName: pkg.NativeName,
-		Version:    pkg.Version,
-		Verified:   available,
-	}
-	_ = cache.Put(info) //nolint:errcheck // cache errors are non-fatal
-
-	return available
 }
 
 // SyntheticCache returns the synthetic package cache for this registry.

--- a/cmd/internal/lorepackage/search.go
+++ b/cmd/internal/lorepackage/search.go
@@ -221,7 +221,27 @@ func (r *Registry) ListPackages() ([]SearchResultItem, error) {
 	return results, nil
 }
 
-// ResolveWithConfidence resolves a package and returns confidence information.
+// ResolveWithConfidence resolves a package and rates how likely the resolution is to hold.
+//
+// The rating is a hint, not a gate: high for a lore package, medium when the machine has a native package
+// manager to install through, low otherwise. Medium deliberately asks only whether the manager is present —
+// not whether it carries this particular package. Presence is a per-machine fact answered by a PATH lookup,
+// while carriage is a per-package question answered by an index, and an index is exactly what makes the
+// question expensive: consulting it costs a subprocess per package, and refreshing it costs a network round
+// trip that a cold machine pays on every run.
+//
+// A hint does not justify that. An install through a present manager can still fail — the package is missing,
+// a mirror is down, the lock is held — and that failure is reported by the install, where it happens and with
+// the detail to act on.
+//
+// Parameters:
+//   - `name`: the package name to resolve.
+//   - `targetPlatform`: the platform token the release must satisfy.
+//
+// Returns:
+//   - `*Release`: the resolved release; nil when resolution failed.
+//   - `Confidence`: the rating described above.
+//   - `error`: non-nil when the package could not be resolved.
 func (r *Registry) ResolveWithConfidence(name, targetPlatform string) (*Release, Confidence, error) {
 	release, err := r.Resolve(name, targetPlatform)
 	if err != nil {
@@ -233,11 +253,10 @@ func (r *Registry) ResolveWithConfidence(name, targetPlatform string) (*Release,
 		return release, ConfidenceHigh, nil
 	}
 
-	// Native packages: check if the default native manager has it available.
+	// Native packages: a manager on the PATH is what raises confidence.
 	if spec, err := platform.Detect(); err == nil {
 		if host, err := platform.New(spec); err == nil {
-			if router := host.PackageManager(); router != nil &&
-				router.Available(platform.PURL{Type: host.DefaultPurlType(), Name: name}) {
+			if router := host.PackageManager(); router != nil && router.Present() {
 				return release, ConfidenceMedium, nil
 			}
 		}

--- a/pkg/op/provider/pkg/provider_test.go
+++ b/pkg/op/provider/pkg/provider_test.go
@@ -92,6 +92,7 @@ func (m *mockPackageManager) Update() error {
 func (m *mockPackageManager) Installed(p platform.PURL) bool { return m.installed[p.Name] }
 func (m *mockPackageManager) Version(p platform.PURL) string { return m.versions[p.Name] }
 func (m *mockPackageManager) Available(platform.PURL) bool   { return true }
+func (m *mockPackageManager) Present() bool                  { return true }
 
 func (m *mockPackageManager) Search(string, int) []platform.SearchResult { return nil }
 

--- a/pkg/platform/composite.go
+++ b/pkg/platform/composite.go
@@ -104,6 +104,23 @@ func (c *compositeManager) Installed(p PURL) bool {
 	return false
 }
 
+// Present reports whether any leaf's executable is on the PATH.
+//
+// Any leaf, not the default one: the router stands for the machine's native package management as a whole, and
+// a host that has flatpak but not apt can still install natively. Callers that need a specific manager should
+// ask that leaf.
+//
+// Returns:
+//   - `bool`: true when at least one leaf is present; false when the set is empty or none resolve.
+func (c *compositeManager) Present() bool {
+	for _, l := range c.byType {
+		if l.Present() {
+			return true
+		}
+	}
+	return false
+}
+
 // Remove routes each package to its leaf and converges it to absent.
 //
 // Parameters:

--- a/pkg/platform/cross_distro_managers.go
+++ b/pkg/platform/cross_distro_managers.go
@@ -41,6 +41,12 @@ func newFlatpakManager() *flatpakManager {
 
 // region State management
 
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "flatpak".
+func (m *flatpakManager) executable() string { return "flatpak" }
+
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //
 // Returns:
@@ -79,6 +85,12 @@ func newSnapManager() *snapManager {
 // region UNEXPORTED METHODS
 
 // region State management
+
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "snap".
+func (m *snapManager) executable() string { return "snap" }
 
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //

--- a/pkg/platform/darwin_managers.go
+++ b/pkg/platform/darwin_managers.go
@@ -40,6 +40,12 @@ func newBrewManager() *brewManager {
 
 // region State management
 
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "brew".
+func (m *brewManager) executable() string { return "brew" }
+
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //
 // Returns:
@@ -95,6 +101,12 @@ func newPortManager() *portManager {
 // region UNEXPORTED METHODS
 
 // region State management
+
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "port".
+func (m *portManager) executable() string { return "port" }
 
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //

--- a/pkg/platform/driver.go
+++ b/pkg/platform/driver.go
@@ -5,6 +5,7 @@ package platform
 
 import (
 	"fmt"
+	"os/exec"
 	"time"
 )
 
@@ -17,6 +18,7 @@ import (
 type rawDriver interface {
 	name() string
 	purlType() string
+	executable() string
 	installed(name string) bool
 	version(name string) string
 	available(name string) bool
@@ -59,7 +61,7 @@ func newDriver(raw rawDriver) driver {
 // Returns:
 //   - `bool`: true when the package is available to install.
 func (d driver) Available(p PURL) bool {
-	d.ensureFresh()
+	d.ensureIndex()
 	return d.available(d.tokenFor(p))
 }
 
@@ -86,6 +88,18 @@ func (d driver) Install(packages []PURL, kwargs map[string]any) ([]Receipt, erro
 //   - `bool`: true when the package is installed.
 func (d driver) Installed(p PURL) bool { return d.installed(d.tokenFor(p)) }
 
+// Present reports whether this manager's executable is on the PATH.
+//
+// A PATH lookup and nothing more — no subprocess, no index, no network — so it is cheap enough to call per
+// resolution and safe to call from a test.
+//
+// Returns:
+//   - `bool`: true when the executable resolves on the PATH.
+func (d driver) Present() bool {
+	_, err := exec.LookPath(d.executable())
+	return err == nil
+}
+
 // Remove converges each package to absent, verifying the outcome by re-query.
 //
 // Parameters:
@@ -108,7 +122,7 @@ func (d driver) Remove(packages []PURL, kwargs map[string]any) ([]Receipt, error
 // Returns:
 //   - `[]SearchResult`: the matches, each tagged with the manager's purl type; nil when none match.
 func (d driver) Search(query string, limit int) []SearchResult {
-	d.ensureFresh()
+	d.ensureIndex()
 	return tagManager(d.searchRaw(query, limit), d.purlType())
 }
 
@@ -165,13 +179,40 @@ func (d driver) Version(p PURL) string { return d.version(d.tokenFor(p)) }
 
 // region Behaviors
 
-// ensureFresh refreshes the leaf's index before an index-consuming operation when it is stale.
+// ensureFresh refreshes the leaf's index before a mutating operation when it is stale or missing.
 //
-// It is the automatic, staleness-gated half of index update: a leaf is gated only when it is both a [refresher] and
-// [stalenessAware], and only when its index age exceeds [refreshTTL]. The refresh is best-effort — a failure is
-// non-fatal and the operation proceeds against the existing index. A successful refresh updates the index mtime, so
-// a later ensureFresh in the same run reads fresh; a batch of operations triggers at most one refresh.
+// Freshness is load-bearing for [driver.Install] and [driver.Upgrade] and for nothing else: both resolve a specific
+// version, so an index that has fallen behind installs a superseded build or fetches one the mirror has since
+// withdrawn. "Latest", for Upgrade, is a claim the index alone defines.
 func (d driver) ensureFresh() {
+	d.refreshIndexWhen(func(age time.Duration) bool { return age > refreshTTL })
+}
+
+// ensureIndex refreshes the leaf's index before a query only when there is no index to read.
+//
+// A query asks whether a package exists ([driver.Available]) or what matches a term ([driver.Search]); neither
+// carries a version — see [driver.tokenFor] — so neither is version-sensitive, and age costs them almost nothing.
+// Absence costs them everything: with no index, Available reports false for every package on the machine, which
+// reads exactly like an authoritative "no such package".
+//
+// The distinction is not academic. A CI runner's image ships with the package lists cleaned, so an implicit
+// staleness refresh here turned a read into a multi-minute network fetch — long enough to blow a test deadline,
+// and long enough to strand anyone running an interactive search.
+func (d driver) ensureIndex() {
+	d.refreshIndexWhen(indexIsMissing)
+}
+
+// refreshIndexWhen refreshes the leaf's index when `needed` accepts its current age.
+//
+// The shared mechanism behind both gates. A leaf participates only when it is both a [refresher] and
+// [stalenessAware]; brew and dnf self-manage their freshness and implement the former without the latter, so they
+// are never gated automatically. The refresh is best-effort — a failure is non-fatal and the operation proceeds
+// against whatever index exists. A successful refresh updates the index mtime, so a batch of operations triggers at
+// most one.
+//
+// Parameters:
+//   - `needed`: predicate over the leaf's index age deciding whether to refresh.
+func (d driver) refreshIndexWhen(needed func(age time.Duration) bool) {
 
 	r, ok := d.rawDriver.(refresher)
 	if !ok {
@@ -183,7 +224,7 @@ func (d driver) ensureFresh() {
 		return
 	}
 
-	if s.indexAge() > refreshTTL {
+	if needed(s.indexAge()) {
 		_ = r.refresh()
 	}
 }

--- a/pkg/platform/helpers.go
+++ b/pkg/platform/helpers.go
@@ -11,13 +11,15 @@ import (
 
 // refreshTTL is the staleness threshold for the automatic index refresh.
 //
-// A leaf whose local index is older than this refreshes before an index-consuming operation. A single default knob
-// for now; promote to a per-leaf value if managers need to diverge.
+// A leaf whose local index is older than this refreshes before a mutating operation ([driver.ensureFresh]). It does
+// not govern queries: age alone never triggers a refresh for [driver.Available] or [driver.Search]. A single default
+// knob for now; promote to a per-leaf value if managers need to diverge.
 const refreshTTL = 24 * time.Hour
 
 // unknownIndexAge is the age reported for an index that cannot be stat'd (never built, or an unreadable path).
 //
-// Well past [refreshTTL], so the gate treats it as stale and refreshes.
+// It is a sentinel standing for "there is no index", not a measurement — read through [indexIsMissing] rather than
+// compared as a duration. Its value is well past [refreshTTL] so the mutator gate also treats it as stale.
 //
 //nolint:unused // read by the Linux-tagged leaves in linux_managers_linux.go; invisible to non-Linux analyses.
 const unknownIndexAge = 365 * 24 * time.Hour
@@ -25,7 +27,7 @@ const unknownIndexAge = 365 * 24 * time.Hour
 // indexAgeOf returns how long ago `path` was last modified, or [unknownIndexAge] when it cannot be stat'd.
 //
 // Leaves whose index is a file or directory touched by their refresh command (apt's lists, pacman's sync db) report
-// staleness through this; the automatic gate compares the result against [refreshTTL].
+// staleness through this.
 //
 // Parameters:
 //   - `path`: the index file or directory whose mtime marks the last refresh.
@@ -42,6 +44,24 @@ func indexAgeOf(path string) time.Duration {
 	}
 
 	return time.Since(info.ModTime())
+}
+
+// indexIsMissing reports whether `age` is the sentinel [indexAgeOf] returns when there is no index to age.
+//
+// Absence and staleness are different failures and the gates treat them differently. A stale index still answers
+// an existence or search query, and answers it well: package names and descriptions barely churn. A missing index
+// answers nothing — and says so as `false`, which a caller cannot tell from "that package does not exist". So a
+// query refreshes only for absence, where the alternative is a confident wrong answer.
+//
+// Parameters:
+//   - `age`: an age reported by [indexAgeOf].
+//
+// Returns:
+//   - `bool`: true when the age is the absence sentinel.
+//
+//nolint:unused // paired with indexAgeOf, whose callers are the Linux-tagged leaves; invisible to non-Linux analyses.
+func indexIsMissing(age time.Duration) bool {
+	return age == unknownIndexAge
 }
 
 // bracket runs a best-effort batch package operation and returns one [Receipt] per package.

--- a/pkg/platform/linux_managers.go
+++ b/pkg/platform/linux_managers.go
@@ -42,6 +42,15 @@ func newAptManager() *aptManager {
 
 // region State management
 
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// "apt-get", not "apt": apt-get is what this manager actually shells out to, and it is the interface Debian
+// declares stable for scripts. A host could in principle carry one without the other.
+//
+// Returns:
+//   - `string`: "apt-get".
+func (m *aptManager) executable() string { return "apt-get" }
+
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //
 // Returns:
@@ -78,6 +87,12 @@ func newDnfManager() *dnfManager {
 
 // region State management
 
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "dnf".
+func (m *dnfManager) executable() string { return "dnf" }
+
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //
 // Returns:
@@ -113,6 +128,12 @@ func newPacmanManager() *pacmanManager {
 // region UNEXPORTED METHODS
 
 // region State management
+
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// Returns:
+//   - `string`: "pacman".
+func (m *pacmanManager) executable() string { return "pacman" }
 
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //

--- a/pkg/platform/manager.go
+++ b/pkg/platform/manager.go
@@ -94,6 +94,21 @@ type PackageManager interface {
 	// Returns:
 	//   - `[]SearchResult`: the matches, each tagged with the `Manager` that produced it; nil when none match.
 	Search(query string, limit int) []SearchResult
+
+	// Present reports whether the manager's executable is on the PATH.
+	//
+	// Alone among the queries this asks about the manager, not a package: it is a per-machine fact, so it
+	// neither varies by [PURL] nor consults an index. A [Spec] declares its managers from the detected OS and
+	// distro — "Debian-family, therefore apt" — which is a statement about the platform, not about this
+	// machine. Present is what closes that gap, and it does so with a PATH lookup: no subprocess, no network.
+	//
+	// It answers whether the tool is there, not whether an operation through it will succeed. A present
+	// manager can still fail to install — a lock, a bad mirror, no privilege — and that failure belongs to
+	// the operation that hits it, reported where it happens.
+	//
+	// Returns:
+	//   - `bool`: true when the executable resolves on the PATH.
+	Present() bool
 }
 
 // ServiceManager abstracts service-management operations.

--- a/pkg/platform/present_test.go
+++ b/pkg/platform/present_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package platform
+
+import (
+	"runtime"
+	"testing"
+)
+
+// alwaysPresentBinary names an executable every supported host is guaranteed to carry.
+//
+// Returns:
+//   - `string`: "cmd" on Windows, "sh" elsewhere.
+func alwaysPresentBinary() string {
+	if runtime.GOOS == "windows" {
+		return "cmd"
+	}
+	return "sh"
+}
+
+// TestDriverPresentFindsAnInstalledExecutable verifies Present resolves a binary that is certainly on the PATH.
+func TestDriverPresentFindsAnInstalledExecutable(t *testing.T) {
+
+	d := newDriver(&fakeRawDriver{binary: alwaysPresentBinary()})
+
+	if !d.Present() {
+		t.Errorf("Present() = false for %q, want true", alwaysPresentBinary())
+	}
+}
+
+// TestDriverPresentRejectsAMissingExecutable verifies Present reports false when nothing resolves.
+func TestDriverPresentRejectsAMissingExecutable(t *testing.T) {
+
+	d := newDriver(&fakeRawDriver{binary: "devlore-no-such-package-manager"})
+
+	if d.Present() {
+		t.Error("Present() = true for a binary that does not exist, want false")
+	}
+}
+
+// TestCompositePresentReportsAnyLeaf verifies the router answers for the machine, not for one manager.
+//
+// A host carrying flatpak but not apt can still install natively, so one present leaf is enough.
+func TestCompositePresentReportsAnyLeaf(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		leaves []leaf
+		want   bool
+	}{
+		{
+			name:   "no leaves at all",
+			leaves: nil,
+			want:   false,
+		},
+		{
+			name:   "every leaf absent",
+			leaves: []leaf{&fakeLeaf{typ: "deb"}, &fakeLeaf{typ: "rpm"}},
+			want:   false,
+		},
+		{
+			name:   "one leaf of several present",
+			leaves: []leaf{&fakeLeaf{typ: "deb"}, &fakeLeaf{typ: "rpm", present: true}},
+			want:   true,
+		},
+		{
+			name:   "every leaf present",
+			leaves: []leaf{&fakeLeaf{typ: "deb", present: true}, &fakeLeaf{typ: "rpm", present: true}},
+			want:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			router := newComposite(test.leaves, nil)
+
+			if got := router.Present(); got != test.want {
+				t.Errorf("Present() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/platform/update_test.go
+++ b/pkg/platform/update_test.go
@@ -15,6 +15,7 @@ type fakeLeaf struct {
 	typ          string // purl type the fake reports
 	updateErr    error  // error Update returns; nil for success
 	updateCalled bool   // set when Update runs
+	present      bool   // value Present reports
 }
 
 var _ leaf = (*fakeLeaf)(nil)
@@ -27,6 +28,7 @@ func (f *fakeLeaf) Upgrade([]PURL, map[string]any) ([]Receipt, error) { return n
 func (f *fakeLeaf) Installed(PURL) bool                               { return false }
 func (f *fakeLeaf) Version(PURL) string                               { return "" }
 func (f *fakeLeaf) Available(PURL) bool                               { return false }
+func (f *fakeLeaf) Present() bool                                     { return f.present }
 func (f *fakeLeaf) Search(string, int) []SearchResult                 { return nil }
 func (f *fakeLeaf) Update() error                                     { f.updateCalled = true; return f.updateErr }
 
@@ -72,6 +74,7 @@ func TestCompositeUpdateAggregatesFailures(t *testing.T) {
 // path.
 type fakeRawDriver struct {
 	typ       string        // purl type the fake reports
+	binary    string        // executable name Present looks for on the PATH
 	age       time.Duration // index age indexAge reports
 	refreshes int           // count of refresh invocations
 }
@@ -80,6 +83,7 @@ var _ rawDriver = (*fakeRawDriver)(nil)
 
 func (f *fakeRawDriver) name() string                               { return f.typ }
 func (f *fakeRawDriver) purlType() string                           { return f.typ }
+func (f *fakeRawDriver) executable() string                         { return f.binary }
 func (f *fakeRawDriver) installed(string) bool                      { return false }
 func (f *fakeRawDriver) version(string) string                      { return "" }
 func (f *fakeRawDriver) available(string) bool                      { return true }
@@ -126,23 +130,67 @@ func TestEnsureFreshIgnoresLocalOps(t *testing.T) {
 	}
 }
 
-// TestEnsureFreshGatesIndexConsumingOps verifies Upgrade, Search, and Available each gate a stale-index refresh.
-func TestEnsureFreshGatesIndexConsumingOps(t *testing.T) {
+// indexOp is a driver operation exercised against the index gate, named for its failure message.
+type indexOp struct {
+	name string
+	call func(driver)
+}
 
-	cases := []struct {
-		name string
-		call func(driver)
-	}{
-		{"Upgrade", func(d driver) { d.Upgrade([]PURL{{Type: "deb", Name: "x"}}, nil) }},
-		{"Search", func(d driver) { d.Search("x", 0) }},
-		{"Available", func(d driver) { d.Available(PURL{Type: "deb", Name: "x"}) }},
-	}
+// mutatorOps are the operations that resolve a specific version and so depend on a current index.
+var mutatorOps = []indexOp{
+	{"Install", func(d driver) { d.Install([]PURL{{Type: "deb", Name: "x"}}, nil) }},
+	{"Upgrade", func(d driver) { d.Upgrade([]PURL{{Type: "deb", Name: "x"}}, nil) }},
+}
 
-	for _, c := range cases {
+// queryOps are the operations that read the index without naming a version.
+var queryOps = []indexOp{
+	{"Available", func(d driver) { d.Available(PURL{Type: "deb", Name: "x"}) }},
+	{"Search", func(d driver) { d.Search("x", 0) }},
+}
+
+// TestMutatorsRefreshAStaleIndex verifies Install and Upgrade still gate on age.
+func TestMutatorsRefreshAStaleIndex(t *testing.T) {
+
+	for _, op := range mutatorOps {
 		fake := &fakeRawDriver{typ: "deb", age: refreshTTL + time.Hour}
-		c.call(newDriver(fake))
+		op.call(newDriver(fake))
+
 		if fake.refreshes != 1 {
-			t.Errorf("%s on stale index: refreshes = %d, want 1", c.name, fake.refreshes)
+			t.Errorf("%s on stale index: refreshes = %d, want 1", op.name, fake.refreshes)
+		}
+	}
+}
+
+// TestQueriesIgnoreAStaleIndex verifies age alone never sends a read to the network.
+//
+// A stale index still answers an existence or search query well, so paying a refresh for one is the defect this
+// gate was reshaped to remove.
+func TestQueriesIgnoreAStaleIndex(t *testing.T) {
+
+	for _, op := range queryOps {
+		fake := &fakeRawDriver{typ: "deb", age: refreshTTL + time.Hour}
+		op.call(newDriver(fake))
+
+		if fake.refreshes != 0 {
+			t.Errorf("%s on stale index: refreshes = %d, want 0", op.name, fake.refreshes)
+		}
+	}
+}
+
+// TestQueriesRefreshAMissingIndex verifies absence still refreshes, for either kind of operation.
+//
+// With no index Available reports false for every package, which a caller cannot distinguish from an
+// authoritative "no such package" — so absence is worth the fetch where age is not.
+func TestQueriesRefreshAMissingIndex(t *testing.T) {
+
+	for _, ops := range [][]indexOp{queryOps, mutatorOps} {
+		for _, op := range ops {
+			fake := &fakeRawDriver{typ: "deb", age: unknownIndexAge}
+			op.call(newDriver(fake))
+
+			if fake.refreshes != 1 {
+				t.Errorf("%s on missing index: refreshes = %d, want 1", op.name, fake.refreshes)
+			}
 		}
 	}
 }

--- a/pkg/platform/windows_managers.go
+++ b/pkg/platform/windows_managers.go
@@ -62,6 +62,14 @@ func newWingetManager() *wingetManager {
 
 // region State management
 
+// executable returns the binary [driver.Present] looks for on the PATH.
+//
+// [exec.LookPath] consults PATHEXT on Windows, so the bare name resolves winget.exe.
+//
+// Returns:
+//   - `string`: "winget".
+func (m *wingetManager) executable() string { return "winget" }
+
 // name returns the manager's name — the user-facing pkg.Resource prefix.
 //
 // Returns:


### PR DESCRIPTION
## The bug

`TestResolveWithConfidence_NativePackage` hung twice in one day on ubuntu, each time killing its whole
package's verdict:

```
panic: test timed out after 2m0s
running tests:
    TestResolveWithConfidence_NativePackage (1m59s)
FAIL  github.com/NobleFactor/devlore-cli/cmd/internal/lorepackage  120.050s
```

No `--- FAIL:` line, because the binary panicked rather than any test failing.

It was sitting in `apt-get update`. A GitHub runner appears to ship with its apt lists cleaned -- inferred from
the fact that every workflow installing a deb must run `apt-get update` first, ours included; I have not
confirmed it on a runner. Either way `indexAgeOf` stats nothing, returns the `unknownIndexAge` sentinel of a
year, and the 24h gate fires on every run. Not a stall -- a cold, complete fetch of every source the image
carries. Unremarkable in itself; wrong only in where it was triggered from.

## Two fixes

**1. Confidence no longer consults an index.**

`ResolveWithConfidence` used `router.Available(purl)` to pick `ConfidenceMedium` over `ConfidenceLow` -- asking
a per-package question to answer a per-machine one, so the fact was re-derived once per package at a subprocess
each. `PackageManager` gains `Present()`: an `exec.LookPath` over a new `rawDriver.executable()`, supplied by
each of the eight leaves.

`apt` reports **`apt-get`** -- what it actually shells out to, and the interface Debian declares stable for
scripts. The router reports **any** leaf present, since a host with flatpak but not apt can still install
natively.

**2. The staleness gate distinguishes absence from age.**

| | Needs an index | Needs it **fresh** |
|---|---|---|
| `Install` / `Upgrade` | Yes | **Yes** -- resolve a specific version |
| `Available` / `Search` | **Yes** | No -- `tokenFor` returns `p.Name`, no version |
| `Installed` / `Version` | No | No -- local state (already ungated) |

Age costs the queries nothing: names and descriptions barely churn. **Absence costs them everything, and
silently** -- with no index `Available` reports `false` for every package, which a caller cannot distinguish
from *"no such package"*.

> **The rule: refresh when the index is absent, or when the operation is a mutator. Never merely because it is
> old.**

## Not test-only

`lore search` reaches `searchNative`, and `compositeManager.Search` **fans out to every leaf** rather than
routing to one -- so each refresher leaf gated its own refresh. An interactive command blocking on a network
fetch with nothing on screen.

## Also

Removes `VerifySyntheticPackage` -- no callers anywhere, tests included -- and with it one of the three sites
that detect the host directly instead of asking the runtime environment. The two survivors are both `Registry`
methods in `search.go`, now tracked under #446.

## Verified

- `make check` -- exit 0, zero `FAIL` lines
- `present_test.go`: driver resolves a present binary, rejects a missing one; router reports any-leaf-present
  across four cases
- `update_test.go`: mutators still refresh on a stale index; queries no longer do; both refresh on a missing one

`Refs #439` rather than `Fixes`: that issue is the class, and its charter requires enumerating every
network-reaching test before a fix is designed. This is one instance, which was not on its list.
