### PR TITLE
feat(op): the graph document carries its catalog — mandatory even empty, refused when absent

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_graph_catalog_contract.star
+++ b/cmd/devlore-test/devloretest/data/test_graph_catalog_contract.star
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_graph_catalog_contract.star — the serialized graph carries the catalog as input intent
+# (4-resource-management.md §5, ruled 2026-08-20; judgment scenarios in docs/plans/resource-construction.md).
+#
+# The contract: the graph's resource catalog represents what must exist when the graph runs. file.copy is the
+# exemplar because its signature spans both grammars: `source` is resource-typed (a string value mints a
+# pending entry), `destination_path` is a plain string naming a product — a runtime fact with no plan-time
+# presence.
+#
+# Front to back: fixture -> plan -> save -> read the document back -> judge the document.
+
+src = t.tmp("original.txt")
+dst = t.tmp("duplicate.txt")
+doc = t.tmp("graph.json")
+
+t.write(src, "bytes to copy")
+
+node  = plan.file.copy(source=src, destination_path=dst, mode=0o600)
+graph = plan.assemble_definition([node])
+plan.save_definition(graph, doc)
+
+# The end result: the artifact a later session loads.
+document = json.decode(data=file.read_text(resource=doc))
+
+# Sanity: the document is real and carries the planned node — the harness ran front to back.
+t.expect_equal(len(document["nodes"]), 1)
+t.expect_equal(document["nodes"][0]["action_name"], "file.copy")
+
+# 1 — the catalog section exists: mandatory, even when empty.
+t.expect_equal("resources" in document, True)
+
+entries = document["resources"]
+
+# 2 — the source is present, as pending intent.
+t.expect_equal(len([e for e in entries if "original.txt" in str(e)]), 1)
+t.expect_equal(len([e for e in entries if "original.txt" in str(e) and e["state"] == "pending"]), 1)
+
+# 3 — the destination is ABSENT: a product is a runtime fact, not intent.
+t.expect_equal(len([e for e in entries if "duplicate.txt" in str(e)]), 0)

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -119,7 +119,7 @@ Windows known-failures.
    is its subject) and retire; `package-signatures.md` is `Epic:LorePackaging` material — moves to that
    epic's design home, not this plan's scope beyond the move.
 
-### Phase 1 — the catalog section: serialize + enforce — status: pending
+### Phase 1 — the catalog section: serialize + enforce — status: complete 2026-08-20
 
 1. `graphData` gains a mandatory `resources` section: every current-generation ledger entry as intent —
    `{id, uri, state: pending}` (per the phase-3 ruling, plan-time entries are all Pending; no producer
@@ -192,7 +192,11 @@ the catalog at plan time. The plan-time catalog is the graph's *input intent*, a
    step-48 snapshot keeps the observed side).
 5. Acceptance: **both pins flip green with corrected assertions** — the stored document carries
    `original.txt` (pending), and asserts `duplicate.txt` **absent**, pinning the product ruling in both
