### PR TITLE
refactor(document): split the codec from file creation; Write goes to a stream, WriteFile to a path

### DIFF
--- a/cmd/devlore-index/main.go
+++ b/cmd/devlore-index/main.go
@@ -311,5 +311,5 @@ func writeIndex(domainPath string, index *KnowledgeIndex) error {
 	header := "# Auto-generated file list by: go run ./cmd/gen-index\n" +
 		"# Metadata (purpose, source_system, description) is preserved and should be edited manually.\n"
 
-	return document.Write(filepath.Join(domainPath, "index.yaml"), index, document.WithHeader(header))
+	return document.WriteFile(filepath.Join(domainPath, "index.yaml"), index, document.WithHeader(header))
 }

--- a/cmd/internal/cli/config.go
+++ b/cmd/internal/cli/config.go
@@ -300,7 +300,7 @@ func loadConfig(path string) (map[string]interface{}, error) {
 //   - error: marshal or write error
 func saveConfig(path string, config map[string]interface{}) error {
 
-	return document.Write(path, config)
+	return document.WriteFile(path, config)
 }
 
 // configEdit opens the config file in the user's editor, seeding it with defaults when absent.

--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -103,7 +103,7 @@ func Save(cfg *Config) error {
 	fileCfg := *cfg
 	fileCfg.Model.APIKey = ""
 
-	return document.Write(Path(), &fileCfg)
+	return document.WriteFile(Path(), &fileCfg)
 }
 
 // applyEnvOverrides applies environment variable overrides to the config.

--- a/cmd/internal/e2e/harness.go
+++ b/cmd/internal/e2e/harness.go
@@ -200,12 +200,12 @@ type TestReport struct {
 func (r *TestReport) WriteReport(outDir string) error {
 
 	// Write JSON report
-	if err := document.Write(filepath.Join(outDir, "results.json"), r); err != nil {
+	if err := document.WriteFile(filepath.Join(outDir, "results.json"), r); err != nil {
 		return err
 	}
 
 	// Write YAML report
-	if err := document.Write(filepath.Join(outDir, "results.yaml"), r); err != nil {
+	if err := document.WriteFile(filepath.Join(outDir, "results.yaml"), r); err != nil {
 		return err
 	}
 

--- a/cmd/internal/lorepackage/synthetic.go
+++ b/cmd/internal/lorepackage/synthetic.go
@@ -89,7 +89,7 @@ func (c *SyntheticCache) Put(info *SyntheticPackageInfo) error {
 		info.VerifiedAt = time.Now()
 	}
 
-	return document.Write(c.cachePathForPackage(info.Source, info.Name), info)
+	return document.WriteFile(c.cachePathForPackage(info.Source, info.Name), info)
 }
 
 // Delete removes a synthetic package from the cache.

--- a/cmd/writ/writ/migrate/execute.go
+++ b/cmd/writ/writ/migrate/execute.go
@@ -126,7 +126,7 @@ func WriteMigratedMarker(sourceRoot string, graph *op.Graph, analysis *Migration
 		Renames:   renames,
 	}
 	markerPath := filepath.Join(sourceRoot, ".writ-migrated")
-	return document.Write(markerPath, &marker)
+	return document.WriteFile(markerPath, &marker)
 }
 
 // joinWords concatenates words with spaces.

--- a/cmd/writ/writ/migrate/receipt_integration_test.go
+++ b/cmd/writ/writ/migrate/receipt_integration_test.go
@@ -72,8 +72,8 @@ func TestExecutionTrace_SerializesAsMigrationReceipt(t *testing.T) {
 	}
 
 	receiptPath := filepath.Join(tmp, ".writ-migrate-receipt.json")
-	if err := document.Write(receiptPath, trace); err != nil {
-		t.Fatalf("document.Write(receipt): %v", err)
+	if err := document.WriteFile(receiptPath, trace); err != nil {
+		t.Fatalf("document.WriteFile(receipt): %v", err)
 	}
 
 	info, err := os.Stat(receiptPath)

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -963,12 +963,23 @@ read an unmoved 28 after phase 3 as a failed migration.**
       and zero cleared. The three `scenario` legs — the self-install scenario's first run under
       branch protection — passed on all platforms.
 
-- [ ] **3.3b — `document.Write` takes a root.** Deferred deliberately, per the 2026-08-17 ruling:
-      it lands with the configuration work and the JSON/YAML/protobuf codec, because its remaining
-      **18-19** callers are ordinary config-shaped documents and its extension-sniffing is precisely
-      what the single-codec design replaces. Threading a root through it now would be work done
-      twice. Until then `pkg/document` keeps its two `os.*` sites, and the three permission
-      tests behind it stay where they are — they move in phase 5 regardless.
+- [ ] **3.3b — `document.WriteFile` takes a root.** The 2026-08-17 deferral is superseded by the
+      2026-08-20 rulings on [#558](https://github.com/NobleFactor/devlore-cli/issues/558): both steps
+      land now, as two PRs. The work-done-twice concern is answered rather than waited out — the
+      stream form `Write(w io.Writer, format Format, v any, …)` takes its format **explicitly** (the
+      `SaveGraph` rule: format is stated, not inferred), which IS the single-codec seam a protobuf
+      rendering plugs into; extension-sniffing survives only in the path form as a file-boundary
+      convenience.
+      - [x] **PR-A — the codec split.** `Write` → `WriteFile` (the `Read`/`ReadFile` symmetry the
+        write side was missing), `Write(w, format, v, …)` added, `WithPerm` documented as
+        [WriteFile]-only. Ten production call sites renamed mechanically; no behavior change; the
+        windows leg holds.
+      - [ ] **PR-B — the root.** `WriteFile(dir fsroot.Dir, p fsroot.Path, v, …)`; the ten call
+        sites take roots threaded from the CLI layer that owns the purpose-named tree (ruled: no
+        library opens a root for itself). The two 0o600 mode assertions gate to unix, and a
+        `document_windows_test.go` DACL read-back proves protection, in phase 2's shape. The
+        windows leg moves **6 → 4**: `TestWrite_JSONCreatesFileWith0o600`,
+        `TestWrite_YAMLCreatesFileWith0o600`.
 - [ ] **3.4 — the writ deploy/sops output path** ([#433](https://github.com/NobleFactor/devlore-cli/issues/433)) — behind `TestExecute_SopsChains`, and the one
       that writes **decrypted plaintext**, which makes it the second-most security-relevant site in
       the campaign after the private key.

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -68,7 +68,7 @@ func fileSet(key, secret string) error {
 	header := "# DevLore credentials - stored with 0600 permissions\n" +
 		"# Prefer environment variables or credential helpers for better security\n"
 
-	return document.Write(path, creds, document.WithHeader(header))
+	return document.WriteFile(path, creds, document.WithHeader(header))
 }
 
 // fileDelete removes a credential from the credentials file. No-op if the file does not exist.
@@ -96,5 +96,5 @@ func fileDelete(key string) error {
 		return os.Remove(path)
 	}
 
-	return document.Write(path, creds)
+	return document.WriteFile(path, creds)
 }

--- a/internal/registry/git.go
+++ b/internal/registry/git.go
@@ -522,7 +522,7 @@ func (g *gitTransport) writeSyncInfo(cacheDir, ref string, syncedAt time.Time) e
 		Endpoint: g.repoURL,
 	}
 
-	return document.Write(filepath.Join(cacheDir, ".sync-info.yaml"), &info, document.WithPerm(0o644))
+	return document.WriteFile(filepath.Join(cacheDir, ".sync-info.yaml"), &info, document.WithPerm(0o644))
 }
 
 // endregion

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -19,7 +19,23 @@ import (
 
 // region EXPORTED TYPES
 
-// Option configures Write behavior.
+// Format names a rendering the codec produces.
+//
+// The stream form ([Write]) takes it explicitly — with no file name there is nothing to infer from, and the
+// output syntax is not an option but a decision (the same rule op.SaveGraph follows: format is stated). The
+// path form ([WriteFile]) infers it from the file extension as a convenience at the file boundary only.
+type Format string
+
+const (
+
+	// JSON renders the document as indented JSON.
+	JSON Format = "json"
+
+	// YAML renders the document as YAML.
+	YAML Format = "yaml"
+)
+
+// Option configures write behavior.
 type Option func(*writeOpts)
 
 // endregion
@@ -84,39 +100,62 @@ func ReadFile[T any](path string) (*T, error) {
 	return &v, nil
 }
 
-// Write serializes v to disk as a structured document. Format is inferred from the file extension. Creates parent
-// directories (0o750) if needed. Default file permission is 0o600; override with WithPerm.
+// Write serializes v to a stream in the given [Format] — the codec alone, owning no file creation.
+//
+// The seam the write side was missing (#558): [Read] separates codec from I/O and Write now mirrors it, so
+// creation concerns (permissions, directories) stay with whoever owns the destination. [WithPerm] is
+// meaningless here and is ignored; it belongs to [WriteFile].
 //
 // Parameters:
-//   - path: filesystem path for the output document
-//   - v: value to serialize
-//   - opts: optional configuration (WithPerm, WithIndent, WithHeader)
+//   - `w`: the stream to write the rendered document to.
+//   - `format`: the [Format] to render; [JSON] or [YAML].
+//   - `v`: the value to serialize.
+//   - `opts`: optional configuration ([WithIndent], [WithHeader]).
 //
 // Returns:
-//   - error: wraps marshal, directory creation, and write errors with the file path for context
-func Write(path string, v any, opts ...Option) error {
+//   - `error`: an unknown format, a marshal error, or a stream write error.
+func Write(w io.Writer, format Format, v any, opts ...Option) error {
 
-	cfg := writeOpts{
-		perm:         0o600,
-		jsonPrefix:   "",
-		jsonIndent:   "  ",
-		indentCustom: false,
-	}
+	cfg := defaultWriteOpts()
 	for _, o := range opts {
 		o(&cfg)
 	}
 
-	data, err := marshal(path, v, &cfg)
+	data, err := encode(format, v, &cfg)
 	if err != nil {
-		return fmt.Errorf("marshal %s: %w", path, err)
+		return fmt.Errorf("marshal: %w", err)
 	}
 
-	if cfg.header != "" {
-		h := cfg.header
-		if !strings.HasSuffix(h, "\n") {
-			h += "\n"
-		}
-		data = append([]byte(h), data...)
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	return nil
+}
+
+// WriteFile serializes v to disk as a structured document. Format is inferred from the file extension. Creates
+// parent directories (0o750) if needed. Default file permission is 0o600; override with WithPerm.
+//
+// The rename of the former path-only Write, freeing that name for the stream form — the same
+// [Read] / [ReadFile] symmetry the read side always had (#558).
+//
+// Parameters:
+//   - `path`: filesystem path for the output document.
+//   - `v`: the value to serialize.
+//   - `opts`: optional configuration ([WithPerm], [WithIndent], [WithHeader]).
+//
+// Returns:
+//   - `error`: wraps marshal, directory creation, and write errors with the file path for context.
+func WriteFile(path string, v any, opts ...Option) error {
+
+	cfg := defaultWriteOpts()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	data, err := encode(formatFromExt(path), v, &cfg)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
 	}
 
 	dir := filepath.Dir(path)
@@ -131,13 +170,14 @@ func Write(path string, v any, opts ...Option) error {
 	return nil
 }
 
-// WithPerm overrides the default 0o600 file permission.
+// WithPerm overrides the default 0o600 file permission. A creation concern: it applies to [WriteFile] only
+// and is ignored by the stream form, which owns no file.
 //
 // Parameters:
-//   - mode: the file permission mode to use
+//   - `mode`: the file permission mode to use.
 //
 // Returns:
-//   - Option: a write option that sets the file permission
+//   - `Option`: a write option that sets the file permission.
 func WithPerm(mode os.FileMode) Option {
 
 	return func(o *writeOpts) {
@@ -197,42 +237,90 @@ type writeOpts struct {
 
 // region Behaviors
 
-// formatFromExt returns "json" or "yaml" based on the file extension.
-//
-// Parameters:
-//   - path: filesystem path whose extension determines the format
+// defaultWriteOpts returns the write configuration before options apply.
 //
 // Returns:
-//   - string: "json" for .json files, "yaml" for everything else
-func formatFromExt(path string) string {
+//   - `writeOpts`: the defaults — 0o600 permission, two-space JSON indent, no prefix, no header.
+func defaultWriteOpts() writeOpts {
 
-	if strings.ToLower(filepath.Ext(path)) == ".json" {
-		return "json"
+	return writeOpts{
+		perm:         0o600,
+		jsonPrefix:   "",
+		jsonIndent:   "  ",
+		indentCustom: false,
 	}
-	return "yaml"
 }
 
-// marshal serializes v according to the format inferred from the file extension.
+// encode renders v in the given format, with the configured header prepended.
 //
 // Parameters:
-//   - path: filesystem path whose extension determines the format
-//   - v: value to serialize
-//   - cfg: write options controlling indentation
+//   - `format`: the [Format] to render.
+//   - `v`: the value to serialize.
+//   - `cfg`: write options controlling indentation and the header.
 //
 // Returns:
-//   - []byte: serialized content
-//   - error: marshal error from the underlying codec
-func marshal(path string, v any, cfg *writeOpts) ([]byte, error) {
+//   - `[]byte`: the rendered document.
+//   - `error`: an unknown format, or a marshal error from the underlying codec.
+func encode(format Format, v any, cfg *writeOpts) ([]byte, error) {
 
-	if formatFromExt(path) == "json" {
+	data, err := marshal(format, v, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.header != "" {
+		h := cfg.header
+		if !strings.HasSuffix(h, "\n") {
+			h += "\n"
+		}
+		data = append([]byte(h), data...)
+	}
+
+	return data, nil
+}
+
+// formatFromExt returns the [Format] a file extension names.
+//
+// Parameters:
+//   - `path`: filesystem path whose extension determines the format.
+//
+// Returns:
+//   - `Format`: [JSON] for .json files, [YAML] for everything else.
+func formatFromExt(path string) Format {
+
+	if strings.ToLower(filepath.Ext(path)) == ".json" {
+		return JSON
+	}
+	return YAML
+}
+
+// marshal serializes v in the given format.
+//
+// Parameters:
+//   - `format`: the [Format] to render.
+//   - `v`: the value to serialize.
+//   - `cfg`: write options controlling indentation.
+//
+// Returns:
+//   - `[]byte`: serialized content.
+//   - `error`: an unknown format, or a marshal error from the underlying codec.
+func marshal(format Format, v any, cfg *writeOpts) ([]byte, error) {
+
+	switch format {
+
+	case JSON:
 		data, err := json.MarshalIndent(v, cfg.jsonPrefix, cfg.jsonIndent)
 		if err != nil {
 			return nil, err
 		}
 		return append(data, '\n'), nil
-	}
 
-	return yaml.Marshal(v)
+	case YAML:
+		return yaml.Marshal(v)
+
+	default:
+		return nil, fmt.Errorf("document: unknown format %q", format)
+	}
 }
 
 // unmarshal deserializes data into v according to the format inferred from the file extension.

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -4,6 +4,8 @@
 package document
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,7 +140,7 @@ func TestWrite_YAMLCreatesFileWith0o600(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "out.yaml")
 	doc := testDoc{Name: "dave", Count: 99}
 
-	if err := Write(path, &doc); err != nil {
+	if err := WriteFile(path, &doc); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -164,7 +166,7 @@ func TestWrite_JSONCreatesFileWith0o600(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "out.json")
 	doc := testDoc{Name: "eve", Count: 5}
 
-	if err := Write(path, &doc); err != nil {
+	if err := WriteFile(path, &doc); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -185,12 +187,62 @@ func TestWrite_JSONCreatesFileWith0o600(t *testing.T) {
 	}
 }
 
+// TestWrite_StreamRendersTheStatedFormat pins the codec seam (#558): the stream form takes its format
+// explicitly — nothing is inferred from a file name, and creation concerns never enter.
+func TestWrite_StreamRendersTheStatedFormat(t *testing.T) {
+
+	doc := testDoc{Name: "stream", Count: 7}
+
+	var jsonBuf bytes.Buffer
+	if err := Write(&jsonBuf, JSON, &doc); err != nil {
+		t.Fatalf("Write(JSON): %v", err)
+	}
+	if !strings.HasPrefix(jsonBuf.String(), "{") {
+		t.Errorf("JSON rendering = %q, want a JSON object", jsonBuf.String())
+	}
+
+	var yamlBuf bytes.Buffer
+	if err := Write(&yamlBuf, YAML, &doc); err != nil {
+		t.Fatalf("Write(YAML): %v", err)
+	}
+
+	parsed, err := Read[testDoc](&yamlBuf)
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+	if parsed.Name != "stream" || parsed.Count != 7 {
+		t.Errorf("round-trip = %+v, want the original", parsed)
+	}
+}
+
+// TestWrite_StreamHonorsTheHeader pins that encoding options ride the stream form: the header lands ahead of
+// the rendered document, newline-terminated.
+func TestWrite_StreamHonorsTheHeader(t *testing.T) {
+
+	var buf bytes.Buffer
+	if err := Write(&buf, YAML, &testDoc{Name: "h", Count: 1}, WithHeader("# generated")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !strings.HasPrefix(buf.String(), "# generated\n") {
+		t.Errorf("stream = %q, want the header first, newline-terminated", buf.String())
+	}
+}
+
+// TestWrite_UnknownFormatIsRefused pins the explicit-format contract: an unstated or misspelled rendering is
+// an error, never a silent default.
+func TestWrite_UnknownFormatIsRefused(t *testing.T) {
+
+	if err := Write(io.Discard, Format("toml"), &testDoc{}); err == nil {
+		t.Fatal("Write(unknown format) = nil error, want a refusal")
+	}
+}
+
 func TestWrite_CreatesParentDirectories(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "a", "b", "c", "deep.yaml")
 	doc := testDoc{Name: "nested", Count: 1}
 
-	if err := Write(path, &doc); err != nil {
+	if err := WriteFile(path, &doc); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -205,7 +257,7 @@ func TestWrite_WithHeaderPrependsText(t *testing.T) {
 	doc := testDoc{Name: "grace", Count: 10}
 	header := "# Auto-generated — do not edit\n"
 
-	if err := Write(path, &doc, WithHeader(header)); err != nil {
+	if err := WriteFile(path, &doc, WithHeader(header)); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -227,7 +279,7 @@ func TestWrite_WithHeaderAppendsNewlineIfMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "header2.yaml")
 	doc := testDoc{Name: "heidi", Count: 2}
 
-	if err := Write(path, &doc, WithHeader("# no trailing newline")); err != nil {
+	if err := WriteFile(path, &doc, WithHeader("# no trailing newline")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -243,7 +295,7 @@ func TestWrite_WithHeaderAppendsNewlineIfMissing(t *testing.T) {
 func TestWrite_JSONTrailingNewline(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "out.json")
-	if err := Write(path, &testDoc{Name: "ivan", Count: 1}); err != nil {
+	if err := WriteFile(path, &testDoc{Name: "ivan", Count: 1}); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -301,7 +353,7 @@ func TestRoundTrip_YAMLReadWritePreservesData(t *testing.T) {
 	original := testDoc{Name: "round", Count: 77}
 
 	path := filepath.Join(dir, "trip.yaml")
-	if err := Write(path, &original); err != nil {
+	if err := WriteFile(path, &original); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -321,7 +373,7 @@ func TestRoundTrip_JSONReadWritePreservesData(t *testing.T) {
 	original := testDoc{Name: "trip", Count: 88}
 
 	path := filepath.Join(dir, "trip.json")
-	if err := Write(path, &original); err != nil {
+	if err := WriteFile(path, &original); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 

--- a/pkg/document/document_unix_test.go
+++ b/pkg/document/document_unix_test.go
@@ -23,7 +23,7 @@ func TestWrite_WithPermOverridesPermission(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "perm.yaml")
 	doc := testDoc{Name: "frank", Count: 0}
 
-	if err := Write(path, &doc, WithPerm(0o644)); err != nil {
+	if err := WriteFile(path, &doc, WithPerm(0o644)); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 

--- a/pkg/op/provider/plan/git_resume_test.go
+++ b/pkg/op/provider/plan/git_resume_test.go
@@ -99,8 +99,8 @@ func gitCloneResumeThenFail(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.Write(tracePath, executor.Trace()); writeErr != nil {
-		t.Fatalf("document.Write(trace): %v", writeErr)
+	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
 	if err != nil {

--- a/pkg/op/provider/plan/lifecycle_api_test.go
+++ b/pkg/op/provider/plan/lifecycle_api_test.go
@@ -108,8 +108,8 @@ func TestGraphSaveLoadExecuteTrace_ViaPublicAPI(t *testing.T) {
 	if trace.GraphChecksum != loaded.Checksum() {
 		t.Errorf("trace.GraphChecksum %q != loaded graph checksum %q", trace.GraphChecksum, loaded.Checksum())
 	}
-	if err := document.Write(tracePath, trace); err != nil {
-		t.Fatalf("document.Write(trace): %v", err)
+	if err := document.WriteFile(tracePath, trace); err != nil {
+		t.Fatalf("document.WriteFile(trace): %v", err)
 	}
 	if _, statErr := os.Stat(tracePath); statErr != nil {
 		t.Errorf("trace receipt not saved: %v", statErr)
@@ -338,8 +338,8 @@ func TestGraphSaveLoadResume_ViaPublicAPI(t *testing.T) {
 	if original.Catalog == nil || len(original.Catalog.Entries) == 0 {
 		t.Fatalf("Trace.Catalog: want a non-empty resource ledger snapshot, got %+v", original.Catalog)
 	}
-	if writeErr := document.Write(tracePath, original); writeErr != nil {
-		t.Fatalf("document.Write(trace): %v", writeErr)
+	if writeErr := document.WriteFile(tracePath, original); writeErr != nil {
+		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
 	if err != nil {
@@ -449,8 +449,8 @@ func resumeThenFailRollsBack(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.Write(tracePath, executor.Trace()); writeErr != nil {
-		t.Fatalf("document.Write(trace): %v", writeErr)
+	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
 	if err != nil {
@@ -546,8 +546,8 @@ func resumePromiseFidelity(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.Write(tracePath, executor.Trace()); writeErr != nil {
-		t.Fatalf("document.Write(trace): %v", writeErr)
+	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
 	if err != nil {

--- a/pkg/op/provider/plan/lifecycle_e2e_test.go
+++ b/pkg/op/provider/plan/lifecycle_e2e_test.go
@@ -254,8 +254,8 @@ func saveAndReload(t *testing.T, tmp string, trace *op.Trace) *op.Trace {
 	t.Helper()
 
 	tracePath := filepath.Join(tmp, "trace.json")
-	if err := document.Write(tracePath, trace); err != nil {
-		t.Fatalf("document.Write(trace): %v", err)
+	if err := document.WriteFile(tracePath, trace); err != nil {
+		t.Fatalf("document.WriteFile(trace): %v", err)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
 	if err != nil {


### PR DESCRIPTION
#558 step one of two — the codec split, no behavior change.

## The asymmetry was the bug's shape

The read side always separated codec from I/O (`Read` stream / `ReadFile` path). The write side had one
path-only `Write` doing four jobs: choose the rendering from the extension, create the parent chain, apply
the permission policy, wrap errors. `WithPerm` sitting beside `WithIndent` was the tell — a creation concern
among encoding concerns.

## After

| | |
|---|---|
| `Write(w io.Writer, format Format, v any, opts...)` | the codec alone — **format stated, not inferred** (the `SaveGraph` rule); unknown format is a refusal, never a silent default |
| `WriteFile(path string, v any, opts...)` | the former `Write`, renamed for `Read`/`ReadFile` symmetry; extension inference survives as a file-boundary convenience; `WithPerm` documented as WriteFile-only |

The stream form is the **single-codec seam**: a protobuf rendering plugs in as a third `Format`, not a new
function pair. This answers the 2026-08-17 deferral's work-done-twice concern — recorded in
`windows-native-permissions.md` §3.3b, which now carries both PRs of the superseding ruling.

10 production call sites + 4 external test files rename mechanically. New tests pin the stream contract:
stated-format rendering, header-on-stream, unknown-format refusal.

## Not in this PR — PR-B

`WriteFile(dir fsroot.Dir, p fsroot.Path, v, opts...)`: the root, the ten call sites receiving theirs from
the CLI layer (ruled: no library opens a root for itself), unix/windows test split with DACL read-back.
**That** PR moves the Windows leg 6 → 4; this one holds at 6, name for name.

## Verified

- `make check` — 103 packages ok, 0 failures
- `make vet` GOOS=windows, GOOS=linux
- `gofmt -l` — clean

Refs #558, #405.
