### PR TITLE
test(cli): assert on what the CLI owns, not on what the OS says

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
 // binary is the path to the compiled devlore-test binary, set by TestMain.
@@ -129,7 +131,12 @@ func TestCLI_RunTooManyArgs(t *testing.T) {
 func TestCLI_RunMissingFile(t *testing.T) {
 	_, stderr, code := run("run", "nonexistent.star")
 	assertExit(t, 1, code)
-	assertContains(t, stderr, "no such file")
+
+	// The wrapped syscall text belongs to the OS -- "no such file or directory" on Unix, "The system cannot
+	// find the file specified." on Windows -- so asserting on it tested the platform, not the CLI. These two
+	// substrings are ours: the message the runner writes, and the path the caller passed.
+	assertContains(t, stderr, "reading script")
+	assertContains(t, stderr, "nonexistent.star")
 }
 
 func TestCLI_ScriptFirst(t *testing.T) {
@@ -321,7 +328,11 @@ func TestCLI_HelpRun(t *testing.T) {
 func TestCLI_ConfigPath(t *testing.T) {
 	stdout, _, code := run("config", "path")
 	assertExit(t, 0, code)
-	assertContains(t, stdout, "devlore/config.yaml")
+
+	// xdg.ConfigPath, not a literal: the printed path is OS-native, so "devlore/config.yaml" only ever matched
+	// on Unix. Asking xdg rather than cli.SharedConfigPath keeps the assertion independent of the accessor the
+	// command itself calls -- a wrong helper should fail here, not agree with itself.
+	assertContains(t, stdout, xdg.ConfigPath("devlore", "config.yaml"))
 }
 
 func TestCLI_SelfInstallHelp(t *testing.T) {


### PR DESCRIPTION
Two of the eighteen known windows failures were tests asserting text that was never ours to depend on.
Neither is a product defect: the CLI behaves correctly on windows in both cases.

## `TestCLI_ConfigPath`

```
cli_test.go:324: output missing "devlore/config.yaml" (len=73)
```

The printed path is OS-native, so the literal only ever matched on Unix -- windows prints
`devlore\config.yaml`. Under the identity/access rule a config path is **access**, so the CLI is right and
the test encoded a Unix assumption.

It now asserts `xdg.ConfigPath("devlore", "config.yaml")`.

Asking `xdg` rather than `cli.SharedConfigPath()` is deliberate: `SharedConfigPath` is the very function the
command calls, so asserting against it would agree with itself however wrong it became. `xdg` is one level
down and states the claim independently.

## `TestCLI_RunMissingFile`

```
cli_test.go:132: output missing "no such file" (len=1091)
```

The runner wraps `os.ReadFile` with `%w`:

```go
return nil, fmt.Errorf("reading script %s: %w", r.script, err)
```

so the tail of that message is the OS speaking -- `no such file or directory` on Unix, `The system cannot
find the file specified.` on windows. The test was asserting which platform it ran on.

It now asserts the two substrings we produce: the `reading script` prefix, and the path the caller passed.

**Accepted trade:** the assertion can no longer distinguish a missing file from an unreadable one. This is a
CLI smoke test, and the wrapped error still carries the OS's specific diagnosis for anyone reading it. The
alternative -- normalizing `fs.ErrNotExist` into our own phrasing -- buys uniform text at the cost of a
precise one, and works against the `%w` idiom.

## Verified

- `make check` -- clean
- Windows baseline expected to move **18 -> 16**, verified name-for-name against `develop` before merge

Refs #373.
