### PR TITLE
fix(platform): run commands as argv, not as strings handed to a shell

### DIFF
--- a/pkg/platform/cross_distro_managers_linux.go
+++ b/pkg/platform/cross_distro_managers_linux.go
@@ -28,7 +28,7 @@ import "strings"
 // Returns:
 //   - `bool`: true when `flatpak remote-info` resolves the app.
 func (m *flatpakManager) available(name string) bool {
-	return runShellCommand("flatpak remote-info flathub "+name, false).OK
+	return runCommand([]string{"flatpak", "remote-info", "flathub", name}, false).OK
 }
 
 // installRaw installs the named apps from flathub.
@@ -40,7 +40,7 @@ func (m *flatpakManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *flatpakManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("flatpak install -y flathub "+strings.Join(names, " "), false)
+	return runCommand(append([]string{"flatpak", "install", "-y", "flathub"}, names...), false)
 }
 
 // installed reports whether the named app is installed.
@@ -51,7 +51,7 @@ func (m *flatpakManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `bool`: true when `flatpak info` resolves the app.
 func (m *flatpakManager) installed(name string) bool {
-	return runShellCommand("flatpak info "+name, false).OK
+	return runCommand([]string{"flatpak", "info", name}, false).OK
 }
 
 // removeRaw uninstalls the named apps.
@@ -62,7 +62,7 @@ func (m *flatpakManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *flatpakManager) removeRaw(names []string) Result {
-	return runShellCommand("flatpak uninstall -y "+strings.Join(names, " "), false)
+	return runCommand(append([]string{"flatpak", "uninstall", "-y"}, names...), false)
 }
 
 // searchRaw returns up to `limit` apps matching `query`.
@@ -74,7 +74,7 @@ func (m *flatpakManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *flatpakManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("flatpak search "+query, false)
+	result := runCommand([]string{"flatpak", "search", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -111,7 +111,7 @@ func (m *flatpakManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *flatpakManager) version(name string) string {
-	result := runShellCommand("flatpak info --show-version "+name, false)
+	result := runCommand([]string{"flatpak", "info", "--show-version", name}, false)
 	if !result.OK {
 		return ""
 	}
@@ -138,7 +138,7 @@ func (m *flatpakManager) version(name string) string {
 // Returns:
 //   - `bool`: true when `snap info` resolves the snap.
 func (m *snapManager) available(name string) bool {
-	return runShellCommand("snap info "+name, false).OK
+	return runCommand([]string{"snap", "info", name}, false).OK
 }
 
 // installRaw installs the named snaps.
@@ -150,7 +150,7 @@ func (m *snapManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *snapManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("snap install "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"snap", "install"}, names...), true)
 }
 
 // installed reports whether the named snap is installed.
@@ -161,7 +161,7 @@ func (m *snapManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `bool`: true when `snap list` resolves the snap.
 func (m *snapManager) installed(name string) bool {
-	return runShellCommand("snap list "+name, false).OK
+	return runCommand([]string{"snap", "list", name}, false).OK
 }
 
 // removeRaw uninstalls the named snaps.
@@ -172,7 +172,7 @@ func (m *snapManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *snapManager) removeRaw(names []string) Result {
-	return runShellCommand("snap remove "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"snap", "remove"}, names...), true)
 }
 
 // searchRaw returns up to `limit` snaps matching `query`.
@@ -184,7 +184,7 @@ func (m *snapManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *snapManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("snap find "+query, false)
+	result := runCommand([]string{"snap", "find", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -218,7 +218,7 @@ func (m *snapManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *snapManager) version(name string) string {
-	result := runShellCommand("snap list "+name, false)
+	result := runCommand([]string{"snap", "list", name}, false)
 	if !result.OK {
 		return ""
 	}

--- a/pkg/platform/darwin_managers_darwin.go
+++ b/pkg/platform/darwin_managers_darwin.go
@@ -32,7 +32,7 @@ import (
 // Returns:
 //   - `bool`: true when `brew info` resolves the package.
 func (m *brewManager) available(name string) bool {
-	return runShellCommand("brew info "+name, false).OK
+	return runCommand([]string{"brew", "info", name}, false).OK
 }
 
 // installRaw installs the named packages, honoring a `cask` kwarg for GUI applications.
@@ -45,12 +45,12 @@ func (m *brewManager) available(name string) bool {
 //   - `Result`: the command result.
 func (m *brewManager) installRaw(names []string, kwargs map[string]any) Result {
 
-	command := "brew install "
+	argv := []string{"brew", "install"}
 	if cask, ok := kwargs["cask"].(bool); ok && cask {
-		command = "brew install --cask "
+		argv = append(argv, "--cask")
 	}
 
-	return runShellCommand(command+strings.Join(names, " "), false)
+	return runCommand(append(argv, names...), false)
 }
 
 // refresh updates Homebrew's formula and cask metadata.
@@ -58,7 +58,7 @@ func (m *brewManager) installRaw(names []string, kwargs map[string]any) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *brewManager) refresh() Result {
-	return runShellCommand("brew update", false)
+	return runCommand([]string{"brew", "update"}, false)
 }
 
 // installed reports whether the named package is installed as a formula or a cask.
@@ -69,10 +69,10 @@ func (m *brewManager) refresh() Result {
 // Returns:
 //   - `bool`: true when the package is installed under either kind.
 func (m *brewManager) installed(name string) bool {
-	if runShellCommand("brew list --formula "+name, false).OK {
+	if runCommand([]string{"brew", "list", "--formula", name}, false).OK {
 		return true
 	}
-	return runShellCommand("brew list --cask "+name, false).OK
+	return runCommand([]string{"brew", "list", "--cask", name}, false).OK
 }
 
 // removeRaw uninstalls the named packages.
@@ -83,7 +83,7 @@ func (m *brewManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *brewManager) removeRaw(names []string) Result {
-	return runShellCommand("brew uninstall "+strings.Join(names, " "), false)
+	return runCommand(append([]string{"brew", "uninstall"}, names...), false)
 }
 
 // searchRaw returns up to `limit` packages matching `query`.
@@ -95,7 +95,7 @@ func (m *brewManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *brewManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("brew search "+query, false)
+	result := runCommand([]string{"brew", "search", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -127,7 +127,7 @@ func (m *brewManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *brewManager) version(name string) string {
-	result := runShellCommand("brew list --versions "+name, false)
+	result := runCommand([]string{"brew", "list", "--versions", name}, false)
 	if !result.OK {
 		return ""
 	}
@@ -161,11 +161,11 @@ func (m *launchdManager) Disable(name string) Result {
 	userPlist := "~/Library/LaunchAgents/" + name + ".plist"
 	systemPlist := "/Library/LaunchDaemons/" + name + ".plist"
 
-	result := runShellCommand("launchctl unload -w "+userPlist, false)
+	result := runCommand([]string{"launchctl", "unload", "-w", userPlist}, false)
 	if result.OK {
 		return result
 	}
-	return runShellCommand("launchctl unload -w "+systemPlist, true)
+	return runCommand([]string{"launchctl", "unload", "-w", systemPlist}, true)
 }
 
 // Enable loads the named launchd job, trying the user agent before the system daemon.
@@ -179,11 +179,11 @@ func (m *launchdManager) Enable(name string) Result {
 	userPlist := "~/Library/LaunchAgents/" + name + ".plist"
 	systemPlist := "/Library/LaunchDaemons/" + name + ".plist"
 
-	result := runShellCommand("launchctl load -w "+userPlist, false)
+	result := runCommand([]string{"launchctl", "load", "-w", userPlist}, false)
 	if result.OK {
 		return result
 	}
-	return runShellCommand("launchctl load -w "+systemPlist, true)
+	return runCommand([]string{"launchctl", "load", "-w", systemPlist}, true)
 }
 
 // Exists reports whether a launchd job with the given label is loaded.
@@ -194,7 +194,9 @@ func (m *launchdManager) Enable(name string) Result {
 // Returns:
 //   - `bool`: true when the job appears in `launchctl list`.
 func (m *launchdManager) Exists(name string) bool {
-	return runShellCommand("launchctl list | grep -q "+name, false).OK
+	// `| grep -q` in Go rather than in a shell: the pipe's right-hand side was a substring test, and a
+	// substring test is strings.Contains.
+	return strings.Contains(runCommand([]string{"launchctl", "list"}, false).Stdout, name)
 }
 
 // IsEnabled reports whether the named job is enabled. launchd exposes no reliable query, so this is always false.
@@ -232,7 +234,7 @@ func (m *launchdManager) IsRunning(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *launchdManager) Start(name string) Result {
-	return runShellCommand("launchctl start "+name, false)
+	return runCommand([]string{"launchctl", "start", name}, false)
 }
 
 // Status returns "running" when the named job is loaded, otherwise "stopped".
@@ -243,7 +245,7 @@ func (m *launchdManager) Start(name string) Result {
 // Returns:
 //   - `string`: "running" or "stopped".
 func (m *launchdManager) Status(name string) string {
-	if runShellCommand("launchctl list "+name, false).OK {
+	if runCommand([]string{"launchctl", "list", name}, false).OK {
 		return "running"
 	}
 	return "stopped"
@@ -257,7 +259,7 @@ func (m *launchdManager) Status(name string) string {
 // Returns:
 //   - `Result`: the command result.
 func (m *launchdManager) Stop(name string) Result {
-	return runShellCommand("launchctl stop "+name, false)
+	return runCommand([]string{"launchctl", "stop", name}, false)
 }
 
 // endregion
@@ -280,7 +282,7 @@ func (m *launchdManager) Stop(name string) Result {
 // Returns:
 //   - `bool`: true when `port info` resolves the package.
 func (m *portManager) available(name string) bool {
-	return runShellCommand("port info "+name, false).OK
+	return runCommand([]string{"port", "info", name}, false).OK
 }
 
 // installRaw installs the named ports (MacPorts requires elevation).
@@ -292,7 +294,7 @@ func (m *portManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *portManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("port install -N "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"port", "install", "-N"}, names...), true)
 }
 
 // refresh updates MacPorts and synchronizes the ports tree, non-interactively.
@@ -303,7 +305,7 @@ func (m *portManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *portManager) refresh() Result {
-	return runShellCommand("port -N selfupdate", true)
+	return runCommand([]string{"port", "-N", "selfupdate"}, true)
 }
 
 // installed reports whether the named port is installed.
@@ -314,7 +316,9 @@ func (m *portManager) refresh() Result {
 // Returns:
 //   - `bool`: true when `port installed` lists the package.
 func (m *portManager) installed(name string) bool {
-	return runShellCommand("port installed "+name+" | grep -q "+name, false).OK
+	// As with launchctl above: port reports "None of the specified ports are installed" on a miss, so the
+	// name's presence in its own output is the answer.
+	return strings.Contains(runCommand([]string{"port", "installed", name}, false).Stdout, name)
 }
 
 // removeRaw uninstalls the named ports.
@@ -325,7 +329,7 @@ func (m *portManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *portManager) removeRaw(names []string) Result {
-	return runShellCommand("port uninstall "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"port", "uninstall"}, names...), true)
 }
 
 // searchRaw returns up to `limit` ports matching `query`.
@@ -337,7 +341,7 @@ func (m *portManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *portManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("port search --name "+query, false)
+	result := runCommand([]string{"port", "search", "--name", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -370,7 +374,7 @@ func (m *portManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *portManager) version(name string) string {
-	result := runShellCommand("port installed "+name, false)
+	result := runCommand([]string{"port", "installed", name}, false)
 	if !result.OK {
 		return ""
 	}

--- a/pkg/platform/detect_linux.go
+++ b/pkg/platform/detect_linux.go
@@ -138,7 +138,7 @@ func isServerVariant(variantID string) bool {
 	}
 
 	// VARIANT_ID absent or unrecognized — fall back to systemd's default-target signal.
-	result := runShellCommand("systemctl get-default", false)
+	result := runCommand([]string{"systemctl", "get-default"}, false)
 	if !result.OK {
 		return false
 	}

--- a/pkg/platform/helpers_unix.go
+++ b/pkg/platform/helpers_unix.go
@@ -29,43 +29,50 @@ const commandTimeout = 30 * time.Minute
 // this stream.
 const confirmReplies = 4096
 
-// runShellCommand executes a shell command via bash, optionally with sudo, capturing the result.
+// runCommand executes a command as an argv vector, optionally under sudo, capturing the result.
 //
-// It captures stdout, stderr, and the exit code into a [Result]. Used by every Linux/Darwin [PackageManager] and
-// [ServiceManager] mutator. The command string is passed to `bash -c` directly; callers are responsible for safe
-// quoting.
+// The vector is handed to the kernel as a vector: no shell parses it, so nothing needs quoting and no argument
+// can inject. A package name containing a semicolon is a package name containing a semicolon, not a second
+// command (issue #561). Everything this package runs is expressible this way -- a format string quoted only to
+// hide it from a shell is a plain argument, and a pipe whose right-hand side is a text utility is a Go
+// expression.
 //
-// Hang safety, in layers: the call is bounded by [commandTimeout]; an endless `y\n` stream on stdin auto-confirms
-// any prompt a tool raises despite its non-interactive flags — a backstop for the ones port's `-N` misses — so the
-// op proceeds rather than blocking or aborting on EOF; sudo runs with `-n`, so it fails fast instead of prompting
-// for a password on the tty (credential handling is the elevation model's job — see TODO); and
-// `DEBIAN_FRONTEND=noninteractive` keeps apt quiet (and safely keeps modified config files). Callers still pass
-// per-tool non-interactive flags (apt `-y`, pacman `--noconfirm`, port `-N`).
+// Hang safety, in layers: the call is bounded by [commandTimeout]; an endless `y\n` stream on stdin
+// auto-confirms any prompt a tool raises despite its non-interactive flags, so the op proceeds rather than
+// blocking or aborting on EOF; sudo runs with `-n`, so it fails fast instead of prompting for a password on the
+// tty (credential handling is the elevation model's job -- see TODO); and `DEBIAN_FRONTEND=noninteractive`
+// keeps apt quiet, and safely keeps modified config files. Callers still pass per-tool non-interactive flags
+// (apt `-y`, pacman `--noconfirm`, port `-N`).
 //
-// It is a package var, not a plain func, so tests can substitute a recording fake. It carries the unix constraint
-// with its two knobs above because every consumer does: the Linux and Darwin manager leaves shell out through bash,
-// while the Windows leaves drive winget through their own path — under a windows analysis all three were dead code
-// (#373 phase 1b).
+// It is a package var, not a plain func, so tests can substitute a recording fake. It carries the unix
+// constraint with its two knobs above because every consumer does: the Linux and Darwin manager leaves run
+// through it, while the Windows leaves drive winget through their own path -- under a windows analysis all
+// three were dead code (#373 phase 1b).
 //
 // Parameters:
-//   - `command`: the shell command, passed to `bash -c` verbatim.
+//   - `argv`: the command and its arguments; `argv[0]` is the executable.
 //   - `sudo`: whether to run under `sudo -n`.
 //
 // Returns:
 //   - `Result`: the captured stdout, stderr, and exit code.
-var runShellCommand = func(command string, sudo bool) Result {
+var runCommand = func(argv []string, sudo bool) Result {
+
+	if len(argv) == 0 {
+		return Result{Code: -1, Stderr: "platform: no command given"}
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
 	defer cancel()
 
-	var cmd *exec.Cmd
+	name, args := argv[0], argv[1:]
+
 	if sudo {
-		// TODO(elevation): centralize this. Route privileged execution through the ElevationOffer/Elevator — one
-		// credential-cached, policy-governed, audited sudo session — instead of every command inlining `sudo -n`.
-		cmd = exec.CommandContext(ctx, "sudo", "-n", "bash", "-c", command) //nolint:gosec // G204: internal caller
-	} else {
-		cmd = exec.CommandContext(ctx, "bash", "-c", command) //nolint:gosec // G204: internal caller
+		// TODO(elevation): centralize this. Route privileged execution through the ElevationOffer/Elevator -- one
+		// credential-cached, policy-governed, audited sudo session -- instead of every command inlining `sudo -n`.
+		name, args = "sudo", append([]string{"-n"}, argv...)
 	}
+
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: argv from internal callers, never parsed
 
 	cmd.Env = append(cmd.Environ(), "DEBIAN_FRONTEND=noninteractive")
 	cmd.Stdin = strings.NewReader(strings.Repeat("y\n", confirmReplies))

--- a/pkg/platform/linux_managers_linux.go
+++ b/pkg/platform/linux_managers_linux.go
@@ -31,7 +31,7 @@ import (
 // Returns:
 //   - `bool`: true when `apt-cache show` resolves the package.
 func (m *aptManager) available(name string) bool {
-	return runShellCommand("apt-cache show "+name, false).OK
+	return runCommand([]string{"apt-cache", "show", name}, false).OK
 }
 
 // installRaw installs the named packages.
@@ -43,7 +43,7 @@ func (m *aptManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *aptManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("apt-get install -y "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"apt-get", "install", "-y"}, names...), true)
 }
 
 // refresh updates the apt package index.
@@ -51,7 +51,7 @@ func (m *aptManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *aptManager) refresh() Result {
-	return runShellCommand("apt-get update", true)
+	return runCommand([]string{"apt-get", "update"}, true)
 }
 
 // indexAge reports how long ago the apt package index was last refreshed (the mtime of /var/lib/apt/lists).
@@ -70,7 +70,7 @@ func (m *aptManager) indexAge() time.Duration {
 // Returns:
 //   - `bool`: true when `dpkg-query` resolves the package.
 func (m *aptManager) installed(name string) bool {
-	return runShellCommand("dpkg-query -W "+name, false).OK
+	return runCommand([]string{"dpkg-query", "-W", name}, false).OK
 }
 
 // removeRaw uninstalls the named packages.
@@ -81,7 +81,7 @@ func (m *aptManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *aptManager) removeRaw(names []string) Result {
-	return runShellCommand("apt-get remove -y "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"apt-get", "remove", "-y"}, names...), true)
 }
 
 // searchRaw returns up to `limit` packages matching `query`.
@@ -93,7 +93,7 @@ func (m *aptManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *aptManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("apt-cache search "+query, false)
+	result := runCommand([]string{"apt-cache", "search", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -123,7 +123,9 @@ func (m *aptManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *aptManager) version(name string) string {
-	result := runShellCommand("dpkg-query -W -f='${Version}' "+name, false)
+	// The single quotes were only ever hiding ${Version} from a shell; dpkg parses the format itself, so as
+	// an argv element it needs none.
+	result := runCommand([]string{"dpkg-query", "-W", "-f=${Version}", name}, false)
 	if !result.OK {
 		return ""
 	}
@@ -150,7 +152,7 @@ func (m *aptManager) version(name string) string {
 // Returns:
 //   - `bool`: true when `dnf info` resolves the package.
 func (m *dnfManager) available(name string) bool {
-	return runShellCommand("dnf info "+name, false).OK
+	return runCommand([]string{"dnf", "info", name}, false).OK
 }
 
 // installRaw installs the named packages.
@@ -162,7 +164,7 @@ func (m *dnfManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *dnfManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("dnf install -y "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"dnf", "install", "-y"}, names...), true)
 }
 
 // refresh rebuilds the dnf metadata cache.
@@ -170,7 +172,7 @@ func (m *dnfManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *dnfManager) refresh() Result {
-	return runShellCommand("dnf makecache", true)
+	return runCommand([]string{"dnf", "makecache"}, true)
 }
 
 // installed reports whether the named package is installed.
@@ -181,7 +183,7 @@ func (m *dnfManager) refresh() Result {
 // Returns:
 //   - `bool`: true when `rpm -q` resolves the package.
 func (m *dnfManager) installed(name string) bool {
-	return runShellCommand("rpm -q "+name, false).OK
+	return runCommand([]string{"rpm", "-q", name}, false).OK
 }
 
 // removeRaw uninstalls the named packages.
@@ -192,7 +194,7 @@ func (m *dnfManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *dnfManager) removeRaw(names []string) Result {
-	return runShellCommand("dnf remove -y "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"dnf", "remove", "-y"}, names...), true)
 }
 
 // searchRaw returns up to `limit` packages matching `query`.
@@ -204,7 +206,7 @@ func (m *dnfManager) removeRaw(names []string) Result {
 // Returns:
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *dnfManager) searchRaw(query string, limit int) []SearchResult {
-	result := runShellCommand("dnf search "+query, false)
+	result := runCommand([]string{"dnf", "search", query}, false)
 	if !result.OK {
 		return nil
 	}
@@ -244,7 +246,8 @@ func (m *dnfManager) searchRaw(query string, limit int) []SearchResult {
 // Returns:
 //   - `string`: the installed version, or "".
 func (m *dnfManager) version(name string) string {
-	result := runShellCommand("rpm -q --queryformat '%{VERSION}' "+name, false)
+	// As with dpkg above, the quotes existed to hide %{VERSION} from a shell. rpm parses it itself.
+	result := runCommand([]string{"rpm", "-q", "--queryformat", "%{VERSION}", name}, false)
 	if !result.OK {
 		return ""
 	}
@@ -271,7 +274,7 @@ func (m *dnfManager) version(name string) string {
 // Returns:
 //   - `bool`: true when `pacman -Si` resolves the package.
 func (m *pacmanManager) available(name string) bool {
-	return runShellCommand("pacman -Si "+name, false).OK
+	return runCommand([]string{"pacman", "-Si", name}, false).OK
 }
 
 // installRaw installs the named packages.
@@ -283,7 +286,7 @@ func (m *pacmanManager) available(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *pacmanManager) installRaw(names []string, _ map[string]any) Result {
-	return runShellCommand("pacman -S --noconfirm --needed "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"pacman", "-S", "--noconfirm", "--needed"}, names...), true)
 }
 
 // refresh synchronizes the pacman package databases.
@@ -291,7 +294,7 @@ func (m *pacmanManager) installRaw(names []string, _ map[string]any) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *pacmanManager) refresh() Result {
-	return runShellCommand("pacman -Sy --noconfirm", true)
+	return runCommand([]string{"pacman", "-Sy", "--noconfirm"}, true)
 }
 
 // indexAge reports how long ago the pacman sync databases were last refreshed (the mtime of /var/lib/pacman/sync).
@@ -310,7 +313,7 @@ func (m *pacmanManager) indexAge() time.Duration {
 // Returns:
 //   - `bool`: true when `pacman -Q` resolves the package.
 func (m *pacmanManager) installed(name string) bool {
-	return runShellCommand("pacman -Q "+name, false).OK
+	return runCommand([]string{"pacman", "-Q", name}, false).OK
 }
 
 // removeRaw uninstalls the named packages.
@@ -321,7 +324,7 @@ func (m *pacmanManager) installed(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *pacmanManager) removeRaw(names []string) Result {
-	return runShellCommand("pacman -R --noconfirm "+strings.Join(names, " "), true)
+	return runCommand(append([]string{"pacman", "-R", "--noconfirm"}, names...), true)
 }
 
 // searchRaw returns up to `limit` packages matching `query`.
@@ -334,7 +337,7 @@ func (m *pacmanManager) removeRaw(names []string) Result {
 //   - `[]SearchResult`: the matches, or nil on failure.
 func (m *pacmanManager) searchRaw(query string, limit int) []SearchResult { //nolint:gocognit // parsing format requires nesting
 
-	result := runShellCommand("pacman -Ss "+query, false)
+	result := runCommand([]string{"pacman", "-Ss", query}, false)
 
 	if !result.OK {
 		return nil
@@ -387,7 +390,7 @@ func (m *pacmanManager) searchRaw(query string, limit int) []SearchResult { //no
 //   - `string`: the installed version, or "".
 func (m *pacmanManager) version(name string) string {
 
-	result := runShellCommand("pacman -Q "+name, false)
+	result := runCommand([]string{"pacman", "-Q", name}, false)
 
 	if !result.OK {
 		return ""
@@ -422,7 +425,7 @@ func (m *pacmanManager) version(name string) string {
 // Returns:
 //   - `Result`: the command result.
 func (m *systemdManager) Disable(name string) Result {
-	return runShellCommand("systemctl disable "+name, true)
+	return runCommand([]string{"systemctl", "disable", name}, true)
 }
 
 // Enable enables the named service to start at boot.
@@ -433,7 +436,7 @@ func (m *systemdManager) Disable(name string) Result {
 // Returns:
 //   - `Result`: the command result.
 func (m *systemdManager) Enable(name string) Result {
-	return runShellCommand("systemctl enable "+name, true)
+	return runCommand([]string{"systemctl", "enable", name}, true)
 }
 
 // Exists reports whether a unit with the given name is known to systemd.
@@ -444,7 +447,7 @@ func (m *systemdManager) Enable(name string) Result {
 // Returns:
 //   - `bool`: true when `systemctl cat` resolves the unit.
 func (m *systemdManager) Exists(name string) bool {
-	return runShellCommand("systemctl cat "+name, false).OK
+	return runCommand([]string{"systemctl", "cat", name}, false).OK
 }
 
 // IsEnabled reports whether the named service is enabled to start at boot.
@@ -455,7 +458,7 @@ func (m *systemdManager) Exists(name string) bool {
 // Returns:
 //   - `bool`: true when `systemctl is-enabled` succeeds.
 func (m *systemdManager) IsEnabled(name string) bool {
-	return runShellCommand("systemctl is-enabled --quiet "+name, false).OK
+	return runCommand([]string{"systemctl", "is-enabled", "--quiet", name}, false).OK
 }
 
 // IsRunning reports whether the named service is currently active.
@@ -466,7 +469,7 @@ func (m *systemdManager) IsEnabled(name string) bool {
 // Returns:
 //   - `bool`: true when `systemctl is-active` succeeds.
 func (m *systemdManager) IsRunning(name string) bool {
-	return runShellCommand("systemctl is-active --quiet "+name, false).OK
+	return runCommand([]string{"systemctl", "is-active", "--quiet", name}, false).OK
 }
 
 // Start starts the named service.
@@ -477,7 +480,7 @@ func (m *systemdManager) IsRunning(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *systemdManager) Start(name string) Result {
-	return runShellCommand("systemctl start "+name, true)
+	return runCommand([]string{"systemctl", "start", name}, true)
 }
 
 // Status returns the active-state string for the named service.
@@ -488,7 +491,7 @@ func (m *systemdManager) Start(name string) Result {
 // Returns:
 //   - `string`: the trimmed `systemctl is-active` output (e.g. "active", "inactive").
 func (m *systemdManager) Status(name string) string {
-	result := runShellCommand("systemctl is-active "+name, false)
+	result := runCommand([]string{"systemctl", "is-active", name}, false)
 	return strings.TrimSpace(result.Stdout)
 }
 
@@ -500,7 +503,7 @@ func (m *systemdManager) Status(name string) string {
 // Returns:
 //   - `Result`: the command result.
 func (m *systemdManager) Stop(name string) Result {
-	return runShellCommand("systemctl stop "+name, true)
+	return runCommand([]string{"systemctl", "stop", name}, true)
 }
 
 // sysVinitNoBoot is the error returned by [sysVinitManager.Enable] / [sysVinitManager.Disable], which are
@@ -541,7 +544,7 @@ func (m *sysVinitManager) Enable(_ string) Result {
 // Returns:
 //   - `bool`: true when /etc/init.d/<name> is present and executable.
 func (m *sysVinitManager) Exists(name string) bool {
-	return runShellCommand("test -x /etc/init.d/"+name, false).OK
+	return runCommand([]string{"test", "-x", "/etc/init.d/" + name}, false).OK
 }
 
 // IsEnabled reports false: SysVinit boot-persistence is not tracked here.
@@ -561,7 +564,7 @@ func (m *sysVinitManager) IsEnabled(_ string) bool { return false }
 // Returns:
 //   - `bool`: true when `service <name> status` exits zero.
 func (m *sysVinitManager) IsRunning(name string) bool {
-	return runShellCommand("service "+name+" status", false).OK
+	return runCommand([]string{"service", name, "status"}, false).OK
 }
 
 // Start starts the named service via the SysVinit `service` wrapper.
@@ -572,7 +575,7 @@ func (m *sysVinitManager) IsRunning(name string) bool {
 // Returns:
 //   - `Result`: the command result.
 func (m *sysVinitManager) Start(name string) Result {
-	return runShellCommand("service "+name+" start", true)
+	return runCommand([]string{"service", name, "start"}, true)
 }
 
 // Status returns a coarse run-state for the named service.
@@ -583,7 +586,7 @@ func (m *sysVinitManager) Start(name string) Result {
 // Returns:
 //   - `string`: "running" when `service <name> status` exits zero, else "stopped".
 func (m *sysVinitManager) Status(name string) string {
-	if runShellCommand("service "+name+" status", false).OK {
+	if runCommand([]string{"service", name, "status"}, false).OK {
 		return "running"
 	}
 	return "stopped"
@@ -597,7 +600,7 @@ func (m *sysVinitManager) Status(name string) string {
 // Returns:
 //   - `Result`: the command result.
 func (m *sysVinitManager) Stop(name string) Result {
-	return runShellCommand("service "+name+" stop", true)
+	return runCommand([]string{"service", name, "stop"}, true)
 }
 
 // endregion

--- a/pkg/platform/update_darwin_test.go
+++ b/pkg/platform/update_darwin_test.go
@@ -5,15 +5,18 @@
 
 package platform
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // TestBrewRefreshIssuesUnelevatedUpdate verifies brew refreshes without sudo (Homebrew is user-owned).
 func TestBrewRefreshIssuesUnelevatedUpdate(t *testing.T) {
 
-	cmd, sudo := captureRefresh(t, (&brewManager{}).refresh)
+	argv, sudo := captureRefresh(t, (&brewManager{}).refresh)
 
-	if cmd != "brew update" || sudo {
-		t.Errorf("brew refresh = (%q, sudo=%v), want (%q, sudo=false)", cmd, sudo, "brew update")
+	if !slices.Equal(argv, []string{"brew", "update"}) || sudo {
+		t.Errorf("brew refresh = (%v, sudo=%v), want (%q, sudo=false)", argv, sudo, []string{"brew", "update"})
 	}
 }
 
@@ -22,9 +25,9 @@ func TestBrewRefreshIssuesUnelevatedUpdate(t *testing.T) {
 // MacPorts lives under /opt/local (root-owned), so the refresh requires elevation; `-N` keeps it non-interactive.
 func TestPortRefreshIssuesElevatedNonInteractiveSelfupdate(t *testing.T) {
 
-	cmd, sudo := captureRefresh(t, (&portManager{}).refresh)
+	argv, sudo := captureRefresh(t, (&portManager{}).refresh)
 
-	if cmd != "port -N selfupdate" || !sudo {
-		t.Errorf("port refresh = (%q, sudo=%v), want (%q, sudo=true)", cmd, sudo, "port -N selfupdate")
+	if !slices.Equal(argv, []string{"port", "-N", "selfupdate"}) || !sudo {
+		t.Errorf("port refresh = (%v, sudo=%v), want (%v, sudo=true)", argv, sudo, []string{"port", "-N", "selfupdate"})
 	}
 }

--- a/pkg/platform/update_linux_test.go
+++ b/pkg/platform/update_linux_test.go
@@ -5,34 +5,37 @@
 
 package platform
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // TestAptRefreshIssuesElevatedUpdate verifies apt refreshes the index under sudo.
 func TestAptRefreshIssuesElevatedUpdate(t *testing.T) {
 
-	cmd, sudo := captureRefresh(t, (&aptManager{}).refresh)
+	argv, sudo := captureRefresh(t, (&aptManager{}).refresh)
 
-	if cmd != "apt-get update" || !sudo {
-		t.Errorf("apt refresh = (%q, sudo=%v), want (%q, sudo=true)", cmd, sudo, "apt-get update")
+	if !slices.Equal(argv, []string{"apt-get", "update"}) || !sudo {
+		t.Errorf("apt refresh = (%v, sudo=%v), want (%v, sudo=true)", argv, sudo, []string{"apt-get", "update"})
 	}
 }
 
 // TestDnfRefreshIssuesElevatedMakecache verifies dnf rebuilds its metadata cache under sudo.
 func TestDnfRefreshIssuesElevatedMakecache(t *testing.T) {
 
-	cmd, sudo := captureRefresh(t, (&dnfManager{}).refresh)
+	argv, sudo := captureRefresh(t, (&dnfManager{}).refresh)
 
-	if cmd != "dnf makecache" || !sudo {
-		t.Errorf("dnf refresh = (%q, sudo=%v), want (%q, sudo=true)", cmd, sudo, "dnf makecache")
+	if !slices.Equal(argv, []string{"dnf", "makecache"}) || !sudo {
+		t.Errorf("dnf refresh = (%v, sudo=%v), want (%v, sudo=true)", argv, sudo, []string{"dnf", "makecache"})
 	}
 }
 
 // TestPacmanRefreshIssuesElevatedNonInteractiveSync verifies pacman syncs its databases under sudo, non-interactively.
 func TestPacmanRefreshIssuesElevatedNonInteractiveSync(t *testing.T) {
 
-	cmd, sudo := captureRefresh(t, (&pacmanManager{}).refresh)
+	argv, sudo := captureRefresh(t, (&pacmanManager{}).refresh)
 
-	if cmd != "pacman -Sy --noconfirm" || !sudo {
-		t.Errorf("pacman refresh = (%q, sudo=%v), want (%q, sudo=true)", cmd, sudo, "pacman -Sy --noconfirm")
+	if !slices.Equal(argv, []string{"pacman", "-Sy", "--noconfirm"}) || !sudo {
+		t.Errorf("pacman refresh = (%v, sudo=%v), want (%v, sudo=true)", argv, sudo, []string{"pacman", "-Sy", "--noconfirm"})
 	}
 }

--- a/pkg/platform/update_test.go
+++ b/pkg/platform/update_test.go
@@ -32,7 +32,7 @@ func (f *fakeLeaf) Present() bool                                     { return f
 func (f *fakeLeaf) Search(string, int) []SearchResult                 { return nil }
 func (f *fakeLeaf) Update() error                                     { f.updateCalled = true; return f.updateErr }
 
-// captureRefresh lives in update_unix_test.go: it fakes the unix-scoped runShellCommand for the tagged refresh tests.
+// captureRefresh lives in update_unix_test.go: it fakes the unix-scoped runCommand for the tagged refresh tests.
 
 // TestCompositeUpdateFansOutToEveryLeaf verifies the router invokes Update on every registered leaf.
 func TestCompositeUpdateFansOutToEveryLeaf(t *testing.T) {

--- a/pkg/platform/update_unix_test.go
+++ b/pkg/platform/update_unix_test.go
@@ -7,12 +7,12 @@ package platform
 
 import "testing"
 
-// captureRefresh records the command and elevation flag a leaf refresh issues.
+// captureRefresh records the argv and elevation flag a leaf refresh issues.
 //
-// It swaps in a recording [runShellCommand], invokes `refresh`, and restores the real command runner on return — so
-// it asserts a leaf's refresh wiring (the command and its elevation flag) without shelling out or needing root.
+// It swaps in a recording [runCommand], invokes `refresh`, and restores the real command runner on return — so it
+// asserts a leaf's refresh wiring (the argv and its elevation flag) without shelling out or needing root.
 //
-// It carries the unix constraint because [runShellCommand] does, and because its callers are the darwin- and
+// It carries the unix constraint because [runCommand] does, and because its callers are the darwin- and
 // linux-tagged refresh tests.
 //
 // Parameters:
@@ -20,25 +20,25 @@ import "testing"
 //   - `refresh`: the leaf refresh method value to invoke.
 //
 // Returns:
-//   - `string`: the command the refresh issued.
+//   - `[]string`: the argv the refresh issued.
 //   - `bool`: the sudo (elevation) flag it requested.
-func captureRefresh(t *testing.T, refresh func() Result) (string, bool) {
+func captureRefresh(t *testing.T, refresh func() Result) ([]string, bool) {
 
 	t.Helper()
 
 	var (
-		gotCmd  string
+		gotArgv []string
 		gotSudo bool
 	)
 
-	original := runShellCommand
-	runShellCommand = func(command string, sudo bool) Result {
-		gotCmd, gotSudo = command, sudo
+	original := runCommand
+	runCommand = func(argv []string, sudo bool) Result {
+		gotArgv, gotSudo = argv, sudo
 		return Result{OK: true}
 	}
-	defer func() { runShellCommand = original }()
+	defer func() { runCommand = original }()
 
 	refresh()
 
-	return gotCmd, gotSudo
+	return gotArgv, gotSudo
 }


### PR DESCRIPTION
Every command in `pkg/platform` was assembled by concatenation and handed to `sudo -n bash -c`, unquoted:

```go
runShellCommand("apt-get install -y "+strings.Join(names, " "), true)   // true = sudo
```

`ParsePURL` applies no charset validation to a name and decodes the version through `url.PathUnescape`, so
`%3B` arrives as `;`. A name carrying shell metacharacters ran **as root**.

## The change

```go
var runShellCommand = func(command string, sudo bool) Result   // before
var runCommand      = func(argv []string, sudo bool) Result    // after
```

The vector reaches the kernel as a vector. No shell parses it, nothing needs quoting, and no argument can
inject — a package name containing a semicolon is a package name containing a semicolon.

**70 call sites: 64 mechanical, 5 by hand.** The five are the ones that looked like they needed a shell and
didn't:

| Site | Why it looked shell-shaped | Resolution |
|---|---|---|
| `dpkg-query -W -f='${Version}'` | `${…}` | dpkg parses the format itself; the quotes only hid it from `sh` |
| `rpm -q --queryformat '%{VERSION}'` | `%{…}` | same, for rpm |
| `brew` install | command built as a string to vary on `--cask` | appends to an argv slice |
| `launchctl list \| grep -q` | a pipe | `strings.Contains` over captured stdout |
| `port installed \| grep -q` | a pipe | same |

The two pipes are also *more* precise as Go: `strings.Contains` searches what we mean, where `grep` matched a
pattern.

## What the wrapper keeps

Everything that concerns the child process rather than the shell: `commandTimeout`, the endless `y\n` stdin
that auto-confirms prompts a tool raises despite its non-interactive flags, `DEBIAN_FRONTEND=noninteractive`,
and `sudo -n` so elevation fails fast instead of prompting on a tty.

`captureRefresh` records argv rather than a command string; the three refresh tests compare with
`slices.Equal`.

## Deliberately not done

**No `pkg/process` consolidation.** `pkg/platform` imports only `pkg/iox` from this module, and every command
uses `context.Background()`. Routing it through `pkg/process.Runner` would add a dependency on `pkg/result` and
`pkg/status` and thread a runner through the manager constructors — a layering decision, charted by
[`6.2`](docs/architecture/6.2-process-pool.md) and [`6.3`](docs/architecture/6.3-command-execution.md), not a
mechanical rewrite.

**No script tier.** All 70 commands are argv-shaped, so 6.3's tier 2 has no consumer here. Building an unused
fallback would be speculative.

## Verified

- `make check` — exit 0, zero `FAIL`, 103 packages
- `make build-all`, `make vet-all` — linux, darwin, windows. **46 of the conversions are in linux-tagged files
  that a darwin-only build never compiles**, so the per-GOOS sweep is doing real work here.
- Spot-checked the shapes a naive split would corrupt: `"/etc/init.d/" + name` stays one argument, `service
  <name> start` keeps the name in the middle, and `flatpak install -y flathub` keeps `flathub` as a fixed
  argument rather than a package.

Fixes #561.
