### PR TITLE
test(file): assert owner-only enforcement, and that it did not lock us out

### DIFF
--- a/docs/architecture/4.5-fsroot-variants.md
+++ b/docs/architecture/4.5-fsroot-variants.md
@@ -1,0 +1,159 @@
+# fsroot — Variants and Containment Rules
+
+> **Status:** requirements (draft, 2026-08-18). Records the stated requirements for `pkg/fsroot`'s three
+> variants and derives the rules that follow from them. No implementation.
+>
+> **Relationship to the neighbours.** [`4.4-root-path-triad.md`](4.4-root-path-triad.md) owns the cooperative
+> triad — Root produces and consumes Path, RecoverySite delegates to Root — and describes it under the pre-split
+> `op.Root` / `op.Path` names. **This document owns the variants**: what each one confines, by what mechanism,
+> and what that implies method by method. It **supersedes `4.4` §4's mode-switch table**, which states rules the
+> requirements below replace. Companion: [`4.5-fsroot-variants.status.md`](4.5-fsroot-variants.status.md).
+
+## Thesis
+
+**fsroot is `os.Root` plus two variants, and the variants differ in *what is unconfined* — never in whether the
+root is a root.** Today two of the three enforce nothing at all: every operation on an unconfined root is
+`os.X(p.abs)` straight through, so `Path`'s `root` field is decorative outside the confined variant, and each
+caller that needs containment invents its own. That invention is how the archive provider came to carry a
+hand-rolled `containedLinkTarget`, and how that guard came to be wrong on Windows (#556).
+
+## 1. The three variants
+
+**Requirements, as stated:**
+
+1. **Confined root** — must prevent changes outside the directory targeted by a writ or lore operation. A writ
+   deploy must not allow changes outside Home or System. The whole-filesystem case is deliberately degenerate:
+   on Unix everything is mounted under `/`, and on Windows under `%SYSTEMDRIVE%\`, so a root at either confines
+   to what the OS already enforces. No special-casing required.
+2. **Unconfined read-only root** — reads may go anywhere; **updates only inside `fsroot.Dir`**.
+3. **Unconfined read-write root** — reads and writes may go anywhere. There is no sandbox. `fsroot.Dir` is a
+   convenience for formulating relative paths.
+
+**One axis, three positions:**
+
+| Variant | Read | Write |
+| --- | --- | --- |
+| Confined | confined | confined |
+| Unconfined read-only | **anywhere** | confined to `Dir` |
+| Unconfined read-write | anywhere | anywhere |
+
+The fourth cell — confined reads with unconfined writes — is incoherent, which is why there are three variants
+and not four.
+
+**The names say what is *unconfined*, not what is *permitted*.** "Unconfined read-only" means *unconfined for
+reads only*; it still writes, within `Dir`. Reading the name as "this root cannot write" is the mistake the
+current implementation makes (§5).
+
+## 2. Mechanism: the kernel owns the write side
+
+For the unconfined read-only variant, **writes route through `*os.Root` and reads do not**. The variant is a
+composition of the other two: reads from the read-write variant (`os.*` on `p.abs`), writes from the confined
+variant (`*os.Root` on `p.rel`).
+
+Four reasons to let the kernel bound writes rather than checking paths ourselves:
+
+1. **TOCTOU.** A lexical check followed by `os.WriteFile` leaves a window: validate `dir/x`, something swaps
+   `dir` for a symlink, the write lands outside. `os.Root` resolves each component with the kernel holding the
+   invariant across the operation. For a variant whose purpose is bounding writes, a check that can be raced is
+   not a bound.
+2. **It answers "inside `Dir`" when a symlink already crosses out.** The kernel resolves the link and refuses.
+   A lexical check calls that write contained when it is not.
+3. **We stop reimplementing path resolution** — symlink following, `..` handling, Windows volume semantics.
+   That is the family of mistakes [#547](https://github.com/NobleFactor/devlore-cli/issues/547) catalogues, and
+   fsroot is the package that exists to end them.
+4. **`confinedRoot` already does exactly this**, so no new platform exposure is introduced.
+
+**Costs.** An open root descriptor for the variant's lifetime (negligible). Writes dispatch on `p.rel`, so a
+`Path` whose `rel` climbs out is refused by the OS — the desired outcome, but the error wants wrapping to name
+which root refused and why. And a caller that writes *through* a symlink pointing outside `Dir` cannot use this
+variant; the kernel refuses. If writ's deploy does that, deploy belongs on the read-write variant (§6).
+
+## 3. Method classification
+
+The `Dir` interface carries 26 methods. Fifteen are writes, five are reads, three need a ruling, and three are
+not I/O.
+
+**Through `os.Root` (writes):** `Chmod`, `Chown`, `Chtimes`, `Lchown`, `Create`, `CreateTemp`, `Link`,
+`Symlink`, `Mkdir`, `MkdirAll`, `MkdirTemp`, `Remove`, `RemoveAll`, `Rename`, `WriteFile`
+
+**Direct `os.*` (reads):** `Lstat`, `Open`, `ReadFile`, `Readlink`, `Stat`
+
+**Not I/O:** `Name`, `NewPath`, `Close`
+
+**The three that need a ruling:**
+
+1. **`OpenFile(p, flag, perm)`** routes at runtime on `flag`. `O_RDONLY` is `0`, so the test must be on the
+   write bits — `O_WRONLY | O_RDWR | O_CREATE | O_TRUNC | O_APPEND` — never an equality check against
+   `O_RDONLY`. Inverting this is silent: every read would be confined and every write unconfined.
+2. **`OpenRoot(p) (Dir, error)` is a capability grant, not a read.** If the unconfined read-only variant permits
+   `OpenRoot` anywhere because "opening is not writing", a caller opens `/etc`, receives a Dir whose writes are
+   confined to `/etc`, and the original bound is gone in one call. `OpenRoot` must therefore be **confined even
+   on the read-unconfined variant**, and the returned Dir must inherit the same variant. Narrowing the root is
+   safe; relocating it is not.
+3. **The metadata mutators** — `Chmod`, `Chown`, `Chtimes`, `Lchown` — are writes that write no bytes, which is
+   why they get missed. This project has already paid for that: #405's phase 2 enforced nothing on the
+   unconfined root, and the private-key defect (#422) was a *permission* on a file whose contents were correct.
+
+`FS() fs.FS` is a read-only view and follows the read rule.
+
+## 4. Symlink targets
+
+`os.Root.Symlink` stores the target as text and does not resolve it, so **the kernel does not bound where a link
+points** — only where the link itself is created. Target containment is therefore fsroot's own rule, and one of
+the "additional variants" it adds over `os.Root`.
+
+The rule is not invented; it **follows the write rule**, because an escaping target is a write-escape vector: a
+later write through the link lands outside.
+
+| Variant | Symlink target may escape? | Because |
+| --- | --- | --- |
+| Confined | **No** | The trust boundary — untrusted bytes, archive extraction |
+| Unconfined read-only | **No** | Its writes may not escape `Dir`; a link that escapes defeats that |
+| Unconfined read-write | **Yes** | No sandbox; crossing trees is the deploy feature |
+
+**This is what `verbatim` has been standing in for.** `file.Provider.Link`'s two postures need opposite answers
+— a writ deploy symlinks `~/.config/git/config` into a repo clone and the target is *supposed* to leave the
+root, while a tar entry's escaping target is the tar-slip attack. Same call, opposite verdicts. No single rule
+serves both, so the call site grew a flag to choose a policy the root should have owned. Once the variant
+carries the rule, the flag has nothing left to say.
+
+## 5. Gaps between the requirements and the code
+
+Verified against `pkg/fsroot/fsroot.go` on 2026-08-18:
+
+1. **`unconfinedRootReader` forbids all writes.** Every mutator returns `errReadOnly`. The requirement is that
+   it writes, confined to `Dir`. The implementation read "read-only" as "no writes" rather than "unconfined for
+   reads only", so the variant is strictly less capable than specified — and the containment check it should
+   have on writes was never written, because there were no writes to check.
+2. **The unconfined variants validate nothing.** `os.Open(p.abs)`, `os.WriteFile(p.abs, …)` — straight through.
+   Containment on these variants is entirely notional.
+3. **`makePath` does not validate containment.** `filepath.Rel(rootName, path)` happily yields
+   `../../etc/passwd`, so a `Path` can name something outside the root it carries.
+4. **`makePath` asks `filepath.IsAbs` about input that may be neutral.** Given `/etc/passwd` against root
+   `/data`, Unix takes the absolute branch and produces `rel = ../../etc/passwd` (escaping); Windows takes the
+   relative branch and produces `rel = /etc/passwd`, `abs = <root>\etc\passwd` (contained). Same input, opposite
+   containment outcomes — and the Windows `rel` carries a leading slash, which `fs.ValidPath` rejects, in the
+   half documented as feeding `io/fs`.
+5. **`makePath` panics through `assert.Must`** when `filepath.Rel` cannot express the relationship — on Windows,
+   whenever root and path are on different volumes. That is an ordinary condition, not an assertion failure.
+6. **`4.4` §4 records the read-write variant's use case as "testing"**, while CLI-side roots appear to use it in
+   production. *Unverified — worth confirming before acting on it.*
+
+## 6. Open questions
+
+1. **Does the confined variant block *reads* outside its root?** `os.Root` does. The requirement says only that
+   it "must prevent **changes** outside". If reads should be permitted, the confined variant is not plain
+   `os.Root` and needs its readers routed around the kernel.
+2. **What does "inside `Dir`" mean when a symlink already crosses out?** §2 answers this by deferring to the
+   kernel, but deploy trees are built from links that leave the tree — so the answer determines whether the
+   unconfined read-only variant is usable for writ at all.
+3. **Does writ's deploy write *through* escaping symlinks?** Checkable against the deploy paths, and it decides
+   question 2 in practice.
+
+## 7. What this settles elsewhere
+
+- [#556](https://github.com/NobleFactor/devlore-cli/issues/556) — the archive symlink containment bypass. The
+  extractor stops carrying a guard and states its trust requirement by choosing the confined variant.
+- [#547](https://github.com/NobleFactor/devlore-cli/issues/547) — items 3–5 above are the same defect this issue
+  catalogues, in the package meant to end it.
+- `file.Provider.Link`'s `verbatim` flag, and its projection into the Starlark surface (§4).

--- a/docs/architecture/4.5-fsroot-variants.status.md
+++ b/docs/architecture/4.5-fsroot-variants.status.md
@@ -1,0 +1,43 @@
+# fsroot — Variants and Containment Rules — Status
+
+**Document:** [4.5-fsroot-variants.md](4.5-fsroot-variants.md)
+**State:** Requirements draft (2026-08-18), written from requirements stated in session. Captures the three
+variants as one axis — what is unconfined — and derives the symlink-target rule from the write rule. No
+implementation. Supersedes [`4.4`](4.4-root-path-triad.md) §4's mode-switch table.
+
+## Completion
+
+- [x] The three variants stated as requirements, with the whole-filesystem degenerate case (`/`,
+  `%SYSTEMDRIVE%\`) named as deliberate rather than needing special handling.
+- [x] **The naming clarified** — the variant names say what is *unconfined*, not what is *permitted*. Reading
+  "unconfined read-only" as "cannot write" is the mistake the current implementation makes.
+- [x] Mechanism decided for the read-only variant: writes through `*os.Root` on `p.rel`, reads direct on
+  `p.abs` — justified on TOCTOU, on symlink resolution answering "inside `Dir`", on not reimplementing path
+  resolution, and on `confinedRoot` already proving the pattern.
+- [x] **All 26 `Dir` methods classified** — 15 writes, 5 reads, 3 needing a ruling, 3 not I/O.
+- [x] The three rulings named, with the failure mode of each: `OpenFile`'s flag test (`O_RDONLY` is `0`),
+  `OpenRoot` as a capability grant rather than a read, and the metadata mutators as writes that write no bytes.
+- [x] **Symlink-target rule derived rather than invented** — it follows the write rule, because an escaping
+  target is a write-escape vector.
+- [x] `verbatim` explained as a policy flag at the call site standing in for a rule the root should own.
+- [x] Six gaps between requirements and code, verified against `pkg/fsroot/fsroot.go`.
+
+## Open
+
+- [ ] **Does the confined variant block reads outside its root?** The requirement says "prevent *changes*
+  outside"; `os.Root` blocks reads too. If reads should be permitted, the confined variant is not plain
+  `os.Root`.
+- [ ] **What does "inside `Dir`" mean when a symlink crosses out?** Deferred to the kernel here, but deploy
+  trees are built from such links.
+- [ ] **Does writ's deploy write through escaping symlinks?** Checkable against the deploy paths; decides the
+  question above in practice, and decides whether deploy can use the read-only variant or needs the read-write
+  one.
+- [ ] Whether the read-write variant's use case is genuinely "testing" as `4.4` records, given CLI-side roots
+  appear to use it in production. **Unverified.**
+- [ ] Whether `Path` construction should refuse an escaping `rel`, or only operations should. This document
+  places enforcement on operations, matching `os.Root`, which leaves the 206 `NewPath` call sites untouched.
+
+## Not yet decided
+
+No implementation plan, no issue filed for the fsroot work itself. #556 is filed and is downstream of this
+document's §4.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -58,6 +58,7 @@ Each architecture document has a companion `*.status.md` file tracking completio
   - [Memory Resources](4.2-mem-resource.md) ([status](4.2-mem-resource.status.md)) — `mem:` scheme, callable serialization lifecycle
   - [Resource Registration](4.3-resource-registration.md) ([status](4.3-resource-registration.status.md)) — Generated announcements into the receiver registry, environment-aware constructors, source-type declarations, rehydration by type id
   - [Root-Path Triad](4.4-root-path-triad.md) ([status](4.4-root-path-triad.status.md)) — Root interface, Path struct, RecoverySite, OS-enforced I/O confinement
+  - [fsroot Variants and Containment Rules](4.5-fsroot-variants.md) ([status](4.5-fsroot-variants.status.md)) — the three variants as one axis (what is unconfined, not what is permitted); writes through `*os.Root` and reads direct; all 26 `Dir` methods classified; the symlink-target rule derived from the write rule; supersedes 4.4 §4
 
 ### 5. Operational Integrity
 

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -199,24 +199,6 @@ func TestWrite_CreatesParentDirectories(t *testing.T) {
 	}
 }
 
-func TestWrite_WithPermOverridesPermission(t *testing.T) {
-
-	path := filepath.Join(t.TempDir(), "perm.yaml")
-	doc := testDoc{Name: "frank", Count: 0}
-
-	if err := Write(path, &doc, WithPerm(0o644)); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0o644 {
-		t.Errorf("permission = %o, want %o", perm, 0o644)
-	}
-}
-
 func TestWrite_WithHeaderPrependsText(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "header.yaml")

--- a/internal/document/document_unix_test.go
+++ b/internal/document/document_unix_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build !windows
+
+package document
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWrite_WithPermOverridesPermission asserts WithPerm reaches the file, and is Unix-scoped deliberately.
+//
+// 0o644 grants **other**, so it is not a private mode: fsroot leaves such a file inheriting its parent's DACL
+// rather than protecting it, which is the correct meaning of "not private". There is therefore no enforcement
+// state to observe on Windows, and Mode().Perm() reports 0666 there regardless — the assertion has nothing
+// true to say. This is the one case in the permission set where platform scoping is the right answer rather
+// than an evasion; every other case moved to a portable fact instead (issue #435).
+func TestWrite_WithPermOverridesPermission(t *testing.T) {
+
+	path := filepath.Join(t.TempDir(), "perm.yaml")
+	doc := testDoc{Name: "frank", Count: 0}
+
+	if err := Write(path, &doc, WithPerm(0o644)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("permission = %o, want %o", perm, 0o644)
+	}
+}

--- a/pkg/fsroot/fsroot.go
+++ b/pkg/fsroot/fsroot.go
@@ -45,6 +45,30 @@ var errTempPatternSeparator = fmt.Errorf("temporary name pattern contains a path
 // maxTempAttempts bounds the collision retries in [createTempIn] and [mkdirTempIn], matching [os.CreateTemp].
 const maxTempAttempts = 10000
 
+// Permission-class masks for the three classes a Unix mode names.
+//
+// Go supplies no symbol for these. [fs.ModePerm] covers all nine bits at once, and syscall's S_IRWXU, S_IRWXG
+// and S_IRWXO are unix-only, so they cannot appear in code that also builds for windows.
+//
+// They exist because the two rules that matter are one character apart as literals — `perm&0o007` excludes
+// only other, `perm&0o077` excludes group as well — and that is how this package's enforcement gate and its own
+// documentation came to disagree about which one it implements. Named, the rules stop resembling each other:
+// `perm&PermOther == 0` and `perm&(PermGroup|PermOther) == 0` cannot be misread for one another.
+//
+// Migrating the existing call sites onto these, and ruling which of the two the enforcement gate should mean,
+// is tracked separately.
+const (
+
+	// PermOwner masks the owner's read, write, and execute bits.
+	PermOwner os.FileMode = 0o700
+
+	// PermGroup masks the group's read, write, and execute bits.
+	PermGroup os.FileMode = 0o070
+
+	// PermOther masks other's — the world's — read, write, and execute bits.
+	PermOther os.FileMode = 0o007
+)
+
 // Dir provides scoped filesystem operations. All path arguments are [Path] values created through [Dir.NewPath].
 //
 // Three concrete implementations provide different access modes:

--- a/pkg/op/provider/file/observe_fields_test.go
+++ b/pkg/op/provider/file/observe_fields_test.go
@@ -4,23 +4,24 @@
 package file
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
 
-// TestObserve_ReportsFileFields asserts the measurement fields of an Observation (Size / Mode / ModTime), beyond the
-// single existing observe unit which asserts only Exists (step-52 backfill).
+// TestObserve_ReportsFileFields asserts the platform-independent measurement fields of an Observation, beyond
+// the single existing observe unit which asserts only Exists (step-52 backfill).
+//
+// Mode is covered separately in observe_fields_unix_test.go: Windows reports 0666 for every file whatever its
+// access-control list, so an assertion on the mode bits there decides on nothing.
 func TestObserve_ReportsFileFields(t *testing.T) {
 	dir := t.TempDir()
 	p := testProvider(t, dir)
 
 	path := filepath.Join(dir, "measured.txt")
 	content := []byte("twelve bytes")
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(path, 0o640); err != nil {
+
+	root := p.RuntimeEnvironment().Root()
+	if err := root.WriteFile(root.NewPath(path), content, 0o640); err != nil {
 		t.Fatal(err)
 	}
 
@@ -39,9 +40,6 @@ func TestObserve_ReportsFileFields(t *testing.T) {
 	}
 	if observation.Size != int64(len(content)) {
 		t.Errorf("Observe: Size = %d, want %d", observation.Size, len(content))
-	}
-	if observation.Mode.Perm() != 0o640 {
-		t.Errorf("Observe: Mode.Perm() = %o, want %o", observation.Mode.Perm(), os.FileMode(0o640))
 	}
 	if observation.ModTime.IsZero() {
 		t.Error("Observe: ModTime is zero for a real file")

--- a/pkg/op/provider/file/observe_fields_unix_test.go
+++ b/pkg/op/provider/file/observe_fields_unix_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build !windows
+
+package file
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestObserve_ReportsModeBits asserts Observe carries the file's permission bits through, and is unix-scoped.
+//
+// Windows reports 0666 from [os.FileMode] for every file regardless of its access-control list, so there is no
+// mode signal there to observe and no true assertion to make. Whether a file excludes other accounts is a
+// separate question with a separate instrument — see OwnerOnly — and it is not what this test is about.
+func TestObserve_ReportsModeBits(t *testing.T) {
+
+	dir := t.TempDir()
+	p := testProvider(t, dir)
+
+	path := filepath.Join(dir, "measured.txt")
+
+	root := p.RuntimeEnvironment().Root()
+	if err := root.WriteFile(root.NewPath(path), []byte("twelve bytes"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	resource, err := DiscoverRegular(p.RuntimeEnvironment(), path)
+	if err != nil {
+		t.Fatalf("DiscoverRegular: %v", err)
+	}
+
+	observation, err := p.Observe(resource)
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+
+	if observation.Mode.Perm() != 0o640 {
+		t.Errorf("Observe: Mode.Perm() = %o, want %o", observation.Mode.Perm(), 0o640)
+	}
+}

--- a/pkg/op/provider/file/owneronly_unix_test.go
+++ b/pkg/op/provider/file/owneronly_unix_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build !windows
+
+package file
+
+import (
+	"fmt"
+	"os"
+)
+
+// OwnerOnly reports whether the file at `path` grants nothing to group or other.
+//
+// Test-only, and deliberately so: no production path needs to ask this. It exists to verify that enforcement
+// happened — that a write which requested owner-only permissions actually produced them — which is the one
+// defect a seam assertion cannot catch, since the call can be correct while the effect is absent (#405 phase 2,
+// where the unconfined root's WriteFile never applied the mode at all).
+//
+// It answers exclusion, never access. A caller asking whether it can open the file should open the file: the
+// kernel evaluates the whole token, group memberships included, where reading permissions does not.
+//
+// Parameters:
+//   - `path`: the absolute path to inspect.
+//
+// Returns:
+//   - `bool`: true when neither group nor other is granted anything.
+//   - `error`: non-nil when the file cannot be stat'd.
+func OwnerOnly(path string) (bool, error) {
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("owner-only check: stat %s: %w", path, err)
+	}
+
+	return info.Mode().Perm()&0o077 == 0, nil
+}

--- a/pkg/op/provider/file/owneronly_windows_test.go
+++ b/pkg/op/provider/file/owneronly_windows_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package file
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// meaningfulAccess is the set of rights that let a trustee reach or reshape a file.
+//
+// An allow entry granting none of these — SYNCHRONIZE or FILE_READ_ATTRIBUTES alone, say — names a trustee who
+// still cannot read the contents, write them, delete the file, or rewrite its access list. Counting such an
+// entry as access would report a properly protected file as open.
+const meaningfulAccess = windows.FILE_READ_DATA |
+	windows.FILE_WRITE_DATA |
+	windows.FILE_APPEND_DATA |
+	windows.FILE_EXECUTE |
+	windows.DELETE |
+	windows.WRITE_DAC |
+	windows.WRITE_OWNER
+
+// OwnerOnly reports whether the file at `path` grants nothing beyond its owner.
+//
+// Test-only, and deliberately so: no production path needs to ask this. It exists to verify that enforcement
+// happened — that a write which requested owner-only permissions actually produced them — which is the one
+// defect a seam assertion cannot catch, since the call can be correct while the effect is absent (#405 phase 2,
+// where the unconfined root's WriteFile never applied the mode at all).
+//
+// Mode bits cannot answer here. [os.FileMode] reports 0666 for every file on Windows whatever its
+// access-control list, so the Unix form of this check would pass or fail on something unrelated to who can read
+// the file. The list itself has to be read.
+//
+// Owner-only means both halves of what applyMode writes. The DACL must be **protected** — inheritance broken —
+// because inherited entries otherwise survive and keep the file readable whatever is granted explicitly. And
+// every entry that actually grants access must name the owner, SYSTEM, or Administrators. Those last two are
+// kept because excluding them buys nothing: an administrator takes ownership at will.
+//
+// Two kinds of entry are passed over. **Deny entries** only ever narrow access, so an unexpected trustee in one
+// makes the file more restricted, not less; counting a `DENY Everyone` as a grant would report a hardened file
+// as open. And **allow entries conferring no [meaningfulAccess]** name a trustee who cannot reach the contents.
+//
+// Trustees are compared as SIDs rather than by matching the descriptor's SDDL text. SDDL renders well-known
+// accounts as two-letter aliases on some hosts and as numeric SIDs on others, and matching one rendering is
+// what made #405 phase 2's first CI run fail against a DACL that was correct.
+//
+// A file with no DACL is not owner-only: a nil DACL grants everyone full access, the opposite of the intent,
+// and must never read as true.
+//
+// It answers exclusion, never access. A caller asking whether it can open the file should open the file: the
+// kernel evaluates the whole token, group memberships included, where reading an access list does not — a
+// trustee's rights may arrive through a group whose SID appears nowhere in the entries.
+//
+// Parameters:
+//   - `path`: the absolute path to inspect.
+//
+// Returns:
+//   - `bool`: true when no account beyond the owner, SYSTEM, and Administrators is granted access.
+//   - `error`: non-nil when the security descriptor, its control flags, its owner, or an entry cannot be read.
+func OwnerOnly(path string) (bool, error) {
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return false, fmt.Errorf("owner-only check: read security info for %s: %w", path, err)
+	}
+
+	control, _, err := descriptor.Control()
+	if err != nil {
+		return false, fmt.Errorf("owner-only check: read control flags for %s: %w", path, err)
+	}
+
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return false, nil
+	}
+
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		return false, fmt.Errorf("owner-only check: read dacl for %s: %w", path, err)
+	}
+
+	if dacl == nil {
+		return false, nil
+	}
+
+	permitted, err := permittedTrustees(descriptor)
+	if err != nil {
+		return false, err
+	}
+
+	return daclGrantsOnly(dacl, permitted, path)
+}
+
+// region HELPER FUNCTIONS
+
+// permittedTrustees returns the SIDs an enforced file may grant: its owner, SYSTEM, and Administrators.
+//
+// Parameters:
+//   - `descriptor`: the security descriptor whose owner completes the set.
+//
+// Returns:
+//   - `[]*windows.SID`: the permitted trustees.
+//   - `error`: non-nil when the owner or a well-known SID cannot be resolved.
+func permittedTrustees(descriptor *windows.SECURITY_DESCRIPTOR) ([]*windows.SID, error) {
+
+	owner, _, err := descriptor.Owner()
+	if err != nil {
+		return nil, fmt.Errorf("owner-only check: read owner: %w", err)
+	}
+
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return nil, fmt.Errorf("owner-only check: create SYSTEM sid: %w", err)
+	}
+
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return nil, fmt.Errorf("owner-only check: create Administrators sid: %w", err)
+	}
+
+	return []*windows.SID{owner, system, administrators}, nil
+}
+
+// daclGrantsOnly reports whether every access-granting entry in `dacl` names one of `permitted`.
+//
+// Parameters:
+//   - `dacl`: the access-control list to walk.
+//   - `permitted`: the trustees an enforced file may grant.
+//   - `path`: the inspected path, for the error message.
+//
+// Returns:
+//   - `bool`: true when no granting entry names a trustee outside `permitted`.
+//   - `error`: non-nil when an entry cannot be read.
+func daclGrantsOnly(dacl *windows.ACL, permitted []*windows.SID, path string) (bool, error) {
+
+	for index := uint32(0); index < uint32(dacl.AceCount); index++ {
+
+		var entry *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, index, &entry); err != nil {
+			return false, fmt.Errorf("owner-only check: read dacl entry %d for %s: %w", index, path, err)
+		}
+
+		if entry.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+
+		if entry.Mask&meaningfulAccess == 0 {
+			continue
+		}
+
+		//nolint:gosec // G103: the SID follows the ACE header inline; &SidStart is the documented way to reach it.
+		trustee := (*windows.SID)(unsafe.Pointer(&entry.SidStart))
+
+		if !isPermittedTrustee(trustee, permitted) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// isPermittedTrustee reports whether `trustee` is one of `permitted`.
+//
+// Parameters:
+//   - `trustee`: the SID named by a DACL entry.
+//   - `permitted`: the trustees an enforced file may grant.
+//
+// Returns:
+//   - `bool`: true when the trustee is permitted.
+func isPermittedTrustee(trustee *windows.SID, permitted []*windows.SID) bool {
+
+	for _, allowed := range permitted {
+		if trustee.Equals(allowed) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// endregion

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -72,6 +72,46 @@ func testActivation(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment) *op
 	return op.NewActivationRecord(nil, "", runtimeEnvironment)
 }
 
+// assertOwnerOnlyAndReadable fails the test unless the file at `path` excludes others and still admits us.
+//
+// Two failures are possible when a file is protected, and they need different instruments.
+//
+// **Others are in.** Answered by [OwnerOnly], which reads the mode on Unix and the DACL on Windows — where
+// Mode().Perm() reports 0666 for every file whatever its access list, so a mode comparison there decides on
+// something unrelated to who can read the file (issue #435).
+//
+// **We are out.** Answered by opening the file. Enforcement breaks DACL inheritance, so a wrong owner or a
+// malformed entry list produces a file nobody can read — which the exclusion check happily calls restricted.
+// Nothing beats the kernel at this: os.Open evaluates the caller's whole token, group memberships included,
+// where scanning an access list for a SID does not. It also costs one line and works on every platform.
+//
+// Together they are what keeps the write enforced. A provider write that stopped flowing through the root
+// would stop applying the DACL, and the exclusion half notices on the windows leg; a write that over-applied
+// it and locked the owner out is caught everywhere.
+func assertOwnerOnlyAndReadable(t *testing.T, path string) {
+
+	t.Helper()
+
+	ownerOnly, err := OwnerOnly(path)
+	if err != nil {
+		t.Fatalf("OwnerOnly(%s): %v", path, err)
+	}
+
+	if !ownerOnly {
+		t.Errorf("OwnerOnly(%s) = false, want true — the file grants access beyond its owner", path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Errorf("Open(%s) after enforcement: %v — protection locked out the caller", path, err)
+		return
+	}
+
+	if err := file.Close(); err != nil {
+		t.Errorf("Close(%s): %v", path, err)
+	}
+}
+
 // testFileResource creates a Resource backed by a temp file with the given content.
 func testFileResource(t *testing.T, content []byte) *Regular {
 
@@ -396,13 +436,7 @@ func TestCopy_WritesNewFile(t *testing.T) {
 		t.Errorf("file content = %q, want %q", got, "hello world")
 	}
 
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat() error = %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("file mode = %o, want %o", info.Mode().Perm(), 0o600)
-	}
+	assertOwnerOnlyAndReadable(t, path)
 }
 
 func TestCopy_OverwritesExistingFile(t *testing.T) {
@@ -806,13 +840,7 @@ func TestWriteBytes_WritesContentToNewFile(t *testing.T) {
 		t.Errorf("file content = %q, want %q", got, "binary data")
 	}
 
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat() error = %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("file mode = %o, want %o", info.Mode().Perm(), 0o600)
-	}
+	assertOwnerOnlyAndReadable(t, path)
 }
 
 // --- Move ---


### PR DESCRIPTION
`Mode().Perm()` reports **0666 for every file on Windows** regardless of its access-control list. Four of the
sixteen known windows failures were permission assertions comparing those bits — not testing the wrong value,
but a value that does not exist on that platform.

## Two failure directions, two instruments

Protection fails in both directions, and one check cannot see both:

| Failure | Instrument | Why |
|---|---|---|
| **Others are in** | `OwnerOnly(path)` | mode bits on Unix, DACL read-back on Windows |
| **We are out** | `os.Open(path)` | enforcement breaks DACL inheritance, so a wrong owner yields a file nobody can open — and an exclusion check calls that success |

The second is the one worth dwelling on: the kernel evaluates the caller's whole token, group memberships
included, where scanning an access list for a SID does not. It costs one line and works everywhere.

## What `OwnerOnly` checks on Windows

Both halves of what `applyMode` writes: the DACL must be **protected** (inherited entries otherwise survive and
keep the file readable), and every entry that actually grants access must name the owner, SYSTEM, or
Administrators.

Two kinds of entry are passed over — **deny** entries, since they only narrow access and counting a
`DENY Everyone` as a grant would report a hardened file as open; and allow entries granting nothing that
reaches the contents.

Trustees are compared as **SIDs, not SDDL text**, whose alias-versus-numeric rendering varies by host and broke
#405 phase 2's first CI run against a DACL that was correct.

## The one production change

`fsroot` gains `PermOwner`, `PermGroup`, `PermOther`. Go supplies no symbol for the permission classes —
`fs.ModePerm` covers all nine bits, and syscall's `S_IRWX*` are unix-only — and that absence is why this went
wrong. As literals the two candidate rules are **one character apart**:

```go
perm & 0o007   // excludes other
perm & 0o077   // excludes group as well
```

Four sites disagree about which they mean. The encryption provider's secret floor, this change's `OwnerOnly`,
and `applyMode`'s own documentation all say owner-only; `isPrivateMode` — the line that actually decides whether
enforcement fires — says no-world. Named, they stop resembling each other:

```go
perm & PermOther == 0                  // no world access
perm & (PermGroup|PermOther) == 0      // owner only
```

Migrating the call sites and ruling which the gate should mean is filed separately. **No behavior changes here.**

## Otherwise no production surface

`OwnerOnly` is test-only. No production path needs to ask whether a file is owner-only, and an earlier draft's
`Observation.Restricted` field is gone with it — `Observe` has no non-test caller, so it would have recorded a
fact for nobody.

What a user actually wants is to learn an operation **cannot** be performed, ideally before it starts. That's a
preflight probe over the paths a plan intends to write — a different capability, filed separately.

## The fourth test

`TestWrite_WithPermOverridesPermission` moves to a unix-tagged file rather than migrating: `0o644` grants
*other*, so it is not owner-only, `applyMode` leaves such a file inheriting its parent DACL by design, and there
is no enforcement state to observe. The same reasoning splits `Observe`'s mode assertion out of
`TestObserve_ReportsFileFields`, whose remaining fields hold on both platforms.

## Also

`docs/architecture/4.5-fsroot-variants.md` — requirements for fsroot's three variants: one axis (what is
*unconfined*, not what is *permitted*), all 26 `Dir` methods classified, and the symlink-target rule derived
from the write rule rather than invented. Supersedes `4.4` §4.

## Verified

- `make check` — run by the commit script itself, before committing
- `make build-all`, `make vet-all`, `make lint-all` — clean under linux, darwin **and windows**. The windows
  half cannot execute here, so compiling, vetting and linting under `GOOS=windows` is the available proof.
- Baseline expected **16 → 12**, verified name-for-name before merge

Refs #435.
