### PR TITLE
fix(archive): symlink targets go to the kernel; digests and compares go slash-canonical

### DIFF
--- a/pkg/op/provider/archive/provider.go
+++ b/pkg/op/provider/archive/provider.go
@@ -398,11 +398,11 @@ func extractEntry(
 		}
 		return product, receipt, nil
 	case entrySymlink:
-		// §10 ruling 1a: contained targets only; the link lands verbatim so the on-disk content — and the
-		// SymbolicLink digest, which hashes the literal target — stays faithful to the archive.
-		if guardErr := containedLinkTarget(entry.Name, entry.Linkname); guardErr != nil {
-			return nil, nil, guardErr
-		}
+		// The link lands verbatim so the on-disk content — and the SymbolicLink digest, which hashes the
+		// literal target — stays faithful to the archive (§10 ruling 1a). The target itself is not judged:
+		// the kernel restricts following, not making, and a follow through a confined root refuses an
+		// escaping target at use. The hand-rolled guard that once judged it here was a second implementation
+		// of that rule, broken on Windows, and 4.5-fsroot-variants.md §4 retired it (#556).
 		product, receipt, err := fileProvider.Link(activationRecord, entry.Linkname, target, true)
 		if err != nil {
 			return nil, nil, fmt.Errorf("archive: link %q: %w", target, err)
@@ -959,35 +959,6 @@ func containedTarget(prefix, name string) (string, error) {
 	}
 
 	return lexical, nil
-}
-
-// containedLinkTarget judges a symlink entry's target under §10 ruling 1a: relative and non-escaping only.
-//
-// The target is entry-directory-relative by tar convention, so containment is judged from the entry's own
-// directory. An absolute target, or one that climbs above the extraction prefix after cleaning, is a hard error
-// naming the entry — deploy-domain archives whose links point outside their own tree are suspect input. The link's
-// own location was already judged by [containedTarget]; the target is judged lexically (it may legally dangle, so
-// there is nothing on disk to resolve).
-//
-// Parameters:
-//   - `entryName`: the symlink entry's archived path.
-//   - `linkname`: the literal archived target.
-//
-// Returns:
-//   - `error`: non-nil when the target is absolute or escapes the extraction prefix.
-func containedLinkTarget(entryName, linkname string) error {
-
-	if filepath.IsAbs(linkname) {
-		return fmt.Errorf("archive: entry %q: symlink target %q is absolute", entryName, linkname)
-	}
-
-	resolved := filepath.Clean(filepath.Join(filepath.Dir(filepath.Clean(entryName)), linkname))
-
-	if resolved == ".." || strings.HasPrefix(resolved, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("archive: entry %q: symlink target %q escapes the extraction prefix", entryName, linkname)
-	}
-
-	return nil
 }
 
 // tarTypeflagName names a tar typeflag for the unsupported-entry diagnostics (§10 ruling 1c).

--- a/pkg/op/provider/archive/provider_test.go
+++ b/pkg/op/provider/archive/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/ulikunitz/xz"
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen" // registers file.Provider so Instance + the compensator index resolve
@@ -551,9 +553,11 @@ func TestExtract_TarSymlink(t *testing.T) {
 	}
 }
 
