### PR TITLE
test: stop four fixtures asserting Unix-shaped assumptions

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_compensation.star
+++ b/cmd/devlore-test/devloretest/data/test_compensation.star
@@ -6,11 +6,18 @@
 
 dest = t.tmp("compensated.txt")
 
+# The copy is made to fail by giving its destination a parent that is a regular file, which no platform
+# will create a directory over. The previous mechanism -- a destination under "/dev/null" -- only fails
+# where /dev/null exists and is not a directory: on Windows it named an ordinary path, the copy succeeded,
+# compensation never ran, and the test created directories at the root of the current drive.
+blocker = t.tmp("blocker")
+t.write(blocker, "not a directory")
+
 written = plan.file.write_text(destination_path=dest, content="should be undone", mode=0o644)
 
 # Copy using the write output as source (creates an edge for ordering),
-# but target a read-only path that will fail.
-copied = plan.file.copy(source=written, destination_path="/dev/null/impossible/path.txt", mode=0o644)
+# but target a path beneath the blocker, which cannot be created.
+copied = plan.file.copy(source=written, destination_path=t.tmp("blocker/child.txt"), mode=0o644)
 
 graph = plan.assemble_definition([written, copied])
 

--- a/cmd/devlore-test/devloretest/data/test_shell_exec.star
+++ b/cmd/devlore-test/devloretest/data/test_shell_exec.star
@@ -7,8 +7,11 @@
 
 dest = t.tmp("shell_output.txt")
 
+# The destination is single-quoted. shell.exec runs `sh -c`, on every platform, so an unquoted path is
+# subject to shell escaping: on Windows t.tmp returns a native path and sh consumes its backslashes, turning
+# C:\Users\... into C:Users... and writing the file somewhere else entirely.
 graph = plan.assemble_definition([
-    plan.shell.exec(command="printf 'from shell' > " + dest),
+    plan.shell.exec(command="printf 'from shell' > '" + dest + "'"),
 ])
 
 t.expect_file(dest, content="from shell")

--- a/cmd/devlore-test/devloretest/data/test_source.star
+++ b/cmd/devlore-test/devloretest/data/test_source.star
@@ -12,8 +12,11 @@ dest = t.tmp("source_input.txt")
 
 # Use shell to create the file outside the graph's file provider,
 # so plan.file.read_text reads it independently.
+# The destination is single-quoted for the shell, but passed raw to file.read_text: the first is a command
+# string sh will parse, where a native path's backslashes read as escapes, and the second is a path argument
+# that must stay in the platform's own form.
 graph = plan.assemble_definition([
-    plan.shell.exec(command="printf 'source test' > " + dest),
+    plan.shell.exec(command="printf 'source test' > '" + dest + "'"),
     plan.file.read_text(resource=dest),
 ])
 

--- a/pkg/op/provider/plan/gather_api_test.go
+++ b/pkg/op/provider/plan/gather_api_test.go
@@ -89,7 +89,11 @@ func TestGatherFailureUnwind_ViaPublicAPI(t *testing.T) {
 	if runErr == nil {
 		t.Fatal("Run: expected a gather failure (unwritable item), got nil error")
 	}
-	if !strings.Contains(runErr.Error(), "boom.txt") {
+	// "blocker", not "boom.txt": the write fails while creating boom's parent, and the two platforms name
+	// different parts of that failure -- unix reports the path it could not make a directory of, windows
+	// reports the same failure as `mkdirat blocker: file exists`. The parent is named by both, and only the
+	// boom item has it, so it identifies the failing iteration just as precisely.
+	if !strings.Contains(runErr.Error(), "blocker") {
 		t.Fatalf("Run error %q does not name the failing write; the gather body may not have dispatched", runErr)
 	}
 


### PR DESCRIPTION
Four of the twelve known windows failures were fixtures encoding assumptions that hold only on Unix. **None is a
product defect** — each asserts something true in one place and meaningless in the other.

## `test_compensation.star` — the failure never happened

It forced the copy to fail by targeting `/dev/null/impossible/path.txt`, which fails on Unix because `/dev/null`
exists and is not a directory. On Windows that names an ordinary path, so the copy **succeeded**, compensation
never ran, and the test was quietly creating directories at the root of the current drive.

It now fails the copy the way `gather_api_test.go` already does — a destination whose parent is a regular file,
which no platform will make a directory over.

## `test_shell_exec.star` and `test_source.star` — sh ate the path

Both interpolate `t.tmp(...)` into an `sh -c` command string. `t.tmp` returns `filepath.Join(...)`, so on Windows
that path is native and **backslash is sh's escape character**:

```
C:\Users\RUNNER~1\AppData\...   →   C:UsersRUNNER~1AppData...
```

a drive-relative path, so the redirect wrote somewhere unintended and `expect_file` reported it missing.

Single-quoting the destination fixes both. POSIX single quotes preserve backslashes literally, and the MSYS
runtime forwards a Windows path to the Win32 API unconverted. **Path translation was never involved** — it
applies to arguments handed to *native executables*, and a redirect is resolved by `sh` itself.

The same hazard exists in production: `pkg/platform` concatenates package names into shell strings and runs some
under `sudo`. Filed as **#561**, where the remedy is argv rather than better quoting.

## `TestGatherFailureUnwind_ViaPublicAPI` — the error names the parent

It asserted the run error contains `boom.txt`. The write fails while creating boom's *parent*, and the two
platforms name different halves of that failure — Windows reports `mkdirat blocker: file exists`.

The assertion now looks for `blocker`, which both platforms name and which only the boom item has, so it
identifies the failing iteration just as precisely. Verified against the Unix error before changing it.

## Verified

- `make check` — clean
- Baseline expected **12 → 8**, verified name-for-name before merge

Refs #373.
