### PR TITLE
docs: fsroot follows the kernel on symlink targets, and charters the unconfined-reads work

### DIFF
--- a/docs/architecture/4.5-fsroot-variants.md
+++ b/docs/architecture/4.5-fsroot-variants.md
@@ -96,35 +96,52 @@ not I/O.
 
 `FS() fs.FS` is a read-only view and follows the read rule.
 
-## 4. Symlink targets
+## 4. Symlink targets — the kernel's answer, unchanged
 
-`os.Root.Symlink` stores the target as text and does not resolve it, so **the kernel does not bound where a link
-points** — only where the link itself is created. Target containment is therefore fsroot's own rule, and one of
-the "additional variants" it adds over `os.Root`.
+`os.Root` draws a deliberate asymmetry, and its source says so verbatim:
 
-The rule is not invented; it **follows the write rule**, because an escaping target is a write-escape vector: a
-later write through the link lands outside.
+> **`Root`:** "Methods on Root will follow symbolic links, but symbolic links may not reference a location
+> outside the root."
+>
+> **`Root.Symlink`:** "Symlink does not validate oldname, which may reference a location outside the root."
 
-| Variant | Symlink target may escape? | Because |
-| --- | --- | --- |
-| Confined | **No** | The trust boundary — untrusted bytes, archive extraction |
-| Unconfined read-only | **No** | Its writes may not escape `Dir`; a link that escapes defeats that |
-| Unconfined read-write | **Yes** | No sandbox; crossing trees is the deploy feature |
+The kernel restricts **following**, not **making**. An escaping link can be created through a root; it cannot be
+traversed through one.
 