-   directions.
+   directions. **Delivered early — the pins flipped with phase 1**: planning already interned the
+   resource-typed source, so serialization was the missing half and the destination's absence was already
+   true. Phase 3's remaining substance is the claiming discipline itself: plan-time minting must be
+   pending-only with no existence I/O (today's Discover can still resolve at plan time), and the promise
+   grammar verified.
 
 ### Phase 4 — run time consumes the catalog, never strings — status: pending
 

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,10 +82,12 @@ type Graph struct {
 	// [RuntimeEnvironment.ResourceCatalog] so each Run gets an independent working catalog and the graph's planning
 	// catalog stays pristine across "plan once, run many" reuse.
 	//
-	// Partially serialized: the catalog's content-addressed entries travel in the document's content section — a
-	// content resource IS its bytes, so [Graph.packContent] packs each ([Packer]) and [unpackContent] reconstructs
-	// them into a fresh catalog on load ([Unpacker]). Reference entries ([AddressingLocation]) and the per-run state
-	// (lifecycle, producer stamps) do not travel — references recreate on the target host from the slot URIs.
+	// Serialized as intent (4-resource-management.md §5.4, ruled 2026-08-20): every current-generation entry
+	// travels in the document's mandatory resources section as a pending row; content-addressed entries
+	// additionally carry their packed bytes in the content section — a content resource IS its bytes, so
+	// [Graph.packContent] packs each ([Packer]) and [unpackCatalog] reconstructs the whole catalog on load.
+	// Per-run state (lifecycle, producer stamps, content identity) never travels here — that is the trace's
+	// ledger snapshot.
 	resourceCatalog *ResourceCatalog
 
 	// root is the graph's root subgraph. [NewGraph] constructs it from the supplied `units` (top-level children),
@@ -455,7 +458,14 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 		return nil, err
 	}
 
-	catalog, err := unpackContent(env, p.Content)
+	// The catalog section is mandatory even when empty (4-resource-management.md §5.4, ruled 2026-08-20):
+	// a nil section means a pre-ruling document, which does not load — it is rewritten by re-planning.
+	if p.Resources == nil {
+		return nil, fmt.Errorf(
+			"op.LoadGraph: document carries no resource catalog section — mandatory even when empty; re-plan the graph")
+	}
+
+	catalog, err := unpackCatalog(env, p.Resources, p.Content)
 	if err != nil {
 		return nil, err
 	}
@@ -482,51 +492,143 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 	return g, nil
 }
 
-// unpackContent reconstructs a document's content section into a fresh [*ResourceCatalog] — the load-side dual of
-// [Graph.packContent].
+// unpackCatalog reconstructs a document's catalog from its intent rows and content blobs — the load-side dual
+// of [Graph.marshalData]'s Resources + Content pair (4-resource-management.md §5.4).
 //
-// Each entry's URI fragment names the concrete resource type; the announced inventory resolves it to the type's
-// [Unpacker] ([receiverRegistry.UnpackerByTypeID]), whose Unpack materializes the bytes into the local
-// content-addressed store and verifies the reconstructed URI against the recorded one — the integrity link covering
-// the (unsigned) content section. Reconstructed resources enter the catalog as discoveries: production stamps and
-// lifecycle are per-run state that does not travel.
+// Every row restores as a [Pending] ledger entry with its recorded id — the stored catalog is intent, so no
+// producer stamps, states, or content identity are read from the document. A row whose URI has a content blob
+// reconstructs through the type's [Unpacker], which materializes the bytes into the local content-addressed
+// store and verifies the reconstructed URI against the recorded one; every other row reconstructs through the
+// registered [ResourceConstructor] from the URI's `specific` part (the trace-rehydrate discipline: interning
+// disabled so restoreEntry stamps the recorded id). A content blob with no intent row is an orphan and an
+// error — the intent section is the catalog; the content section only carries bytes for it.
 //
 // Parameters:
-//   - `env`: the runtime environment; supplies the local content-addressed store.
-//   - `entries`: the document's content section; may be empty.
+//   - `env`: the runtime environment; supplies the local content-addressed store and construction context.
+//   - `rows`: the document's mandatory resources section; empty is legal, nil never reaches here ([LoadGraph]
+//     refuses the document first).
+//   - `content`: the document's content section; may be empty.
 //
 // Returns:
