### PR TITLE
refactor(cli): open CLI trees confined, creating them when absent

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -241,9 +241,17 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 
 	receiverRegistry := op.ReceiverRegistry()
 
-	// The test context writes through an unconfined root over the same tree: scripts under test address absolute
-	// paths, which a confined root refuses by design. The workspace above owns the tree's lifetime either way.
-	root := fsroot.OpenWritableUnconfined(tmpDir)
+	// The test context writes through a confined root over the workspace tree, which owns its lifetime.
+	//
+	// This was unconfined, justified by scripts under test addressing absolute paths. Traced 2026-08-19 and
+	// untrue: an absolute path *inside* the anchor is fine, since [fsroot.Path] derives its root-relative half
+	// from it. The fixture paths that genuinely sit outside — "/some/dir/file.txt" for file.name and
+	// file.parent, and the "/tmp/fake.*" arguments to archive and encryption — are pure string operations or
+	// plan-shape fixtures that never execute against a real file.
+	root, err := fsroot.OpenConfined(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("confine the workspace tree: %w", err)
+	}
 	defer iox.Close(&err, root)
 
 	hostSpec, err := platform.Detect()
@@ -264,7 +272,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 	spec := op.NewRuntimeEnvironmentSpec("devlore-test").
 		WithStatus(cli.UI()).
 		WithModules(receiverRegistry.Modules()...).
-		WithRoot(tmpDir, fsroot.ModeWritableUnconfined).
+		WithRoot(tmpDir, fsroot.ModeConfined).
 		WithPlatform(hostPlatform).
 		WithApplication(app)
 

