### PR TITLE
refactor(fsroot): delete the unconfined variants

### DIFF
--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -33,14 +33,6 @@ jobs:
         with:
           path: devlore-cli
 
-      - name: Checkout devlore-registry
-        uses: actions/checkout@v4
-        with:
-          repository: NobleFactor/devlore-registry
-          token: ${{ steps.app-token.outputs.token }}
-          ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
-          path: devlore-registry
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -51,29 +43,40 @@ jobs:
         working-directory: devlore-cli
         run: make star
 
+      # Checked out INSIDE the cli tree, and only after the build: star's session root is confined to
+      # the directory it runs in, so the target must live inside that tree — and a nested foreign repo
+      # must not exist yet while make generates. Accommodating a genuinely cross-root target is #571.
+      - name: Checkout devlore-registry
+        uses: actions/checkout@v4
+        with:
+          repository: NobleFactor/devlore-registry
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+          path: devlore-cli/devlore-registry
+
       - name: Build knowledge base
         working-directory: devlore-cli
         run: |
           ./build/star devlore knowledge extract \
             --domain all \
             --source ${{ github.workspace }}/devlore-cli \
-            --target ${{ github.workspace }}/devlore-registry
+            --target ${{ github.workspace }}/devlore-cli/devlore-registry
 
       - name: Validate package schemas
         working-directory: devlore-cli
         run: |
           ./build/star devlore package validate \
-            --target=${{ github.workspace }}/devlore-registry
+            --target=${{ github.workspace }}/devlore-cli/devlore-registry
 
       - name: Validate knowledge schemas
         working-directory: devlore-cli
         run: |
           ./build/star devlore knowledge validate \
-            --target=${{ github.workspace }}/devlore-registry
+            --target=${{ github.workspace }}/devlore-cli/devlore-registry
 
       - name: Report knowledge changes (PR only)
         if: github.event_name == 'pull_request'
-        working-directory: devlore-registry
+        working-directory: devlore-cli/devlore-registry
         run: |
           if git diff --quiet; then
             echo "No knowledge changes detected"
@@ -86,7 +89,7 @@ jobs:
 
       - name: Create PR to devlore-registry (push only)
         if: github.event_name == 'push'