-//   - `*ResourceCatalog`: a fresh catalog holding the reconstructed content resources.
-//   - `error`: non-nil on an unresolvable type id, an Unpack failure (including a URI mismatch), or a catalog
-//     failure.
-func unpackContent(env *RuntimeEnvironment, entries []contentEntry) (*ResourceCatalog, error) {
+//   - `*ResourceCatalog`: the reconstructed catalog, ids preserved, every entry Pending.
+//   - `error`: non-nil on a malformed URI, an unresolvable type id, an Unpack or construction failure, or an
+//     orphan content blob.
+func unpackCatalog(env *RuntimeEnvironment, rows []LedgerEntrySnapshot, content []contentEntry) (*ResourceCatalog, error) {
+
+	blobs := make(map[string][]byte, len(content))
+	for _, entry := range content {
+		blobs[entry.URI] = entry.Content
+	}
 
 	catalog := NewResourceCatalog()
 
-	for _, entry := range entries {
+	// Interning disabled during reconstruction (the Rehydrate discipline): constructors return bare
+	// candidates and restoreEntry stamps the recorded id rather than minting a fresh one.
+	saved := env.ResourceCatalog
+	env.ResourceCatalog = nil
+	defer func() { env.ResourceCatalog = saved }()
 
-		_, typeID, err := ExtractTagSpecific(entry.URI)
+	nextID := 0
+
+	for _, row := range rows {
+
+		resource, err := reconstructIntentRow(env, row, blobs)
 		if err != nil {
-			return nil, fmt.Errorf("op.LoadGraph: content entry %s: %w", entry.URI, err)
+			return nil, err
 		}
+
+		catalog.restoreEntry(row.ID, resource, "", Pending)
+
+		if n, ok := parseLedgerID(row.ID); ok && n >= nextID {
+			nextID = n + 1
+		}
+	}
+
+	if len(blobs) > 0 {
+		orphans := make([]string, 0, len(blobs))
+		for uri := range blobs {
+			orphans = append(orphans, uri)
+		}
+		sort.Strings(orphans)
+		return nil, fmt.Errorf("op.LoadGraph: content entries with no resource row (the intent section is the catalog): %s",
+			strings.Join(orphans, ", "))
+	}
+
+	catalog.nextID = nextID
+
+	return catalog, nil
+}
+
+// reconstructIntentRow rebuilds one intent row's Resource: through the type's [Unpacker] when the row's URI
+// has a content blob (consuming it from `blobs`), through the registered [ResourceConstructor] otherwise.
+//
+// Parameters:
+//   - `env`: the runtime environment, with interning already disabled by the caller.
+//   - `row`: the intent row under reconstruction.
+//   - `blobs`: the remaining content blobs by URI; the matched blob is deleted.
+//
+// Returns:
+//   - `Resource`: the reconstructed resource.
+//   - `error`: a malformed URI, an unresolvable type id, or an Unpack/construction failure.
+func reconstructIntentRow(env *RuntimeEnvironment, row LedgerEntrySnapshot, blobs map[string][]byte) (Resource, error) {
+
+	specific, typeID, err := ExtractTagSpecific(row.URI)
+	if err != nil {
+		return nil, fmt.Errorf("op.LoadGraph: resource entry %s: %w", row.URI, err)
+	}
+
+	if blob, ok := blobs[row.URI]; ok {
 
 		unpacker, ok := ReceiverRegistry().UnpackerByTypeID(typeID)
 		if !ok {
 			return nil, fmt.Errorf("op.LoadGraph: content entry %s: no announced op.Unpacker for type id %q",
-				entry.URI, typeID)
+				row.URI, typeID)
 		}
 
-		resource, err := unpacker.Unpack(env, entry.URI, entry.Content)
-		if err != nil {
-			return nil, fmt.Errorf("op.LoadGraph: content entry %s: %w", entry.URI, err)
+		resource, unpackErr := unpacker.Unpack(env, row.URI, blob)
+		if unpackErr != nil {
+			return nil, fmt.Errorf("op.LoadGraph: content entry %s: %w", row.URI, unpackErr)
 		}
 
-		if _, err := catalog.Discover(resource.URI(), func() (Resource, error) { return resource, nil }); err != nil {
-			return nil, fmt.Errorf("op.LoadGraph: content entry %s: %w", entry.URI, err)
-		}
+		delete(blobs, row.URI)
+		return resource, nil
 	}
 
-	return catalog, nil
+	construct, ok := ReceiverRegistry().ResourceConstructorByTypeID(typeID)
+	if !ok {
+		return nil, fmt.Errorf("op.LoadGraph: resource entry %s: no resource type registered for %q",
+			row.URI, typeID)
+	}
+
+	resource, constructErr := construct(env, specific)
+	if constructErr != nil {
+		return nil, fmt.Errorf("op.LoadGraph: resource entry %s: reconstruct: %w", row.URI, constructErr)
+	}
+
+	return resource, nil
+}
+
+// parseLedgerID extracts the numeric component of a catalog id (`res-N`).
+//
+// Parameters:
+//   - `id`: the ledger id to parse.
+//
+// Returns:
+//   - `int`: the numeric component.
+//   - `bool`: false when the id does not carry the `res-N` shape.
+func parseLedgerID(id string) (int, bool) {
+
+	numeric, ok := strings.CutPrefix(id, "res-")
+	if !ok {
+		return 0, false
+	}
+
+	n, err := strconv.Atoi(numeric)
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
 }
 
 // region EXPORTED METHODS
@@ -888,6 +990,7 @@ func (g *Graph) marshalData() (graphData, error) {
 		Content:   content,
 		Edges:     edges,
 		Nodes:     nodePayloads,
+		Resources: g.resourceCatalog.IntentEntries(),
 		Subgraphs: subgraphPayloads,
 	}, nil
 }
@@ -1118,10 +1221,18 @@ type graphData struct {
 	Signature *Signature `json:"signature,omitempty"  yaml:"signature,omitempty"`
 
 	// Content
-	Children  []string       `json:"children"             yaml:"children"`
-	Content   []contentEntry `json:"content,omitempty"    yaml:"content,omitempty"`
-	Edges     []Edge         `json:"edges,omitempty"      yaml:"edges,omitempty"`
-	Nodes     []nodeData     `json:"nodes,omitempty"      yaml:"nodes,omitempty"`
+	Children []string       `json:"children"             yaml:"children"`
+	Content  []contentEntry `json:"content,omitempty"    yaml:"content,omitempty"`
+	Edges    []Edge         `json:"edges,omitempty"      yaml:"edges,omitempty"`
+	Nodes    []nodeData     `json:"nodes,omitempty"      yaml:"nodes,omitempty"`
+
+	// Resources is the catalog's intent section — what must exist when the graph runs
+	// (4-resource-management.md §5.4, ruled 2026-08-20): every current-generation entry as
+	// `{id, uri, state: pending}`, in ledger append order. Deliberately NOT omitempty: the section is
+	// mandatory even when empty, and [LoadGraph] refuses a document without it. Like the content section it
+	// sits outside [Graph.CanonicalContent].
+	Resources []LedgerEntrySnapshot `json:"resources"            yaml:"resources"`
+
 	Subgraphs []subgraphData `json:"subgraphs,omitempty"  yaml:"subgraphs,omitempty"`
 }
 

--- a/pkg/op/graph_catalog_section_test.go
+++ b/pkg/op/graph_catalog_section_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+)
+
+// The graph document's catalog section is mandatory even when empty, and it is intent — pending rels, what
+// must exist when the graph runs (4-resource-management.md §5.4, ruled 2026-08-20). These tests pin the
+// section's presence, its refusal when absent, its round trip, and the executor's pre-flight backstop.
+
+// intentProbeResource is an announced resource whose constructor round-trips its URI `specific` — the
+// contract [unpackCatalog] relies on (the file provider honors it by stripping its own scheme prefix).
+type intentProbeResource struct {
+	ResourceBase
+}
+
+// newIntentProbeResource constructs the probe from a path-ish string, tolerating its own emitted specific on
+// the rehydration round trip.
+func newIntentProbeResource(runtimeEnvironment *RuntimeEnvironment, value any) (Resource, error) {
+
+	s, _ := value.(string)
+	s = strings.TrimPrefix(s, "probe:")
+
+	base, err := NewResourceBase(runtimeEnvironment, "probe:"+s, reflect.TypeFor[*intentProbeResource]())
+	if err != nil {
+		return nil, err
+	}
+
+	return &intentProbeResource{ResourceBase: base}, nil
+}
+
+func init() {
+	AnnounceResource(reflect.TypeFor[*intentProbeResource](), newIntentProbeResource, nil)
+}
+
+// TestGraphDocument_CatalogSectionIsPresentEvenEmpty pins the mandatory section: a graph with an empty
+// catalog still serializes `"resources": []`, loads back, and repacks byte-identically.
+func TestGraphDocument_CatalogSectionIsPresentEvenEmpty(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+
+	document := serializeGraph(t, graph, "json")
+	if !bytes.Contains(document, []byte(`"resources": []`)) &&
+		!bytes.Contains(document, []byte(`"resources":[]`)) {
+		t.Fatalf("document lacks the empty resources section:\n%s", document)
+	}
+
+	loaded, err := LoadGraph(formatIdentityEnvironment(t), document, "json")
+	if err != nil {
+		t.Fatalf("LoadGraph: %v", err)
+	}
+
+	repacked := serializeGraph(t, loaded, "json")
+	if !bytes.Equal(document, repacked) {
+		t.Errorf("pack → unpack → pack is not byte-identical:\n--- first ---\n%s\n--- second ---\n%s",
+			document, repacked)
+	}
+}
+
+// TestLoadGraph_RefusesDocumentWithoutCatalogSection pins the hard gate: a document lacking the resources
+// section — every pre-ruling document — does not load.
+func TestLoadGraph_RefusesDocumentWithoutCatalogSection(t *testing.T) {
+
+	document := serializeGraph(t, formatIdentityGraph(t), "json")
+
+	var decoded map[string]any
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	delete(decoded, "resources")
+	stripped, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadGraph(formatIdentityEnvironment(t), stripped, "json"); err == nil {
+		t.Fatal("LoadGraph = nil error for a document without the resources section, want the refusal")
+	} else if !strings.Contains(err.Error(), "resource catalog section") {
+		t.Errorf("refusal does not name the section: %v", err)
+	}
+}
+
+// TestGraphDocument_IntentRowsRoundTrip pins the row shape and the id-preserving reconstruction: entries
+// serialize as pending intent and reload with their ids, URIs, and Pending state — and nothing else.
+func TestGraphDocument_IntentRowsRoundTrip(t *testing.T) {
+
+	environment, err := NewRuntimeEnvironment(context.Background(),
+		NewRuntimeEnvironmentSpec("test").WithApplication(&application.Application{Name: "test"}))
+	if err != nil {
+		t.Fatalf("NewRuntimeEnvironment: %v", err)
+	}
+
+	catalog := NewResourceCatalog()
+	for _, name := range []string{"etc/first.conf", "etc/second.conf"} {
+		resource, probeErr := newIntentProbeResource(environment, name)
+		if probeErr != nil {
+			t.Fatalf("probe %s: %v", name, probeErr)
+		}
+		if _, discoverErr := catalog.Discover(resource.URI(),
+			func() (Resource, error) { return resource, nil }); discoverErr != nil {
+			t.Fatalf("Discover %s: %v", name, discoverErr)
+		}
+	}
+
+	registry := ReceiverRegistry()
+	completeAction, err := registry.BuildAction("flow.complete")
+	if err != nil {
+		t.Fatalf("BuildAction: %v", err)
+	}
+	leaf, err := NewNode(NewNodeSpec().WithID("leaf").WithAction(completeAction))
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	graph, err := NewGraph(NewGraphSpec().WithUnits(leaf).WithResourceCatalog(catalog))
+	if err != nil {
+		t.Fatalf("NewGraph: %v", err)
+	}
+
+	document := serializeGraph(t, graph, "json")
+
+	loaded, err := LoadGraph(environment, document, "json")
+	if err != nil {
+		t.Fatalf("LoadGraph: %v", err)
+	}
+
+	rows := loaded.ResourceCatalog().IntentEntries()
+	if len(rows) != 2 {
+		t.Fatalf("reloaded catalog carries %d intent rows, want 2: %+v", len(rows), rows)
+	}
+	for i, want := range []string{"etc/first.conf", "etc/second.conf"} {
+		if !strings.Contains(rows[i].URI, want) {
+			t.Errorf("row %d URI = %q, want it to name %q", i, rows[i].URI, want)
+		}
+		if rows[i].State != Pending {
+			t.Errorf("row %d state = %v, want Pending — the stored catalog is intent", i, rows[i].State)
+		}
+	}
+
+	repacked := serializeGraph(t, loaded, "json")
+	if !bytes.Equal(document, repacked) {
+		t.Errorf("pack → unpack → pack is not byte-identical with intent rows:\n--- first ---\n%s\n--- second ---\n%s",
+			document, repacked)
+	}
+}
+
+// TestRun_CatalogLessGraph_PreflightFailed pins the executor backstop: a graph stripped of its catalog —
+// unreachable through NewGraph or LoadGraph, so induced directly — refuses to dispatch.
+func TestRun_CatalogLessGraph_PreflightFailed(t *testing.T) {
+
+	graph := formatIdentityGraph(t)
+	graph.resourceCatalog = nil
+
+	executor := NewGraphExecutor(graph, NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}))
+
+	if _, runErr := executor.Run(context.Background(), nil); runErr == nil {
+		t.Fatal("Run = nil error for a catalog-less graph, want the pre-flight refusal")
+	}
+
+	got := executor.RunStatus()
+	if got.Phase != PhaseStopped || got.Condition != ConditionExecutionFailed || got.Reason != ReasonPreflightFailed {
+		t.Errorf("RunStatus() = %v, want stopped × execution_failed × preflight_failed", got)
+	}
+}

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -299,6 +299,11 @@ func (e *GraphExecutor) ResumeUnwind(ctx context.Context) error {
 		return fmt.Errorf("ResumeUnwind: executor is not at stopped × compensation_failed (status: %s)", e.status)
 	}
 