-**This is what `verbatim` has been standing in for.** `file.Provider.Link`'s two postures need opposite answers
-— a writ deploy symlinks `~/.config/git/config` into a repo clone and the target is *supposed* to leave the
-root, while a tar entry's escaping target is the tar-slip attack. Same call, opposite verdicts. No single rule
-serves both, so the call site grew a flag to choose a policy the root should have owned. Once the variant
-carries the rule, the flag has nothing left to say.
+**fsroot matches this and adds nothing.** An earlier draft of this document proposed a per-variant rule
+forbidding escaping targets on the confined and read-only variants. That was policy invented on top of a kernel
+that had already ruled, and applying the ruling honestly dissolves the case for it:
+
+- **Divergent receipts and lying traces cannot happen.** A write *through* an escaping link is refused by the
+  kernel, so devlore never records a resource inside the root whose bytes landed outside. That argument only
+  ever applied to unconfined roots, which have no confinement to violate.
+- **Tar-slip is contained** for the same reason: a planted link is inert to every confined operation.
+
+**One residual, accepted rather than solved.** The escaping link *is* created on disk, and anything outside
+devlore's confined I/O that follows it escapes — a user's `cp -r`, another tool, a later run on an unconfined
+root. That is the cost of matching the kernel, and every archive tool already accepts it: `tar` extracts
+absolute symlink targets too.
+
+**Two consequences for the code.**
+
+`containedLinkTarget` in the archive provider is a second, hand-rolled implementation of a rule the kernel
+enforces correctly — and it is the hand-rolled one that is broken on Windows
+([#556](https://github.com/NobleFactor/devlore-cli/issues/556)). It should be **deleted, not fixed**. The
+guarantee then comes from extraction running confined, which it does: nothing calls `WithRootMode`, so every
+runtime environment takes the zero value, and that value is `ModeConfined` deliberately.
+
+And `file.Provider.Link`'s `verbatim` flag **survives**. Writing an archive's target as authored is simply
+correct once containment is the kernel's business, so the flag was not policy smuggled to a call site after all.
 
 ## 5. Gaps between the requirements and the code
 
 Verified against `pkg/fsroot/fsroot.go` on 2026-08-18:
 
-1. **`unconfinedRootReader` forbids all writes.** Every mutator returns `errReadOnly`. The requirement is that
-   it writes, confined to `Dir`. The implementation read "read-only" as "no writes" rather than "unconfined for
-   reads only", so the variant is strictly less capable than specified — and the containment check it should
-   have on writes was never written, because there were no writes to check.
+1. **`unconfinedRootReader` forbids all writes.** Fourteen mutators return `errReadOnly`, plus `OpenFile` and
+   `CreateTemp`. The requirement is that it writes, confined to `Dir`. The implementation read "read-only" as
+   "this root cannot write" rather than "unconfined for reads **only**", so the variant is strictly less
+   capable than specified — and the containment those writes need was never written, because there were no
+   writes to contain. **This is the next piece of work; §5.1 details it.**
 2. **The unconfined variants validate nothing.** `os.Open(p.abs)`, `os.WriteFile(p.abs, …)` — straight through.
    Containment on these variants is entirely notional.
 3. **`makePath` does not validate containment.** `filepath.Rel(rootName, path)` happily yields
@@ -139,21 +156,57 @@ Verified against `pkg/fsroot/fsroot.go` on 2026-08-18:
 6. **`4.4` §4 records the read-write variant's use case as "testing"**, while CLI-side roots appear to use it in
    production. *Unverified — worth confirming before acting on it.*
 
+### 5.1 The unconfined-reads work
+
+**Answer question 3 first.** If this variant's writes go through `os.Root`, a write *through* a symlink that
+leaves `Dir` is refused by the kernel. Deploy trees are built from links that leave the tree, so if writ's
+deploy writes through one, deploy needs the read-write variant and this one's audience is narrower than it
+looks. Checkable against the deploy paths; it gates the rest.
+
+**Then compose it from the two variants that already work.** Reads stay as they are — `Open`, `ReadFile`,
+`Readlink`, `Stat`, `Lstat` on `p.abs`. The fifteen mutators delegate to an `*os.Root` anchored at `Dir`, on
+`p.rel`, exactly as `confinedRoot` does. The kernel does the confinement; nothing lexical is added (§2, §4).
+
+**Accept a fallible constructor.** `OpenUnconfined(dir) Dir` cannot fail today; opening an `os.Root` can. It
+becomes `(Dir, error)`, and [`Open`](../../pkg/fsroot/fsroot.go)'s comment that `ModeConfined` "is the only
+branch that can fail" stops being true. A signature change with callers.
+
+**Three methods need decisions rather than transcription**, all from §3:
+
+- **`OpenFile`** routes at runtime on `flag`, and `O_RDONLY` is `0`. The test must be on the write bits;
+  inverting it silently confines every read and frees every write.
+- **`OpenRoot` mints a capability and is not a read.** The kernel settles it: `os.Root.OpenRoot` is confined, so
+  this variant's must be too. Otherwise `OpenRoot("/etc")` returns a root whose writes are confined to `/etc`,
+  and the original bound is gone in one call.
+- **`Chmod`, `Chown`, `Chtimes`, `Lchown`** are writes that write no bytes — the class #405 phase 2 missed,
+  where the private-key defect was a permission on a file whose contents were correct.
+
+**What it does not include:** any validation of a symlink target. The kernel declines that deliberately and
+fsroot matches it (§4).
+
 ## 6. Open questions
 
-1. **Does the confined variant block *reads* outside its root?** `os.Root` does. The requirement says only that
-   it "must prevent **changes** outside". If reads should be permitted, the confined variant is not plain
-   `os.Root` and needs its readers routed around the kernel.
-2. **What does "inside `Dir`" mean when a symlink already crosses out?** §2 answers this by deferring to the
-   kernel, but deploy trees are built from links that leave the tree — so the answer determines whether the
-   unconfined read-only variant is usable for writ at all.
-3. **Does writ's deploy write *through* escaping symlinks?** Checkable against the deploy paths, and it decides
-   question 2 in practice.
+1. ~~**Does the confined variant block reads outside its root?**~~ **Answered 2026-08-19 by the kernel rule.**
+   `os.Root` blocks them — "Methods on Root can only access files and directories beneath a root directory" —
+   and fsroot matches rather than routing readers around the kernel to widen access the requirement never
+   asked for.
+2. **What does "inside `Dir`" mean when a symlink already crosses out?** §2 defers to the kernel, which refuses
+   to traverse such a link — so the answer determines whether the unconfined read-only variant is usable for
+   writ at all, since deploy trees are built from links that leave the tree.
+3. **Does writ's deploy write *through* escaping symlinks?** Checkable against the deploy paths rather than
+   ruled on, and it decides question 2 in practice. **This is the one remaining blocker on §5.1's work.**
+4. **Does `errReadOnly` survive?** If the read-only variant writes (§5.1), nothing returns it — unless a
+   genuinely no-write root is still wanted for planning, which would be a fourth variant. Interacts with
+   [#563](https://github.com/NobleFactor/devlore-cli/issues/563)'s hermetic-subset question.
 
 ## 7. What this settles elsewhere
 
-- [#556](https://github.com/NobleFactor/devlore-cli/issues/556) — the archive symlink containment bypass. The
-  extractor stops carrying a guard and states its trust requirement by choosing the confined variant.
-- [#547](https://github.com/NobleFactor/devlore-cli/issues/547) — items 3–5 above are the same defect this issue
+- [#556](https://github.com/NobleFactor/devlore-cli/issues/556) — **inverted by §4.** It was filed to fix the
+  archive extractor's containment guard; the ruling says delete it. The kernel refuses to traverse an escaping
+  link, extraction already runs confined, and the guard is a second implementation of a rule already enforced —
+  broken only in its hand-rolled copy. `TestExtract_SymlinkTargetEscapes` then asserts a refusal that is no
+  longer ours to make.
+- [#547](https://github.com/NobleFactor/devlore-cli/issues/547) — gaps 3–5 above are the same defect this issue
   catalogues, in the package meant to end it.
-- `file.Provider.Link`'s `verbatim` flag, and its projection into the Starlark surface (§4).
+- `file.Provider.Link`'s `verbatim` flag **survives** (§4), rather than being designed away as an earlier draft
+  proposed.

--- a/docs/architecture/4.5-fsroot-variants.md
+++ b/docs/architecture/4.5-fsroot-variants.md
@@ -1,100 +1,88 @@
-# fsroot — Variants and Containment Rules
+# fsroot — One Confinement, Two Types
 
-> **Status:** requirements (draft, 2026-08-18). Records the stated requirements for `pkg/fsroot`'s three
-> variants and derives the rules that follow from them. No implementation.
+> **Status:** design (draft 2026-08-18, rewritten 2026-08-19). Records what `pkg/fsroot` is for and what it adds
+> to `os.Root`. An earlier draft described three confinement variants; that design is replaced here by a single
+> confinement behaviour, for the reasons in §5. No implementation. Companion:
+> [`4.5-fsroot-variants.status.md`](4.5-fsroot-variants.status.md).
 >
 > **Relationship to the neighbours.** [`4.4-root-path-triad.md`](4.4-root-path-triad.md) owns the cooperative
-> triad — Root produces and consumes Path, RecoverySite delegates to Root — and describes it under the pre-split
-> `op.Root` / `op.Path` names. **This document owns the variants**: what each one confines, by what mechanism,
-> and what that implies method by method. It **supersedes `4.4` §4's mode-switch table**, which states rules the
-> requirements below replace. Companion: [`4.5-fsroot-variants.status.md`](4.5-fsroot-variants.status.md).
+> triad — Root produces and consumes Path, RecoverySite delegates to Root — under the pre-split `op.Root` names.
+> **This document owns what a root is and what it guarantees.** It **supersedes `4.4` §4's mode-switch table**,
+> which describes three implementations selected at startup.
 
 ## Thesis
 
-**fsroot is `os.Root` plus two variants, and the variants differ in *what is unconfined* — never in whether the
-root is a root.** Today two of the three enforce nothing at all: every operation on an unconfined root is
-`os.X(p.abs)` straight through, so `Path`'s `root` field is decorative outside the confined variant, and each
-caller that needs containment invents its own. That invention is how the archive provider came to carry a
-hand-rolled `containedLinkTarget`, and how that guard came to be wrong on Windows (#556).
+**There is one confinement behaviour, and it is the kernel's.** fsroot exists not to offer a choice of
+confinement but to supply the five things `os.Root` lacks — most importantly, permission enforcement that means
+something on Windows.
 
-## 1. The three variants
+An earlier draft defined three variants differing in *what is unconfined*. Working through their consumers
+found none: every production caller of the unconfined variants anchors at a tree it owns and writes only inside
+it, and the one place the reason is written down gives a different one entirely — bootstrapping, because
+`os.OpenRoot` cannot open a directory that does not exist yet. That is a reason to create a directory, not a
+reason to abandon confinement (§3).
 
-**Requirements, as stated:**
+## 1. The two types
 
-1. **Confined root** — must prevent changes outside the directory targeted by a writ or lore operation. A writ
-   deploy must not allow changes outside Home or System. The whole-filesystem case is deliberately degenerate:
-   on Unix everything is mounted under `/`, and on Windows under `%SYSTEMDRIVE%\`, so a root at either confines
-   to what the OS already enforces. No special-casing required.
-2. **Unconfined read-only root** — reads may go anywhere; **updates only inside `fsroot.Dir`**.
-3. **Unconfined read-write root** — reads and writes may go anywhere. There is no sandbox. `fsroot.Dir` is a
-   convenience for formulating relative paths.
-
-**One axis, three positions:**
-
-| Variant | Read | Write |
+| Opener | Type | Lifetime |
 | --- | --- | --- |
-| Confined | confined | confined |
-| Unconfined read-only | **anywhere** | confined to `Dir` |
-| Unconfined read-write | anywhere | anywhere |
+| `OpenConfined(dir)` | `confinedDir` | the caller's |
+| `OpenScratch(pattern)` | `confinedScratchDir` | removes its tree on `Close` |
 
-The fourth cell — confined reads with unconfined writes — is incoherent, which is why there are three variants
-and not four.
+Both confine reads and writes to their root, by the kernel, through `*os.Root`.
 
-**The names say what is *unconfined*, not what is *permitted*.** "Unconfined read-only" means *unconfined for
-reads only*; it still writes, within `Dir`. Reading the name as "this root cannot write" is the mistake the
-current implementation makes (§5).
+Two types rather than one with a flag: `Close` means something different for each, and a type whose `Close`
+sometimes deletes the tree is one nobody can reason about at a call site. The scratch contract — that cleanup
+is impossible to forget — holds only if it is the type's contract.
 
-## 2. Mechanism: the kernel owns the write side
+No `Mode`, and no mode-dispatched constructor. With one confinement behaviour there is nothing to select, and a
+selector only invites a caller to widen access by passing a constant.
 
-For the unconfined read-only variant, **writes route through `*os.Root` and reads do not**. The variant is a
-composition of the other two: reads from the read-write variant (`os.*` on `p.abs`), writes from the confined
-variant (`*os.Root` on `p.rel`).
+## 2. What fsroot adds to `os.Root`
 
-Four reasons to let the kernel bound writes rather than checking paths ourselves:
+Five things, and the first is why the package exists.
 
-1. **TOCTOU.** A lexical check followed by `os.WriteFile` leaves a window: validate `dir/x`, something swaps
-   `dir` for a symlink, the write lands outside. `os.Root` resolves each component with the kernel holding the
-   invariant across the operation. For a variant whose purpose is bounding writes, a check that can be raced is
-   not a bound.
-2. **It answers "inside `Dir`" when a symlink already crosses out.** The kernel resolves the link and refuses.
-   A lexical check calls that write contained when it is not.
-3. **We stop reimplementing path resolution** — symlink following, `..` handling, Windows volume semantics.
-   That is the family of mistakes [#547](https://github.com/NobleFactor/devlore-cli/issues/547) catalogues, and
-   fsroot is the package that exists to end them.
-4. **`confinedRoot` already does exactly this**, so no new platform exposure is introduced.
+**1. Permission enforcement that survives Windows.** `os.Root.Chmod` on Windows toggles only the read-only
+attribute, so a `0o600` request there yields a file every account with directory access can read. `applyMode`
+translates the one distinction Windows can honour — private versus not — into a **protected** DACL granting the
+owner, SYSTEM and Administrators, with inheritance broken. It runs from `Chmod`, `Mkdir`, `MkdirAll`,
+`WriteFile`, and `OpenFile` on `O_CREATE`. `os.Root` offers nothing here; this is #405's subject, and #422 the
+defect it fixed.
 
-**Costs.** An open root descriptor for the variant's lifetime (negligible). Writes dispatch on `p.rel`, so a
-`Path` whose `rel` climbs out is refused by the OS — the desired outcome, but the error wants wrapping to name
-which root refused and why. And a caller that writes *through* a symlink pointing outside `Dir` cannot use this
-variant; the kernel refuses. If writ's deploy does that, deploy belongs on the read-write variant (§6).
+**2. `Path`, the two-form value.** `os.Root`'s methods take strings. fsroot's take `Path{root, rel, abs}`:
+`rel` slash-canonical on **every** platform, so serialized documents and checksums are byte-identical
+everywhere (#377); `abs` OS-native, carrying the syscalls. It serializes as `{root, rel}`, with `abs` derived
+on read. Without such a value every caller re-derives the neutral/native distinction for itself, which is
+precisely the defect class [#547](https://github.com/NobleFactor/devlore-cli/issues/547) catalogues.
 
-## 3. Method classification
+**3. `CreateTemp` and `MkdirTemp`.** Absent from `os.Root` as of Go 1.26, and `os.CreateTemp` cannot be
+confined to a root.
 
-The `Dir` interface carries 26 methods. Fifteen are writes, five are reads, three need a ruling, and three are
-not I/O.
+**4. Temp-pattern hardening.** A pattern containing a path separator is refused, since it would let a caller
+redirect creation through the *name* rather than the directory argument.
 
-**Through `os.Root` (writes):** `Chmod`, `Chown`, `Chtimes`, `Lchown`, `Create`, `CreateTemp`, `Link`,
-`Symlink`, `Mkdir`, `MkdirAll`, `MkdirTemp`, `Remove`, `RemoveAll`, `Rename`, `WriteFile`
+**5. Scratch lifetime.** A confined tree that removes itself, so process scratch flows through the same seam as
+every other mutation and inherits its platform behaviour.
 
-**Direct `os.*` (reads):** `Lstat`, `Open`, `ReadFile`, `Readlink`, `Stat`
+Strip these and the package is a wrapper for its own sake. Keep them and it is the only place that knows how to
+make a mode mean the same thing on two operating systems.
 
-**Not I/O:** `Name`, `NewPath`, `Close`
+## 3. Two rules about opening
 
-**The three that need a ruling:**
+**Open is a query.** No `Open…` constructor creates anything. A caller that opens a root to read must not leave
+a directory behind — the same defect as a staleness refresh hidden inside a method named `Available`, and
+rejected for the same reason.
 
-1. **`OpenFile(p, flag, perm)`** routes at runtime on `flag`. `O_RDONLY` is `0`, so the test must be on the
-   write bits — `O_WRONLY | O_RDWR | O_CREATE | O_TRUNC | O_APPEND` — never an equality check against
-   `O_RDONLY`. Inverting this is silent: every read would be confined and every write unconfined.
-2. **`OpenRoot(p) (Dir, error)` is a capability grant, not a read.** If the unconfined read-only variant permits
-   `OpenRoot` anywhere because "opening is not writing", a caller opens `/etc`, receives a Dir whose writes are
-   confined to `/etc`, and the original bound is gone in one call. `OpenRoot` must therefore be **confined even
-   on the read-unconfined variant**, and the returned Dir must inherit the same variant. Narrowing the root is
-   safe; relocating it is not.
-3. **The metadata mutators** — `Chmod`, `Chown`, `Chtimes`, `Lchown` — are writes that write no bytes, which is
-   why they get missed. This project has already paid for that: #405's phase 2 enforced nothing on the
-   unconfined root, and the private-key defect (#422) was a *permission* on a file whose contents were correct.
+**A root that does not exist is an error.** That failure is the diagnostic which catches a misspelled path. A
+constructor that created the anchor would swallow it, and would have to answer three questions it has no
+business answering: what permissions the new directory carries (a `0o755` directory holding `0o600` files is
+half-enforced), how to close the window between `MkdirAll` and `OpenRoot` in which the path can be replaced by
+a symlink, and who removes the directory when the operation that prompted it fails.
 
-`FS() fs.FS` is a read-only view and follows the read rule.
+**So a caller whose target does not exist yet** opens a confined root at an existing **ancestor**, creates the
+chain through it, then opens the target root. `/` always exists, so an ancestor always does. Both steps stay
+confined, the mode is applied on the way, and the creation is visible at the call site rather than implied by
+an open.
 
 ## 4. Symlink targets — the kernel's answer, unchanged
 
@@ -105,108 +93,69 @@ not I/O.
 >
 > **`Root.Symlink`:** "Symlink does not validate oldname, which may reference a location outside the root."
 
-The kernel restricts **following**, not **making**. An escaping link can be created through a root; it cannot be
-traversed through one.
+The kernel restricts **following**, not **making**. fsroot matches it and adds nothing.
 
-**fsroot matches this and adds nothing.** An earlier draft of this document proposed a per-variant rule
-forbidding escaping targets on the confined and read-only variants. That was policy invented on top of a kernel
-that had already ruled, and applying the ruling honestly dissolves the case for it:
+An earlier draft proposed forbidding escaping targets. The arguments for that do not survive: a write *through*
+an escaping link is refused by the kernel, so receipts cannot diverge from where bytes landed and traces cannot
+lie — the two objections that were not about attackers. Tar-slip is contained for the same reason.
 
-- **Divergent receipts and lying traces cannot happen.** A write *through* an escaping link is refused by the
-  kernel, so devlore never records a resource inside the root whose bytes landed outside. That argument only
-  ever applied to unconfined roots, which have no confinement to violate.
-- **Tar-slip is contained** for the same reason: a planted link is inert to every confined operation.
+**Residual, accepted:** the link exists on disk, and anything outside devlore's confined I/O that follows it
+escapes. `tar` accepts the same cost; it extracts absolute symlink targets too.
 
-**One residual, accepted rather than solved.** The escaping link *is* created on disk, and anything outside
-devlore's confined I/O that follows it escapes — a user's `cp -r`, another tool, a later run on an unconfined
-root. That is the cost of matching the kernel, and every archive tool already accepts it: `tar` extracts
-absolute symlink targets too.
+**Consequences.** `containedLinkTarget` in the archive provider is a second implementation of a rule the kernel
+already enforces — and it is the hand-rolled copy that is broken on Windows
+([#556](https://github.com/NobleFactor/devlore-cli/issues/556)). Delete it, do not fix it. Extraction runs
+confined by explicit choice: `pkg/op/provider/plan/provider.go:488` and `cmd/writ/writ/deploy/plan.go:387` both
+pass a confined mode today. And `file.Provider.Link`'s `verbatim` flag **survives** — writing an archive's
+target as authored is simply correct once containment is the kernel's business.
 
-**Two consequences for the code.**
+## 5. Why the unconfined variants go
 
-`containedLinkTarget` in the archive provider is a second, hand-rolled implementation of a rule the kernel
-enforces correctly — and it is the hand-rolled one that is broken on Windows
-([#556](https://github.com/NobleFactor/devlore-cli/issues/556)). It should be **deleted, not fixed**. The
-guarantee then comes from extraction running confined, which it does: nothing calls `WithRootMode`, so every
-runtime environment takes the zero value, and that value is `ModeConfined` deliberately.
+The evidence, gathered 2026-08-19:
 
-And `file.Provider.Link`'s `verbatim` flag **survives**. Writing an archive's target as authored is simply
-correct once containment is the kernel's business, so the flag was not policy smuggled to a call site after all.
+**Nothing reads outside its own tree.** Every production `OpenWritableUnconfined` anchors at
+`devlore.ConfigHome()`, `StateHome()`, `CacheHome()`, an install prefix, a man install path, or a test temp
+directory. Each writes within its anchor.
 
-## 5. Gaps between the requirements and the code
+**The stated reason is bootstrapping, not access.** From `cmd/internal/cli/selfinstall.go`: *"Writable-
+unconfined because the prefix need not exist yet — a first install creates it — and a confined root requires
+its anchor to exist."* §3 answers that without a variant.
 
-Verified against `pkg/fsroot/fsroot.go` on 2026-08-18:
+**writ deploy does not need it either.** Deploy reads its layer sources at planning time, in Go; the graph's
+root is anchored at the *target* and used only for writes — `deploySpec`'s own doc calls its argument "the
+absolute path the confined Root is anchored at". System scope targets `/`, and a confined root at `/` bounds
+nothing on Unix, so 2.4's "System is unconfined" is a degenerate case of confinement rather than a second
+variant.
 
-1. **`unconfinedRootReader` forbids all writes.** Fourteen mutators return `errReadOnly`, plus `OpenFile` and
-   `CreateTemp`. The requirement is that it writes, confined to `Dir`. The implementation read "read-only" as
-   "this root cannot write" rather than "unconfined for reads **only**", so the variant is strictly less
-   capable than specified — and the containment those writes need was never written, because there were no
-   writes to contain. **This is the next piece of work; §5.1 details it.**
-2. **The unconfined variants validate nothing.** `os.Open(p.abs)`, `os.WriteFile(p.abs, …)` — straight through.
-   Containment on these variants is entirely notional.
-3. **`makePath` does not validate containment.** `filepath.Rel(rootName, path)` happily yields
-   `../../etc/passwd`, so a `Path` can name something outside the root it carries.
-4. **`makePath` asks `filepath.IsAbs` about input that may be neutral.** Given `/etc/passwd` against root
-   `/data`, Unix takes the absolute branch and produces `rel = ../../etc/passwd` (escaping); Windows takes the
-   relative branch and produces `rel = /etc/passwd`, `abs = <root>\etc\passwd` (contained). Same input, opposite
-   containment outcomes — and the Windows `rel` carries a leading slash, which `fs.ValidPath` rejects, in the
-   half documented as feeding `io/fs`.
-5. **`makePath` panics through `assert.Must`** when `filepath.Rel` cannot express the relationship — on Windows,
-   whenever root and path are on different volumes. That is an ordinary condition, not an assertion failure.
-6. **`4.4` §4 records the read-write variant's use case as "testing"**, while CLI-side roots appear to use it in
-   production. *Unverified — worth confirming before acting on it.*
+**And "read from elsewhere, write here" wants two roots, not one half-confined one.** Two confined roots state
+the actual intent — read tree A, write tree B. A write-confined root grants **unbounded** reads to express a
+**bounded** need, which is strictly more authority than any caller has asked for.
 
-### 5.1 The unconfined-reads work
+### 5.1 The work
 
-**Answer question 3 first.** If this variant's writes go through `os.Root`, a write *through* a symlink that
-leaves `Dir` is refused by the kernel. Deploy trees are built from links that leave the tree, so if writ's
-deploy writes through one, deploy needs the read-write variant and this one's audience is narrower than it
-looks. Checkable against the deploy paths; it gates the rest.
+1. **Verify the premise.** Trace every `OpenWritableUnconfined` call site and confirm none writes outside its
+   anchor. Mechanical, and the only thing that can invalidate this design. **Do this first.**
+2. **Migrate the call sites.** Tests against `t.TempDir()` become `OpenConfined` directly. The bootstrapping
+   cases — prefix, ConfigHome, StateHome, CacheHome, installPath — create through an ancestor root, then open.
+3. **Delete** `unconfinedRootReader`, `unconfinedRootReaderWriter`, `rootBase`, `errReadOnly`, `Mode` and its
+   constants, `Open`, `OpenUnconfined`, `OpenWritableUnconfined`.
+4. **Rename** `confinedRoot` → `confinedDir`, `scratchRoot` → `confinedScratchDir`.
+5. **`WithRoot(path, mode)` → `WithRoot(path)`**, and `WithRootMode` with it.
 
-**Then compose it from the two variants that already work.** Reads stay as they are — `Open`, `ReadFile`,
-`Readlink`, `Stat`, `Lstat` on `p.abs`. The fifteen mutators delegate to an `*os.Root` anchored at `Dir`, on
-`p.rel`, exactly as `confinedRoot` does. The kernel does the confinement; nothing lexical is added (§2, §4).
-
-**Accept a fallible constructor.** `OpenUnconfined(dir) Dir` cannot fail today; opening an `os.Root` can. It
-becomes `(Dir, error)`, and [`Open`](../../pkg/fsroot/fsroot.go)'s comment that `ModeConfined` "is the only
-branch that can fail" stops being true. A signature change with callers.
-
-**Three methods need decisions rather than transcription**, all from §3:
-
-- **`OpenFile`** routes at runtime on `flag`, and `O_RDONLY` is `0`. The test must be on the write bits;
-  inverting it silently confines every read and frees every write.
-- **`OpenRoot` mints a capability and is not a read.** The kernel settles it: `os.Root.OpenRoot` is confined, so
-  this variant's must be too. Otherwise `OpenRoot("/etc")` returns a root whose writes are confined to `/etc`,
-  and the original bound is gone in one call.
-- **`Chmod`, `Chown`, `Chtimes`, `Lchown`** are writes that write no bytes — the class #405 phase 2 missed,
-  where the private-key defect was a permission on a file whose contents were correct.
-
-**What it does not include:** any validation of a symlink target. The kernel declines that deliberately and
-fsroot matches it (§4).
+Five types become two. The `Dir` interface stops being a substitution point for confinement policy and survives
+only as the seam every provider already programs against.
 
 ## 6. Open questions
 
-1. ~~**Does the confined variant block reads outside its root?**~~ **Answered 2026-08-19 by the kernel rule.**
-   `os.Root` blocks them — "Methods on Root can only access files and directories beneath a root directory" —
-   and fsroot matches rather than routing readers around the kernel to widen access the requirement never
-   asked for.
-2. **What does "inside `Dir`" mean when a symlink already crosses out?** §2 defers to the kernel, which refuses
-   to traverse such a link — so the answer determines whether the unconfined read-only variant is usable for
-   writ at all, since deploy trees are built from links that leave the tree.
-3. **Does writ's deploy write *through* escaping symlinks?** Checkable against the deploy paths rather than
-   ruled on, and it decides question 2 in practice. **This is the one remaining blocker on §5.1's work.**
-4. **Does `errReadOnly` survive?** If the read-only variant writes (§5.1), nothing returns it — unless a
-   genuinely no-write root is still wanted for planning, which would be a fourth variant. Interacts with
-   [#563](https://github.com/NobleFactor/devlore-cli/issues/563)'s hermetic-subset question.
+1. **Does any current unconfined caller write outside its anchor?** §5.1 step 1 — the only open item, and a
+   trace rather than a decision.
+2. **Do `TestIsPrivateMode` and `TestNewPath` belong in the public API?** They are exported from non-test files.
 
 ## 7. What this settles elsewhere
 
-- [#556](https://github.com/NobleFactor/devlore-cli/issues/556) — **inverted by §4.** It was filed to fix the
-  archive extractor's containment guard; the ruling says delete it. The kernel refuses to traverse an escaping
-  link, extraction already runs confined, and the guard is a second implementation of a rule already enforced —
-  broken only in its hand-rolled copy. `TestExtract_SymlinkTargetEscapes` then asserts a refusal that is no
-  longer ours to make.
-- [#547](https://github.com/NobleFactor/devlore-cli/issues/547) — gaps 3–5 above are the same defect this issue
-  catalogues, in the package meant to end it.
-- `file.Provider.Link`'s `verbatim` flag **survives** (§4), rather than being designed away as an earlier draft
-  proposed.
+- [#556](https://github.com/NobleFactor/devlore-cli/issues/556) — **inverted.** Filed to fix the archive
+  extractor's containment guard; §4 says delete it.
+- [#547](https://github.com/NobleFactor/devlore-cli/issues/547) — `Path` (§2) is the mechanism that issue says
+  does not exist; fsroot is where it lives.
+- [#568](https://github.com/NobleFactor/devlore-cli/issues/568) — the rename, now a collapse to two types.
+- `file.Provider.Link`'s `verbatim` flag **survives** (§4) rather than being designed away.

--- a/docs/architecture/4.5-fsroot-variants.status.md
+++ b/docs/architecture/4.5-fsroot-variants.status.md
@@ -1,49 +1,48 @@
-# fsroot — Variants and Containment Rules — Status
+# fsroot — One Confinement, Two Types — Status
 
 **Document:** [4.5-fsroot-variants.md](4.5-fsroot-variants.md)
-**State:** Requirements draft (2026-08-18), written from requirements stated in session. Captures the three
-variants as one axis — what is unconfined. Revised 2026-08-19 onto the rule that fsroot follows the kernel and
-adds nothing without a compelling need, which rewrote §4 and answered one open question. No
-implementation. Supersedes [`4.4`](4.4-root-path-triad.md) §4's mode-switch table.
+**State:** Design draft (2026-08-18), **rewritten 2026-08-19**. The first draft specified three confinement
+variants from stated requirements; tracing their consumers found the middle one unimplemented and the outer one
+justified by bootstrapping rather than access, so the design collapses to a single confinement behaviour and
+two types. No implementation.
 
-## Completion
+## Settled
 
-- [x] The three variants stated as requirements, with the whole-filesystem degenerate case (`/`,
-  `%SYSTEMDRIVE%\`) named as deliberate rather than needing special handling.
-- [x] **The naming clarified** — the variant names say what is *unconfined*, not what is *permitted*. Reading
-  "unconfined read-only" as "cannot write" is the mistake the current implementation makes.
-- [x] Mechanism decided for the read-only variant: writes through `*os.Root` on `p.rel`, reads direct on
-  `p.abs` — justified on TOCTOU, on symlink resolution answering "inside `Dir`", on not reimplementing path
-  resolution, and on `confinedRoot` already proving the pattern.
-- [x] **All 26 `Dir` methods classified** — 15 writes, 5 reads, 3 needing a ruling, 3 not I/O.
-- [x] The three rulings named, with the failure mode of each: `OpenFile`'s flag test (`O_RDONLY` is `0`),
-  `OpenRoot` as a capability grant rather than a read, and the metadata mutators as writes that write no bytes.
-- [x] **Symlink-target rule withdrawn.** An earlier draft derived a per-variant rule forbidding escaping
-  targets. `os.Root` had already ruled — it restricts *following*, not *making*, and says so verbatim — and the
-  arguments for adding to it do not survive scrutiny: a write *through* an escaping link is refused by the
-  kernel, so receipts cannot diverge and traces cannot lie. fsroot matches the kernel. **This inverts #556**,
-  which was filed to fix the archive extractor's guard and should now delete it.
-- [x] `verbatim` explained as a policy flag at the call site standing in for a rule the root should own.
-- [x] Six gaps between requirements and code, verified against `pkg/fsroot/fsroot.go`.
+- [x] **One confinement behaviour, and it is the kernel's.** fsroot does not offer a choice of confinement.
+- [x] **Two types**: `confinedDir` and `confinedScratchDir`. Two rather than one with a flag, because `Close`
+  means something different for each, and the scratch contract — cleanup impossible to forget — holds only if
+  it is the type's contract.
+- [x] **`Mode` and the mode-dispatched constructor go.** Nothing to select, and a selector invites a caller to
+  widen access by passing a constant.
+- [x] **What fsroot adds to `os.Root` enumerated** — permission enforcement that survives Windows, the two-form
+  `Path`, `CreateTemp`/`MkdirTemp`, temp-pattern hardening, scratch lifetime. Checked against Go 1.26's actual
+  `os.Root` method set rather than the package's own claim about it.
+- [x] **Open is a query**, and **a missing root is an error**. A caller whose target does not exist opens a
+  confined root at an existing ancestor, creates the chain, then opens the target.
+- [x] **Symlink targets left to the kernel.** It restricts following, not making, and says so verbatim. An
+  earlier draft's per-variant rule is withdrawn: a write *through* an escaping link is refused by the kernel,
+  so receipts cannot diverge and traces cannot lie. **This inverts #556** — delete the guard rather than fix it
+  — and `verbatim` survives.
+- [x] **The unconfined variants have no production justification.** Every caller anchors at a tree it owns;
+  `selfinstall` states bootstrapping as the reason; writ deploy reads sources at plan time and writes through a
+  confined root anchored at the target; and cross-tree work wants two confined roots rather than one granting
+  unbounded reads to express a bounded need.
+- [x] **Corrected**: an earlier revision claimed extraction runs confined because nobody sets the mode. Wrong
+  reason, right conclusion — production sets it explicitly at `plan/provider.go:488` and `deploy/plan.go:387`.
 
 ## Open
 
-- [x] ~~Does the confined variant block reads outside its root?~~ **Answered 2026-08-19 by the kernel rule** —
-  `os.Root` blocks them and fsroot matches, rather than routing readers around the kernel to widen access the
-  requirement never asked for.
-- [ ] **What does "inside `Dir`" mean when a symlink crosses out?** Deferred to the kernel here, but deploy
-  trees are built from such links.
-- [ ] **Does writ's deploy write through escaping symlinks?** Checkable against the deploy paths rather than
-  ruled on; decides whether deploy can use the read-only variant or needs the read-write one. **The one
-  remaining blocker on §5.1's work**, and the only open item that can be settled without a decision.
-- [ ] **Does `errReadOnly` survive?** If the read-only variant writes, nothing returns it — unless a genuinely
-  no-write root is wanted for planning, which would be a fourth variant. Interacts with #563.
-- [ ] Whether the read-write variant's use case is genuinely "testing" as `4.4` records, given CLI-side roots
-  appear to use it in production. **Unverified.**
-- [ ] Whether `Path` construction should refuse an escaping `rel`, or only operations should. This document
-  places enforcement on operations, matching `os.Root`, which leaves the 206 `NewPath` call sites untouched.
+- [ ] **Does any current `OpenWritableUnconfined` caller write outside its anchor?** §5.1 step 1. Sampled, not
+  exhaustively traced — and the only thing that can invalidate this design. A trace, not a decision.
+- [ ] **`TestIsPrivateMode` and `TestNewPath`** are exported from non-test files, so they sit in the public API.
 
-## Not yet decided
+## Superseded by this revision
 
-No implementation plan, no issue filed for the fsroot work itself. #556 is filed and is downstream of this
-document's §4.
+The first draft's three-variant table, its write-side mechanism, its method classification (15 writes / 5 reads
+/ 3 rulings), its symlink-target rule, and its unconfined-reads work plan. The classification and the write-side
+routing existed to serve a middle variant that is now removed; with one behaviour, every operation goes through
+`*os.Root`.
+
+[#568](https://github.com/NobleFactor/devlore-cli/issues/568) was filed as a three-variant rename carrying an
+ordering constraint, to avoid one name silently acquiring a wider meaning. **That hazard disappears with the
+variants** — no name is reused, because the wider meanings are deleted.

--- a/docs/architecture/4.5-fsroot-variants.status.md
+++ b/docs/architecture/4.5-fsroot-variants.status.md
@@ -2,7 +2,8 @@
 
 **Document:** [4.5-fsroot-variants.md](4.5-fsroot-variants.md)
 **State:** Requirements draft (2026-08-18), written from requirements stated in session. Captures the three
-variants as one axis — what is unconfined — and derives the symlink-target rule from the write rule. No
+variants as one axis — what is unconfined. Revised 2026-08-19 onto the rule that fsroot follows the kernel and
+adds nothing without a compelling need, which rewrote §4 and answered one open question. No
 implementation. Supersedes [`4.4`](4.4-root-path-triad.md) §4's mode-switch table.
 
 ## Completion
@@ -17,21 +18,26 @@ implementation. Supersedes [`4.4`](4.4-root-path-triad.md) §4's mode-switch tab
 - [x] **All 26 `Dir` methods classified** — 15 writes, 5 reads, 3 needing a ruling, 3 not I/O.
 - [x] The three rulings named, with the failure mode of each: `OpenFile`'s flag test (`O_RDONLY` is `0`),
   `OpenRoot` as a capability grant rather than a read, and the metadata mutators as writes that write no bytes.
-- [x] **Symlink-target rule derived rather than invented** — it follows the write rule, because an escaping
-  target is a write-escape vector.
+- [x] **Symlink-target rule withdrawn.** An earlier draft derived a per-variant rule forbidding escaping
+  targets. `os.Root` had already ruled — it restricts *following*, not *making*, and says so verbatim — and the
+  arguments for adding to it do not survive scrutiny: a write *through* an escaping link is refused by the
+  kernel, so receipts cannot diverge and traces cannot lie. fsroot matches the kernel. **This inverts #556**,
+  which was filed to fix the archive extractor's guard and should now delete it.
 - [x] `verbatim` explained as a policy flag at the call site standing in for a rule the root should own.
 - [x] Six gaps between requirements and code, verified against `pkg/fsroot/fsroot.go`.
 
 ## Open
 
-- [ ] **Does the confined variant block reads outside its root?** The requirement says "prevent *changes*
-  outside"; `os.Root` blocks reads too. If reads should be permitted, the confined variant is not plain
-  `os.Root`.
+- [x] ~~Does the confined variant block reads outside its root?~~ **Answered 2026-08-19 by the kernel rule** —
+  `os.Root` blocks them and fsroot matches, rather than routing readers around the kernel to widen access the
+  requirement never asked for.
 - [ ] **What does "inside `Dir`" mean when a symlink crosses out?** Deferred to the kernel here, but deploy
   trees are built from such links.
-- [ ] **Does writ's deploy write through escaping symlinks?** Checkable against the deploy paths; decides the
-  question above in practice, and decides whether deploy can use the read-only variant or needs the read-write
-  one.
+- [ ] **Does writ's deploy write through escaping symlinks?** Checkable against the deploy paths rather than
+  ruled on; decides whether deploy can use the read-only variant or needs the read-write one. **The one
+  remaining blocker on §5.1's work**, and the only open item that can be settled without a decision.
+- [ ] **Does `errReadOnly` survive?** If the read-only variant writes, nothing returns it — unless a genuinely
+  no-write root is wanted for planning, which would be a fourth variant. Interacts with #563.
 - [ ] Whether the read-write variant's use case is genuinely "testing" as `4.4` records, given CLI-side roots
   appear to use it in production. **Unverified.**
 - [ ] Whether `Path` construction should refuse an escaping `rel`, or only operations should. This document

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -59,7 +59,7 @@ Each architecture document has a companion `*.status.md` file tracking completio
   - [Memory Resources](4.2-mem-resource.md) ([status](4.2-mem-resource.status.md)) — `mem:` scheme, callable serialization lifecycle
   - [Resource Registration](4.3-resource-registration.md) ([status](4.3-resource-registration.status.md)) — Generated announcements into the receiver registry, environment-aware constructors, source-type declarations, rehydration by type id
   - [Root-Path Triad](4.4-root-path-triad.md) ([status](4.4-root-path-triad.status.md)) — Root interface, Path struct, RecoverySite, OS-enforced I/O confinement
-  - [fsroot Variants and Containment Rules](4.5-fsroot-variants.md) ([status](4.5-fsroot-variants.status.md)) — the three variants as one axis (what is unconfined, not what is permitted); writes through `*os.Root` and reads direct; all 26 `Dir` methods classified; the symlink-target rule derived from the write rule; supersedes 4.4 §4
+  - [fsroot Variants and Containment Rules](4.5-fsroot-variants.md) ([status](4.5-fsroot-variants.status.md)) — the three variants as one axis (what is unconfined, not what is permitted); writes through `*os.Root` and reads direct; all 26 `Dir` methods classified; symlink targets left to the kernel, which restricts following rather than making; supersedes 4.4 §4
 
 ### 5. Operational Integrity
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -59,7 +59,7 @@ Each architecture document has a companion `*.status.md` file tracking completio
   - [Memory Resources](4.2-mem-resource.md) ([status](4.2-mem-resource.status.md)) — `mem:` scheme, callable serialization lifecycle
   - [Resource Registration](4.3-resource-registration.md) ([status](4.3-resource-registration.status.md)) — Generated announcements into the receiver registry, environment-aware constructors, source-type declarations, rehydration by type id
   - [Root-Path Triad](4.4-root-path-triad.md) ([status](4.4-root-path-triad.status.md)) — Root interface, Path struct, RecoverySite, OS-enforced I/O confinement
-  - [fsroot Variants and Containment Rules](4.5-fsroot-variants.md) ([status](4.5-fsroot-variants.status.md)) — the three variants as one axis (what is unconfined, not what is permitted); writes through `*os.Root` and reads direct; all 26 `Dir` methods classified; symlink targets left to the kernel, which restricts following rather than making; supersedes 4.4 §4
+  - [fsroot — One Confinement, Two Types](4.5-fsroot-variants.md) ([status](4.5-fsroot-variants.status.md)) — one confinement behaviour, the kernel's; `confinedDir` and `confinedScratchDir`; what fsroot adds to `os.Root` (Windows permission enforcement, the two-form `Path`, confined temp creation); open is a query and a missing root is an error; symlink targets left to the kernel; supersedes 4.4 §4
 
 ### 5. Operational Integrity
 


### PR DESCRIPTION
## The ruling

**fsroot follows `os.Root` and adds nothing without a compelling need.**

An earlier draft of `4.5` derived a per-variant rule forbidding symlink targets that leave the root. The kernel
had already ruled, verbatim:

> **`Root`:** "Methods on Root will follow symbolic links, but symbolic links may not reference a location
> outside the root."
>
> **`Root.Symlink`:** "Symlink does not validate oldname, which may reference a location outside the root."

It restricts **following**, not **making**.

## Why the invention doesn't survive scrutiny

The two arguments I made that weren't about attackers were the ones that mattered — and both evaporate under a
confined root:

- **Receipts can't diverge.** A write *through* an escaping link is refused by the kernel, so devlore never
  records a resource inside the root whose bytes landed outside.
- **Traces can't lie**, for the same reason.

Tar-slip is contained too: the planted link is inert to every confined operation.

**Residual, accepted:** the link exists on disk, and anything outside devlore's confined I/O that follows it
escapes. That's the cost of matching the kernel, and `tar` accepts it too — it extracts absolute symlink
targets.

## This inverts #556

It was filed to **fix** the archive extractor's guard; the ruling says **delete** it. The guard is a second
implementation of a rule the kernel already enforces, and it's the hand-rolled copy that's broken on Windows.
Extraction already runs confined — nothing calls `WithRootMode`, so every environment takes the zero value, and
that value is the confined mode deliberately.

`file.Provider.Link`'s `verbatim` flag **survives** rather than being designed away.

## Open question 1 answered by the same rule

`os.Root` confines reads as well as writes, so fsroot does too — rather than routing readers around the kernel
to widen access the requirement never asked for.

## §5.1 charters the unconfined-reads work

1. **Answer question 3 first** — a write through a symlink leaving the root is refused by the kernel, and deploy
   trees are built from such links, so this decides whether writ can use the variant at all.
2. Compose it from the two that already work: reads direct, the 15 mutators through an `*os.Root`.
3. Accept a fallible constructor — opening a root can fail where the current one cannot.
4. Decide three methods rather than transcribe them: `OpenFile` routes on a flag whose read case is `0`,
   `OpenRoot` mints a capability rather than performing a read, and the metadata mutators write no bytes —
   the class #405 phase 2 missed.