--- a/cmd/internal/cli/config.go
+++ b/cmd/internal/cli/config.go
@@ -219,9 +219,12 @@ func newConfigEditCmd(info ConfigInfo) *cobra.Command {
 		Short: "Open configuration file in $EDITOR",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			// The command owns the root; writable-unconfined because the config tree may not exist on
-			// first run and a confined root requires its anchor to exist (#405, phase 2b).
-			configRoot := fsroot.OpenWritableUnconfined(devlore.ConfigHome())
+			// The command owns the root (#405, phase 2b). OpenTree because the config tree may not exist
+			// on first run, and opening is a query: it creates the tree, then opens a confined root at it.
+			configRoot, err := OpenTree(devlore.ConfigHome())
+			if err != nil {
+				return err
+			}
 			defer iox.Close(&err, configRoot)
 
 			return configEdit(configRoot, configRoot.NewPath(SharedConfigPath()), info.DefaultConfig)

--- a/cmd/internal/cli/man.go
+++ b/cmd/internal/cli/man.go
@@ -64,9 +64,13 @@ Examples:
 			}
 
 			if install {
-				// The command owns the root: --path lets the operator name any directory, and
-				// writable-unconfined because it need not exist yet (#405, phase 2b).
-				manRoot := fsroot.OpenWritableUnconfined(installPath)
+				// The command owns the root: --path lets the operator name any directory, and OpenTree
+				// because it need not exist yet (#405, phase 2b). An operator naming a relative path is
+				// refused rather than resolved against the working directory.
+				manRoot, err := OpenTree(installPath)
+				if err != nil {
+					return err
+				}
 				defer iox.Close(&err, manRoot)
 
 				return installManPages(rootCmd, h, manRoot)

--- a/cmd/internal/cli/selfinstall.go
+++ b/cmd/internal/cli/selfinstall.go
@@ -218,9 +218,11 @@ func runSelfInstall(rootCmd *cobra.Command, prefix string, info SelfInstallInfo,
 	// only tree here whose anchor is an operator-supplied argument rather than an XDG accessor, so it is
 	// opened once at the top rather than derived from a package accessor further down.
 	//
-	// Writable-unconfined because the prefix need not exist yet — a first install creates it — and a confined
-	// root requires its anchor to exist.
-	prefixRoot := fsroot.OpenWritableUnconfined(prefix)
+	// OpenTree because the prefix need not exist yet — a first install creates it — and opening is a query.
+	prefixRoot, err := OpenTree(prefix)
+	if err != nil {
+		return err
+	}
 	defer iox.Close(&err, prefixRoot)
 
 	// 1. Install binary.
@@ -459,7 +461,10 @@ func printInstallSummary(toolName, prefix string, installed, installedShells []s
 func runSelfUninstall(prefix string, info SelfInstallInfo) (err error) {
 
 	// One root for the whole uninstall, matching runSelfInstall (#405, phase 2b).
-	prefixRoot := fsroot.OpenWritableUnconfined(prefix)
+	prefixRoot, err := OpenTree(prefix)
+	if err != nil {
+		return err
+	}
 	defer iox.Close(&err, prefixRoot)
 
 	m, err := readManifest(prefix, info.Name)
@@ -543,8 +548,12 @@ func runSelfUninstall(prefix string, info SelfInstallInfo) (err error) {
 func removeDevloreConfig(toolName string) {
 
 	// The uninstall path owns the config tree for the length of this removal (#405, phase 2b).
-	configRoot := fsroot.OpenWritableUnconfined(devlore.ConfigHome())
-	//nolint:errcheck // diagnose-ignored-error: an unconfined root holds no handle, so Close cannot fail; see docs/architecture/2.8-eventing-infrastructure.md
+	configRoot, err := OpenTree(devlore.ConfigHome())
+	if err != nil {
+		return // nothing to remove from a tree that cannot be opened
+	}
+
+	//nolint:errcheck // diagnose-ignored-error: best-effort removal, and the entries are already gone; see docs/architecture/2.8-eventing-infrastructure.md
 	defer configRoot.Close()
 
 	toolConfig := configRoot.NewPath("config.d", toolName+".yaml")
@@ -558,8 +567,12 @@ func removeDevloreConfig(toolName string) {
 // removeDevloreCache removes the tool's cache directory.
 func removeDevloreCache(toolName string) {
 
-	cacheRoot := fsroot.OpenWritableUnconfined(devlore.CacheHome())
-	//nolint:errcheck // diagnose-ignored-error: an unconfined root holds no handle, so Close cannot fail; see docs/architecture/2.8-eventing-infrastructure.md
+	cacheRoot, err := OpenTree(devlore.CacheHome())
+	if err != nil {
+		return // nothing to remove from a tree that cannot be opened
+	}
+
+	//nolint:errcheck // diagnose-ignored-error: best-effort removal, and the entries are already gone; see docs/architecture/2.8-eventing-infrastructure.md
 	defer cacheRoot.Close()
 
 	cacheDir := cacheRoot.NewPath(toolName)
@@ -925,8 +938,11 @@ func initDevloreConfig(info SelfInstallInfo) (paths []string, err error) {
 		return nil, nil
 	}
 
-	// One root for the config tree; writable-unconfined because it may not exist yet (#405, phase 2b).
-	configRoot := fsroot.OpenWritableUnconfined(devlore.ConfigHome())
+	// One root for the config tree; OpenTree because it may not exist yet (#405, phase 2b).
+	configRoot, err := OpenTree(devlore.ConfigHome())
+	if err != nil {
+		return nil, err
+	}
 	defer iox.Close(&err, configRoot)
 
 	// NewPath(".") is the root's own directory, so the 0750 is applied by the root that anchors it and
@@ -962,7 +978,10 @@ func initDevloreConfig(info SelfInstallInfo) (paths []string, err error) {
 // initDevloreCache creates the unified devlore cache structure.
 func initDevloreCache(toolName string) (path string, err error) {
 
-	cacheRoot := fsroot.OpenWritableUnconfined(devlore.CacheHome())
+	cacheRoot, err := OpenTree(devlore.CacheHome())
+	if err != nil {
+		return "", err
+	}
 	defer iox.Close(&err, cacheRoot)
 
 	cacheDir := cacheRoot.NewPath(toolName)
@@ -981,7 +1000,10 @@ func initDevloreCache(toolName string) (path string, err error) {
 // conversion is deliberately shallow so that move stays a move.
 func initWritLayers() (created []string, err error) {
 
-	layersRoot := fsroot.OpenWritableUnconfined(devlore.WritLayersDir())
+	layersRoot, err := OpenTree(devlore.WritLayersDir())
+	if err != nil {
+		return nil, err
+	}
 	defer iox.Close(&err, layersRoot)
 
 	for _, layer := range []string{"base", "team", "personal"} {

--- a/cmd/internal/cli/store.go
+++ b/cmd/internal/cli/store.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/signing"
@@ -66,7 +65,10 @@ func WriteGraph(graph *op.Graph) (path string, err error) {
 	// One root for the whole store write. The CLI is the session owner for CLI-side work, so it opens the
 	// tree's authority once and every mutation within it — the document, the index line, and for a trace the
 	// `latest` symlink — is anchored by the same root (#405, phase 2b).
-	stateRoot := fsroot.OpenWritableUnconfined(devlore.StateHome())
+	stateRoot, err := OpenTree(devlore.StateHome())
+	if err != nil {
+		return "", err
+	}
 	defer iox.Close(&err, stateRoot)
 
 	// The store owns its layout, so the store creates it. op.SaveGraph deliberately does not: a save that
@@ -111,7 +113,10 @@ func WriteGraph(graph *op.Graph) (path string, err error) {
 func WriteTrace(trace *op.Trace) (path string, err error) {
 
 	// One root for the whole store write — see [WriteGraph].
-	stateRoot := fsroot.OpenWritableUnconfined(devlore.StateHome())
+	stateRoot, err := OpenTree(devlore.StateHome())
+	if err != nil {
+		return "", err
+	}
 	defer iox.Close(&err, stateRoot)
 
 	directory := filepath.Join(TracesDir(), safeChecksum(trace.GraphChecksum))
@@ -226,10 +231,14 @@ func signArtifact(unsigned bool, namespace string, signWith func(func([]byte) (*
 	}
 
 	// The CLI is the session owner for CLI-side work, so it opens the root and signing receives one —
-	// a leaf never constructs its own filesystem access (#405, phase 2b). Writable-unconfined because the
-	// config tree may not exist yet on first use, and a confined root requires its anchor to exist.
-	configRoot := fsroot.OpenWritableUnconfined(devlore.ConfigHome())
-	//nolint:errcheck // diagnose-ignored-error: an unconfined root holds no handle, so Close cannot fail; see docs/architecture/2.8-eventing-infrastructure.md
+	// a leaf never constructs its own filesystem access (#405, phase 2b). OpenTree because the config tree
+	// may not exist yet on first use, and opening is a query.
+	configRoot, err := OpenTree(devlore.ConfigHome())
+	if err != nil {
+		return // best effort: the artifact writes unsigned and verification reports the fact
+	}
+
+	//nolint:errcheck // diagnose-ignored-error: best-effort signing, and the artifact is already written; see docs/architecture/2.8-eventing-infrastructure.md
 	defer configRoot.Close()
 
 	signer, err := signing.DefaultSigner(configRoot, xdg.UserHomePath(".ssh", "id_ed25519"))

--- a/cmd/internal/cli/tree.go
+++ b/cmd/internal/cli/tree.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+)
+
+// OpenTree creates the directory at `dir` if it is absent, then opens a confined root at it.
+//
+// CLI-side trees are addressed before they exist — a first install creates its prefix, and the config, state
+// and cache trees appear on first use — but [fsroot.OpenConfined] is a query: it opens what is there and errors
+// when nothing is. This is the compound operation that reconciles the two, and it is deliberately named for the
+// creation so that opening keeps meaning only opening.
+//
+// Creation runs through a root rather than [os.MkdirAll] because a mode is worth nothing on Windows without the
+// access-control list that fsroot applies for it — a directory made 0o700 by os.MkdirAll is inherited-DACL and
+// readable by every account with access to its parent. The chain is made through a root anchored at the volume,
+// so every component is resolved by the kernel and no window opens between creating the path and opening it.
+//
+// The mode is 0o700 because the XDG Base Directory Specification says so: "If, when attempting to write a file,
+// the destination directory is non-existent an attempt should be made to create it with permission 0700." That
+// is owner-only, which is also what makes it enforceable on Windows.
+//
+// Parameters:
+//   - `dir`: the absolute path of the tree to open, created when absent.
+//
+// Returns:
+//   - `fsroot.Dir`: a confined root anchored at `dir`. The caller owns it and must Close it.
+//   - `error`: when `dir` is not absolute on this platform, or the tree cannot be created or opened.
+func OpenTree(dir string) (fsroot.Dir, error) {
+
+	// A path that is not absolute on this platform cannot anchor a root. On Windows that includes a leading
+	// separator with no volume, which is drive-relative and lands on whatever drive the process is standing on
+	// — the defect #392 owns for the System target root, and not one to guess at here.
+	if !filepath.IsAbs(dir) {
+		return nil, fmt.Errorf("open tree %s: not an absolute path on this platform", dir)
+	}
+
+	volume, err := fsroot.OpenConfined(filepath.VolumeName(dir) + string(filepath.Separator))
+	if err != nil {
+		return nil, fmt.Errorf("open tree %s: anchor at volume: %w", dir, err)
+	}
+
+	//nolint:errcheck // diagnose-ignored-error: the volume anchor is released, not written; see docs/architecture/2.8-eventing-infrastructure.md
+	defer volume.Close()
+
+	if err := volume.MkdirAll(volume.NewPath(dir), 0o700); err != nil {
+		return nil, fmt.Errorf("open tree %s: create: %w", dir, err)
+	}
+
+	root, err := fsroot.OpenConfined(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open tree %s: %w", dir, err)
+	}
+
+	return root, nil
+}

--- a/cmd/internal/cli/tree_test.go
+++ b/cmd/internal/cli/tree_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenTree_CreatesAChainAndOpensIt verifies the compound operation: a tree several levels below anything
+// that exists is created, and the returned root is usable for writes.
+func TestOpenTree_CreatesAChainAndOpensIt(t *testing.T) {
+
+	deep := filepath.Join(t.TempDir(), "a", "b", "c")
+
+	root, err := OpenTree(deep)
+	if err != nil {
+		t.Fatalf("OpenTree(%s): %v", deep, err)
+	}
+
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("Close: %v", closeErr)
+		}
+	}()
+
+	info, err := os.Stat(deep)
+	if err != nil {
+		t.Fatalf("stat after OpenTree: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Errorf("OpenTree(%s) produced a non-directory", deep)
+	}
+
+	if err := root.WriteFile(root.NewPath("f.txt"), []byte("x"), 0o600); err != nil {
+		t.Errorf("write through the opened root: %v", err)
+	}
+}
+
+// TestOpenTree_OpensATreeThatAlreadyExists verifies creation is idempotent — the common case, since a tree is
+// absent only on first use.
+func TestOpenTree_OpensATreeThatAlreadyExists(t *testing.T) {
+
+	existing := t.TempDir()
+
+	root, err := OpenTree(existing)
+	if err != nil {
+		t.Fatalf("OpenTree(%s): %v", existing, err)
+	}
+
+	if closeErr := root.Close(); closeErr != nil {
+		t.Errorf("Close: %v", closeErr)
+	}
+}
+
+// TestOpenTree_RefusesAPathThatCannotAnchorARoot verifies a non-absolute path is refused rather than guessed at.
+//
+// On Windows this is the case that matters: a leading separator with no volume is drive-relative and resolves
+// against whatever drive the process is standing on. Guessing a volume here would answer a question #392 owns.
+func TestOpenTree_RefusesAPathThatCannotAnchorARoot(t *testing.T) {
+
+	for _, path := range []string{"relative/path", ""} {
+		if _, err := OpenTree(path); err == nil {
+			t.Errorf("OpenTree(%q) = nil error, want a refusal", path)
+		}
+	}
+}

--- a/cmd/star/main.go
+++ b/cmd/star/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra/doc"
 
 	_ "github.com/NobleFactor/devlore-cli/cmd/star/inventory"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/inventory"
 )
 
@@ -365,8 +364,13 @@ func installStarExtensions(prefix string) []string {
 
 	// The hook owns the root for the length of its work: it receives a prefix string, because the hook
 	// contract is a path (#405, phase 2b — the contract itself is the campaign's LAST item).
-	prefixRoot := fsroot.OpenWritableUnconfined(prefix)
-	//nolint:errcheck // diagnose-ignored-error: an unconfined root holds no handle, so Close cannot fail; see docs/architecture/2.8-eventing-infrastructure.md
+	prefixRoot, err := cli.OpenTree(prefix)
+	if err != nil {
+		cli.Warn("Failed to open the install prefix: %v", err)
+		return nil
+	}
+
+	//nolint:errcheck // diagnose-ignored-error: best-effort hook, and the extensions are already copied; see docs/architecture/2.8-eventing-infrastructure.md
 	defer prefixRoot.Close()
 
 	targetExtDir := prefixRoot.NewPath("share", "star", "extensions")

--- a/cmd/star/provider/starcode/provider_test.go
+++ b/cmd/star/provider/starcode/provider_test.go
@@ -31,7 +31,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/docs/architecture/4.5-fsroot-variants.status.md
+++ b/docs/architecture/4.5-fsroot-variants.status.md
@@ -29,11 +29,19 @@ two types. No implementation.
   unbounded reads to express a bounded need.
 - [x] **Corrected**: an earlier revision claimed extraction runs confined because nobody sets the mode. Wrong
   reason, right conclusion — production sets it explicitly at `plan/provider.go:488` and `deploy/plan.go:387`.
+- [x] **No `OpenWritableUnconfined` caller writes outside its anchor.** §5.1 step 1, traced exhaustively
+  (2026-08-19), and the only thing that could have invalidated this design. Two candidates examined and
+  dismissed: `store.go` hands a config-anchored root a path under `~/.ssh`, but that path bypasses the root and
+  reaches `loadSSHKeyfile` directly; and `devlore-test/runner.go`'s comment claiming a confined root "refuses by
+  design" was simply false — an absolute path *inside* the anchor is fine, and the fixture paths that do sit
+  outside never execute against a real file.
+- [x] **Trees are created before they are opened, by `cli.OpenTree`.** §5.1 step 2. Creation is a separate
+  compound operation named for what it does, which is what lets Open stay a query. It creates through a
+  volume-anchored root rather than `os.MkdirAll`, since a mode without fsroot's access-control list is worth
+  nothing on Windows.
 
 ## Open
 
-- [ ] **Does any current `OpenWritableUnconfined` caller write outside its anchor?** §5.1 step 1. Sampled, not
-  exhaustively traced — and the only thing that can invalidate this design. A trace, not a decision.
 - [ ] **`TestIsPrivateMode` and `TestNewPath`** are exported from non-test files, so they sit in the public API.
 
 ## Superseded by this revision

--- a/pkg/op/inventory/seam_test.go
+++ b/pkg/op/inventory/seam_test.go
@@ -29,7 +29,7 @@ func seamEnv(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -36,7 +36,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -561,10 +561,17 @@ func TestExtract_SymlinkTargetEscapes(t *testing.T) {
 		"escaping": {Name: "link", Typeflag: tar.TypeSymlink, Linkname: "../../etc/passwd", Mode: 0o777},
 		"absolute": {Name: "link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0o777},
 	} {
-		archivePath := filepath.Join(tmp, name+".tar.gz")
+		// The archive lives inside the tree the provider is rooted at. Left in the parent it is a
+		// cross-tree read, which a confined root refuses before the entry under test is ever reached.
+		caseDir := filepath.Join(tmp, name)
+		if err := os.MkdirAll(caseDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		archivePath := filepath.Join(caseDir, name+".tar.gz")
 		createTarGzHeaders(t, archivePath, []tar.Header{header}, nil)
 
-		err := extractIntoExpectingError(t, filepath.Join(tmp, name), archivePath)
+		err := extractIntoExpectingError(t, caseDir, archivePath)
 		if err == nil || !strings.Contains(err.Error(), "symlink target") {
 			t.Errorf("%s target = %v; want the symlink-target refusal", name, err)
 		}
@@ -591,11 +598,17 @@ func TestExtract_Hardlink(t *testing.T) {
 		t.Errorf("hardlink copy = %q (err %v), want %q", got, err, "shared bytes")
 	}
 
-	missingPath := filepath.Join(tmp, "missing.tar.gz")
+	// As above: the archive sits inside the tree the provider is rooted at.
+	missingDir := filepath.Join(tmp, "missing")
+	if err := os.MkdirAll(missingDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	missingPath := filepath.Join(missingDir, "missing.tar.gz")
 	createTarGzHeaders(t, missingPath, []tar.Header{
 		{Name: "alias.txt", Typeflag: tar.TypeLink, Linkname: "never-extracted.txt", Mode: 0o644},
 	}, nil)
-	err = extractIntoExpectingError(t, filepath.Join(tmp, "missing"), missingPath)
+	err = extractIntoExpectingError(t, missingDir, missingPath)
 	if err == nil || !strings.Contains(err.Error(), "hardlink referent") {
 		t.Errorf("missing referent = %v; want the referent refusal", err)
 	}

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -41,7 +41,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -38,7 +38,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -112,11 +112,13 @@ func assertOwnerOnlyAndReadable(t *testing.T, path string) {
 	}
 }
 
-// testFileResource creates a Resource backed by a temp file with the given content.
-func testFileResource(t *testing.T, content []byte) *Regular {
+// testFileResource creates a Resource backed by a temp file in `dir` with the given content.
+//
+// The directory is the caller's because a provider's root confines it: a source in some other temp tree is a
+// cross-tree read, which is exactly what a confined root refuses.
+func testFileResource(t *testing.T, dir string, content []byte) *Regular {
 
 	t.Helper()
-	dir := t.TempDir()
 	f, err := os.CreateTemp(dir, "file-*")
 	if err != nil {
 		t.Fatalf("creating temp file: %v", err)
@@ -416,7 +418,7 @@ func TestCopy_WritesNewFile(t *testing.T) {
 
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "output.txt")
-	fileResource := testFileResource(t, []byte("hello world"))
+	fileResource := testFileResource(t, tmp, []byte("hello world"))
 
 	p := testProvider(t, tmp)
 	result, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), fileResource, path, 0o600, "", "")
@@ -448,7 +450,7 @@ func TestCopy_OverwritesExistingFile(t *testing.T) {
 	}
 
 	p := testProvider(t, tmp)
-	blob := testFileResource(t, []byte("replaced"))
+	blob := testFileResource(t, tmp, []byte("replaced"))
 	_, _, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
@@ -1232,7 +1234,10 @@ func TestIsDir_NonExistent(t *testing.T) {
 
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
-	got, err := p.IsDir("/nonexistent/path")
+
+	// Absent, but inside the root: a path outside it is not this provider's to answer about, and asking
+	// costs an escape error rather than the false the test is after.
+	got, err := p.IsDir(filepath.Join(tmp, "nonexistent", "path"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1279,7 +1284,10 @@ func TestIsFile_NonExistent(t *testing.T) {
 
 	tmp := t.TempDir()
 	p := testProvider(t, tmp)
-	got, err := p.IsFile("/nonexistent/path")
+
+	// Absent, but inside the root: a path outside it is not this provider's to answer about, and asking
+	// costs an escape error rather than the false the test is after.
+	got, err := p.IsFile(filepath.Join(tmp, "nonexistent", "path"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2021,7 +2029,7 @@ func TestCopy_CompensateCopy_RoundTrip_NewFile(t *testing.T) {
 	path := filepath.Join(tmp, "new.txt")
 
 	p := testProvider(t, tmp)
-	blob := testFileResource(t, []byte("new content"))
+	blob := testFileResource(t, tmp, []byte("new content"))
 	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)
@@ -2046,7 +2054,7 @@ func TestCopy_CompensateCopy_RoundTrip_Overwrite(t *testing.T) {
 	}
 
 	p := testProvider(t, tmp)
-	blob := testFileResource(t, []byte("replaced"))
+	blob := testFileResource(t, tmp, []byte("replaced"))
 	_, state, err := p.Copy(testActivation(t, p.RuntimeEnvironment()), blob, path, 0o644, "", "")
 	if err != nil {
 		t.Fatalf("Copy() error = %v", err)

--- a/pkg/op/provider/file/seam_test.go
+++ b/pkg/op/provider/file/seam_test.go
@@ -20,7 +20,7 @@ func TestCompensateFileMutation_UnknownKind_Errors(t *testing.T) {
 
 	dir := t.TempDir()
 	p := testProvider(t, dir)
-	resource := testFileResource(t, []byte("x"))
+	resource := testFileResource(t, t.TempDir(), []byte("x"))
 
 	receipt := NewReceipt(NewReceiptSpec(resource, MutationKind("bogus")))
 

--- a/pkg/op/provider/function/resource_test.go
+++ b/pkg/op/provider/function/resource_test.go
@@ -33,7 +33,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -36,7 +36,7 @@ func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) 
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test", Flags: map[string]any{"dry_run": dryRun}}).
 			WithStatus(status.NewNarrator("test", captureSink)))
 	if err != nil {

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -33,7 +33,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeWritableUnconfined).
+			WithRoot(dir, fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/json/resource_test.go
+++ b/pkg/op/provider/json/resource_test.go
@@ -32,7 +32,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -36,7 +36,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/service/resource_test.go
+++ b/pkg/op/provider/service/resource_test.go
@@ -30,7 +30,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/yaml/resource_test.go
+++ b/pkg/op/provider/yaml/resource_test.go
@@ -31,7 +31,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -30,7 +30,7 @@ func newTestRecoverySite(t *testing.T) (*RecoverySite, fsroot.Dir) {
 
 	runtimeEnvironment, err := NewRuntimeEnvironment(context.Background(),
 		NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeWritableUnconfined).
+			WithRoot(t.TempDir(), fsroot.ModeConfined).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("NewRuntimeEnvironment: %v", err)

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -52,7 +52,7 @@ func newTriadRW(t *testing.T) triadEnv {
 
 	t.Helper()
 
-	return newTriad(t, fsroot.ModeWritableUnconfined, t.TempDir())
+	return newTriad(t, fsroot.ModeConfined, t.TempDir())
 }
 
 func newTriadConfined(t *testing.T) triadEnv {


### PR DESCRIPTION
#568 step 2. Step 1's trace found no caller reading or writing outside its own tree, so the only thing keeping
CLI roots unconfined was **bootstrapping** — the one site that recorded a reason said so:

> "the prefix need not exist yet — a first install creates it — and a confined root requires its anchor to
> exist."

## `cli.OpenTree`

Creates the directory when absent, then opens a confined root at it. Named for the creation, so
`fsroot.OpenConfined` stays a query and a missing root stays an error.

- **Creates through a root, not `os.MkdirAll`** — a mode is worth nothing on Windows without the DACL fsroot
  applies for it. A `0o700` directory from `os.MkdirAll` carries an inherited DACL and is readable by every
  account with access to its parent.
- **Anchored at the volume**, so every component is kernel-resolved and no window opens between creating the
  path and opening it.
- **Refuses a path that isn't absolute on this platform.** On Windows that includes a leading separator with no
  volume — drive-relative, and #392's territory, not something to guess at here.
- **`0o700`, per the XDG specification**: *"If, when attempting to write a file, the destination directory is
  non-existent an attempt should be made to create it with permission 0700."* The sites used `0o750`, so this
  drops group access on config, state, cache and layers — and owner-only is what makes them enforceable on
  Windows.

## 14 production sites

`config`, `store`, `selfinstall` (7), `man`, star's extension hook, and devlore-test's workspace — the last
needing only `OpenConfined`, since its tree already exists.

Several carried a `//nolint` reading *"an unconfined root holds no handle, so Close cannot fail."* Untrue of a
confined root, so those now state what is actually being ignored and why.

## 8 fixtures were reaching across trees

| Fixture | Defect |
|---|---|
| `TestIsDir/IsFile_NonExistent` | `"/nonexistent/path"` as a convenient absent value — outside the root, so confined it's an *escape*, not a not-exist |
| `TestCopy_*` (4) | `testFileResource` called `t.TempDir()` **itself**, putting the source in a second tree |
| `TestExtract_*` (2) | tarball written one level above the root it extracted into |

**Production has been confined all along** — `plan/provider.go:488`, `deploy/plan.go:387` — so these tests were
exercising a path production never takes. `testFileResource` now takes its directory, which puts the constraint
at the call site rather than hiding it in the helper.

## Verified

- `make check` — 103 packages ok, 0 failures
- `make build-all`, `make vet-all` — linux, darwin, windows
- `gofmt -l` over the change set — clean

`4.5-fsroot-variants.status.md` moves step 1's trace and step 2's creation rule from **Open** to **Settled**.

## Not in this PR

The remaining test call sites still use `OpenWritableUnconfined`, which still exists. They go with #568 step 3,
which deletes the constructor they call — migrating them first would mean touching them twice.

Refs #568.