+	// The Run-side mandatory-catalog backstop, repeated here so a catalog-less graph cannot reach the clone.
+	if e.graph.ResourceCatalog() == nil {
+		return fmt.Errorf("ResumeUnwind: graph carries no resource catalog — mandatory even when empty")
+	}
+
 	environment, buildErr := NewRuntimeEnvironment(ctx, e.spec.WithCatalog(e.graph.ResourceCatalog().Clone()))
 	if buildErr != nil {
 		return fmt.Errorf("ResumeUnwind: build runtime environment: %w", buildErr)
@@ -483,6 +488,16 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 
 	if e.status.Phase != PhasePreparing && !resuming {
 		return nil, fmt.Errorf("executor already used (state: %s)", e.status)
+	}
+
+	// A graph without a resource catalog does not dispatch — even an empty catalog is mandatory
+	// (4-resource-management.md §5.4, ruled 2026-08-20). [NewGraph] always supplies one and [LoadGraph]
+	// refuses a document without the section, so this guard is the pre-flight backstop for any other
+	// construction path.
+	if e.graph.ResourceCatalog() == nil {
+		e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
+			Reason: ReasonPreflightFailed, Message: "graph carries no resource catalog"}
+		return nil, fmt.Errorf("Run: graph carries no resource catalog — mandatory even when empty")
 	}
 
 	environment, buildErr := NewRuntimeEnvironment(ctx, e.spec.WithCatalog(e.graph.ResourceCatalog().Clone()))