-        working-directory: devlore-registry
+        working-directory: devlore-cli/devlore-registry
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/cmd/internal/cli/index_test.go
+++ b/cmd/internal/cli/index_test.go
@@ -29,7 +29,10 @@ func stateRootForTest(t *testing.T) fsroot.Dir {
 
 	t.Helper()
 
-	root := fsroot.OpenWritableUnconfined(devlore.StateHome())
+	root, err := OpenTree(devlore.StateHome())
+	if err != nil {
+		t.Fatalf("OpenTree(%s): %v", devlore.StateHome(), err)
+	}
 	t.Cleanup(func() { _ = root.Close() })
 
 	return root

--- a/cmd/internal/cli/selfinstall.go
+++ b/cmd/internal/cli/selfinstall.go
@@ -1078,7 +1078,9 @@ func CopyDir(dstRoot fsroot.Dir, src string, dst fsroot.Path) error {
 		return fmt.Errorf("%s is not a directory", src)
 	}
 
-	if err := dstRoot.MkdirAll(dst, srcInfo.Mode()); err != nil {
+	// Perm(), not Mode(): a directory's Mode carries fs.ModeDir, which os.Mkdir silently discards but
+	// [os.Root.Mkdir] rejects as an unsupported file mode. Only the permission bits are the caller's to ask for.
+	if err := dstRoot.MkdirAll(dst, srcInfo.Mode().Perm()); err != nil {
 		return err
 	}
 

--- a/cmd/internal/cli/selfinstall_test.go
+++ b/cmd/internal/cli/selfinstall_test.go
@@ -224,7 +224,10 @@ func TestCopyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dstRoot := fsroot.OpenWritableUnconfined(tmpDir)
+	dstRoot, err := fsroot.OpenConfined(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = dstRoot.Close() })
 
 	dst := dstRoot.NewPath("dest.txt")
@@ -247,7 +250,10 @@ func TestCopyFile_NonExistentSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	src := filepath.Join(tmpDir, "nonexistent.txt")
 
-	dstRoot := fsroot.OpenWritableUnconfined(tmpDir)
+	dstRoot, err := fsroot.OpenConfined(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = dstRoot.Close() })
 
 	if err := copyFile(dstRoot, src, dstRoot.NewPath("dest.txt")); err == nil {
@@ -259,7 +265,10 @@ func TestCopyFile_NonExistentSource(t *testing.T) {
 func TestCopyDir(t *testing.T) {
 	src := t.TempDir()
 
-	dstRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	dstRoot, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = dstRoot.Close() })
 	dstPath := dstRoot.NewPath("dest")
 	dst := dstPath.Abs()
@@ -423,7 +432,10 @@ func TestWriteAndReadManifest(t *testing.T) {
 	}
 
 	// Write manifest.
-	prefixRoot := fsroot.OpenWritableUnconfined(tmpDir)
+	prefixRoot, err := fsroot.OpenConfined(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = prefixRoot.Close() })
 
 	if err := writeManifest(prefixRoot, "test", "1.0.0", []string{"bin/test"}); err != nil {
@@ -526,7 +538,10 @@ func TestManifestUninstall(t *testing.T) {
 	}
 
 	// Write manifest.
-	prefixRoot := fsroot.OpenWritableUnconfined(tmpDir)
+	prefixRoot, err := fsroot.OpenConfined(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = prefixRoot.Close() })
 
 	if err := writeManifest(prefixRoot, "test", "1.0.0", []string{"bin/test", "share/man/man1/test.1"}); err != nil {

--- a/cmd/star/star/application.go
+++ b/cmd/star/star/application.go
@@ -72,13 +72,18 @@ func NewApplication(rootCmd *cobra.Command) *Application {
 	wd, err := os.Getwd()
 	assert.True("os.Getwd succeeded", err == nil)
 
+	// The session root anchors at the working directory, confined — star scripts resolve relative
+	// paths against the root's anchor, so any other anchor changes what every relative path in every
+	// script means (a volume anchor was tried and broke the generator's go.mod walk). Whether star
+	// should instead anchor at the repository root, home, the volume, or a set of declared roots is
+	// #571, open until the hermeticity design (#563) rules it.
 	app := application.NewApplication("star", rootCmd)
 	registry := op.ReceiverRegistry()
 
 	spec := op.NewRuntimeEnvironmentSpec("star").
 		WithApplication(app).
 		WithModules(registry.Modules()...).
-		WithRoot(wd, fsroot.ModeWritableUnconfined)
+		WithRoot(wd, fsroot.ModeConfined)
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(), spec)
 	assert.NoError("op.NewRuntimeEnvironment", err)

--- a/cmd/star/star/lint_copyright_test.go
+++ b/cmd/star/star/lint_copyright_test.go
@@ -198,6 +198,10 @@ func setupExtension(t *testing.T, testDir string) (*Application, error) {
 	// Create runtime (Root picks up current working directory)
 	r := NewApplication(&cobra.Command{Use: "star"})
 
+	// The Application owns a confined root on the directory above — a real OS handle. Close it, or
+	// Windows cannot remove the temp tree this test stands in.
+	t.Cleanup(func() { _ = r.Close() })
+
 	// Load extensions from the project's star/extensions directory
 	extDir := filepath.Join(projectRoot, "cmd", "star", "extensions")
 	if err := r.LoadExtensionsFrom(extDir); err != nil {

--- a/cmd/star/star/lint_integration_test.go
+++ b/cmd/star/star/lint_integration_test.go
@@ -68,6 +68,9 @@ func setupLintRuntime(t *testing.T, testDir string) (*Application, error) {
 	// Create runtime
 	r := NewApplication(&cobra.Command{Use: "star"})
 
+	// The Application owns a confined root on the working directory — a real OS handle to release.
+	t.Cleanup(func() { _ = r.Close() })
+
 	// Change to test directory for config loading
 	origDir, err := os.Getwd()
 	if err != nil {
@@ -522,6 +525,9 @@ func TestLintCommands_NoConfigOutsideGitRepo(t *testing.T) {
 	}
 
 	r := NewApplication(&cobra.Command{Use: "star"})
+
+	// The Application owns a confined root on the working directory — a real OS handle to release.
+	t.Cleanup(func() { _ = r.Close() })
 
 	origDir, err := os.Getwd()
 	if err != nil {

--- a/pkg/fsroot/applymode_windows_test.go
+++ b/pkg/fsroot/applymode_windows_test.go
@@ -34,50 +34,6 @@ const (
 	aceTrusteeEnd = ")"
 )
 
-// TestApplyMode_BothWritableRootsProtect pins the parity that matters most in practice: CLI-side roots are
-// unconfined and writable (the campaign's ruling for code outside an execution), so an implementation that
-// enforces only on the confined root protects the code paths that were already safest and leaves the rest
-// silently exposed.
-//
-// That is exactly what happened. WriteFile on the unconfined writable root reached production without an
-// applyMode call, and no test caught it because every DACL test here used a confined root. The signing key's
-// own read-back found it, on a real Windows runner, printing D:AI(A;ID;…) — purely inherited ACEs.
-func TestApplyMode_BothWritableRootsProtect(t *testing.T) {
-
-	directory := t.TempDir()
-
-	confined, err := OpenConfined(directory)
-	if err != nil {
-		t.Fatalf("OpenConfined: %v", err)
-	}
-	t.Cleanup(func() { _ = confined.Close() })
-
-	for name, root := range map[string]Dir{
-		"confinedRoot":               confined,
-		"unconfinedRootReaderWriter": OpenWritableUnconfined(directory),
-	} {
-		t.Run(name, func(t *testing.T) {
-
-			target := root.NewPath(name + ".key")
-			if err := root.WriteFile(target, []byte("private"), 0o600); err != nil {
-				t.Fatalf("WriteFile: %v", err)
-			}
-
-			control, sddl := readSecurity(t, target.Abs())
-
-			if control&windows.SE_DACL_PROTECTED == 0 {
-				t.Errorf("WriteFile at 0600 left the DACL unprotected: %s", sddl)
-			}
-			if !hasTrustee(sddl, systemAlias, systemSID) {
-				t.Errorf("DACL is missing SYSTEM: %s", sddl)
-			}
-			if !hasTrustee(sddl, adminsAlias, adminsSID) {
-				t.Errorf("DACL is missing Administrators: %s", sddl)
-			}
-		})
-	}
-}
-
 func TestApplyMode_PrivateFileGetsProtectedDACL(t *testing.T) {
 
 	root := testConfinedRoot(t)

--- a/pkg/fsroot/fsroot.go
+++ b/pkg/fsroot/fsroot.go
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Noble Factor. All rights reserved.
 
-// Package fsroot provides scoped filesystem roots.
+// Package fsroot provides confined filesystem roots.
 //
 // All provider I/O flows through the [Dir] interface, confining reads and writes to a directory
-// tree. Three implementations serve the three lifecycles: confined roots for execution, read-only
-// roots for planning, and writable unconfined roots for tests.
+// tree. The confinement is the kernel's, via [*os.Root]: one behavior, two lifetimes —
+// [OpenConfined] anchors at an existing directory for the caller's lifetime, and [OpenScratch]
+// anchors at a new temporary directory whose tree is removed with the handle on Close.
 package fsroot
 
 import (
@@ -28,14 +29,7 @@ import (
 var (
 	_ Dir = (*confinedRoot)(nil)
 	_ Dir = (*scratchRoot)(nil)
-	_ Dir = (*unconfinedRootReader)(nil)
-	_ Dir = (*unconfinedRootReaderWriter)(nil)
 )
-
-// errReadOnly is returned by write operations on a [unconfinedRootReader]. It wraps the standard
-// [errors.ErrUnsupported] sentinel so callers can test for it with `errors.Is(err, errors.ErrUnsupported)` without
-// depending on this package.
-var errReadOnly = fmt.Errorf("write operation not available in read-only mode: %w", errors.ErrUnsupported)
 
 // errTempPatternSeparator is returned when a temporary-name pattern contains a path separator, which would let a
 // caller redirect the created object through the name instead of the directory argument. It wraps
@@ -71,14 +65,10 @@ const (
 
 // Dir provides scoped filesystem operations. All path arguments are [Path] values created through [Dir.NewPath].
 //
-// Three concrete implementations provide different access modes:
+// Two constructors produce the two lifetimes, both confined by [*os.Root]:
 //
-//   - [OpenConfined] wraps [*os.Dir] for OS-enforced confinement (execution)
-//   - [OpenUnconfined] delegates to os.* for unconfined read-only access (planning)
-//   - [OpenWritableUnconfined] delegates to os.* for unconfined read-write access (testing)
-//
-// [Open] constructs any of the three from a [Mode] value; [OpenScratch] constructs a confined root
-// at a temporary directory that removes itself on [Dir.Close].
+//   - [OpenConfined] anchors at an existing directory; the root lives until the caller closes it
+//   - [OpenScratch] anchors at a new temporary directory; Close removes the tree with the handle
 //
 // The method set mirrors [*os.Dir] in full, so code that knows the standard library's root knows
 // this one. Every filesystem mutation in the repository is expected to flow through this interface;
@@ -119,51 +109,31 @@ type Dir interface {
 
 // Mode selects which [Dir] implementation [Open] constructs.
 //
-// The zero value is [ModeConfined], so a caller that never sets a mode gets OS-enforced confinement
-// rather than silently widened access.
+// One implementation remains, so the only value is [ModeConfined] — the zero value. The type
+// survives solely because op.RuntimeEnvironmentSpec.WithRoot still carries a Mode parameter; it is
+// deleted with that parameter in #568 step 5.
 type Mode int
 
-const (
-
-	// ModeConfined selects the OS-enforced confined implementation ([OpenConfined]).
-	ModeConfined Mode = iota
-
-	// ModeUnconfined selects the unconfined read-only implementation ([OpenUnconfined]).
-	ModeUnconfined
-
-	// ModeWritableUnconfined selects the unconfined read-write implementation ([OpenWritableUnconfined]).
-	ModeWritableUnconfined
-)
+// ModeConfined selects the OS-enforced confined implementation ([OpenConfined]). The zero value.
+const ModeConfined Mode = 0
 
 // Open opens a [Dir] at dir in the given [Mode].
 //
-// The single mode-dispatched constructor. [ModeConfined] routes to [OpenConfined] — the only branch
-// that can fail — while the unconfined modes construct handle-free roots that cannot.
+// With [ModeConfined] the only mode, this is [OpenConfined] behind a mode assertion. It is deleted
+// together with [Mode] in #568 step 5.
 //
 // Parameters:
 //   - `dir`: the directory to anchor the root at.
 //   - `mode`: the [Mode] selecting the implementation.
 //
 // Returns:
-//   - `Root`: the constructed root.
-//   - `error`: any error from [OpenConfined] when mode is [ModeConfined]; nil for the unconfined modes.
+//   - `Dir`: the constructed root.
+//   - `error`: any error from [OpenConfined].
 func Open(dir string, mode Mode) (Dir, error) {
 
-	switch mode {
+	assert.True("fsroot.Open: mode is ModeConfined", mode == ModeConfined)
 
-	case ModeConfined:
-		return OpenConfined(dir)
-
-	case ModeUnconfined:
-		return OpenUnconfined(dir), nil
-
-	case ModeWritableUnconfined:
-		return OpenWritableUnconfined(dir), nil
-
-	default:
-		assert.Unreachablef("fsroot.Open: unknown mode %d", mode)
-		return nil, nil
-	}
+	return OpenConfined(dir)
 }
 
 // OpenScratch opens a confined [Dir] at a newly created temporary directory that removes itself.
@@ -201,11 +171,6 @@ func OpenScratch(pattern string) (Dir, error) {
 	return &scratchRoot{Dir: confined, dir: dir}, nil
 }
 
-// rootBase holds the root directory path shared by all implementations.
-type rootBase struct {
-	name string
-}
-
 // scratchRoot is a confined [Dir] over a temporary directory it owns and removes on Close.
 //
 // Every method other than Close is the embedded confined root's; only the lifetime differs.
@@ -230,45 +195,6 @@ type scratchRoot struct {
 // Returns:
 //   - `error`: the joined close and removal errors, or nil.
 func (r *scratchRoot) Close() error { return errors.Join(r.Dir.Close(), os.RemoveAll(r.dir)) }
-
-// endregion
-
-// endregion
-
-// region EXPORTED METHODS
-
-// region State management
-
-// FS returns a [fs.FS] rooted at the base directory.
-//
-// Returns:
-//   - `fs.FS`: a read-only filesystem view rooted at the base directory.
-func (b *rootBase) FS() fs.FS { return os.DirFS(b.name) }
-
-// Name returns the base directory path. Matches [os.Root.Name].
-//
-// Returns:
-//   - `string`: the base directory path.
-func (b *rootBase) Name() string { return b.name }
-
-// endregion
-
-// region Behaviors
-
-// Close releases the root. Unconfined roots hold no OS handle, so this is a no-op.
-//
-// Returns:
-//   - `error`: always nil.
-func (b *rootBase) Close() error { return nil }
-
-// NewPath builds a [Path] from an input path, resolved against the base directory.
-//
-// Parameters:
-//   - `path`: the input path, absolute or relative to the base directory.
-//
-// Returns:
-//   - `Path`: the constructed path with both rel and abs populated.
-func (b *rootBase) NewPath(name ...string) Path { return makePath(b.name, name) }
 
 // endregion
 
@@ -654,485 +580,6 @@ func (r *confinedRoot) WriteFile(p Path, data []byte, perm os.FileMode) error {
 
 // endregion
 
-// unconfinedRootReader provides unconfined, read-only filesystem access.
-//
-// Write operations return [errReadOnly]. Used during planning when providers need to inspect source files without
-// mutation capability.
-type unconfinedRootReader struct {
-	rootBase
-}
-
-// OpenUnconfined creates a read-only [Dir] at dir. Write operations return [errReadOnly].
-//
-// Parameters:
-//   - `dir`: the base directory for all path resolution.
-//
-// Returns:
-//   - `Root`: a read-only, unconfined root.
-func OpenUnconfined(dir string) Dir {
-	return &unconfinedRootReader{rootBase{name: dir}}
-}
-
-// region EXPORTED METHODS
-
-// region Behaviors
-
-// Chmod is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Chmod(Path, os.FileMode) error { return errReadOnly }
-
-// Chown is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Chown(Path, int, int) error { return errReadOnly }
-
-// Chtimes is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Chtimes(Path, time.Time, time.Time) error { return errReadOnly }
-
-// Create is unavailable in read-only mode.
-//
-// Returns:
-//   - `*os.File`: always nil.
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Create(Path) (*os.File, error) { return nil, errReadOnly }
-
-// CreateTemp is unavailable in read-only mode.
-//
-// Returns:
-//   - `*os.File`: always nil.
-//   - `Path`: always the zero Path.
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) CreateTemp(Path, string) (*os.File, Path, error) {
-	return nil, Path{}, errReadOnly
-}
-
-// Lchown is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Lchown(Path, int, int) error { return errReadOnly }
-
-// Link is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Link(_, _ Path) error { return errReadOnly }
-
-// Lstat returns file info for the path without following a terminal symlink.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `fs.FileInfo`: the file info.
-//   - `error`: any error from [os.Lstat].
-func (r *unconfinedRootReader) Lstat(p Path) (fs.FileInfo, error) { return os.Lstat(p.abs) }
-
-// Mkdir is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Mkdir(Path, os.FileMode) error { return errReadOnly }
-
-// MkdirAll is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) MkdirAll(Path, os.FileMode) error { return errReadOnly }
-
-// MkdirTemp is unavailable in read-only mode.
-//
-// Returns:
-//   - `Path`: always the zero Path.
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) MkdirTemp(Path, string) (Path, error) { return Path{}, errReadOnly }
-
-// Open opens the path for reading.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `*os.File`: the opened file.
-//   - `error`: any error from [os.Open].
-func (r *unconfinedRootReader) Open(p Path) (*os.File, error) { return os.Open(p.abs) }
-
-// OpenFile is unavailable in read-only mode.
-//
-// Returns:
-//   - `*os.File`: always nil.
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) OpenFile(Path, int, os.FileMode) (*os.File, error) {
-	return nil, errReadOnly
-}
-
-// OpenRoot opens the directory at the path as its own read-only [Dir].
-//
-// The sub-root inherits this root's access mode, so it is read-only too. Unconfined roots hold no
-// handle, so this cannot fail.
-//
-// Parameters:
-//   - `p`: the directory to open as a root.
-//
-// Returns:
-//   - `Root`: a read-only, unconfined root anchored at `p`.
-//   - `error`: always nil.
-func (r *unconfinedRootReader) OpenRoot(p Path) (Dir, error) { return OpenUnconfined(p.abs), nil }
-
-// ReadFile reads the entire contents of the path.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `[]byte`: the file contents.
-//   - `error`: any error from [os.ReadFile].
-func (r *unconfinedRootReader) ReadFile(p Path) ([]byte, error) { return os.ReadFile(p.abs) }
-
-// Readlink returns the destination of the symbolic link at the path.
-//
-// Parameters:
-//   - `p`: the symlink path.
-//
-// Returns:
-//   - `string`: the link destination.
-//   - `error`: any error from [os.Readlink].
-func (r *unconfinedRootReader) Readlink(p Path) (string, error) { return os.Readlink(p.abs) }
-
-// Remove is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Remove(Path) error { return errReadOnly }
-
-// RemoveAll is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) RemoveAll(Path) error { return errReadOnly }
-
-// Rename is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Rename(_, _ Path) error { return errReadOnly }
-
-// Stat returns file info for the path, following symlinks.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `fs.FileInfo`: the file info.
-//   - `error`: any error from [os.Stat].
-func (r *unconfinedRootReader) Stat(p Path) (fs.FileInfo, error) { return os.Stat(p.abs) }
-
-// Symlink is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) Symlink(_ string, _ Path) error { return errReadOnly }
-
-// WriteFile is unavailable in read-only mode.
-//
-// Returns:
-//   - `error`: always [errReadOnly].
-func (r *unconfinedRootReader) WriteFile(Path, []byte, os.FileMode) error { return errReadOnly }
-
-// endregion
-
-// endregion
-
-// unconfinedRootReaderWriter provides unconfined, read-write filesystem access.
-//
-// Reads are inherited from [unconfinedRootReader]. Write operations delegate to os.* without OS-level confinement.
-type unconfinedRootReaderWriter struct {
-	unconfinedRootReader
-}
-
-// OpenWritableUnconfined creates a read-write [Dir] at dir without OS-level confinement.
-//
-// Parameters:
-//   - `dir`: the base directory for all path resolution.
-//
-// Returns:
-//   - `Root`: a read-write, unconfined root.
-func OpenWritableUnconfined(dir string) Dir {
-	return &unconfinedRootReaderWriter{unconfinedRootReader{rootBase{name: dir}}}
-}
-
-// region EXPORTED METHODS
-
-// region Behaviors
-
-// Chmod changes the mode of the path.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `mode`: the permission bits to apply.
-//
-// On Windows a restrictive mode is additionally enforced as an access-control list, because
-// [os.Chmod] there toggles only the read-only attribute (issue #405).
-//
-// Returns:
-//   - `error`: any error from [os.Chmod], or from the Windows enforcement pass.
-func (r *unconfinedRootReaderWriter) Chmod(p Path, mode os.FileMode) error {
-
-	if err := os.Chmod(p.abs, mode); err != nil {
-		return err
-	}
-
-	info, err := os.Stat(p.abs)
-	if err != nil {
-		return err
-	}
-
-	return applyMode(p.abs, mode, info.IsDir())
-}
-
-// Chown changes the numeric owner and group of the path.
-//
-// Unsupported on Windows, where the underlying syscall always fails.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `uid`: the owner id, or -1 to leave unchanged.
-//   - `gid`: the group id, or -1 to leave unchanged.
-//
-// Returns:
-//   - `error`: any error from [os.Chown].
-func (r *unconfinedRootReaderWriter) Chown(p Path, uid, gid int) error {
-	return os.Chown(p.abs, uid, gid)
-}
-
-// Chtimes changes the access and modification times of the path.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `atime`: the access time to set.
-//   - `mtime`: the modification time to set.
-//
-// Returns:
-//   - `error`: any error from [os.Chtimes].
-func (r *unconfinedRootReaderWriter) Chtimes(p Path, atime, mtime time.Time) error {
-	return os.Chtimes(p.abs, atime, mtime)
-}
-
-// Create creates or truncates the path for reading and writing.
-//
-// The created file carries mode 0o666 before umask — an unrestricted file by definition. Never use
-// Create for sensitive content; use [unconfinedRootReaderWriter.OpenFile] with an explicit
-// restrictive mode.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `*os.File`: the created file, opened read-write.
-//   - `error`: any error from [os.Create].
-func (r *unconfinedRootReaderWriter) Create(p Path) (*os.File, error) { return os.Create(p.abs) }
-
-// Lchown changes the numeric owner and group of the path without following a terminal symlink.
-//
-// Unsupported on Windows, where the underlying syscall always fails.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `uid`: the owner id, or -1 to leave unchanged.
-//   - `gid`: the group id, or -1 to leave unchanged.
-//
-// Returns:
-//   - `error`: any error from [os.Lchown].
-func (r *unconfinedRootReaderWriter) Lchown(p Path, uid, gid int) error {
-	return os.Lchown(p.abs, uid, gid)
-}
-
-// Link creates a hard link at newPath pointing to oldPath.
-//
-// Parameters:
-//   - `oldPath`: the existing file the link points to.
-//   - `newPath`: the path at which to create the link.
-//
-// Returns:
-//   - `error`: any error from [os.Link].
-func (r *unconfinedRootReaderWriter) Link(oldPath, newPath Path) error {
-	return os.Link(oldPath.abs, newPath.abs)
-}
-
-// Mkdir creates the directory at the path.
-//
-// Parents must already exist; use [unconfinedRootReaderWriter.MkdirAll] otherwise.
-//
-// Parameters:
-//   - `p`: the directory path.
-//   - `perm`: the permission bits for the created directory.
-//
-// Returns:
-//   - `error`: any error from [os.Mkdir], or from the Windows enforcement pass.
-func (r *unconfinedRootReaderWriter) Mkdir(p Path, perm os.FileMode) error {
-
-	if err := os.Mkdir(p.abs, perm); err != nil {
-		return err
-	}
-
-	return applyMode(p.abs, perm, true)
-}
-
-// CreateTemp creates a uniquely named file under `dir`.
-//
-// Parameters:
-//   - `dir`: the directory to create the file under; use `NewPath(".")` for the root directory itself.
-//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
-//
-// Returns:
-//   - `*os.File`: the open file, owned by the caller.
-//   - `Path`: the created file's path.
-//   - `error`: any error from [createTempIn].
-func (r *unconfinedRootReaderWriter) CreateTemp(dir Path, pattern string) (*os.File, Path, error) {
-	return createTempIn(r, dir, pattern)
-}
-
-// MkdirTemp creates a uniquely named directory under `dir`.
-//
-// Parameters:
-//   - `dir`: the directory to create the directory under; use `NewPath(".")` for the root directory itself.
-//   - `pattern`: the name pattern; the random string replaces the last `*`, or is appended when there is none.
-//
-// Returns:
-//   - `Path`: the created directory's path.
-//   - `error`: any error from [mkdirTempIn].
-func (r *unconfinedRootReaderWriter) MkdirTemp(dir Path, pattern string) (Path, error) {
-	return mkdirTempIn(r, dir, pattern)
-}
-
-// MkdirAll creates the directory at the path along with any necessary parents.
-//
-// Parameters:
-//   - `p`: the directory path.
-//   - `perm`: the permission bits for created directories.
-//
-// Returns:
-//   - `error`: any error from [os.MkdirAll], or from the Windows enforcement pass.
-func (r *unconfinedRootReaderWriter) MkdirAll(p Path, perm os.FileMode) error {
-
-	if err := os.MkdirAll(p.abs, perm); err != nil {
-		return err
-	}
-
-	return applyMode(p.abs, perm, true)
-}
-
-// OpenFile opens the path with the given flags and permissions.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `flag`: the [os.OpenFile] flags.
-//   - `perm`: the permission bits applied on creation.
-//
-// Returns:
-//   - `*os.File`: the opened file.
-//   - `error`: any error from [os.OpenFile].
-func (r *unconfinedRootReaderWriter) OpenFile(p Path, flag int, perm os.FileMode) (*os.File, error) {
-
-	file, err := os.OpenFile(p.abs, flag, perm)
-	if err != nil {
-		return nil, err
-	}
-
-	if flag&os.O_CREATE != 0 {
-		if modeErr := applyMode(p.abs, perm, false); modeErr != nil {
-			return nil, errors.Join(modeErr, file.Close())
-		}
-	}
-
-	return file, nil
-}
-
-// OpenRoot opens the directory at the path as its own read-write [Dir].
-//
-// The sub-root inherits this root's access mode, so it is read-write and unconfined too. Unconfined
-// roots hold no handle, so this cannot fail.
-//
-// Parameters:
-//   - `p`: the directory to open as a root.
-//
-// Returns:
-//   - `Root`: a read-write, unconfined root anchored at `p`.
-//   - `error`: always nil.
-func (r *unconfinedRootReaderWriter) OpenRoot(p Path) (Dir, error) {
-	return OpenWritableUnconfined(p.abs), nil
-}
-
-// Remove deletes the file or empty directory at the path.
-//
-// Parameters:
-//   - `p`: the target path.
-//
-// Returns:
-//   - `error`: any error from [os.Remove].
-func (r *unconfinedRootReaderWriter) Remove(p Path) error { return os.Remove(p.abs) }
-
-// RemoveAll removes the path and any children it contains.
-//
-// Parameters:
-//   - `p`: the target path; a missing path is not an error.
-//
-// Returns:
-//   - `error`: any error from [os.RemoveAll].
-func (r *unconfinedRootReaderWriter) RemoveAll(p Path) error { return os.RemoveAll(p.abs) }
-
-// Rename moves oldPath to newPath.
-//
-// Parameters:
-//   - `oldPath`: the source path.
-//   - `newPath`: the destination path.
-//
-// Returns:
-//   - `error`: any error from [os.Rename].
-func (r *unconfinedRootReaderWriter) Rename(oldPath, newPath Path) error {
-	return os.Rename(oldPath.abs, newPath.abs)
-}
-
-// Symlink creates a symbolic link at link pointing to target.
-//
-// Parameters:
-//   - `target`: the link destination.
-//   - `link`: the path at which to create the link.
-//
-// Returns:
-//   - `error`: any error from [os.Symlink].
-func (r *unconfinedRootReaderWriter) Symlink(target string, link Path) error {
-	return os.Symlink(target, link.abs)
-}
-
-// WriteFile writes data to the path, creating or truncating it.
-//
-// Parameters:
-//   - `p`: the target path.
-//   - `data`: the bytes to write.
-//   - `perm`: the permission bits applied on creation.
-//
-// Returns:
-//   - `error`: any error from [os.WriteFile], or from the Windows enforcement pass.
-func (r *unconfinedRootReaderWriter) WriteFile(p Path, data []byte, perm os.FileMode) error {
-
-	if err := os.WriteFile(p.abs, data, perm); err != nil {
-		return err
-	}
-
-	return applyMode(p.abs, perm, false)
-}
-
-// endregion
-
-// endregion
-
 // region SUPPORTING TYPES
 
 // Path holds both root-relative and absolute forms of a filesystem path.
@@ -1167,7 +614,7 @@ func NewPath(root, rel string) Path {
 
 // region State management
 
-// Abs returns the absolute path used for unconfined I/O, URIs, display, and logging.
+// Abs returns the absolute path used for direct os.* I/O, URIs, display, and logging.
 //
 // Returns:
 //   - `string`: the absolute path.
@@ -1336,8 +783,8 @@ func isPrivateMode(perm os.FileMode) bool { return perm.Perm()&0o007 == 0 }
 
 // makePath computes a [Path] from a root directory name and an input path.
 //
-// Absolute inputs compute Rel via [filepath.Rel] (may contain ../ prefixes for paths outside root — valid in
-// unconfined mode, rejected by [*os.Root] in confined mode). Relative inputs compute Abs via [filepath.Join]. Rel is
+// Absolute inputs compute Rel via [filepath.Rel] (may contain ../ prefixes for paths outside root, which
+// [*os.Root] refuses at use). Relative inputs compute Abs via [filepath.Join]. Rel is
 // stored in canonical slash form on every platform: it is the half that serializes, and equal logical paths must
 // produce equal document bytes everywhere. Abs stays OS-native and carries all direct filesystem I/O.
 //

--- a/pkg/fsroot/fsroot_test.go
+++ b/pkg/fsroot/fsroot_test.go
@@ -169,19 +169,7 @@ func TestRoot_Close(t *testing.T) {
 
 	dir := t.TempDir()
 
-	// RootReader — Close is a no-op.
-	r := fsroot.OpenUnconfined(dir)
-	if err := r.Close(); err != nil {
-		t.Errorf("RootReader.Close() = %v", err)
-	}
-
-	// RootReaderWriter — Close is a no-op.
-	rw := fsroot.OpenWritableUnconfined(dir)
-	if err := rw.Close(); err != nil {
-		t.Errorf("RootReaderWriter.Close() = %v", err)
-	}
-
-	// confinedRoot — Close releases the file descriptor.
+	// Close releases the file descriptor.
 	cr, err := fsroot.OpenConfined(dir)
 	if err != nil {
 		t.Fatalf("fsroot.OpenConfined: %v", err)
@@ -348,9 +336,9 @@ func TestRoot_Readlink(t *testing.T) {
 func TestRoot_MkdirAll(t *testing.T) {
 
 	dir := t.TempDir()
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			p := tc.root.NewPath(tc.name, "a", "b", "c")
 			if err := tc.root.MkdirAll(p, 0o755); err != nil {
@@ -370,9 +358,9 @@ func TestRoot_MkdirAll(t *testing.T) {
 func TestRoot_OpenFile(t *testing.T) {
 
 	dir := t.TempDir()
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			p := tc.root.NewPath(tc.name + "_openfile.txt")
 			f, err := tc.root.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
@@ -398,9 +386,9 @@ func TestRoot_OpenFile(t *testing.T) {
 func TestRoot_Remove(t *testing.T) {
 
 	dir := t.TempDir()
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			name := tc.name + "_remove.txt"
 			writeFixture(t, dir, name, "doomed")
@@ -419,9 +407,9 @@ func TestRoot_Remove(t *testing.T) {
 func TestRoot_Rename(t *testing.T) {
 
 	dir := t.TempDir()
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			oldName := tc.name + "_old.txt"
 			newName := tc.name + "_new.txt"
@@ -451,9 +439,9 @@ func TestRoot_Symlink(t *testing.T) {
 
 	dir := t.TempDir()
 	writeFixture(t, dir, "symtarget.txt", "data")
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			linkName := tc.name + "_symlink.txt"
 			link := tc.root.NewPath(linkName)
@@ -476,9 +464,9 @@ func TestRoot_Symlink(t *testing.T) {
 func TestRoot_WriteFile(t *testing.T) {
 
 	dir := t.TempDir()
-	writableRoots := writableRoots(t, dir)
+	roots := allRoots(t, dir)
 
-	for _, tc := range writableRoots {
+	for _, tc := range roots {
 		t.Run(tc.name, func(t *testing.T) {
 			p := tc.root.NewPath(tc.name + "_writefile.txt")
 			if err := tc.root.WriteFile(p, []byte("payload"), 0o644); err != nil {
@@ -490,34 +478,6 @@ func TestRoot_WriteFile(t *testing.T) {
 			}
 			if string(data) != "payload" {
 				t.Errorf("content = %q, want %q", data, "payload")
-			}
-		})
-	}
-}
-
-func TestRootReader_WritesReturnErrReadOnly(t *testing.T) {
-
-	dir := t.TempDir()
-	r := fsroot.OpenUnconfined(dir)
-	p := r.NewPath("file.txt")
-
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"MkdirAll", func() error { return r.MkdirAll(p, 0o755) }},
-		{"OpenFile", func() error { _, err := r.OpenFile(p, os.O_WRONLY, 0o644); return err }},
-		{"Remove", func() error { return r.Remove(p) }},
-		{"Rename", func() error { return r.Rename(p, p) }},
-		{"Symlink", func() error { return r.Symlink("target", p) }},
-		{"WriteFile", func() error { return r.WriteFile(p, []byte("x"), 0o644) }},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.fn()
-			if !errors.Is(err, errors.ErrUnsupported) {
-				t.Errorf("got %v, want ErrReadOnly", err)
 			}
 		})
 	}
@@ -581,50 +541,6 @@ func TestOpen_ModeConfined(t *testing.T) {
 	}
 }
 
-func TestOpen_ModeUnconfined(t *testing.T) {
-
-	dir := t.TempDir()
-	writeFixture(t, dir, "fixture.txt", "content")
-
-	root, err := fsroot.Open(dir, fsroot.ModeUnconfined)
-	if err != nil {
-		t.Fatalf("Open(ModeUnconfined): %v", err)
-	}
-
-	if _, err := root.ReadFile(root.NewPath("fixture.txt")); err != nil {
-		t.Errorf("ReadFile: %v", err)
-	}
-
-	err = root.WriteFile(root.NewPath("probe.txt"), []byte("x"), 0o644)
-	if !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("WriteFile = %v, want errors.ErrUnsupported (read-only mode)", err)
-	}
-}
-
-func TestOpen_ModeWritableUnconfined(t *testing.T) {
-
-	dir := t.TempDir()
-
-	root, err := fsroot.Open(dir, fsroot.ModeWritableUnconfined)
-	if err != nil {
-		t.Fatalf("Open(ModeWritableUnconfined): %v", err)
-	}
-
-	p := root.NewPath("probe.txt")
-	if err := root.WriteFile(p, []byte("writable"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	if err := root.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	// Unconfined roots are handle-free: Close is a no-op and operations keep working.
-	if _, err := root.ReadFile(p); err != nil {
-		t.Errorf("ReadFile after Close = %v, want nil (unconfined roots are handle-free)", err)
-	}
-}
-
 func TestOpen_ConfinedMissingDirFails(t *testing.T) {
 
 	missing := filepath.Join(t.TempDir(), "absent")
@@ -646,7 +562,7 @@ func TestParity_WritableRootsImplementEveryMutation(t *testing.T) {
 
 	dir := t.TempDir()
 
-	for _, tc := range writableRoots(t, dir) {
+	for _, tc := range allRoots(t, dir) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			base := tc.root.NewPath(tc.name)
@@ -732,7 +648,7 @@ func TestCreateTemp_UniqueNamesHonorThePatternAndStayInTheDirectory(t *testing.T
 
 	dir := t.TempDir()
 
-	for _, tc := range writableRoots(t, dir) {
+	for _, tc := range allRoots(t, dir) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			under := tc.root.NewPath(tc.name)
@@ -805,7 +721,12 @@ func TestCreateTemp_UniqueNamesHonorThePatternAndStayInTheDirectory(t *testing.T
 // directory argument — the one way a name could otherwise act as a path.
 func TestCreateTemp_PatternWithSeparatorIsRefused(t *testing.T) {
 
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
+	root, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
 	under := root.NewPath(".")
 
 	if _, _, err := root.CreateTemp(under, "../escape-*"); !errors.Is(err, fs.ErrInvalid) {
@@ -843,46 +764,6 @@ func TestCreateTemp_ScratchRootKeepsItsTempFilesInsideTheTree(t *testing.T) {
 	}
 	if _, err := os.Stat(absolute); !os.IsNotExist(err) {
 		t.Errorf("Stat after scratch Close = %v, want the file gone with the tree", err)
-	}
-}
-
-func TestParity_ReadOnlyRootRefusesEveryMutation(t *testing.T) {
-
-	dir := t.TempDir()
-	writeFixture(t, dir, "fixture.txt", "content")
-
-	root := fsroot.OpenUnconfined(dir)
-	p := root.NewPath("fixture.txt")
-
-	if _, err := root.Create(p); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("Create = %v, want ErrUnsupported", err)
-	}
-	if _, _, err := root.CreateTemp(root.NewPath("."), "temp-*"); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("CreateTemp = %v, want ErrUnsupported", err)
-	}
-
-	for name, err := range map[string]error{
-		"Chmod":     root.Chmod(p, 0o600),
-		"Chown":     root.Chown(p, -1, -1),
-		"Chtimes":   root.Chtimes(p, time.Now(), time.Now()),
-		"Lchown":    root.Lchown(p, -1, -1),
-		"Link":      root.Link(p, root.NewPath("link.txt")),
-		"Mkdir":     root.Mkdir(root.NewPath("sub"), 0o750),
-		"MkdirTemp": mkdirTempError(root),
-		"RemoveAll": root.RemoveAll(p),
-	} {
-		if !errors.Is(err, errors.ErrUnsupported) {
-			t.Errorf("%s = %v, want ErrUnsupported", name, err)
-		}
-	}
-
-	// OpenRoot is a read, so it succeeds — and its sub-root inherits read-only.
-	sub, err := root.OpenRoot(root.NewPath("."))
-	if err != nil {
-		t.Fatalf("OpenRoot: %v", err)
-	}
-	if err := sub.RemoveAll(sub.NewPath("fixture.txt")); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("sub-root RemoveAll = %v, want ErrUnsupported (mode is inherited)", err)
 	}
 }
 
@@ -926,7 +807,8 @@ func TestOpenScratch_IsConfined(t *testing.T) {
 	}
 }
 
-// allRoots returns all three Root implementations rooted at dir. The confinedRoot is registered for cleanup.
+// allRoots returns each Root implementation rooted at dir — one, since the design collapsed to a single
+// confinement behavior. The table shape survives it, so every consumer still names its case.
 func allRoots(t *testing.T, dir string) []rootCase {
 
 	t.Helper()
@@ -939,32 +821,6 @@ func allRoots(t *testing.T, dir string) []rootCase {
 	t.Cleanup(func() { _ = cr.Close() })
 
 	return []rootCase{
-		{"RootReader", fsroot.OpenUnconfined(dir)},
-		{"RootReaderWriter", fsroot.OpenWritableUnconfined(dir)},
-		{"confinedRoot", cr},
-	}
-}
-
-// writableRoots returns Root implementations that support write operations.
-// mkdirTempError returns only MkdirTemp's error, so the read-only refusal table can hold it beside the
-// single-value mutations.
-func mkdirTempError(root fsroot.Dir) error {
-
-	_, err := root.MkdirTemp(root.NewPath("."), "temp-*")
-	return err
-}
-
-func writableRoots(t *testing.T, dir string) []rootCase {
-
-	t.Helper()
-	cr, err := fsroot.OpenConfined(dir)
-	if err != nil {
-		t.Fatalf("fsroot.OpenConfined: %v", err)
-	}
-	t.Cleanup(func() { _ = cr.Close() })
-
-	return []rootCase{
-		{"RootReaderWriter", fsroot.OpenWritableUnconfined(dir)},
 		{"confinedRoot", cr},
 	}
 }

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -2084,7 +2084,12 @@ func TestChecksumFile_ComputesDigest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root := fsroot.OpenWritableUnconfined(tmp)
+	root, err := fsroot.OpenConfined(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
 	got := checksumFile(root, path)
 	if got == "" {
 		t.Fatal("checksumFile() returned empty string")
@@ -2099,8 +2104,15 @@ func TestChecksumFile_ComputesDigest(t *testing.T) {
 
 func TestChecksumFile_NonExistent(t *testing.T) {
 
-	root := fsroot.OpenWritableUnconfined(t.TempDir())
-	got := checksumFile(root, "/nonexistent/file.txt")
+	tmp := t.TempDir()
+
+	root, err := fsroot.OpenConfined(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	got := checksumFile(root, filepath.Join(tmp, "nonexistent", "file.txt"))
 	if got != "" {
 		t.Errorf("checksumFile(nonexistent) = %q, want empty string", got)
 	}

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -6,7 +6,6 @@ package op_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -382,61 +381,6 @@ func TestTriad_RenameThroughRoot(t *testing.T) {
 	}
 }
 
-func TestTriad_RootReaderRejectsWrites(t *testing.T) {
-
-	dir := t.TempDir()
-	root := fsroot.OpenUnconfined(dir)
-
-	p := root.NewPath("file.txt")
-
-	if err := root.WriteFile(p, []byte("data"), 0o644); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("WriteFile err = %v, want ErrReadOnly", err)
-	}
-
-	if err := root.MkdirAll(p, 0o755); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("MkdirAll err = %v, want ErrReadOnly", err)
-	}
-
-	if err := root.Remove(p); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("Remove err = %v, want ErrReadOnly", err)
-	}
-
-	if err := root.Rename(p, p); !errors.Is(err, errors.ErrUnsupported) {
-		t.Errorf("Rename err = %v, want ErrReadOnly", err)
-	}
-}
-
-func TestTriad_RootReaderAllowsReads(t *testing.T) {
-
-	tempDir := t.TempDir()
-	abs := filepath.Join(tempDir, "readable.txt")
-
-	if err := os.WriteFile(abs, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	root := fsroot.OpenUnconfined(tempDir)
-	p := root.NewPath("readable.txt")
-
-	data, err := root.ReadFile(p)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-
-	if string(data) != "hello" {
-		t.Errorf("content = %q, want %q", data, "hello")
-	}
-
-	info, err := root.Stat(p)
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-
-	if info.Size() != 5 {
-		t.Errorf("size = %d, want 5", info.Size())
-	}
-}
-
 func TestTriad_MultipleArchivesCoexist(t *testing.T) {
 
 	env := newTriadRW(t)
@@ -474,7 +418,13 @@ func TestTriad_MultipleArchivesCoexist(t *testing.T) {
 func TestTriad_PathJSONFromRoot(t *testing.T) {
 
 	tempDir := t.TempDir()
-	root := fsroot.OpenWritableUnconfined(tempDir)
+
+	root, err := fsroot.OpenConfined(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
 	p := root.NewPath("sub/file.txt")
 
 	data, err := p.MarshalJSON()

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -28,10 +28,19 @@ func isolate(t *testing.T) (signer Signer, allowedSigners string) {
 	root := t.TempDir()
 
 	// The caller owns the root, exactly as cmd/internal/cli does in production; signing receives it.
-	configRoot := fsroot.OpenWritableUnconfined(filepath.Join(root, "config", "devlore"))
+	// Production creates the tree before opening it (cli.OpenTree); the MkdirAll is that step here.
+	configDir := filepath.Join(root, "config", "devlore")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	configRoot, err := fsroot.OpenConfined(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = configRoot.Close() })
 
-	signer, err := DefaultSigner(configRoot, filepath.Join(root, "absent", "id_ed25519"))
+	signer, err = DefaultSigner(configRoot, filepath.Join(root, "absent", "id_ed25519"))
 	if err != nil {
 		t.Fatalf("DefaultSigner: %v", err)
 	}

--- a/pkg/signing/signing_windows_test.go
+++ b/pkg/signing/signing_windows_test.go
@@ -34,7 +34,10 @@ const (
 // TestGenerateLocalKey_PrivateKeyIsProtectedOnWindows is the assertion this campaign exists to make.
 func TestGenerateLocalKey_PrivateKeyIsProtectedOnWindows(t *testing.T) {
 
-	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	configRoot, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = configRoot.Close() })
 
 	if _, err := localSigner(configRoot); err != nil {
@@ -69,7 +72,10 @@ func TestGenerateLocalKey_PrivateKeyIsProtectedOnWindows(t *testing.T) {
 // protected key inside a world-traversable directory is a weaker guarantee than it looks.
 func TestGenerateLocalKey_SigningDirectoryIsProtectedOnWindows(t *testing.T) {
 
-	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	configRoot, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = configRoot.Close() })
 
 	if _, err := localSigner(configRoot); err != nil {
@@ -89,7 +95,10 @@ func TestGenerateLocalKey_SigningDirectoryIsProtectedOnWindows(t *testing.T) {
 // to be copied into someone else's allowed_signers.
 func TestGenerateLocalKey_PublicHalfIsNotProtected(t *testing.T) {
 
-	configRoot := fsroot.OpenWritableUnconfined(t.TempDir())
+	configRoot, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { _ = configRoot.Close() })
 
 	if _, err := localSigner(configRoot); err != nil {


### PR DESCRIPTION
#568 step 3. Two types remain — the confined root and its scratch sibling — and one behavior, the kernel's.

## Deleted

`unconfinedRootReader`, `unconfinedRootReaderWriter`, `rootBase`, `errReadOnly`, `OpenUnconfined`,
`OpenWritableUnconfined`, both unconfined `Mode` constants, and every test that existed only to pin the
deleted variants' behavior — including `TestApplyMode_BothWritableRootsProtect`, whose surviving half
duplicates `TestApplyMode_PrivateFileGetsProtectedDACL`.

**Kept, as a documented vestige:** `Mode`, `ModeConfined` (now an explicit `= 0`), and `Open` —
`op.RuntimeEnvironmentSpec.WithRoot` still carries the `Mode` parameter, and #568 step 5 deletes all three
with it. Repo-wide grep: zero references to any deleted name.

## Star's anchor (#571)

Star was the last production unconfined root — mode-dispatched, so step 2's constructor migration never saw
it. It now anchors at the **working directory, confined**. A volume anchor was tried first and broke the
generator on the first `make build`: star scripts resolve *relative* paths against the session root's anchor,
so anchoring at `/` redefined every relative path in every script. No current extension uses an absolute path
or XDG (verified), so wd-confined drops nothing exercised today. The real ruling — wd, repo root, home, or
declared roots — is #571, open until #563's hermeticity design.

## Production defect exposed and fixed

`CopyDir` handed `MkdirAll` a full `FileMode`, type bits included. `os.Mkdir` silently discards them;
`os.Root.Mkdir` rejects them (`unsupported file mode`) — and production selfinstall has run confined since
#570, so star's extension-copy hook would have failed on its first directory copy. The unconfined test
structurally could not catch this; the confined one did, immediately. Now `Mode().Perm()`
(cmd/internal/cli/selfinstall.go).

## Test migrations

13 remaining constructor call sites → `OpenConfined` (or `cli.OpenTree` where the tree must be created
first): index (1), selfinstall (5), file provider (2), signing (1), signing_windows (3), triad (1).
`TestChecksumFile_NonExistent` stops reaching for `/nonexistent/file.txt` outside its root — the same fixture
defect class #570 fixed eight of. fsroot's own tests drop the variant tables and the refusal suites.

## Found while gating → #572

Every provider's Makefile `&:` gen group lists `node_builder.gen_test.go`, which the generator no longer
emits — the groups are permanently stale and `GOOS=linux/windows make build` cannot pass on any tree (it
execs target-OS tools on the host). Cross-platform verification for this PR is `make vet` ×3 GOOS + CI's real
Windows job.

## Verified

- `make check` — 103 packages ok, 0 failures
- `make build` (darwin) — full regeneration; every generated file **byte-identical to develop HEAD** by blob
  SHA, across two regeneration cycles
- `make vet` — GOOS=linux, darwin, windows
- `gofmt -l` — clean

Refs #568, #571, #572.
