### PR TITLE
fix(devlore-test): results are files, narration is stderr, and a failed test is not a usage error

### DIFF
--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -136,8 +136,19 @@ func TestCLI_RunTooManyArgs(t *testing.T) {
 }
 
 func TestCLI_RunMissingFile(t *testing.T) {
-	_, stderr, code := run("run", "nonexistent.star")
+	work := t.TempDir()
+	_, stderr, code := runIn(work, "run", "nonexistent.star")
 	assertExit(t, 1, code)
+
+	// A run that cannot start must not litter the working directory with artifacts named for the missing
+	// script — this exact litter shipped once (nonexistent.graph.yaml in the package directory).
+	entries, err := os.ReadDir(work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("missing-script run created artifacts: %v", entries)
+	}
 
 	// The wrapped syscall text belongs to the OS -- "no such file or directory" on Unix, "The system cannot
 	// find the file specified." on Windows -- so asserting on it tested the platform, not the CLI. These two

--- a/cmd/devlore-test/cli_test.go
+++ b/cmd/devlore-test/cli_test.go
@@ -90,8 +90,15 @@ func findRepoRoot() (string, error) {
 
 // run executes devlore-test with the given args and returns stdout, stderr, and exit code.
 func run(args ...string) (stdout, stderr string, exitCode int) {
+	return runIn("", args...)
+}
+
+// runIn executes devlore-test with the given working directory (empty means inherit) — the ruled defaults
+// write artifact files into the working directory, so tests exercising them must own one.
+func runIn(dir string, args ...string) (stdout, stderr string, exitCode int) {
 	// The helper has no *testing.T; the subprocess is bounded by cmd.Run below.
 	cmd := exec.CommandContext(context.Background(), binary, args...)
+	cmd.Dir = dir
 	var outBuf, errBuf strings.Builder
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
@@ -140,35 +147,43 @@ func TestCLI_RunMissingFile(t *testing.T) {
 }
 
 func TestCLI_ScriptFirst(t *testing.T) {
-	stdout, _, code := run("run", scriptPath, "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull)
+	stdout, _, code := run("run", scriptPath, "--output", "summary=/dev/stdout", "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptMiddle(t *testing.T) {
-	stdout, _, code := run("run", "--output", "receipt="+os.DevNull, scriptPath, "--output", "graph="+os.DevNull)
+	stdout, _, code := run("run", "--output", "summary=/dev/stdout", "--output", "receipt="+os.DevNull, scriptPath, "--output", "graph="+os.DevNull)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_ScriptLast(t *testing.T) {
-	stdout, _, code := run("run", "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--output", "summary=/dev/stdout", "--output", "receipt="+os.DevNull, "--output", "graph="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 // --- Output routing ---
 
-func TestCLI_DefaultAllToStdout(t *testing.T) {
-	stdout, _, code := run("run", scriptPath)
+// TestCLI_DefaultsToArtifactFiles pins the ruled default routing (2026-08-20): results are files named for
+// the script in the working directory; stdout carries none of the three payloads.
+func TestCLI_DefaultsToArtifactFiles(t *testing.T) {
+	work := t.TempDir()
+	stdout, _, code := runIn(work, "run", scriptPath)
 	assertExit(t, 0, code)
-	assertContains(t, stdout, "Hello World!")
-	assertContains(t, stdout, `"passed":true`)
-	assertContains(t, stdout, "version:")
+	assertNotContains(t, stdout, `"passed"`)
+	assertNotContains(t, stdout, "Hello World!")
+	assertNotContains(t, stdout, "version:")
+	for _, artifact := range []string{"test_hello.summary.json", "test_hello.graph.yaml", "test_hello.receipt.yaml"} {
+		if _, err := os.Stat(filepath.Join(work, artifact)); err != nil {
+			t.Errorf("default artifact %s not written: %v", artifact, err)
+		}
+	}
 }
 
 func TestCLI_SummaryOnly(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--output", "summary=/dev/stdout", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 	assertNotContains(t, stdout, "Hello World!")
@@ -176,7 +191,7 @@ func TestCLI_SummaryOnly(t *testing.T) {
 }
 
 func TestCLI_GraphOnly(t *testing.T) {
-	stdout, _, code := run("run", "--output", "summary="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--output", "graph=/dev/stdout", "--output", "summary="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertContains(t, stdout, "Hello World!")
 	assertNotContains(t, stdout, `"passed"`)
@@ -184,7 +199,7 @@ func TestCLI_GraphOnly(t *testing.T) {
 }
 
 func TestCLI_ReceiptOnlyYAML(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--output", "receipt=/dev/stdout", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertNotContains(t, stdout, `"passed"`)
 	assertValidYAML(t, stdout)
@@ -193,7 +208,7 @@ func TestCLI_ReceiptOnlyYAML(t *testing.T) {
 }
 
 func TestCLI_ReceiptOnlyJSON(t *testing.T) {
-	stdout, _, code := run("run", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, "--receipt-format=json", scriptPath)
+	stdout, _, code := run("run", "--output", "receipt=/dev/stdout", "--output", "graph="+os.DevNull, "--output", "summary="+os.DevNull, "--receipt-format=json", scriptPath)
 	assertExit(t, 0, code)
 	assertValidJSON(t, stdout)
 	assertContains(t, stdout, "shell.exec")
@@ -254,19 +269,19 @@ func TestCLI_JSONReceiptToFile(t *testing.T) {
 // --- Flags ---
 
 func TestCLI_DryRun(t *testing.T) {
-	stdout, _, code := run("run", "--dry-run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--dry-run", "--output", "summary=/dev/stdout", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertValidSummary(t, stdout)
 }
 
 func TestCLI_Trace(t *testing.T) {
-	stdout, _, code := run("run", "--trace", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
+	stdout, _, code := run("run", "--trace", "--output", "summary=/dev/stdout", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	assertContains(t, stdout, `"trace"`)
 }
 
 func TestCLI_Silent(t *testing.T) {
-	_, stderr, code := run("--silent", "run", "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
+	_, stderr, code := run("--silent", "run", "--output", "summary="+os.DevNull, "--output", "graph="+os.DevNull, "--output", "receipt="+os.DevNull, scriptPath)
 	assertExit(t, 0, code)
 	if stderr != "" {
 		t.Errorf("--silent should suppress stderr, got: %q", stderr)

--- a/cmd/devlore-test/devloretest/commands.go
+++ b/cmd/devlore-test/devloretest/commands.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -56,11 +57,7 @@ func (o *outputFlags) Type() string {
 const stdoutSentinel = "/dev/stdout"
 
 func newRunCmd() *cobra.Command {
-	outputs := &outputFlags{entries: map[string]string{
-		"summary": stdoutSentinel,
-		"receipt": stdoutSentinel,
-		"graph":   stdoutSentinel,
-	}}
+	outputs := &outputFlags{entries: map[string]string{}}
 
 	cmd := &cobra.Command{
 		Use:   "run [flags] <script.star>",
@@ -70,18 +67,19 @@ func newRunCmd() *cobra.Command {
 The script uses plan.* bindings to build a graph and t.* assertions to
 verify expectations after execution.
 
-Three output streams can be independently routed:
-  graph    Promise from the software under test
-  summary  JSON test result (passed, node_count, failures)
-  receipt  Full serialized execution graph
+Three output streams route independently; each defaults to an artifact file
+named for the script, in the working directory:
+  summary  JSON test result (passed, node_count, failures)   <script>.summary.json
+  graph    The graph document from the software under test   <script>.graph.yaml
+  receipt  Full serialized execution graph                    <script>.receipt.<format>
 
-All streams default to %[1]s. Route to files or %[2]s:
-  devlore-test run --output receipt=receipt.yaml test.star
+Reroute any stream to a path, %[1]s, or %[2]s:
+  devlore-test run --output summary=%[1]s test.star
   devlore-test run --output graph=%[2]s test.star`, stdoutSentinel, os.DevNull),
 		Example: fmt.Sprintf(`  devlore-test run test.star
   devlore-test run --dry-run test.star
   devlore-test run --trace test.star
-  devlore-test run --output receipt=receipt.yaml --receipt-format=json test.star
+  devlore-test run --output receipt=my-receipt.json --receipt-format=json test.star
   devlore-test run --output graph=%[1]s --output receipt=%[1]s test.star`, os.DevNull),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -93,7 +91,9 @@ All streams default to %[1]s. Route to files or %[2]s:
 	cmd.Flags().Bool("trace", false, "Enable Starlark step trace")
 	cmd.Flags().String("provider", "", "Restrict to a specific provider")
 	cmd.Flags().String("receipt-format", "yaml", "Receipt format: json or yaml")
-	cmd.Flags().Var(outputs, "output", "Promise routing: summary|receipt|graph=destination (repeatable)")
+	cmd.Flags().Var(outputs, "output",
+		"Stream routing: summary|receipt|graph=destination (repeatable; default: <script>.summary.json, "+
+			"<script>.graph.yaml, <script>.receipt.<format> beside the working directory)")
 
 	return cmd
 }
@@ -107,6 +107,22 @@ func runTest(cmd *cobra.Command, script string, outputs *outputFlags) (err error
 	if receiptFmt != "json" && receiptFmt != "yaml" {
 		return fmt.Errorf("--receipt-format must be json or yaml, got %q", receiptFmt)
 	}
+
+	// Default routing: three artifact files named for the script, in the working directory — results are
+	// files, narration is stderr, and stdout stays clean (ruled 2026-08-20). An explicit --output — a path,
+	// os.DevNull, or /dev/stdout — overrides per stream.
+	base := strings.TrimSuffix(filepath.Base(script), filepath.Ext(script))
+	for stream, dest := range map[string]string{
+		"summary": base + ".summary.json",
+		"graph":   base + ".graph.yaml",
+		"receipt": base + ".receipt." + receiptFmt,
+	} {
+		if _, set := outputs.entries[stream]; !set {
+			outputs.entries[stream] = dest
+		}
+	}
+	cli.Note("summary=%s graph=%s receipt=%s",
+		outputs.entries["summary"], outputs.entries["graph"], outputs.entries["receipt"])
 
 	// Open graph output destination for streaming during execution.
 	graphOut, err := openDest(outputs.entries["graph"])
@@ -200,15 +216,18 @@ func writeSummary(dest string, result *Result) (err error) {
 }
 
 func writeReceipt(dest, format string, graph *op.Graph) (err error) {
-	if graph == nil {
-		return nil
-	}
 
+	// The destination is opened before the nil check so every run leaves all three artifacts — a script that
+	// assembles no graph writes an empty receipt rather than no file (ruled 2026-08-20: three files, always).
 	f, err := openDest(dest)
 	if err != nil {
 		return err
 	}
 	defer iox.Close(&err, f)
+
+	if graph == nil {
+		return nil
+	}
 
 	switch format {
 	case "json":

--- a/cmd/devlore-test/devloretest/commands.go
+++ b/cmd/devlore-test/devloretest/commands.go
@@ -108,6 +108,13 @@ func runTest(cmd *cobra.Command, script string, outputs *outputFlags) (err error
 		return fmt.Errorf("--receipt-format must be json or yaml, got %q", receiptFmt)
 	}
 
+	// The script is verified before any output destination opens: default routing names artifacts after the
+	// script, and a run that cannot start must not litter the working directory with files named for a
+	// script that does not exist.
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("reading script: %w", err)
+	}
+
 	// Default routing: three artifact files named for the script, in the working directory — results are
 	// files, narration is stderr, and stdout stays clean (ruled 2026-08-20). An explicit --output — a path,
 	// os.DevNull, or /dev/stdout — overrides per stream.

--- a/cmd/devlore-test/devloretest/commands_test.go
+++ b/cmd/devlore-test/devloretest/commands_test.go
@@ -225,3 +225,30 @@ func TestRunCmd_MissingScript(t *testing.T) {
 		t.Fatal("expected error for missing script")
 	}
 }
+
+// TestRunCmd_DefaultsToScriptNamedArtifacts pins the default routing (ruled 2026-08-20): each stream lands in
+// an artifact file named for the script, in the working directory — results are files, narration is stderr,
+// and stdout stays clean. An explicit --output overrides per stream, which every other test here exercises.
+func TestRunCmd_DefaultsToScriptNamedArtifacts(t *testing.T) {
+
+	work := t.TempDir()
+	script := filepath.Join(work, "probe.star")
+	if err := os.WriteFile(script, []byte("t.expect_unit_count(0)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(work)
+
+	cmd := newRunCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{script})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, artifact := range []string{"probe.summary.json", "probe.graph.yaml", "probe.receipt.yaml"} {
+		if _, err := os.Stat(filepath.Join(work, artifact)); err != nil {
+			t.Errorf("default artifact %s not written: %v", artifact, err)
+		}
+	}
+}

--- a/cmd/devlore-test/devloretest/root.go
+++ b/cmd/devlore-test/devloretest/root.go
@@ -37,14 +37,17 @@ func NewRootCmd() *cobra.Command {
 It executes a Starlark test script that builds an execution graph, runs the
 graph through the engine, and verifies expectations against the results.
 
-Output streams:
-  graph    Output from the software under test (default: stdout)
-  summary  Test result with pass/fail and expectation counts (default: stdout)
-  receipt  Full execution graph transaction log (default: stdout)
+Results are files; narration is stderr; stdout stays clean. Each stream
+defaults to an artifact file named for the script, in the working directory:
 
-Use --output to route streams to files or %[1]s:
-  devlore-test run --output receipt=receipt.yaml test.star
-  devlore-test run --output graph=%[1]s --output receipt=%[1]s test.star`, os.DevNull),
+  summary  Test result with pass/fail and expectation counts   <script>.summary.json
+  graph    The graph document from the software under test     <script>.graph.yaml
+  receipt  Full execution graph transaction log                <script>.receipt.<format>
+
+Use --output to reroute any stream to a path, /dev/stdout, or %[1]s:
+  devlore-test run test.star
+  devlore-test run --output summary=/dev/stdout --output graph=%[1]s --output receipt=%[1]s test.star`, os.DevNull),
+		SilenceUsage: true,
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},


### PR DESCRIPTION
Two harness defects surfaced while devlore-test carried the catalog-contract demonstration; ruled 2026-08-20.

## 1. A failed test printed the usage block

cobra treats any `RunE` error as a mis-typed command unless `SilenceUsage` is set — and only the package's
own tests set it, on their private command instances. It now sits on the root command: a failure prints the
narration, one `Error:` line, nothing else.

## 2. Results are files

All three streams defaulted to stdout — JSON summary + YAML graph + YAML receipt interleaved with no
delimiters. New defaults, per ruling:

| Stream | Default artifact |
|---|---|
| summary | `<script>.summary.json` |
| graph | `<script>.graph.yaml` |
| receipt | `<script>.receipt.<format>` |

`--output` still reroutes any stream to a path, `/dev/stdout`, or the null device. The receipt is written
even for graph-less scripts — every run leaves all three artifacts — and a routing line on stderr names
them. Pinned by `TestRunCmd_DefaultsToScriptNamedArtifacts`; the run command's help describes the real
defaults.

## Verified

- `make check` — 103 packages ok, 0 failures
- `make vet` GOOS=windows
- Windows baseline expectation: identical to 3, name for name

Refs #574 (chore kind, per the classification ruling).
