### PR TITLE
refactor(op): WithRoot takes only the anchor; fsroot.Mode and Open are gone

### DIFF
--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -272,7 +272,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 	spec := op.NewRuntimeEnvironmentSpec("devlore-test").
 		WithStatus(cli.UI()).
 		WithModules(receiverRegistry.Modules()...).
-		WithRoot(tmpDir, fsroot.ModeConfined).
+		WithRoot(tmpDir).
 		WithPlatform(hostPlatform).
 		WithApplication(app)
 

--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -841,7 +841,7 @@ func (tc *TestContext) buildSpec() (*op.RuntimeEnvironmentSpec, error) {
 
 	return op.NewRuntimeEnvironmentSpec(programName).
 		WithStatus(cli.UI()).
-		WithRoot(tc.tmpDir, fsroot.ModeConfined).
+		WithRoot(tc.tmpDir).
 		WithPlatform(hostPlatform).
 		WithApplication(app), nil
 }

--- a/cmd/lore/lore/commands.go
+++ b/cmd/lore/lore/commands.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -244,7 +243,7 @@ func executeDeployments(ctx context.Context, resolved []resolvedPackage, cfg *lo
 
 	spec := op.NewRuntimeEnvironmentSpec("lore").
 		WithStatus(cli.UI()).
-		WithRoot(wd, fsroot.ModeConfined).
+		WithRoot(wd).
 		WithApplication(&application.Application{
 			Name:  "lore",
 			Flags: map[string]any{"dry-run": cfg.DryRun},

--- a/cmd/star/provider/starcode/provider_test.go
+++ b/cmd/star/provider/starcode/provider_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -31,7 +30,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/cmd/star/star/application.go
+++ b/cmd/star/star/application.go
@@ -16,7 +16,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/star/provider/commands"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
 	"github.com/spf13/cobra"
@@ -83,7 +82,7 @@ func NewApplication(rootCmd *cobra.Command) *Application {
 	spec := op.NewRuntimeEnvironmentSpec("star").
 		WithApplication(app).
 		WithModules(registry.Modules()...).
-		WithRoot(wd, fsroot.ModeConfined)
+		WithRoot(wd)
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(), spec)
 	assert.NoError("op.NewRuntimeEnvironment", err)

--- a/cmd/writ/writ/adopt/batch.go
+++ b/cmd/writ/writ/adopt/batch.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
@@ -266,7 +265,7 @@ func buildSpec(root string) *op.RuntimeEnvironmentSpec {
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{Name: "writ"})
 }
 

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -22,7 +22,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/readback"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -286,7 +285,7 @@ func removalSpec(root string, dryRun bool) *op.RuntimeEnvironmentSpec {
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{
 			Name:  "writ",
 			Flags: map[string]any{"dry-run": dryRun},

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -15,7 +15,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/tree"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
@@ -384,7 +383,7 @@ func deploySpec(root string, dryRun bool, conflict op.ConflictPolicy) *op.Runtim
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{
 			Name:  "writ",
 			Flags: map[string]any{"dry-run": dryRun, "conflict": conflict},

--- a/cmd/writ/writ/migrate/execute.go
+++ b/cmd/writ/writ/migrate/execute.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -72,7 +71,7 @@ func Execute(ctx context.Context, graph *op.Graph, analysis *MigrationAnalysis) 
 		analysis.System, len(graph.Nodes()), len(renameNodes))
 
 	executor := op.NewGraphExecutor(graph, op.NewRuntimeEnvironmentSpec("writ").WithStatus(cli.UI()).
-		WithRoot(analysis.SourceRoot, fsroot.ModeConfined))
+		WithRoot(analysis.SourceRoot))
 
 	if _, err := executor.Run(ctx, nil); err != nil {
 		return executor.Trace(), fmt.Errorf("migration run: %w", err)

--- a/cmd/writ/writ/migrate/helpers.go
+++ b/cmd/writ/writ/migrate/helpers.go
@@ -6,7 +6,6 @@ package migrate
 import (
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -86,6 +85,6 @@ func migrateSpec(root string) *op.RuntimeEnvironmentSpec {
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{Name: "writ"})
 }

--- a/cmd/writ/writ/migrate/receipt_integration_test.go
+++ b/cmd/writ/writ/migrate/receipt_integration_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -29,7 +28,7 @@ func TestExecutionTrace_SerializesAsMigrationReceipt(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/cmd/writ/writ/readback/readback.go
+++ b/cmd/writ/writ/readback/readback.go
@@ -27,7 +27,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
@@ -519,7 +518,7 @@ func loadGraph(environment *op.RuntimeEnvironment, checksum string) (*op.Graph, 
 func loadingEnvironment(ctx context.Context) (*op.RuntimeEnvironment, error) {
 
 	return op.NewRuntimeEnvironment(ctx, op.NewRuntimeEnvironmentSpec("writ").
-		WithRoot(string(filepath.Separator), fsroot.ModeConfined).
+		WithRoot(string(filepath.Separator)).
 		WithApplication(&application.Application{Name: "writ"}))
 }
 

--- a/cmd/writ/writ/secret/encrypt.go
+++ b/cmd/writ/writ/secret/encrypt.go
@@ -24,7 +24,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -248,7 +247,7 @@ func encryptSpec(root string, dryRun bool) *op.RuntimeEnvironmentSpec {
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{
 			Name:  "writ",
 			Flags: map[string]any{"dry-run": dryRun},

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -38,7 +38,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/tree"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/encryption"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
@@ -559,7 +558,7 @@ func upgradeSpec(root string, dryRun bool) *op.RuntimeEnvironmentSpec {
 
 	return op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{
 			Name: "writ",
 			// The regeneration set is classification-cleared (missing / stale / force-approved), so the runs

--- a/cmd/writ/writ/verify/verify.go
+++ b/cmd/writ/writ/verify/verify.go
@@ -24,7 +24,6 @@ import (
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/signing"
@@ -258,7 +257,7 @@ func loadGraph(ctx context.Context, data []byte) (graph *op.Graph, err error) {
 
 	environment, err = op.NewRuntimeEnvironment(ctx, op.NewRuntimeEnvironmentSpec("writ").
 		WithStatus(cli.UI()).
-		WithRoot(string(filepath.Separator), fsroot.ModeConfined).
+		WithRoot(string(filepath.Separator)).
 		WithApplication(&application.Application{Name: "writ"}))
 	if err != nil {
 		return nil, err

--- a/docs/architecture/4.5-fsroot-variants.status.md
+++ b/docs/architecture/4.5-fsroot-variants.status.md
@@ -40,9 +40,14 @@ two types. No implementation.
   volume-anchored root rather than `os.MkdirAll`, since a mode without fsroot's access-control list is worth
   nothing on Windows.
 
+- [x] **The `TestIsPrivateMode` / `TestNewPath` item resolved by inspection** (2026-08-20): both are ordinary
+  `_test.go` functions; nothing test-shaped is exported from a non-test file. The exported non-test API is
+  `NewPath` — public because document deserialization needs it, tests are a secondary consumer — and the
+  `Perm*` masks, whose call-site migration is chartered with #559.
+
 ## Open
 
-- [ ] **`TestIsPrivateMode` and `TestNewPath`** are exported from non-test files, so they sit in the public API.
+Nothing. The design is implemented: one confinement behavior, two types, two constructors.
 
 ## Superseded by this revision
 

--- a/pkg/fsroot/fsroot.go
+++ b/pkg/fsroot/fsroot.go
@@ -107,35 +107,6 @@ type Dir interface {
 	WriteFile(p Path, data []byte, perm os.FileMode) error
 }
 
-// Mode selects which [Dir] implementation [Open] constructs.
-//
-// One implementation remains, so the only value is [ModeConfined] — the zero value. The type
-// survives solely because op.RuntimeEnvironmentSpec.WithRoot still carries a Mode parameter; it is
-// deleted with that parameter in #568 step 5.
-type Mode int
-
-// ModeConfined selects the OS-enforced confined implementation ([OpenConfined]). The zero value.
-const ModeConfined Mode = 0
-
-// Open opens a [Dir] at dir in the given [Mode].
-//
-// With [ModeConfined] the only mode, this is [OpenConfined] behind a mode assertion. It is deleted
-// together with [Mode] in #568 step 5.
-//
-// Parameters:
-//   - `dir`: the directory to anchor the root at.
-//   - `mode`: the [Mode] selecting the implementation.
-//
-// Returns:
-//   - `Dir`: the constructed root.
-//   - `error`: any error from [OpenConfined].
-func Open(dir string, mode Mode) (Dir, error) {
-
-	assert.True("fsroot.Open: mode is ModeConfined", mode == ModeConfined)
-
-	return OpenConfined(dir)
-}
-
 // OpenScratch opens a confined [Dir] at a newly created temporary directory that removes itself.
 //
 // Scratch is not an escape from confinement — it is its own confined tree with a self-destroying

--- a/pkg/fsroot/fsroot_test.go
+++ b/pkg/fsroot/fsroot_test.go
@@ -516,13 +516,13 @@ type rootCase struct {
 	root fsroot.Dir
 }
 
-func TestOpen_ModeConfined(t *testing.T) {
+func TestOpenConfined_CloseReleasesTheHandle(t *testing.T) {
 
 	dir := t.TempDir()
 
-	root, err := fsroot.Open(dir, fsroot.ModeConfined)
+	root, err := fsroot.OpenConfined(dir)
 	if err != nil {
-		t.Fatalf("Open(ModeConfined): %v", err)
+		t.Fatalf("fsroot.OpenConfined: %v", err)
 	}
 
 	p := root.NewPath("probe.txt")
@@ -534,27 +534,9 @@ func TestOpen_ModeConfined(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// Only the confined implementation holds a live OS handle, so failure after Close is the
-	// behavioral discriminator for the dispatch.
+	// A confined root holds a live OS handle, so an operation after Close must fail.
 	if _, err := root.ReadFile(p); err == nil {
 		t.Fatal("ReadFile after Close = nil error, want failure (confined root holds a live handle)")
-	}
-}
-
-func TestOpen_ConfinedMissingDirFails(t *testing.T) {
-
-	missing := filepath.Join(t.TempDir(), "absent")
-
-	if _, err := fsroot.Open(missing, fsroot.ModeConfined); err == nil {
-		t.Fatal("Open(ModeConfined) on a missing directory = nil error, want failure")
-	}
-}
-
-func TestOpen_ZeroValueModeIsConfined(t *testing.T) {
-
-	var mode fsroot.Mode
-	if mode != fsroot.ModeConfined {
-		t.Fatalf("zero-value Mode = %d, want ModeConfined (%d)", mode, fsroot.ModeConfined)
 	}
 }
 

--- a/pkg/op/graph_executor_test.go
+++ b/pkg/op/graph_executor_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // The two fixture providers below exercise the executor's failure-terminal split (phase-8 step 21): each pairs a
@@ -1072,7 +1071,7 @@ func TestRun_BadRootAnchor_PreflightFailed(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "absent")
 	executor := NewGraphExecutor(newRecoverGraph(t), NewRuntimeEnvironmentSpec("test").
 		WithApplication(&application.Application{Name: "test"}).
-		WithRoot(missing, fsroot.ModeConfined))
+		WithRoot(missing))
 
 	if _, runErr := executor.Run(context.Background(), nil); runErr == nil {
 		t.Fatal("Run = nil error, want the mint failure for the missing anchor")
@@ -1094,7 +1093,7 @@ func TestRun_SequentialExecutorsShareOneSpec(t *testing.T) {
 	graph := newRecoverGraph(t)
 	spec := NewRuntimeEnvironmentSpec("test").
 		WithApplication(&application.Application{Name: "test"}).
-		WithRoot(t.TempDir(), fsroot.ModeConfined)
+		WithRoot(t.TempDir())
 
 	for i := 1; i <= 2; i++ {
 		if _, runErr := NewGraphExecutor(graph, spec).Run(context.Background(), nil); runErr != nil {

--- a/pkg/op/inventory/seam_test.go
+++ b/pkg/op/inventory/seam_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/google/uuid"
@@ -29,7 +28,7 @@ func seamEnv(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ulikunitz/xz"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen" // registers file.Provider so Instance + the compensator index resolve
@@ -36,7 +35,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/encryption/provider_test.go
+++ b/pkg/op/provider/encryption/provider_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"filippo.io/age"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/getsops/sops/v3"
 	"github.com/getsops/sops/v3/aes"
 	sopsage "github.com/getsops/sops/v3/age"
@@ -41,7 +40,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/file/provider_test.go
+++ b/pkg/op/provider/file/provider_test.go
@@ -38,7 +38,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/flow/result_flow_starlark_test.go
+++ b/pkg/op/provider/flow/result_flow_starlark_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
 	"go.starlark.net/starlark"
@@ -53,7 +52,7 @@ func TestSubgraphBoundAction_FlowsLeafResult_Starlark(t *testing.T) {
 
 	spec := op.NewRuntimeEnvironmentSpec("test").
 		WithApplication(&application.Application{Name: "test"}).
-		WithRoot(root, fsroot.ModeConfined)
+		WithRoot(root)
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), spec)
 	if err != nil {

--- a/pkg/op/provider/function/resource_test.go
+++ b/pkg/op/provider/function/resource_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
@@ -33,7 +32,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
 	"github.com/NobleFactor/devlore-cli/pkg/status"
@@ -36,7 +35,7 @@ func newNarratingProvider(t *testing.T, dryRun bool) (*Provider, *bytes.Buffer) 
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test", Flags: map[string]any{"dry_run": dryRun}}).
 			WithStatus(status.NewNarrator("test", captureSink)))
 	if err != nil {

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -33,7 +32,7 @@ func testEnvironment(t *testing.T, dir string) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/json/resource_test.go
+++ b/pkg/op/provider/json/resource_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -32,7 +31,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -36,7 +35,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/plan/deferred_default_test.go
+++ b/pkg/op/provider/plan/deferred_default_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -35,7 +34,7 @@ func TestPlannedDeferredDefault_ResolvesAtDispatch(t *testing.T) {
 
 	spec := func() *op.RuntimeEnvironmentSpec {
 		return op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(tmp, fsroot.ModeConfined).
+			WithRoot(tmp).
 			WithApplication(&application.Application{Name: "test"})
 	}
 

--- a/pkg/op/provider/plan/gather_api_test.go
+++ b/pkg/op/provider/plan/gather_api_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/flow"
@@ -32,7 +31,7 @@ func TestGatherFailureUnwind_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/plan/git_resume_test.go
+++ b/pkg/op/provider/plan/git_resume_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/git"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -52,7 +51,7 @@ func gitCloneResumeThenFail(t *testing.T, format string) {
 	}
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/plan/lifecycle_api_test.go
+++ b/pkg/op/provider/plan/lifecycle_api_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/flow"
@@ -44,7 +43,7 @@ func TestGraphSaveLoadExecuteTrace_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -127,7 +126,7 @@ func TestGraphPauseResume_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -210,7 +209,7 @@ func TestGraphPauseResumeNested_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -289,7 +288,7 @@ func TestGraphSaveLoadResume_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -400,7 +399,7 @@ func resumeThenFailRollsBack(t *testing.T, format string) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -501,7 +500,7 @@ func resumePromiseFidelity(t *testing.T, format string) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -605,7 +604,7 @@ func TestResourceLedgerRehydrate_PreservesIDs(t *testing.T) {
 	tmp := t.TempDir()
 
 	spec := op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"})
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), spec)
@@ -655,7 +654,7 @@ func TestGraphSaveLoad_ContentTransport(t *testing.T) {
 
 	newHost := func(dir string) *op.RuntimeEnvironment {
 		host, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, fsroot.ModeConfined).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 		if err != nil {
 			t.Fatalf("op.NewRuntimeEnvironment(%s): %v", dir, err)
@@ -801,7 +800,7 @@ func TestGraphStop_UnwindsToStopped_ViaPublicAPI(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/plan/lifecycle_e2e_test.go
+++ b/pkg/op/provider/plan/lifecycle_e2e_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -229,7 +228,7 @@ func newLifecycleEnv(t *testing.T, tmp string) (*op.RuntimeEnvironment, *plan.Pr
 	t.Helper()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/plan/lifecycle_starlark_test.go
+++ b/pkg/op/provider/plan/lifecycle_starlark_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
 
@@ -51,7 +50,7 @@ plan.run(loaded, plan.spec())
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
 		WithApplication(&application.Application{Name: "test"}).
-		WithRoot(root, fsroot.ModeConfined))
+		WithRoot(root))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
 	}

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -434,8 +434,8 @@ func (p *Provider) SaveDefinition(graph *op.Graph, path string) (err error) {
 // the host that invoked [op.Plan] passed its own [application.Application] and root anchor. Net effect:
 // `plan.spec()` with no arguments produces a spec equivalent to the planning runtime environment's.
 //
-// The spec carries no live [fsroot.Dir] — only the resolved `rootPath` anchor and [fsroot.ModeConfined]; each
-// [Provider.Run]'s executor mints (and closes) its own Root from them (issue #393). The resolved anchor is probed
+// The spec carries no live [fsroot.Dir] — only the resolved `rootPath` anchor; each
+// [Provider.Run]'s executor mints (and closes) its own Root from it (issue #393). The resolved anchor is probed
 // here via [fsroot.OpenConfined] and released immediately, so a bad root path still fails at the `plan.spec` call
 // site rather than at run time. The returned spec's [op.ReceiverRegistry] is a freshly-built one from the announced
 // providers — independent of the planning runtime environment's registry.
@@ -485,7 +485,7 @@ func (p *Provider) Spec(programName, rootPath string, flags map[string]any) (*op
 	}
 
 	return op.NewRuntimeEnvironmentSpec(programName).
-		WithRoot(rootPath, fsroot.ModeConfined).
+		WithRoot(rootPath).
 		WithPlatform(runtimeEnvironment.Platform).
 		WithApplication(&application.Application{
 			Name:      programName,

--- a/pkg/op/provider/plan/provider_test.go
+++ b/pkg/op/provider/plan/provider_test.go
@@ -14,7 +14,6 @@ import (
 	"go.starlark.net/starlark"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -75,7 +74,7 @@ func plannedEnvironmentAt(t *testing.T, rootPath string) *op.RuntimeEnvironment 
 	t.Helper()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(rootPath, fsroot.ModeConfined).
+		WithRoot(rootPath).
 		WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -325,7 +324,7 @@ func TestProvider_Spec_DefaultsFromPlanningEnvironment(t *testing.T) {
 	tmp := t.TempDir()
 
 	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("planner").
-		WithRoot(tmp, fsroot.ModeConfined).
+		WithRoot(tmp).
 		WithApplication(&application.Application{Name: "planner", Flags: map[string]any{"dry-run": true}}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -353,9 +352,6 @@ func TestProvider_Spec_DefaultsFromPlanningEnvironment(t *testing.T) {
 	if spec.RootPath != environment.Root().Name() {
 		t.Fatalf("spec.RootPath = %q, want the planning environment's root path %q",
 			spec.RootPath, environment.Root().Name())
-	}
-	if spec.RootMode != fsroot.ModeConfined {
-		t.Errorf("spec.RootMode = %v, want fsroot.ModeConfined", spec.RootMode)
 	}
 }
 

--- a/pkg/op/provider/plan/wait_until_edge_test.go
+++ b/pkg/op/provider/plan/wait_until_edge_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/flow"
@@ -31,7 +30,7 @@ func waitUntilSpec(t *testing.T, root string) *op.RuntimeEnvironmentSpec {
 	t.Helper()
 
 	return op.NewRuntimeEnvironmentSpec("test").
-		WithRoot(root, fsroot.ModeConfined).
+		WithRoot(root).
 		WithApplication(&application.Application{Name: "test"})
 }
 

--- a/pkg/op/provider/service/resource_test.go
+++ b/pkg/op/provider/service/resource_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -30,7 +29,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/provider/yaml/resource_test.go
+++ b/pkg/op/provider/yaml/resource_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
@@ -31,7 +30,7 @@ func newTestRuntimeEnvironment(t *testing.T) *op.RuntimeEnvironment {
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/pkg/op/recovery_site_test.go
+++ b/pkg/op/recovery_site_test.go
@@ -30,7 +30,7 @@ func newTestRecoverySite(t *testing.T) (*RecoverySite, fsroot.Dir) {
 
 	runtimeEnvironment, err := NewRuntimeEnvironment(context.Background(),
 		NewRuntimeEnvironmentSpec("test").
-			WithRoot(t.TempDir(), fsroot.ModeConfined).
+			WithRoot(t.TempDir()).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("NewRuntimeEnvironment: %v", err)

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -134,9 +134,6 @@ type RuntimeEnvironment struct {
 	// what licenses [RuntimeEnvironment.Root] to assert rather than return an error.
 	rootPath string
 
-	// rootMode selects which [fsroot.Dir] implementation is minted at rootPath.
-	rootMode fsroot.Mode
-
 	// root is the session's filesystem root, minted on first use and released by Close.
 	//
 	// Allocation is lazy so a planning-only session that never touches the filesystem holds no handle at all.
@@ -175,7 +172,7 @@ type RuntimeEnvironment struct {
 //
 // It defaults the absent optionals (Status → [status.Narrator] over [sink.Stderr], Result → [result.Pipeline] writing
 // JSON to [sink.Stdout], a fresh [ResourceCatalog], the detected [platform.Platform], the registry's module set),
-// mints the environment's [fsroot.Dir] via [fsroot.Open] when [RuntimeEnvironmentSpec.RootPath] is non-empty, and
+// mints the environment's [fsroot.Dir] via [fsroot.OpenConfined] when [RuntimeEnvironmentSpec.RootPath] is non-empty, and
 // wires the [RecoverySite] when a Root was minted. The environment owns the minted Root — a spec never carries a
 // live handle (issue #393) — and [RuntimeEnvironment.Close] releases it.
 //
@@ -185,7 +182,7 @@ type RuntimeEnvironment struct {
 //
 // Returns:
 //   - `*RuntimeEnvironment`: the constructed runtime environment; nil when the mint fails.
-//   - `error`: non-nil when [fsroot.Open] fails at the spec's anchor path and mode.
+//   - `error`: non-nil when [fsroot.OpenConfined] fails at the spec's anchor path.
 func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*RuntimeEnvironment, error) {
 
 	assert.NonZero("spec", spec)
@@ -226,7 +223,7 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*
 	// Preflight, not allocation: both anchors are proved usable here and released again, so a bad anchor is
 	// refused before dispatch rather than killing a run halfway through — and so the accessors may assert.
 	if spec.RootPath != "" {
-		if err := probeRootAnchor(spec.RootPath, spec.RootMode); err != nil {
+		if err := probeRootAnchor(spec.RootPath); err != nil {
 			return nil, fmt.Errorf("op.NewRuntimeEnvironment: %w", err)
 		}
 	}
@@ -242,7 +239,6 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*
 		Platform:         platformCapability,
 		ResourceCatalog:  resourceCatalog,
 		rootPath:         spec.RootPath,
-		rootMode:         spec.RootMode,
 		Status:           statusNarrator,
 		Result:           resultPipeline,
 		variableResolver: NewVariableResolver(spec.Application),
@@ -336,7 +332,7 @@ func (re *RuntimeEnvironment) Root() fsroot.Dir {
 	}
 
 	re.rootOnce.Do(func() {
-		minted, err := fsroot.Open(re.rootPath, re.rootMode)
+		minted, err := fsroot.OpenConfined(re.rootPath)
 		assert.NoError("op.RuntimeEnvironment.Root: mint root after successful preflight", err)
 		re.root = minted
 	})
@@ -841,7 +837,7 @@ func NewRuntimeEnvironmentConfig() *RuntimeEnvironmentConfig {
 //
 //	cfg := op.NewRuntimeEnvironmentSpec("lore").
 //	    WithModules(op.ReceiverRegistry().ModuleByName("file"), op.ReceiverRegistry().ModuleByName("json")).
-//	    WithRoot(wd, fsroot.ModeConfined).
+//	    WithRoot(wd).
 //	    WithApplication(app)
 type RuntimeEnvironmentSpec struct {
 
@@ -879,14 +875,9 @@ type RuntimeEnvironmentSpec struct {
 	// RootPath is the anchor directory the constructed runtime environment's [fsroot.Dir] is minted at.
 	//
 	// Empty means no root: the environment's Root stays nil and no [RecoverySite] is wired. The spec carries only
-	// this serializable anchor plus [RuntimeEnvironmentSpec.RootMode] — never a live handle; [NewRuntimeEnvironment]
-	// mints and [RuntimeEnvironment.Close] releases (issue #393).
+	// this serializable anchor — never a live handle; [NewRuntimeEnvironment] mints and
+	// [RuntimeEnvironment.Close] releases (issue #393).
 	RootPath string
-
-	// RootMode selects the [fsroot.Dir] implementation minted at [RuntimeEnvironmentSpec.RootPath].
-	//
-	// The zero value is [fsroot.ModeConfined].
-	RootMode fsroot.Mode
 
 	// Status is the user-facing side-channel narrator.
 	//
@@ -988,21 +979,19 @@ func (c *RuntimeEnvironmentSpec) WithResult(pipeline *result.Pipeline) *RuntimeE
 	return c
 }
 
-// WithRoot sets the anchor path and access mode the constructed runtime environment mints its [fsroot.Dir] from.
+// WithRoot sets the anchor path the constructed runtime environment mints its [fsroot.Dir] from.
 //
-// The spec never carries a live Root: [NewRuntimeEnvironment] mints from these values and
+// The spec never carries a live Root: [NewRuntimeEnvironment] mints from this value and
 // [RuntimeEnvironment.Close] releases what it minted (issue #393).
 //
 // Parameters:
 //   - `path`: the anchor directory; empty means the constructed environment gets no root.
-//   - `mode`: the [fsroot.Mode] selecting the implementation to mint.
 //
 // Returns:
 //   - `*RuntimeEnvironmentSpec`: the config for method chaining.
-func (c *RuntimeEnvironmentSpec) WithRoot(path string, mode fsroot.Mode) *RuntimeEnvironmentSpec {
+func (c *RuntimeEnvironmentSpec) WithRoot(path string) *RuntimeEnvironmentSpec {
 
 	c.RootPath = path
-	c.RootMode = mode
 	return c
 }
 
@@ -1031,13 +1020,12 @@ func (c *RuntimeEnvironmentSpec) WithStatus(narrator *status.Narrator) *RuntimeE
 //
 // Parameters:
 //   - `path`: the anchor directory.
-//   - `mode`: the [fsroot.Mode] the session will mint with.
 //
 // Returns:
-//   - `error`: a wrapped error when the anchor cannot be opened in the requested mode.
-func probeRootAnchor(path string, mode fsroot.Mode) error {
+//   - `error`: a wrapped error when the anchor cannot be opened.
+func probeRootAnchor(path string) error {
 
-	probe, err := fsroot.Open(path, mode)
+	probe, err := fsroot.OpenConfined(path)
 	if err != nil {
 		return fmt.Errorf("open root %s: %w", path, err)
 	}

--- a/pkg/op/runtime_environment_test.go
+++ b/pkg/op/runtime_environment_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
-	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // TestVariableByName_ResolvesSourceSetAfterRegistration verifies the cache-on-found (sync.OnceValues) semantics.
@@ -94,7 +93,7 @@ func TestNewRuntimeEnvironment_MintsRootFromAnchor(t *testing.T) {
 
 	dir := t.TempDir()
 	app := &application.Application{Name: "test"}
-	spec := NewRuntimeEnvironmentSpec(app.Name).WithApplication(app).WithRoot(dir, fsroot.ModeConfined)
+	spec := NewRuntimeEnvironmentSpec(app.Name).WithApplication(app).WithRoot(dir)
 
 	runtimeEnvironment, err := NewRuntimeEnvironment(context.Background(), spec)
 	if err != nil {
@@ -122,7 +121,7 @@ func TestNewRuntimeEnvironment_BadAnchorFails(t *testing.T) {
 
 	app := &application.Application{Name: "test"}
 	missing := filepath.Join(t.TempDir(), "absent")
-	spec := NewRuntimeEnvironmentSpec(app.Name).WithApplication(app).WithRoot(missing, fsroot.ModeConfined)
+	spec := NewRuntimeEnvironmentSpec(app.Name).WithApplication(app).WithRoot(missing)
 
 	if _, err := NewRuntimeEnvironment(context.Background(), spec); err == nil {
 		t.Fatal("NewRuntimeEnvironment = nil error, want a mint failure for the missing anchor")

--- a/pkg/op/triad_test.go
+++ b/pkg/op/triad_test.go
@@ -27,17 +27,17 @@ type triadEnv struct {
 	Dir  string // underlying directory
 }
 
-// newTriad wires a triad for `dir` in the given access mode.
+// newTriad wires a triad for `dir`.
 //
-// The mode is passed rather than a constructed [fsroot.Dir]: the session mints its own root from the spec's
-// anchor, so callers name the tree and the access they want instead of handing over filesystem access.
-func newTriad(t *testing.T, mode fsroot.Mode, dir string) triadEnv {
+// The anchor is passed rather than a constructed [fsroot.Dir]: the session mints its own root from the spec's
+// anchor, so callers name the tree instead of handing over filesystem access.
+func newTriad(t *testing.T, dir string) triadEnv {
 
 	t.Helper()
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(),
 		op.NewRuntimeEnvironmentSpec("test").
-			WithRoot(dir, mode).
+			WithRoot(dir).
 			WithApplication(&application.Application{Name: "test"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
@@ -47,18 +47,11 @@ func newTriad(t *testing.T, mode fsroot.Mode, dir string) triadEnv {
 	return triadEnv{Root: runtimeEnvironment.Root(), Site: op.NewRecoverySite(runtimeEnvironment), Dir: dir}
 }
 
-func newTriadRW(t *testing.T) triadEnv {
-
-	t.Helper()
-
-	return newTriad(t, fsroot.ModeConfined, t.TempDir())
-}
-
 func newTriadConfined(t *testing.T) triadEnv {
 
 	t.Helper()
 
-	return newTriad(t, fsroot.ModeConfined, t.TempDir())
+	return newTriad(t, t.TempDir())
 }
 
 func TestTriad_RootProducesPath(t *testing.T) {
@@ -67,7 +60,6 @@ func TestTriad_RootProducesPath(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -98,7 +90,6 @@ func TestTriad_RootProducesPathFromAbsolute(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -124,7 +115,6 @@ func TestTriad_ArchiveFileRestoreFile(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,7 +177,6 @@ func TestTriad_ArchiveDataRestoreData(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -222,7 +211,6 @@ func TestTriad_NestedPathRecreation(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -277,7 +265,6 @@ func TestTriad_WriteReadThroughRoot(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -317,7 +304,6 @@ func TestTriad_MkdirAllThroughRoot(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -347,7 +333,6 @@ func TestTriad_RenameThroughRoot(t *testing.T) {
 		name     string
 		newTriad func(t *testing.T) triadEnv
 	}{
-		{"RootReaderWriter", newTriadRW},
 		{"confinedDir", newTriadConfined},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -383,7 +368,7 @@ func TestTriad_RenameThroughRoot(t *testing.T) {
 
 func TestTriad_MultipleArchivesCoexist(t *testing.T) {
 
-	env := newTriadRW(t)
+	env := newTriadConfined(t)
 
 	for i, name := range []string{"a.txt", "b.txt", "c.txt"} {
 


### PR DESCRIPTION
#568 step 5 — the last one. With one confinement there is nothing to select, so the mode parameter selected
nothing.

## The signature

`WithRoot(path, mode)` → `WithRoot(path)`. The spec's `RootMode` field and the environment's `rootMode` go;
`probeRootAnchor` and the lazy mint call `fsroot.OpenConfined` directly. `RootMode` was never serialized —
no document or schema carries it — so this is pure Go surface.

## The vestige

`fsroot.Mode`, `ModeConfined`, and the one-branch `Open` that step 3 kept alive for this exact signature are
deleted. Zero references remain (repo-wide grep).

## 42 call sites, 34 orphaned imports

writ (9), lore, star, devlore-test (2), the plan provider, and the test files all drop the constant; 34 files
lose an `fsroot` import that existed only to spell it. Three of those imports were shadowed by *comments*
mentioning `fsroot.` and surfaced only under vet — the sweep now checks compilable references, not text.

## A step-3 leftover collapsed

`newTriadRW` and `newTriadConfined` had become identical, and eight triad tables still ran every test twice —
once under `"RootReaderWriter"`, a type deleted two steps ago. Duplicate helper and rows gone; `newTriad`
takes only the directory.

## Tests

`TestOpen_ModeConfined` survives as `TestOpenConfined_CloseReleasesTheHandle` — the behavior it actually
pinned. The missing-directory and zero-value-`Mode` tests died with the dispatch they tested.

## Status document

The last open item resolves by inspection: `TestIsPrivateMode`/`TestNewPath` are ordinary `_test.go`
functions; nothing test-shaped is exported from a non-test file (`NewPath` is public for document
deserialization; the `Perm*` masks are chartered with #559). **Open section now reads: nothing — the design
is implemented in full.**

## Verified

- `make check` — 103 packages ok, 0 failures
- `make vet` GOOS=windows, GOOS=linux
- `gofmt -l` over pkg/ and cmd/ — clean

Closes #568.