--- a/pkg/op/provider/plan/catalog_contract_test.go
+++ b/pkg/op/provider/plan/catalog_contract_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package plan_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
+
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/plan/gen"
+)
+
+// TestPlannedCopy_TheStoredCatalogIsInputIntent pins the catalog contract for a planned file.copy, starting
+// from Starlark (4-resource-management.md §5, ruled 2026-08-20; judgment scenarios in
+// docs/plans/resource-construction.md).
+//
+// The contract: the graph's resource catalog represents input intent — what must exist when the graph runs.
+// file.copy is the exemplar because its signature spans both grammars: `source` is resource-typed (a string
+// value mints a pending entry), `destination_path` is a plain string naming a product — a runtime fact with
+// no plan-time presence.
+//
+// Asserted against the STORED document, reloaded the way a later session loads it:
+//
+//  1. the catalog section exists (mandatory, even when empty)
+//  2. the source is present, as pending intent
+//  3. the destination is ABSENT — a product, not intent
+func TestPlannedCopy_TheStoredCatalogIsInputIntent(t *testing.T) {
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "original.txt")
+	destinationPath := filepath.Join(root, "duplicate.txt")
+	graphPath := filepath.Join(root, "graph.json")
+
+	if err := os.WriteFile(sourcePath, []byte("bytes to copy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plan — not run — a one-node copy from Starlark, and save the graph document.
+	script := fmt.Sprintf(`
+node  = plan.file.copy(source = %q, destination_path = %q, mode = 0o600, user = "", group = "")
+graph = plan.assemble_definition([node])
+plan.save_definition(graph, %q)
+`, sourcePath, destinationPath, graphPath)
+
+	scriptPath := filepath.Join(root, "catalog.star")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}).
+		WithRoot(root))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = environment.Close() })
+
+	if _, err := starlarkbridge.NewRuntime(environment).Invoke("catalog.star", root); err != nil {
+		t.Fatalf("Invoke(catalog.star): %v", err)
+	}
+
+	data, err := os.ReadFile(graphPath)
+	if err != nil {
+		t.Fatalf("read saved graph: %v", err)
+	}
+
+	// The artifact itself, verbatim — logged on failure so the judgment is against the end result.
+	t.Logf("SAVED GRAPH DOCUMENT (%d bytes):\n%s", len(data), data)
+
+	loaded, err := op.LoadGraph(environment, data, "json")
+	if err != nil {
+		t.Fatalf("op.LoadGraph: %v", err)
+	}
+
+	rows := loaded.ResourceCatalog().IntentEntries()
+
+	// 2 — the source: pending intent in the stored catalog.
+	sourceRow, found := rowNaming(rows, filepath.Base(sourcePath))
+	if !found {
+		t.Errorf("stored catalog carries no entry for the source %q\n  rows: %s", sourcePath, describeRows(rows))
+	} else if sourceRow.State != op.Pending {
+		t.Errorf("source entry state = %v, want Pending — the stored catalog is intent", sourceRow.State)
+	}
+
+	// 3 — the destination: absent, pinning the product ruling in both directions.
+	if row, present := rowNaming(rows, filepath.Base(destinationPath)); present {
+		t.Errorf("stored catalog carries the destination %q — a product is a runtime fact, not intent: %+v",
+			destinationPath, row)
+	}
+}
+
+// rowNaming returns the first intent row whose URI names `needle`.
+func rowNaming(rows []op.LedgerEntrySnapshot, needle string) (op.LedgerEntrySnapshot, bool) {
+
+	for _, row := range rows {
+		if strings.Contains(row.URI, needle) {
+			return row, true
+		}
+	}
+
+	return op.LedgerEntrySnapshot{}, false
+}
+
+// describeRows renders the rows for a failure message.
+func describeRows(rows []op.LedgerEntrySnapshot) string {
+
+	if len(rows) == 0 {
+		return "(none)"
+	}
+
+	uris := make([]string, 0, len(rows))
+	for _, row := range rows {
+		uris = append(uris, row.URI)
+	}
+
+	return strings.Join(uris, "\n        ")
+}

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -112,6 +112,34 @@ func (c *ResourceCatalog) Clone() *ResourceCatalog {
 	}
 }
 
