### PR TITLE
fix(deploy): the sops test asserts the portable fact — mode bits on unix, the DACL on windows

### DIFF
--- a/cmd/writ/writ/deploy/sops_integration_test.go
+++ b/cmd/writ/writ/deploy/sops_integration_test.go
@@ -22,8 +22,10 @@ import (
 
 // TestExecute_SopsChains deploys the two encrypted pipelines end to end — the plain decrypt
 // (`secret.yaml.sops` → decrypted `secret.yaml`) and the decrypt+render chain
-// (`note.yaml.template.sops` → decrypted, rendered `note.yaml`) — asserting content and the 0600 secret mode.
-// The ambient age identity comes from SOPS_AGE_KEY, per the sealed config-free decryption model.
+// (`note.yaml.template.sops` → decrypted, rendered `note.yaml`) — asserting content and that both outputs are
+// private in the platform's own terms: 0600 mode bits on unix, a protected DACL on Windows
+// (assertPrivateFile, the portable-fact pair). The ambient age identity comes from SOPS_AGE_KEY, per the
+// sealed config-free decryption model.
 func TestExecute_SopsChains(t *testing.T) {
 
 	root := t.TempDir()
@@ -73,13 +75,7 @@ func TestExecute_SopsChains(t *testing.T) {
 	if !strings.Contains(string(decrypted), "credential: hello world") {
 		t.Errorf("decrypted secret = %q, want the plaintext credential", decrypted)
 	}
-	info, err := os.Stat(filepath.Join(targetRoot, "secret.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("secret mode = %v, want 0600", info.Mode().Perm())
-	}
+	assertPrivateFile(t, filepath.Join(targetRoot, "secret.yaml"))
 
 	// The decrypt+render chain: decrypted, rendered, 0600.
 	note, err := os.ReadFile(filepath.Join(targetRoot, "note.yaml"))
@@ -89,13 +85,7 @@ func TestExecute_SopsChains(t *testing.T) {
 	if !strings.Contains(string(note), "greeting: hi Darwin") {
 		t.Errorf("rendered note = %q, want the rendered greeting", note)
 	}
-	noteInfo, err := os.Stat(filepath.Join(targetRoot, "note.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if noteInfo.Mode().Perm() != 0o600 {
-		t.Errorf("note mode = %v, want 0600", noteInfo.Mode().Perm())
-	}
+	assertPrivateFile(t, filepath.Join(targetRoot, "note.yaml"))
 }
 
 // sopsEncrypt generates an age identity and encrypts plainYAML with SOPS, returning the encrypted bytes and

--- a/cmd/writ/writ/deploy/sops_integration_unix_test.go
+++ b/cmd/writ/writ/deploy/sops_integration_unix_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build !windows
+
+package deploy_test
+
+import (
+	"os"
+	"testing"
+)
+
+// assertPrivateFile asserts the file at `path` is private in this platform's own terms — here, mode 0600.
+//
+// The portable-fact pattern (#433, #435): the unix half asserts the mode bits; the windows half reads the
+// access-control list back, because Mode().Perm() reports 0666 there however private the file actually is.
+func assertPrivateFile(t *testing.T, path string) {
+
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", path, err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("%s mode = %v, want 0600", path, info.Mode().Perm())
+	}
+}

--- a/cmd/writ/writ/deploy/sops_integration_windows_test.go
+++ b/cmd/writ/writ/deploy/sops_integration_windows_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build windows
+
+package deploy_test
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// assertPrivateFile asserts the file at `path` is private in this platform's own terms — here, a protected
+// DACL.
+//
+// The portable-fact pattern (#433, #435): Mode().Perm() reports 0666 on Windows however private the file
+// actually is, so the truth is the access-control list, read back in the shape phase 2's applymode tests
+// established. Inheritance broken is the load-bearing part: without SE_DACL_PROTECTED the parent's inherited
+// ACEs survive on the decrypted plaintext and it is private in name only.
+func assertPrivateFile(t *testing.T, path string) {
+
+	t.Helper()
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%s): %v", path, err)
+	}
+
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatalf("Control(%s): %v", path, err)
+	}
+
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("%s DACL is not protected; inherited ACEs survive on decrypted plaintext: %s",
+			path, descriptor.String())
+	}
+}

--- a/docs/plans/windows-native-permissions.md
+++ b/docs/plans/windows-native-permissions.md
@@ -984,9 +984,15 @@ read an unmoved 28 after phase 3 as a failed migration.**
         `document_windows_test.go` DACL read-backs prove protection and the 0o644 boundary, in
         phase 2's shape. The windows leg moves **6 → 4**: `TestWrite_JSONCreatesFileWith0o600`,
         `TestWrite_YAMLCreatesFileWith0o600`.
-- [ ] **3.4 — the writ deploy/sops output path** ([#433](https://github.com/NobleFactor/devlore-cli/issues/433)) — behind `TestExecute_SopsChains`, and the one
+- [x] **3.4 — the writ deploy/sops output path** ([#433](https://github.com/NobleFactor/devlore-cli/issues/433)) — behind `TestExecute_SopsChains`, and the one
       that writes **decrypted plaintext**, which makes it the second-most security-relevant site in
-      the campaign after the private key.
+      the campaign after the private key. **Resolved 2026-08-20: production was already correct** —
+      `DecryptSopsFile` writes through the session root (encryption/provider.go), the deploy
+      environment is confined, and `enforceSecretFloor` refuses non-private modes. What remained was
+      the test asserting `Mode().Perm()`, which reports 0666 on Windows regardless; it now asserts
+      the portable fact via a build-tagged `assertPrivateFile` pair — 0600 mode bits on unix, a
+      protected DACL on Windows — so the runner *verifies* the production DACL rather than assuming
+      it. The windows leg moves **4 → 3**.
 - [ ] Exit gate: every restrictive-perm write in these areas flows through a root; a **DACL
       read-back test** proves the private key is protected on Windows, in the shape phase 2's
       `_windows_test.go` established. The 28 does **not** move here.


### PR DESCRIPTION
#433 expected a production fix and found **none owed**: `DecryptSopsFile` already writes the plaintext through
the session root, the deploy environment is confined, and `enforceSecretFloor` refuses any mode granting
group or other. The write has been enforced all along — what remained was the test asserting
`Mode().Perm() == 0600`, which reports 0666 on Windows however private the file actually is.

## The change

`TestExecute_SopsChains` asserts privacy in each platform's own terms via a build-tagged `assertPrivateFile`
pair:

| Platform | Assertion |
|---|---|
| unix | mode bits are 0600, as before |
| windows | the DACL reads back with `SE_DACL_PROTECTED` — inheritance broken, phase 2's shape |

The runner now **verifies** the production DACL on decrypted plaintext rather than assuming it: if the deploy
path ever stops protecting, the Windows leg goes red with this test's name on it.

Zero production change — which is the finding. Plan §3.4 records it.

## Expected Windows movement — the review check

Name-for-name diff vs baseline 4: exactly `TestExecute_SopsChains` removed, none added. **Baseline 4 → 3** —
the write-path cluster closes; the three #547 path-as-text tests are all that remain.

## Verified

- `make check` — 103 packages ok, 0 failures
- `make vet` GOOS=windows (load-bearing: the new windows assertion file)
- `gofmt -l` — clean

Closes #433. Refs #405, #430.
