### PR TITLE
docs: specify command execution as two tiers

### DIFF
--- a/docs/architecture/6.3-command-execution.md
+++ b/docs/architecture/6.3-command-execution.md
@@ -1,0 +1,181 @@
+# Command Execution — Two Tiers
+
+> **Status:** design (draft, 2026-08-19). Specifies the *form* a command takes when devlore runs one: an argv
+> vector always, with shell and PowerShell workflows delivered as script files that the same argv engine
+> executes. No implementation. Companion:
+> [`6.3-command-execution.status.md`](6.3-command-execution.status.md).
+>
+> **Relationship to the neighbours.** [`6-execution-topology.md`](6-execution-topology.md) owns the elevation
+> **policy**, [`6.1-privilege-elevation.md`](6.1-privilege-elevation.md) the provider that fulfills it, and
+> [`6.2-process-pool.md`](6.2-process-pool.md) the **hosts** — how they are identified, allocated and reclaimed.
+> **This document owns what is handed to a host.** 6.2 answers *who runs it*; 6.3 answers *what shape the thing
+> being run has*.
+
+## Thesis
+
+**A command is an argv vector. A script is a file that an argv vector runs.** There is no third thing, and in
+particular there is no command *string* assembled by concatenation and handed to an interpreter's `-c`.
+
+That single rule removes an entire defect class rather than defending against it. Today devlore builds command
+strings by concatenation in three places, and every one of them is either exploitable, broken, or both.
+
+## 1. What the current shape costs
+
+**`pkg/platform` concatenates and runs under `sudo`.** Seventy call sites across four files build strings like
+`"apt-get install -y "+strings.Join(names, " ")` and hand them to `sudo -n bash -c`. `ParsePURL`
+(`pkg/platform/purl.go:86`) applies no charset validation to a package name, and passes the version through
+`url.PathUnescape`, so `%3B` arrives as `;`. A name reaching that concatenation with shell metacharacters
+executes as root.
+
+**`shell.exec` and `powershell.exec` take an opaque string.** Both are `Exec(command string)`, running `sh -c`
+and `pwsh -Command` respectively. Anything an author interpolates — a path, a package name, a URL — is subject
+to that interpreter's escaping rules.
+
+**The escaping rules differ per interpreter**, so a single quoting helper cannot serve both:
+
+```
+sh:          'it'\''s'      close, escape, reopen
+PowerShell:  'it''s'        doubled quote; the escape character is a backtick
+```
+
+**And the failure is not theoretical.** Two test fixtures interpolated an OS-native path into an `sh -c` string.
+On Windows `sh` consumed the backslashes as escapes — `C:\Users\RUNNER~1\…` became `C:UsersRUNNER~1…` — and the
+redirect wrote to a path nobody intended. It was found only because the Windows leg runs.
+
+Go offers no help here deliberately: the standard library ships **no shell quoter**, because `exec.Command(name,
+args...)` never invokes a shell. Ruby needs `Shellwords.escape` because `system("…")` is string-shaped. Go's
+answer is to not be string-shaped, and this design adopts it.
+
+## 2. Tier 1 — the argv engine
+
+Every execution path terminates here:
+
+```go
+exec.CommandContext(ctx, name, args...)
+```
+
+No interpreter, no metacharacters, no quoting, no length limits on a single `-c` argument. Arguments containing
+spaces, quotes, semicolons or newlines are *data*, because the kernel receives them as a vector rather than a
+sentence to be parsed.
+
+**Nearly everything is expressible here.** All seventy `pkg/platform` commands are, once two habits are unlearned:
+
+| Pattern | Looks like it needs a shell | Argv form |
+| --- | --- | --- |
+| `dpkg-query -W -f='${Version}' <name>` | `${…}` | `["dpkg-query","-W","-f=${Version}",name]` — the quotes existed only to hide it from `sh`; dpkg parses `${Version}` itself |
+| `rpm -q --queryformat '%{VERSION}' <name>` | `%{…}` | `["rpm","-q","--queryformat","%{VERSION}",name]` |
+| `launchctl list \| grep -q <name>` | a pipe | run `launchctl list`, then `strings.Contains` on the captured output |
+| `port installed <name> \| grep -q <name>` | a pipe | same |
+
+The last two illustrate the general case: a pipe whose right-hand side is a text utility is usually a Go
+expression. `| grep` is `strings.Contains`, `| wc -l` is a line count, `| sort` is `sort.Strings`. Reaching for
+a shell to run `grep` is reaching for a process to avoid a function call.
+
+## 3. Tier 2 — the script fallback
+
+A pipe whose right-hand side is a *real program*, a loop, a conditional, a heredoc, or simply a legible
+multi-line workflow is not argv-shaped, and pretending otherwise produces worse designs than admitting it.
+
+**So a script arrives as a string, is written to a file, and is executed by tier 1:**
+
+```go
+exec.CommandContext(ctx, "sh", scriptPath, arg1, arg2)
+```
+
+The interpreter is named explicitly and the script is a *file argument*, not a `-c` payload. Everything shell
+syntax offers is available, because it is script content rather than argv.
+
+### 3.1 The body is static; values arrive as arguments
+
+This is the half that makes tier 2 safe rather than merely tidier. A value interpolated into script *text* is
+still shell source, and still needs quoting — tier 2 would have relocated the bug rather than removed it.
+
+```sh
+# body: static, written once, never assembled
+set -eu
+mkdir -p "$(dirname "$2")"
+printf '%s' "$1" > "$2"
+```
+
+```go
+exec.CommandContext(ctx, "sh", scriptPath, content, destination)   // $1, $2
+```
+
+The script text never varies with input, so there is nothing to escape at either tier. It also disposes of the
+Windows case for free: a native path passed as `$2` never passes through `sh`'s escape processing at all.
+
+**Interpolating into the body is the one thing this design forbids.** Where a caller genuinely must — a
+generated script rather than a parameterized one — that is a distinct and reviewable act, not the default path.
+
+### 3.2 Where the file lives
+
+The temporary file is created through the **scratch root**, not `os.CreateTemp` directly.
+
+`fsroot.OpenScratch` already confines its tree, already removes it on `Close`, and already routes writes through
+the code that applies a restrictive mode. That last property matters: a script body can carry a secret, and
+`os.CreateTemp` yields 0600 on Unix but a 0666-reported file with an inherited DACL on Windows. Creating it in a
+confined scratch tree also closes the window in which another process could swap the path between write and
+execute.
+
+**The executable bit is never set.** The interpreter is invoked explicitly — `sh script`, `pwsh -File
+script.ps1` — which avoids the exec-permission question entirely and keeps interpreter selection an explicit
+decision rather than a shebang's.
+
+### 3.3 PowerShell has its own tier 2
+
+`pwsh -File` requires a `.ps1` extension, and parameters arrive through `param()` / `$args` rather than `$1`.
+The dialect difference is real and permanent — which is a third argument for the static-body rule, since it is
+the only approach that needs no quoter for *either* dialect.
+
+### 3.4 The record is the script, not the path
+
+`Result.Command` must carry the **script source** for tier 2, and the **argv vector** for tier 1. Never the temp
+path, and never a joined string.
+
+A trace saying `ran /scratch/abc123/script` is unauditable the moment scratch is reclaimed. A joined argv is
+worse than useless when debugging, because it is not what the kernel received and it re-introduces the ambiguity
+the vector existed to remove.
+
+## 4. The Starlark surface
+
+Two shapes, matching the two tiers:
+
+```python
+plan.shell.run(argv=["systemctl", "restart", name])
+
+plan.shell.script(
+    body = """
+        set -eu
+        journalctl -u "$1" --since "$2" | tail -20
+    """,
+    args = [name, since],
+)
+```
+
+Whether today's `shell.exec(command=…)` survives as a third form is **open** (§6). It is the only shape that
+requires escaping, and keeping it keeps the defect class alive; retiring it is a breaking change to an authoring
+surface.
+
+## 5. What this settles
+
+- **[#561](https://github.com/NobleFactor/devlore-cli/issues/561)** — `pkg/platform`'s rewrite *is* tier 1, and
+  can proceed as the first delivery without waiting for tiers to be built.
+- **Quoting helpers** — not needed at either tier, in either dialect, so the question of where a `Quote` function
+  lives dissolves rather than being answered.
+- **Pipes** — expressible, in tier 2, where they belong.
+- **The Windows escaping failure** — impossible once values arrive as arguments.
+
+## 6. Open questions
+
+1. **Does `command=` survive?** Retiring it is breaking; keeping it preserves the one shape that needs escaping.
+2. **Environment and working directory.** Neither `shell.Exec` nor `powershell.Exec` accepts either today, and
+   `cmd.Dir` is never set, so commands inherit the devlore process's directory. Tier 2 makes a working directory
+   more obviously necessary, since a script is more likely to use relative paths.
+3. **Stdin.** `pkg/platform`'s wrapper feeds an endless `y\n` stream to auto-confirm prompts. Tier 2 scripts may
+   want stdin for their own purposes, so the two uses need separating.
+4. **Elevation.** A tier 2 script under `sudo` must be readable by the elevated identity. Root bypasses Unix
+   permissions, and an elevated Windows process is in Administrators, which `applyMode`'s DACL grants — so both
+   work, but the interaction should be stated rather than discovered.
+5. **Interpreter availability.** `sh` on Windows means Git-for-Windows; `pwsh` is not present by default on Linux
+   or macOS. Tier 2 fails differently depending on which is missing, and [`6.2`](6.2-process-pool.md)'s host
+   identity is where that belongs.

--- a/docs/architecture/6.3-command-execution.status.md
+++ b/docs/architecture/6.3-command-execution.status.md
@@ -1,0 +1,47 @@
+# Command Execution — Two Tiers — Status
+
+**Document:** [6.3-command-execution.md](6.3-command-execution.md)
+**State:** Design draft (2026-08-19), from a two-tier executor design stated in session. Specifies the form a
+command takes; [`6.2`](6.2-process-pool.md) specifies the host that runs it. No implementation.
+
+## Completion
+
+- [x] **The rule stated in one line** — a command is an argv vector, a script is a file an argv vector runs, and
+  there is no command *string* handed to an interpreter's `-c`.
+- [x] The current cost enumerated against the code: 70 concatenating call sites in `pkg/platform` reaching
+  `sudo -n bash -c`, `ParsePURL` applying no charset validation and `url.PathUnescape` decoding `%3B` to `;`,
+  and both `Exec` methods taking an opaque string.
+- [x] **The two dialects shown to need different quoters** (`'it'\''s'` versus `'it''s'`), which is why the
+  design avoids quoting rather than centralizing it.
+- [x] Tier 1 shown sufficient for all 70 platform commands, with the four apparent exceptions worked through —
+  two format strings quoted only to hide them from `sh`, two pipes whose right-hand side is a Go expression.
+- [x] **Tier 2's static-body rule** — values arrive as `$1`, `$2` rather than interpolated — identified as the
+  half that makes the fallback safe rather than merely tidier.
+- [x] Temp file placed in the scratch root rather than `os.CreateTemp`, for confinement, self-removing lifetime,
+  and the restrictive mode a script carrying a secret needs on both platforms.
+- [x] Executable bit deliberately not set; interpreter named explicitly.
+- [x] PowerShell's tier 2 separated (`.ps1`, `param()`), with its dialect difference noted as permanent.
+- [x] **`Result.Command` ruled**: argv vector for tier 1, script *source* for tier 2 — never the temp path,
+  never a joined string.
+- [x] A Starlark surface sketched for both tiers.
+
+## Open
+
+- [ ] **Does `shell.exec(command=…)` survive?** It is the only shape requiring escaping. Retiring it is a
+  breaking change to an authoring surface; keeping it keeps the defect class alive.
+- [ ] **Environment and working directory** — neither provider accepts either, and `cmd.Dir` is never set. Tier 2
+  raises the stakes, since scripts use relative paths.
+- [ ] **Stdin** — `pkg/platform`'s wrapper feeds an endless `y\n` auto-confirm stream; tier 2 scripts may want
+  stdin themselves. The two uses need separating.
+- [ ] **Elevation** — a tier 2 script under `sudo` must be readable by the elevated identity. Believed to work on
+  both platforms (root bypasses Unix permissions; an elevated Windows process is in Administrators, which
+  `applyMode` grants) but unverified.
+- [ ] **Interpreter availability** — `sh` on Windows means Git-for-Windows, `pwsh` is absent by default on Linux
+  and macOS. Belongs with [`6.2`](6.2-process-pool.md)'s host identity.
+
+## Not chartered here
+
+Whether `shell` should be `access=both` rather than `access=planned` is a **separate** question and remains
+open. This document governs *how* a command is shaped, not *when* it may run;
+[`2.4-hermeticity-guarantees.md`](2.4-hermeticity-guarantees.md) governs the latter and currently forbids
+machine-dependent evaluation at plan time.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -72,6 +72,7 @@ Each architecture document has a companion `*.status.md` file tracking completio
 - [Execution Topology](6-execution-topology.md) ([status](6-execution-topology.status.md)) — Elevation, remote execution, telemetry (planned)
   - [Privilege Elevation: The Elevator Provider](6.1-privilege-elevation.md) ([status](6.1-privilege-elevation.status.md)) — The elevator provider: graph/config/runtime split, the two strategies (ProcessSpawn / IdentityAssumption), the token-provider mechanism, the config outline, and failure routing
   - [The Process Pool](6.2-process-pool.md) ([status](6.2-process-pool.status.md)) — Lazily-allocated execution hosts keyed by interpreter × privilege × pooling mode × session; persistent privilege vs persistent interpreter state; multiplexing with request ids; PgBouncer pooling modes; the PowerShell runspace host and why `pwsh` is not the universal one
+  - [Command Execution — Two Tiers](6.3-command-execution.md) ([status](6.3-command-execution.status.md)) — A command is an argv vector and a script is a file an argv vector runs; no command string handed to `-c`; tier 2 keeps script bodies static with values as `$1`/`$2`, written to the scratch root; why quoting dissolves rather than centralizes
 
 ### 7. Knowledge and LLM
 


### PR DESCRIPTION
**A command is an argv vector. A script is a file that an argv vector runs.** No third thing, and in particular
no command string assembled by concatenation and handed to an interpreter's `-c`.

`docs/architecture/6.3-command-execution.md`, with its status companion, indexed after `6.2`.

## Why now

Three places build command strings by concatenation, and each is exploitable, broken, or both:

- `pkg/platform` — 70 concatenating call sites reaching `sudo -n bash -c`, with `ParsePURL` applying no charset
  validation and decoding `%3B` to `;`
- `shell.exec` / `powershell.exec` — both take an opaque string, with **different escaping dialects**, so one
  quoting helper cannot serve both
- two test fixtures interpolated a native path into an `sh -c` string, where Windows backslashes were consumed
  as escapes

## The two tiers

**Tier 1** is `exec.Command` with an argv vector. All 70 platform commands fit, once two habits are unlearned:
a format string quoted only to hide it from `sh` is a plain argument, and a pipe whose right-hand side is a text
utility is a Go expression — `| grep` is `strings.Contains`, `| wc -l` is a line count.

**Tier 2** takes a script string, writes it to a file, and runs it through tier 1. Pipes, loops and redirects
work because they're script *content*.

**Tier 2's body stays static; values arrive as `$1`, `$2`.** This is the half that makes it safe rather than
merely tidier — interpolating into the body would relocate the escaping bug, since script text is still shell
source. It also means no quoter is needed in *either* dialect.

## Two details worth the review

- **The temp file goes in the scratch root**, not `os.CreateTemp` — confinement, self-removing lifetime, and the
  restrictive mode a script carrying a secret needs on both platforms. The executable bit is never set; the
  interpreter is named explicitly.
- **`Result.Command`** carries the argv vector for tier 1 and the **script source** for tier 2. Never the temp
  path, which is unauditable once scratch is reclaimed; never a joined string, which isn't what the kernel
  received.

## Open

Five questions are recorded rather than assumed. The sharpest: does `shell.exec(command=…)` survive? It's the
only shape requiring escaping, so keeping it keeps the defect class alive, and retiring it breaks an authoring
surface.

`#561`'s `pkg/platform` rewrite **is** tier 1 and can proceed as the first delivery without waiting for the
tiers to be built.

Refs #561.