+// IntentEntries returns the graph document's intent rows: every current-generation entry, in ledger append
+// order, rendered [Pending] — the stored catalog is what must exist when the graph runs, never what planning
+// observed, so no producer stamps and no content identity travel here
+// (4-resource-management.md §5.4, ruled 2026-08-20).
+//
+// Returns:
+//   - `[]LedgerEntrySnapshot`: id, URI, and [Pending] per current generation; empty (never nil) when the
+//     ledger holds nothing — the document's section serializes even then, mandatorily.
+func (c *ResourceCatalog) IntentEntries() []LedgerEntrySnapshot {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entries := make([]LedgerEntrySnapshot, 0, len(c.entries))
+
+	for _, resource := range c.entries {
+
+		base := resource.resourceBase()
+		if c.ns[namespaceKey(resource)] != base.id {
+			continue // a superseded generation is history, not intent
+		}
+
+		entries = append(entries, LedgerEntrySnapshot{ID: base.id, URI: resource.URI(), State: Pending})
+	}
+
+	return entries
+}
+
 // ContentResources returns the current-generation content-addressed entries, sorted by URI.
 //
 // This is the list that travels with a serialized graph document: reference resources ([AddressingLocation]) are

--- a/pkg/op/resource_state.go
+++ b/pkg/op/resource_state.go
@@ -4,7 +4,10 @@
 package op
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 )
@@ -49,4 +52,76 @@ func (s ResourceState) String() string {
 
 	assert.Unreachable(fmt.Sprintf("op.ResourceState.String: invalid state value %d", int(s)))
 	return ""
+}
+
+// MarshalJSON serializes the state as its canonical lowercase string — a document carries "pending", never a
+// bare ordinal (the typed-value rule: no value degrades to its least-typed rendering in an artifact).
+//
+// Returns:
+//   - `[]byte`: the JSON string form.
+//   - `error`: any error from the underlying marshal.
+func (s ResourceState) MarshalJSON() ([]byte, error) { return json.Marshal(s.String()) }
+
+// MarshalYAML serializes the state as its canonical lowercase string, mirroring [ResourceState.MarshalJSON].
+//
+// Returns:
+//   - `any`: the string form for the YAML encoder.
+//   - `error`: always nil; present to satisfy the [yaml.Marshaler] interface.
+func (s ResourceState) MarshalYAML() (any, error) { return s.String(), nil }
+
+// UnmarshalJSON deserializes the canonical string form.
+//
+// Parameters:
+//   - `data`: the JSON bytes to decode.
+//
+// Returns:
+//   - `error`: a malformed JSON string, or an unknown state name.
+func (s *ResourceState) UnmarshalJSON(data []byte) error {
+
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	return s.parse(name)
+}
+
+// UnmarshalYAML deserializes the canonical string form, mirroring [ResourceState.UnmarshalJSON].
+//
+// Parameters:
+//   - `value`: the YAML node to decode.
+//
+// Returns:
+//   - `error`: a malformed YAML scalar, or an unknown state name.
+func (s *ResourceState) UnmarshalYAML(value *yaml.Node) error {
+
+	var name string
+	if err := value.Decode(&name); err != nil {
+		return err
+	}
+
+	return s.parse(name)
+}
+
+// parse assigns the state named by `name`.
+//
+// Parameters:
+//   - `name`: the canonical lowercase state name.
+//
+// Returns:
+//   - `error`: non-nil for an unknown name.
+func (s *ResourceState) parse(name string) error {
+
+	switch name {
+	case "pending":
+		*s = Pending
+	case "active":
+		*s = Active
+	case "gone":
+		*s = Gone
+	default:
+		return fmt.Errorf("op.ResourceState: unknown state %q", name)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Phase 1 of [resource-construction](docs/plans/resource-construction.md) —
[4-resource-management.md §5.4](docs/architecture/4-resource-management.md) implemented.

## The section

`graphData` gains a mandatory `resources` section — every current-generation entry as intent
(`{id, uri, state: "pending"}`, append order, via the new `ResourceCatalog.IntentEntries`); content-addressed
entries additionally carry packed bytes as before. Present even when empty; outside the canonical bytes like
the content section.

## The gates

- **`LoadGraph` refuses a document without the section** — every pre-ruling document fails to load and is
  re-planned; `schema_version` stays 1 by ruling.
- **`unpackCatalog`** (replacing `unpackContent`): rows restore as Pending with recorded ids — the
  trace-rehydrate discipline; unpackers consume matching content blobs; an orphan blob errors; `nextID`
  re-derives.
- **Executor backstop**: a catalog-less graph fails pre-flight (`preflight_failed`) before any dispatch, in
  `Run` and `ResumeUnwind` both.
- **`ResourceState` serializes as its name** — `"pending"`, never a bare ordinal (the `mode: 384` lesson,
  applied at the type).

## The judgment pins land green — early

The plan predicted the flip at phase 3; it arrived with phase 1, because planning already interns the
resource-typed source — serialization was the missing half, and the destination's absence (a product is a
runtime fact) was already true. Both pins now assert the ruled contract in both directions:

- `pkg/op/provider/plan/catalog_contract_test.go` — source **pending present**, destination **absent**,
  against the reloaded document
- `cmd/devlore-test/devloretest/data/test_graph_catalog_contract.star` — the same, front to back through the
  harness: **6 expectations, passing**

Plus four new §5.4 pins: empty-section round trip (byte-identical), missing-section refusal, id-preserving
intent-row reconstruction, executor backstop.

## Verified

- `make check` — 103 packages ok, 0 failures — **the tree is fully green, pins included**
- `make vet` GOOS=windows, GOOS=linux
- Windows expectation: identical to baseline 3, name for name

Closes #583. Refs #581, #444. Phase 3's remaining substance (pending-only claiming with no plan-time
existence I/O; the promise grammar) is recorded in the plan.
