### PR TITLE
fix(document): WriteFile takes a root, and the ten call sites receive theirs

### DIFF
--- a/cmd/devlore-index/main.go
+++ b/cmd/devlore-index/main.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // KnowledgeIndex represents the index.yaml manifest for a knowledge domain.
@@ -311,5 +312,13 @@ func writeIndex(domainPath string, index *KnowledgeIndex) error {
 	header := "# Auto-generated file list by: go run ./cmd/gen-index\n" +
 		"# Metadata (purpose, source_system, description) is preserved and should be edited manually.\n"
 
-	return document.WriteFile(filepath.Join(domainPath, "index.yaml"), index, document.WithHeader(header))
+	// The domain tree exists — buildIndex just read it — so opening is a query (#558).
+	root, err := fsroot.OpenConfined(domainPath)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the write's own error is what the tool reports; a close failure after it has nothing left to protect
+	defer root.Close()
+
+	return document.WriteFile(root, root.NewPath("index.yaml"), index, document.WithHeader(header))
 }

--- a/cmd/internal/cli/config.go
+++ b/cmd/internal/cli/config.go
@@ -149,7 +149,14 @@ Examples:
 				setNestedValue(config, key, typed)
 			}
 
-			return saveConfig(cfgPath, config)
+			configRoot, err := OpenTree(devlore.ConfigHome())
+			if err != nil {
+				return err
+			}
+			//nolint:errcheck // diagnose-ignored-error: the write's own error is what the command reports; a close failure after it has nothing left to protect
+			defer configRoot.Close()
+
+			return saveConfig(configRoot, configRoot.NewPath(cfgPath), config)
 		},
 	}
 
@@ -181,7 +188,14 @@ Examples:
 				}
 			}
 
-			return saveConfig(cfgPath, config)
+			configRoot, err := OpenTree(devlore.ConfigHome())
+			if err != nil {
+				return err
+			}
+			//nolint:errcheck // diagnose-ignored-error: the write's own error is what the command reports; a close failure after it has nothing left to protect
+			defer configRoot.Close()
+
+			return saveConfig(configRoot, configRoot.NewPath(cfgPath), config)
 		},
 	}
 