-// TestExtract_SymlinkTargetEscapes pins ruling 1a's containment: an escaping or absolute link target is a hard
-// error naming the entry.
-func TestExtract_SymlinkTargetEscapes(t *testing.T) {
+// TestExtract_EscapingSymlinkTargetLandsVerbatim pins the kernel posture (4.5 §4, #556): the kernel restricts
+// following, not making, so an escaping or absolute target extracts exactly as authored — and the containment
+// lives at the follow, where a confined root refuses the escape. The hand-rolled guard this test used to pin
+// was a second implementation of that rule, broken on Windows, and is deleted.
+func TestExtract_EscapingSymlinkTargetLandsVerbatim(t *testing.T) {
 	tmp := t.TempDir()
 
 	for name, header := range map[string]tar.Header{
@@ -570,9 +574,35 @@ func TestExtract_SymlinkTargetEscapes(t *testing.T) {
 		archivePath := filepath.Join(caseDir, name+".tar.gz")
 		createTarGzHeaders(t, archivePath, []tar.Header{header}, nil)
 
-		err := extractIntoExpectingError(t, caseDir, archivePath)
-		if err == nil || !strings.Contains(err.Error(), "symlink target") {
-			t.Errorf("%s target = %v; want the symlink-target refusal", name, err)
+		_, prefix, products, _ := extractInto(t, caseDir, archivePath)
+		if len(products) != 1 {
+			t.Fatalf("%s: products = %d, want 1", name, len(products))
+		}
+
+		linkPath := filepath.Join(prefix, "link")
+		info, err := os.Lstat(linkPath)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s: Lstat(link) mode = %v (err %v); want a symlink", name, info, err)
+		}
+
+		// Compared in canonical slash form: Windows reads a link back with native separators, and the
+		// on-disk content is the authored path modulo that rendering.
+		target, err := os.Readlink(linkPath)
+		if err != nil || filepath.ToSlash(target) != header.Linkname {
+			t.Errorf("%s: link target = %q (err %v), want the verbatim %q", name, target, err, header.Linkname)
+		}
+
+		// The containment: a follow through a confined root refuses the escape. Stat follows the terminal
+		// link, and the refusal must not read as a missing file.
+		root, err := fsroot.OpenConfined(prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, statErr := root.Stat(root.NewPath("link")); statErr == nil || errors.Is(statErr, os.ErrNotExist) {
+			t.Errorf("%s: confined Stat through the link = %v; want the kernel's escape refusal", name, statErr)
+		}
+		if err := root.Close(); err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -275,7 +275,9 @@ func (p *Provider) Link(
 // existingLinkMatches reports whether the symlink at `linkPath` already stores the canonical name.
 //
 // The default path stores a relativized target (see [Provider.symlink]); the absolutized read is what
-// matches the canonical stored name. Verbatim links compare the raw stored target.
+// matches the canonical stored name. Verbatim links compare the stored target in canonical slash form —
+// Windows reads a link back with native separators, so a raw compare against the authored target never
+// matches there and every re-run would replace an already-correct link (#556).
 //
 // Parameters:
 //   - `linkPath`: the symlink's absolute path.
@@ -286,11 +288,12 @@ func (p *Provider) Link(
 //   - `bool`: true when the existing link already matches.
 func (p *Provider) existingLinkMatches(linkPath, storedName string, verbatim bool) bool {
 
-	existing, readErr := p.rawReadLink(linkPath)
-	if !verbatim {
-		existing, readErr = p.readLink(linkPath)
+	if verbatim {
+		existing, readErr := p.rawReadLink(linkPath)
+		return readErr == nil && filepath.ToSlash(existing) == filepath.ToSlash(storedName)
 	}
 
+	existing, readErr := p.readLink(linkPath)
 	return readErr == nil && existing == storedName
 }
 

--- a/pkg/op/provider/file/symbolic_link.go
+++ b/pkg/op/provider/file/symbolic_link.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"reflect"
 
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
@@ -87,12 +88,15 @@ func DiscoverSymbolicLink(runtimeEnvironment *op.RuntimeEnvironment, value any) 
 
 // region State management
 
-// Digest returns the honest content hash of the link itself: sha256 of the literal readlink target, never following.
+// Digest returns the honest content hash of the link itself: sha256 of its target in canonical slash form,
+// never following.
 //
 // A symbolic link IS a tiny file whose content is a path — hashing that content is the honest digest (step 23,
-// ruling 5a). The target is taken verbatim from readlink (no cleaning, no absolutization): the link's content is
-// what it is. A dangling link digests normally, and no cycle is possible because nothing is followed. The entry
-// itself must be a symbolic link — any other observed kind errors with a kind mismatch (ruling 5e).
+// ruling 5a). The target is taken from readlink with no cleaning and no absolutization — only separator
+// canonicalization to slash form, because Windows reads a created link back with native separators and equal
+// logical targets must digest equally on every platform (the same rule [fsroot.Path]'s Rel follows for document
+// bytes; #556). A dangling link digests normally, and no cycle is possible because nothing is followed. The
+// entry itself must be a symbolic link — any other observed kind errors with a kind mismatch (ruling 5e).
 //
 // Returns:
 //   - `op.Digest`: sha256 algorithm with 32 raw bytes — the hash of the literal target path.
@@ -115,7 +119,7 @@ func (r *SymbolicLink) Digest() (op.Digest, error) {
 		return op.Digest{}, fmt.Errorf("file.SymbolicLink: digest readlink %s: %w", r.SourcePath.Abs(), err)
 	}
 
-	sum := sha256.Sum256([]byte(target))
+	sum := sha256.Sum256([]byte(filepath.ToSlash(target)))
 	return op.Digest{Algorithm: "sha256", Bytes: sum[:]}, nil
 }
 
@@ -218,6 +222,32 @@ func (*SymbolicLink) ConvertFrom(value any) (any, error) {
 	}
 
 	return &SymbolicLink{Resource: Resource{SourcePath: fsroot.NewPath("", str)}}, nil
+}
+
+// Resolve rebinds the source path to the execution fsroot and verifies the link itself exists.
+//
+// Shadows [Resource.Resolve], whose existence check goes through [fsroot.Dir]'s Stat and therefore FOLLOWS the
+// link — an escaping or absolute target would turn the check into the kernel's containment refusal even though
+// the link itself landed exactly as asked (#556). The link is the resource, not its referent (ruling 5b), so the
+// check here is lstat: a dangling or escaping target is a legal on-disk state, and any follow is judged by the
+// kernel at use.
+//
+// Returns:
+//   - `error`: any lstat error other than not-exist.
+func (r *SymbolicLink) Resolve() error {
+
+	root := r.RuntimeEnvironment().Root()
+
+	r.SourcePath = root.NewPath(r.SourcePath.Abs())
+
+	if _, err := root.Lstat(r.SourcePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("file.SymbolicLink: resolve lstat %s: %w", r.SourcePath.Abs(), err)
+	}
+
+	return nil
 }
 
 // UnmarshalJSON populates the receiver from a JSON-encoded string (a file path or file URI).


### PR DESCRIPTION
4.5 §4 ruled it: **the kernel restricts following, not making** — and `containedLinkTarget` was a second
implementation of that rule, the hand-rolled copy that is broken on Windows (a POSIX-absolute target is
rooted but not `filepath.IsAbs`, so both guards wave it through). **Deleted, not fixed.**

## The contract now

An escaping or absolute symlink target extracts **exactly as authored**, and containment lives where the
kernel enforces it: a follow through a confined root is refused at use. `tar` accepts the same residual, for
the same reason. `file.Provider.Link`'s `verbatim` flag survives — writing the archive's target as authored
is simply correct once containment is the kernel's business.

## What the deletion exposed (and this PR fixes)

1. **`Resource.Resolve` follows the link.** Its existence check goes through `Stat`, so the post-create check
   turned the kernel's refusal into a `Link` failure — the exact Windows trace
   (`statat out/link: path escapes from parent`). `SymbolicLink` already observes with lstat in `Digest` and
   `Etag` ("the link is the resource, not its referent"); it now has its own `Resolve` saying the same.
2. **Windows reads a link back with native separators** — proven by the digest failure (`fe57…` ≠ sha256 of
   the authored slash target). `SymbolicLink.Digest` now hashes the target in **canonical slash form**, the
   same rule `Path.Rel` follows for document bytes: equal logical targets digest equally on every platform.
   On Unix `ToSlash` is the identity — no digest changes there.
3. **`existingLinkMatches`' verbatim compare** was broken by the same fact: the authored slash target never
   equals the native read-back, so every Windows re-run replaced an already-correct link. Slash-canonical
   compare now.

## Tests

`TestExtract_SymlinkTargetEscapes` pinned the deleted guard; it becomes
`TestExtract_EscapingSymlinkTargetLandsVerbatim`, pinning the new contract end to end: extraction succeeds
for `../../etc/passwd` and `/etc/passwd`, the link lands verbatim (modulo separator rendering), and a
confined `Stat` through it is refused with something that is **not** not-exist.
`TestSymbolicLinkDigest_LiteralTarget` needed no change — its expectation was the slash form all along.

## Expected Windows movement — the review check

The name-for-name diff against develop's baseline 8 should show **exactly two names removed, none added**:

- `TestExtract_SymlinkTargetEscapes`
- `TestSymbolicLinkDigest_LiteralTarget`

Baseline **8 → 6** — the first count movement since 28 → 8.

## Verified

- `make check` — 103 packages ok, 0 failures (the rewritten test passes on Unix: escaping links extract,
  confined follow refused)
- `make vet` GOOS=windows, GOOS=linux
- `gofmt -l` — clean; repo-wide grep: zero `containedLinkTarget` references

Closes #556. Refs #430, #568.