@@ -292,15 +306,18 @@ func loadConfig(path string) (map[string]interface{}, error) {
 
 // saveConfig saves the config map to file. Supports YAML and JSON formats, detected by file extension.
 //
+// The root is received, never constructed (#405, phase 2b): the command owns the config tree.
+//
 // Parameters:
-//   - path: filesystem path to the config file
+//   - configRoot: the config tree, opened by the calling command
+//   - path: the config file's path within configRoot
 //   - config: config map to serialize
 //
 // Returns:
 //   - error: marshal or write error
-func saveConfig(path string, config map[string]interface{}) error {
+func saveConfig(configRoot fsroot.Dir, path fsroot.Path, config map[string]interface{}) error {
 
-	return document.WriteFile(path, config)
+	return document.WriteFile(configRoot, path, config)
 }
 
 // configEdit opens the config file in the user's editor, seeding it with defaults when absent.

--- a/cmd/internal/cli/config_test.go
+++ b/cmd/internal/cli/config_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
 )
 
 func TestSharedConfigPath(t *testing.T) {
@@ -381,8 +383,14 @@ func TestSaveConfig_CreatesDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	// Directory doesn't exist yet
+	// Directory doesn't exist yet — OpenTree creates it, exactly as the commands do (#558).
 	configPath := SharedConfigPath()
+
+	configRoot, err := OpenTree(devlore.ConfigHome())
+	if err != nil {
+		t.Fatalf("OpenTree: %v", err)
+	}
+	t.Cleanup(func() { _ = configRoot.Close() })
 
 	config := map[string]interface{}{
 		"model": map[string]interface{}{
@@ -390,7 +398,7 @@ func TestSaveConfig_CreatesDirectory(t *testing.T) {
 		},
 	}
 
-	err := saveConfig(configPath, config)
+	err = saveConfig(configRoot, configRoot.NewPath(configPath), config)
 	if err != nil {
 		t.Fatalf("saveConfig() error: %v", err)
 	}

--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -85,16 +85,27 @@ func Load() (*Config, error) {
 
 // Save writes configuration to the config file. API keys are stored in the native keystore, not the config file.
 //
+// Opens the devlore config tree itself: this package sits at the CLI layer (it already fronts for the
+// commands), so per #405 phase 3 it owns its purpose-named root and the library writes below it — the
+// credentials file fallback and the document write — receive it.
+//
 // Parameters:
 //   - cfg: configuration to persist
 //
 // Returns:
-//   - error: credential storage or file write error
+//   - error: root open, credential storage, or file write error
 func Save(cfg *Config) error {
+
+	configRoot, err := cli.OpenTree(devlore.ConfigHome())
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the write's own error is what the caller acts on; a close failure after a successful write has nothing left to protect
+	defer configRoot.Close()
 
 	// Store API key in keystore (not config file)
 	if cfg.Model.APIKey != "" && cfg.Model.Provider != "" && cfg.Model.Provider != "ollama" {
-		if err := credentials.Set(cfg.Model.Provider, cfg.Model.APIKey); err != nil {
+		if err := credentials.Set(configRoot, cfg.Model.Provider, cfg.Model.APIKey); err != nil {
 			cli.Warn("could not store API key in keystore: %v", err)
 		}
 	}
@@ -103,7 +114,7 @@ func Save(cfg *Config) error {
 	fileCfg := *cfg
 	fileCfg.Model.APIKey = ""
 
-	return document.WriteFile(Path(), &fileCfg)
+	return document.WriteFile(configRoot, configRoot.NewPath("config.yaml"), &fileCfg)
 }
 
 // applyEnvOverrides applies environment variable overrides to the config.

--- a/cmd/internal/e2e/harness.go
+++ b/cmd/internal/e2e/harness.go
@@ -39,9 +39,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
+	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/cmd/internal/config"
 	"github.com/NobleFactor/devlore-cli/cmd/internal/model"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
@@ -192,31 +192,38 @@ type TestReport struct {
 
 // WriteReport writes the test report to a directory as JSON, YAML, and markdown summary.
 //
+// Opens the output tree itself, created on first use (#558; #405 phase 3): the harness sits at the CLI layer,
+// so it owns its purpose-named root, and every report write — the two documents and the raw summary — flows
+// through it.
+//
 // Parameters:
 //   - outDir: directory to write results.json, results.yaml, and summary.md
 //
 // Returns:
-//   - error: marshal, directory creation, or write error
+//   - error: root open, marshal, or write error
 func (r *TestReport) WriteReport(outDir string) error {
 
+	outRoot, err := cli.OpenTree(outDir)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the writes' own errors are what the caller acts on; a close failure after them has nothing left to protect
+	defer outRoot.Close()
+
 	// Write JSON report
-	if err := document.WriteFile(filepath.Join(outDir, "results.json"), r); err != nil {
+	if err := document.WriteFile(outRoot, outRoot.NewPath("results.json"), r); err != nil {
 		return err
 	}
 
 	// Write YAML report
-	if err := document.WriteFile(filepath.Join(outDir, "results.yaml"), r); err != nil {
+	if err := document.WriteFile(outRoot, outRoot.NewPath("results.yaml"), r); err != nil {
 		return err
 	}
 
 	// Write summary markdown
-	summaryPath := filepath.Join(outDir, "summary.md")
 	summary := r.GenerateSummary()
-	if err := os.MkdirAll(filepath.Dir(summaryPath), 0o750); err != nil {
-		return fmt.Errorf("create directory %s: %w", filepath.Dir(summaryPath), err)
-	}
-	if err := os.WriteFile(summaryPath, []byte(summary), 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", summaryPath, err)
+	if err := outRoot.WriteFile(outRoot.NewPath("summary.md"), []byte(summary), 0o600); err != nil {
+		return fmt.Errorf("write summary.md: %w", err)
 	}
 
 	return nil

--- a/cmd/internal/lorepackage/synthetic.go
+++ b/cmd/internal/lorepackage/synthetic.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
 )
 
@@ -77,11 +78,14 @@ func (c *SyntheticCache) Get(source PackageSource, name string) *SyntheticPackag
 
 // Put stores a synthetic package in the cache.
 //
+// The cache tree is opened per write and created on first use (#558; #405 phase 3): this package sits at the
+// CLI layer, so it owns its purpose-named root, and the tree may not exist before the first Put.
+//
 // Parameters:
 //   - info: synthetic package metadata to cache
 //
 // Returns:
-//   - error: marshal or write error
+//   - error: root open, marshal, or write error
 func (c *SyntheticCache) Put(info *SyntheticPackageInfo) error {
 
 	info.CachedAt = time.Now()
@@ -89,7 +93,14 @@ func (c *SyntheticCache) Put(info *SyntheticPackageInfo) error {
 		info.VerifiedAt = time.Now()
 	}
 
-	return document.WriteFile(c.cachePathForPackage(info.Source, info.Name), info)
+	cacheRoot, err := cli.OpenTree(c.cacheDir)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the write's own error is what the caller acts on; a close failure after it has nothing left to protect
+	defer cacheRoot.Close()
+
+	return document.WriteFile(cacheRoot, cacheRoot.NewPath(c.cachePathForPackage(info.Source, info.Name)), info)
 }
 
 // Delete removes a synthetic package from the cache.

--- a/cmd/writ/writ/migrate/execute.go
+++ b/cmd/writ/writ/migrate/execute.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 )
@@ -125,8 +126,16 @@ func WriteMigratedMarker(sourceRoot string, graph *op.Graph, analysis *Migration
 		System:    string(analysis.System),
 		Renames:   renames,
 	}
-	markerPath := filepath.Join(sourceRoot, ".writ-migrated")
-	return document.WriteFile(markerPath, &marker)
+
+	// The migration source tree exists — the migration just ran in it — so opening is a query (#558).
+	root, err := fsroot.OpenConfined(sourceRoot)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the write's own error is what the caller acts on; a close failure after it has nothing left to protect
+	defer root.Close()
+
+	return document.WriteFile(root, root.NewPath(".writ-migrated"), &marker)
 }
 
 // joinWords concatenates words with spaces.

--- a/cmd/writ/writ/migrate/receipt_integration_test.go
+++ b/cmd/writ/writ/migrate/receipt_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -72,7 +73,12 @@ func TestExecutionTrace_SerializesAsMigrationReceipt(t *testing.T) {
 	}
 
 	receiptPath := filepath.Join(tmp, ".writ-migrate-receipt.json")
-	if err := document.WriteFile(receiptPath, trace); err != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if err := document.WriteFile(docRoot, docRoot.NewPath(receiptPath), trace); err != nil {
 		t.Fatalf("document.WriteFile(receipt): %v", err)
 	}
 

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -974,11 +974,15 @@ read an unmoved 28 after phase 3 as a failed migration.**
         write side was missing), `Write(w, format, v, …)` added, `WithPerm` documented as
         [WriteFile]-only. Ten production call sites renamed mechanically; no behavior change; the
         windows leg holds.
-      - [ ] **PR-B — the root.** `WriteFile(dir fsroot.Dir, p fsroot.Path, v, …)`; the ten call
+      - [x] **PR-B — the root.** `WriteFile(dir fsroot.Dir, p fsroot.Path, v, …)`; the ten call
         sites take roots threaded from the CLI layer that owns the purpose-named tree (ruled: no
-        library opens a root for itself). The two 0o600 mode assertions gate to unix, and a
-        `document_windows_test.go` DACL read-back proves protection, in phase 2's shape. The
-        windows leg moves **6 → 4**: `TestWrite_JSONCreatesFileWith0o600`,
+        library opens a root for itself). Two sites earned documented exceptions: the git transport
+        opens at its own `.sync-info.yaml` write because its subprocess creates and replaces the
+        cache tree wholesale — there is nothing for a caller to open before Sync, and a held handle
+        would block the replacement on Windows; and `e2e.WriteReport`'s raw `summary.md` write rode
+        along through the same root. The two 0o600 mode assertions gate to unix, and
+        `document_windows_test.go` DACL read-backs prove protection and the 0o644 boundary, in
+        phase 2's shape. The windows leg moves **6 → 4**: `TestWrite_JSONCreatesFileWith0o600`,
         `TestWrite_YAMLCreatesFileWith0o600`.
 - [ ] **3.4 — the writ deploy/sops output path** ([#433](https://github.com/NobleFactor/devlore-cli/issues/433)) — behind `TestExecute_SopsChains`, and the one
       that writes **decrypted plaintext**, which makes it the second-most security-relevant site in

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -14,6 +14,8 @@
 // Environment variables are handled by the caller, not here.
 package credentials
 
+import "github.com/NobleFactor/devlore-cli/pkg/fsroot"
+
 // Get retrieves a credential with priority: keychain > file.
 // Environment variables should be checked by the caller before calling this.
 func Get(key string) (string, error) {
@@ -29,7 +31,11 @@ func Get(key string) (string, error) {
 }
 
 // Set stores a credential in keychain (preferred) or file fallback.
-func Set(key, secret string) error {
+//
+// The config tree's root is received, never constructed (#558; #405 phase 3): the file fallback writes a
+// secret, and only a write through the caller's root makes its 0600 enforceable on Windows. The keychain path
+// never touches it.
+func Set(configRoot fsroot.Dir, key, secret string) error {
 	// Try native keychain first
 	if helper := detectHelper(); helper != "" {
 		if err := helperStore(helper, key, secret); err == nil {
@@ -38,14 +44,14 @@ func Set(key, secret string) error {
 		// Keychain failed, fall back to file
 	}
 
-	return fileSet(key, secret)
+	return fileSet(configRoot, key, secret)
 }
 
-// Delete removes a credential from keychain and/or file.
-func Delete(key string) error {
+// Delete removes a credential from keychain and/or file. The root is received for the file half, as in [Set].
+func Delete(configRoot fsroot.Dir, key string) error {
 	// Try both - don't fail if one doesn't have it
 	if helper := detectHelper(); helper != "" {
 		_ = helperErase(helper, key) //nolint:errcheck // best-effort erase, not critical
 	}
-	return fileDelete(key)
+	return fileDelete(configRoot, key)
 }

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -7,7 +7,26 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
+
+// testConfigRoot opens a config-tree root at the XDG config home the test just isolated, creating the devlore
+// directory production's tree-opener would have made.
+func testConfigRoot(t *testing.T) fsroot.Dir {
+	t.Helper()
+	dir := xdg.ConfigPath("devlore")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsroot.OpenConfined(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
+}
 
 func TestCredentialsRoundTrip(t *testing.T) {
 	// Use a temporary credentials directory for testing
@@ -18,7 +37,7 @@ func TestCredentialsRoundTrip(t *testing.T) {
 	secret := "test-secret-value-12345"
 
 	// Set credential (will use file fallback if no keychain)
-	err := Set(key, secret)
+	err := Set(testConfigRoot(t), key, secret)
 	if err != nil {
 		t.Fatalf("Set failed: %v", err)
 	}
@@ -34,7 +53,7 @@ func TestCredentialsRoundTrip(t *testing.T) {
 	}
 
 	// Delete credential
-	err = Delete(key)
+	err = Delete(testConfigRoot(t), key)
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
@@ -63,7 +82,7 @@ func TestDeleteNonexistent(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Deleting a nonexistent key should not error
-	err := Delete("nonexistent/key")
+	err := Delete(testConfigRoot(t), "nonexistent/key")
 	if err != nil {
 		t.Errorf("Delete of nonexistent key should not error: %v", err)
 	}
@@ -77,13 +96,13 @@ func TestSetOverwrite(t *testing.T) {
 	key := "test/overwrite"
 
 	// Set initial value
-	err := Set(key, "initial")
+	err := Set(testConfigRoot(t), key, "initial")
 	if err != nil {
 		t.Fatalf("Set initial failed: %v", err)
 	}
 
 	// Overwrite
-	err = Set(key, "updated")
+	err = Set(testConfigRoot(t), key, "updated")
 	if err != nil {
 		t.Fatalf("Set update failed: %v", err)
 	}
@@ -98,7 +117,7 @@ func TestSetOverwrite(t *testing.T) {
 	}
 
 	// Cleanup
-	_ = Delete(key)
+	_ = Delete(testConfigRoot(t), key)
 }
 
 func TestCredentialsFilePath(t *testing.T) {
@@ -107,7 +126,7 @@ func TestCredentialsFilePath(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	key := "test/filepath"
-	err := Set(key, "value")
+	err := Set(testConfigRoot(t), key, "value")
 	if err != nil {
 		t.Fatalf("Set failed: %v", err)
 	}
@@ -121,7 +140,7 @@ func TestCredentialsFilePath(t *testing.T) {
 	}
 
 	// Cleanup
-	_ = Delete(key)
+	_ = Delete(testConfigRoot(t), key)
 }
 
 func TestMultipleKeys(t *testing.T) {
@@ -137,7 +156,7 @@ func TestMultipleKeys(t *testing.T) {
 
 	// Set all keys
 	for k, v := range keys {
-		if err := Set(k, v); err != nil {
+		if err := Set(testConfigRoot(t), k, v); err != nil {
 			t.Fatalf("Set %q failed: %v", k, err)
 		}
 	}
@@ -156,6 +175,6 @@ func TestMultipleKeys(t *testing.T) {
 
 	// Cleanup
 	for k := range keys {
-		_ = Delete(k)
+		_ = Delete(testConfigRoot(t), k)
 	}
 }

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -8,12 +8,17 @@ import (
 	"os"
 
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/xdg"
 )
 
-// credentialsPath returns the path to the credentials file.
+// credentialsFileName is the credentials file's name within the devlore config tree — the tree the roots
+// received by [Set] and [Delete] are anchored at.
+const credentialsFileName = "credentials.yaml"
+
+// credentialsPath returns the path to the credentials file, for the read side, which takes no root.
 func credentialsPath() string {
-	return xdg.ConfigPath("devlore", "credentials.yaml")
+	return xdg.ConfigPath("devlore", credentialsFileName)
 }
 
 // fileGet retrieves a credential from the credentials file.
@@ -39,20 +44,19 @@ func fileGet(key string) (string, error) {
 	return (*creds)[key], nil
 }
 
-// fileSet stores a credential in the credentials file.
+// fileSet stores a credential in the credentials file, writing through the received config-tree root.
 //
 // Parameters:
+//   - configRoot: the devlore config tree, opened by the caller
 //   - key: credential key (e.g., "ai/anthropic")
 //   - secret: credential value to store
 //
 // Returns:
 //   - error: read, merge, or write error
-func fileSet(key, secret string) error {
-
-	path := credentialsPath()
+func fileSet(configRoot fsroot.Dir, key, secret string) error {
 
 	// Load existing credentials
-	creds, readErr := document.ReadFile[map[string]string](path)
+	creds, readErr := document.ReadFile[map[string]string](credentialsPath())
 	if readErr != nil {
 		if !errors.Is(readErr, os.ErrNotExist) {
 			return readErr
@@ -68,21 +72,21 @@ func fileSet(key, secret string) error {
 	header := "# DevLore credentials - stored with 0600 permissions\n" +
 		"# Prefer environment variables or credential helpers for better security\n"
 
-	return document.WriteFile(path, creds, document.WithHeader(header))
+	return document.WriteFile(configRoot, configRoot.NewPath(credentialsFileName), creds, document.WithHeader(header))
 }
 
-// fileDelete removes a credential from the credentials file. No-op if the file does not exist.
+// fileDelete removes a credential from the credentials file, mutating through the received config-tree root.
+// No-op if the file does not exist.
 //
 // Parameters:
+//   - configRoot: the devlore config tree, opened by the caller
 //   - key: credential key to remove
 //
 // Returns:
-//   - error: read, merge, or write error
-func fileDelete(key string) error {
+//   - error: read, merge, removal, or write error
+func fileDelete(configRoot fsroot.Dir, key string) error {
 
-	path := credentialsPath()
-
-	creds, err := document.ReadFile[map[string]string](path)
+	creds, err := document.ReadFile[map[string]string](credentialsPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -93,8 +97,8 @@ func fileDelete(key string) error {
 	delete(*creds, key)
 
 	if len(*creds) == 0 {
-		return os.Remove(path)
+		return configRoot.Remove(configRoot.NewPath(credentialsFileName))
 	}
 
-	return document.WriteFile(path, creds)
+	return document.WriteFile(configRoot, configRoot.NewPath(credentialsFileName), creds)
 }

--- a/internal/registry/git.go
+++ b/internal/registry/git.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // gitTransport implements Transport using git.
@@ -522,7 +523,18 @@ func (g *gitTransport) writeSyncInfo(cacheDir, ref string, syncedAt time.Time) e
 		Endpoint: g.repoURL,
 	}
 
-	return document.WriteFile(filepath.Join(cacheDir, ".sync-info.yaml"), &info, document.WithPerm(0o644))
+	// Opened here, not received (#558): the transport's own subprocess creates and replaces the cache tree
+	// wholesale — before Sync there may be nothing for a caller to open, and a handle held across the clone
+	// would block the directory replacement on Windows. By this write the tree its subprocess just made
+	// exists, so opening is a query.
+	root, err := fsroot.OpenConfined(cacheDir)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck // diagnose-ignored-error: the write's own error is what the caller acts on; a close failure after it has nothing left to protect
+	defer root.Close()
+
+	return document.WriteFile(root, root.NewPath(".sync-info.yaml"), &info, document.WithPerm(0o644))
 }
 
 // endregion

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // region EXPORTED TYPES
@@ -133,38 +135,42 @@ func Write(w io.Writer, format Format, v any, opts ...Option) error {
 	return nil
 }
 
-// WriteFile serializes v to disk as a structured document. Format is inferred from the file extension. Creates
-// parent directories (0o750) if needed. Default file permission is 0o600; override with WithPerm.
+// WriteFile serializes v to disk as a structured document, through the caller's root. Format is inferred from
+// the file extension. Creates parent directories (0o750) if needed. Default file permission is 0o600; override
+// with WithPerm.
 //
-// The rename of the former path-only Write, freeing that name for the stream form — the same
-// [Read] / [ReadFile] symmetry the read side always had (#558).
+// The root is received, never constructed (#558; #405 phase 3): file creation belongs to whoever owns the
+// destination tree, and writing through [fsroot.Dir] is what makes a restrictive permission enforceable on
+// Windows, where the mode bits alone protect nothing.
 //
 // Parameters:
-//   - `path`: filesystem path for the output document.
+//   - `dir`: the tree the document belongs to, opened by the caller.
+//   - `p`: the document's path within `dir`.
 //   - `v`: the value to serialize.
 //   - `opts`: optional configuration ([WithPerm], [WithIndent], [WithHeader]).
 //
 // Returns:
-//   - `error`: wraps marshal, directory creation, and write errors with the file path for context.
-func WriteFile(path string, v any, opts ...Option) error {
+//   - `error`: wraps marshal, directory creation, and write errors with the document's path for context.
+func WriteFile(dir fsroot.Dir, p fsroot.Path, v any, opts ...Option) error {
 
 	cfg := defaultWriteOpts()
 	for _, o := range opts {
 		o(&cfg)
 	}
 
-	data, err := encode(formatFromExt(path), v, &cfg)
+	data, err := encode(formatFromExt(p.Rel()), v, &cfg)
 	if err != nil {
-		return fmt.Errorf("marshal %s: %w", path, err)
+		return fmt.Errorf("marshal %s: %w", p.Abs(), err)
 	}
 
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return fmt.Errorf("create directory %s: %w", dir, err)
+	if parent := filepath.Dir(p.Rel()); parent != "." {
+		if err := dir.MkdirAll(dir.NewPath(parent), 0o750); err != nil {
+			return fmt.Errorf("create directory %s: %w", parent, err)
+		}
 	}
 
-	if err := os.WriteFile(path, data, cfg.perm); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
+	if err := dir.WriteFile(p, data, cfg.perm); err != nil {
+		return fmt.Errorf("write %s: %w", p.Abs(), err)
 	}
 
 	return nil

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -8,9 +8,23 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
+
+// testRoot opens a confined root at a fresh temp directory — the shape every WriteFile caller now has (#558).
+func testRoot(t *testing.T) fsroot.Dir {
+	t.Helper()
+	root, err := fsroot.OpenConfined(t.TempDir())
+	if err != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
+}
 
 // testDoc is a simple struct used across all tests.
 type testDoc struct {
@@ -137,22 +151,26 @@ func TestReadFile_ErrorIncludesFilePath(t *testing.T) {
 
 func TestWrite_YAMLCreatesFileWith0o600(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "out.yaml")
+	root := testRoot(t)
+	p := root.NewPath("out.yaml")
 	doc := testDoc{Name: "dave", Count: 99}
 
-	if err := WriteFile(path, &doc); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("permission = %o, want %o", perm, 0o600)
+	// Mode bits are a unix subject; on Windows the truth is the DACL, asserted by the windows test file.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(p.Abs())
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("permission = %o, want %o", perm, 0o600)
+		}
 	}
 
-	readBack, err := ReadFile[testDoc](path)
+	readBack, err := ReadFile[testDoc](p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile back: %v", err)
 	}
@@ -163,22 +181,26 @@ func TestWrite_YAMLCreatesFileWith0o600(t *testing.T) {
 
 func TestWrite_JSONCreatesFileWith0o600(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "out.json")
+	root := testRoot(t)
+	p := root.NewPath("out.json")
 	doc := testDoc{Name: "eve", Count: 5}
 
-	if err := WriteFile(path, &doc); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("permission = %o, want %o", perm, 0o600)
+	// Mode bits are a unix subject; on Windows the truth is the DACL, asserted by the windows test file.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(p.Abs())
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("permission = %o, want %o", perm, 0o600)
+		}
 	}
 
-	readBack, err := ReadFile[testDoc](path)
+	readBack, err := ReadFile[testDoc](p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile back: %v", err)
 	}
@@ -239,29 +261,31 @@ func TestWrite_UnknownFormatIsRefused(t *testing.T) {
 
 func TestWrite_CreatesParentDirectories(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "a", "b", "c", "deep.yaml")
+	root := testRoot(t)
+	p := root.NewPath("a", "b", "c", "deep.yaml")
 	doc := testDoc{Name: "nested", Count: 1}
 
-	if err := WriteFile(path, &doc); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	if _, err := os.Stat(path); err != nil {
+	if _, err := os.Stat(p.Abs()); err != nil {
 		t.Fatalf("file should exist: %v", err)
 	}
 }
 
 func TestWrite_WithHeaderPrependsText(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "header.yaml")
+	root := testRoot(t)
+	p := root.NewPath("header.yaml")
 	doc := testDoc{Name: "grace", Count: 10}
 	header := "# Auto-generated — do not edit\n"
 
-	if err := WriteFile(path, &doc, WithHeader(header)); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc, WithHeader(header)); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -276,14 +300,15 @@ func TestWrite_WithHeaderPrependsText(t *testing.T) {
 
 func TestWrite_WithHeaderAppendsNewlineIfMissing(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "header2.yaml")
+	root := testRoot(t)
+	p := root.NewPath("header2.yaml")
 	doc := testDoc{Name: "heidi", Count: 2}
 
-	if err := WriteFile(path, &doc, WithHeader("# no trailing newline")); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc, WithHeader("# no trailing newline")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -294,12 +319,13 @@ func TestWrite_WithHeaderAppendsNewlineIfMissing(t *testing.T) {
 
 func TestWrite_JSONTrailingNewline(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "out.json")
-	if err := WriteFile(path, &testDoc{Name: "ivan", Count: 1}); err != nil {
-		t.Fatalf("Write: %v", err)
+	root := testRoot(t)
+	p := root.NewPath("out.json")
+	if err := WriteFile(root, p, &testDoc{Name: "ivan", Count: 1}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -349,15 +375,15 @@ func TestFormatFromExt_CaseInsensitive(t *testing.T) {
 
 func TestRoundTrip_YAMLReadWritePreservesData(t *testing.T) {
 
-	dir := t.TempDir()
+	root := testRoot(t)
 	original := testDoc{Name: "round", Count: 77}
 
-	path := filepath.Join(dir, "trip.yaml")
-	if err := WriteFile(path, &original); err != nil {
-		t.Fatalf("Write: %v", err)
+	p := root.NewPath("trip.yaml")
+	if err := WriteFile(root, p, &original); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	restored, err := ReadFile[testDoc](path)
+	restored, err := ReadFile[testDoc](p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -369,15 +395,15 @@ func TestRoundTrip_YAMLReadWritePreservesData(t *testing.T) {
 
 func TestRoundTrip_JSONReadWritePreservesData(t *testing.T) {
 
-	dir := t.TempDir()
+	root := testRoot(t)
 	original := testDoc{Name: "trip", Count: 88}
 
-	path := filepath.Join(dir, "trip.json")
-	if err := WriteFile(path, &original); err != nil {
-		t.Fatalf("Write: %v", err)
+	p := root.NewPath("trip.json")
+	if err := WriteFile(root, p, &original); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	restored, err := ReadFile[testDoc](path)
+	restored, err := ReadFile[testDoc](p.Abs())
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}

--- a/pkg/document/document_unix_test.go
+++ b/pkg/document/document_unix_test.go
@@ -7,7 +7,6 @@ package document
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -20,14 +19,15 @@ import (
 // than an evasion; every other case moved to a portable fact instead (issue #435).
 func TestWrite_WithPermOverridesPermission(t *testing.T) {
 
-	path := filepath.Join(t.TempDir(), "perm.yaml")
+	root := testRoot(t)
+	p := root.NewPath("perm.yaml")
 	doc := testDoc{Name: "frank", Count: 0}
 
-	if err := WriteFile(path, &doc, WithPerm(0o644)); err != nil {
-		t.Fatalf("Write: %v", err)
+	if err := WriteFile(root, p, &doc, WithPerm(0o644)); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
-	info, err := os.Stat(path)
+	info, err := os.Stat(p.Abs())
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}

--- a/pkg/document/document_windows_test.go
+++ b/pkg/document/document_windows_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package document
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// The Windows truth for a restrictive write is the access-control list, not the mode bits — Mode().Perm()
+// reports 0666 here however private the file actually is (#405 ruling 5). These tests read the DACL back off
+// the written document, in the shape phase 2's applymode tests established (#558). A subtly wrong DACL fails
+// OPEN: the file stays readable while every "did the call return nil" assertion passes.
+
+// TestWriteFile_DefaultPermissionIsEnforcedOnWindows proves the 0o600 default lands as a protected DACL — the
+// assertion the unix mode-bit check cannot make here, and the one #558 exists for.
+func TestWriteFile_DefaultPermissionIsEnforcedOnWindows(t *testing.T) {
+
+	root := testRoot(t)
+	p := root.NewPath("secret.yaml")
+
+	if err := WriteFile(root, p, &testDoc{Name: "private", Count: 1}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	control, sddl := readSecurity(t, p.Abs())
+
+	// Inheritance broken is the load-bearing part. Without SE_DACL_PROTECTED the parent's inherited ACEs
+	// survive on the document and it is private in name only.
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("document's DACL is not protected; inherited ACEs survive: %s", sddl)
+	}
+}
+
+// TestWriteFile_NonPrivatePermissionIsLeftAlone pins the boundary: 0o644 grants other, so it is not a private
+// mode, and fsroot leaves the file inheriting its parent's DACL — protection would be wrong, not extra.
+func TestWriteFile_NonPrivatePermissionIsLeftAlone(t *testing.T) {
+
+	root := testRoot(t)
+	p := root.NewPath("shared.yaml")
+
+	if err := WriteFile(root, p, &testDoc{Name: "shared", Count: 2}, WithPerm(0o644)); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if control, sddl := readSecurity(t, p.Abs()); control&windows.SE_DACL_PROTECTED != 0 {
+		t.Errorf("a 0o644 document has a protected DACL; only private modes are enforced: %s", sddl)
+	}
+}
+
+// region HELPER FUNCTIONS
+
+// readSecurity returns the object's security-descriptor control bits and its SDDL form.
+//
+// Parameters:
+//   - `t`: the test.
+//   - `path`: the object to inspect.
+//
+// Returns:
+//   - `control`: the control bits, carrying SE_DACL_PROTECTED.
+//   - `sddl`: the SDDL form, printed on failure so the actual ACL is visible.
+func readSecurity(
+	t *testing.T, path string,
+) (control windows.SECURITY_DESCRIPTOR_CONTROL, sddl string) {
+
+	t.Helper()
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%s): %v", path, err)
+	}
+
+	control, _, err = descriptor.Control()
+	if err != nil {
+		t.Fatalf("Control(%s): %v", path, err)
+	}
+
+	return control, descriptor.String()
+}
+
+// endregion

--- a/pkg/op/provider/plan/git_resume_test.go
+++ b/pkg/op/provider/plan/git_resume_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/git"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -99,7 +100,12 @@ func gitCloneResumeThenFail(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if writeErr := document.WriteFile(docRoot, docRoot.NewPath(tracePath), executor.Trace()); writeErr != nil {
 		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)

--- a/pkg/op/provider/plan/lifecycle_api_test.go
+++ b/pkg/op/provider/plan/lifecycle_api_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/flow"
@@ -108,7 +109,12 @@ func TestGraphSaveLoadExecuteTrace_ViaPublicAPI(t *testing.T) {
 	if trace.GraphChecksum != loaded.Checksum() {
 		t.Errorf("trace.GraphChecksum %q != loaded graph checksum %q", trace.GraphChecksum, loaded.Checksum())
 	}
-	if err := document.WriteFile(tracePath, trace); err != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if err := document.WriteFile(docRoot, docRoot.NewPath(tracePath), trace); err != nil {
 		t.Fatalf("document.WriteFile(trace): %v", err)
 	}
 	if _, statErr := os.Stat(tracePath); statErr != nil {
@@ -338,7 +344,12 @@ func TestGraphSaveLoadResume_ViaPublicAPI(t *testing.T) {
 	if original.Catalog == nil || len(original.Catalog.Entries) == 0 {
 		t.Fatalf("Trace.Catalog: want a non-empty resource ledger snapshot, got %+v", original.Catalog)
 	}
-	if writeErr := document.WriteFile(tracePath, original); writeErr != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if writeErr := document.WriteFile(docRoot, docRoot.NewPath(tracePath), original); writeErr != nil {
 		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
@@ -449,7 +460,12 @@ func resumeThenFailRollsBack(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if writeErr := document.WriteFile(docRoot, docRoot.NewPath(tracePath), executor.Trace()); writeErr != nil {
 		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)
@@ -546,7 +562,12 @@ func resumePromiseFidelity(t *testing.T, format string) {
 	}
 
 	tracePath := filepath.Join(tmp, "trace."+format)
-	if writeErr := document.WriteFile(tracePath, executor.Trace()); writeErr != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if writeErr := document.WriteFile(docRoot, docRoot.NewPath(tracePath), executor.Trace()); writeErr != nil {
 		t.Fatalf("document.WriteFile(trace): %v", writeErr)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)

--- a/pkg/op/provider/plan/lifecycle_e2e_test.go
+++ b/pkg/op/provider/plan/lifecycle_e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/document"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
@@ -254,7 +255,12 @@ func saveAndReload(t *testing.T, tmp string, trace *op.Trace) *op.Trace {
 	t.Helper()
 
 	tracePath := filepath.Join(tmp, "trace.json")
-	if err := document.WriteFile(tracePath, trace); err != nil {
+	docRoot, docRootErr := fsroot.OpenConfined(tmp)
+	if docRootErr != nil {
+		t.Fatalf("fsroot.OpenConfined: %v", docRootErr)
+	}
+	t.Cleanup(func() { _ = docRoot.Close() })
+	if err := document.WriteFile(docRoot, docRoot.NewPath(tracePath), trace); err != nil {
 		t.Fatalf("document.WriteFile(trace): %v", err)
 	}
 	reloaded, err := document.ReadFile[op.Trace](tracePath)


### PR DESCRIPTION
#558 step two of two — the root. `WriteFile(dir fsroot.Dir, p fsroot.Path, v, opts...)` applies the DACL by
construction: a 0600 document is owner-only on Windows instead of readable by every account with directory
access, and **the defect is now unrepresentable** — the path form cannot be called without saying whose tree
the document belongs to.

## The ten sites, as ruled

*The root travels the channel the path string traveled.*

| Site | Root |
|---|---|
| `config.Save` | opens the devlore config tree (`cli.OpenTree`) — it is the CLI layer, and the same root serves the credentials fallback below it |
| `cli` config set/unset | open the config tree in the commands |
| `credentials.Set` / `Delete` | **receive** the config-tree root for the file fallback — the write that stores secrets; `Get` unchanged (rooted reads are phase-4) |
| `SyntheticCache.Put` | opens the cache tree per write (the store.go pattern) |
| `e2e.WriteReport` | opens its output tree — and its raw `summary.md` write rides the same root (same defect class, found sitting beside the document writes) |
| `devlore-index` | opens at the domain it just read (`OpenConfined`) |
| `writ migrate` marker | opens at the migration source the run just executed in |
| `registry.writeSyncInfo` | **documented exception** — see below |

**The exception:** the git transport's subprocess creates and *replaces* the cache tree wholesale. Before
`Sync` there may be nothing for a caller to open, and a handle held across the clone would block the
directory replacement on Windows. So it opens at its one structured write, when the tree its subprocess just
made exists — a query, with the reasoning in a comment at the site.

## Tests

The two 0o600 tests keep their names; the mode-bit assertion gates to unix (`Mode().Perm()` reports 0666 on
Windows regardless), and `document_windows_test.go` reads the DACL back: **0600 must carry `SE_DACL_PROTECTED`,
0644 must not** — phase 2's established shape. External test writers (plan lifecycle/git-resume, writ receipt)
thread roots at their temp trees.

## Expected Windows movement — the review check

Name-for-name diff vs baseline 6: exactly two removed, none added —
`TestWrite_JSONCreatesFileWith0o600`, `TestWrite_YAMLCreatesFileWith0o600`. **Baseline 6 → 4.**

## Verified

- `make check` — 103 packages ok, 0 failures
- `make vet` GOOS=windows (load-bearing: the new windows test file), GOOS=linux
- `gofmt -l` — clean

Closes #558. Refs #405, #430. Plan: `windows-native-permissions.md` §3.3b both boxes ticked.
