### PR TITLE
docs(design): the behavior matrix agrees with the code; judgment scenario 1 proven in CI

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_1_delete_then_copy.star — judgment scenario 1 (docs/plans/resource-construction.md).
+#
+# Two operations against the same named file, no promise between them: delete it, then copy from it. The
+# prediction, authored before implementation: the stored catalog carries exactly one pending file entry with
+# two consumers (ruled 2026-08-20: mutation targets are resource-typed consumers; until #585 migrates
+# file.remove's path-typed signature, the entry is minted by the copy's source alone and the count is the
+# same); pre-flight passes because intent was satisfied at the starting line; the run fails at the copy — under
+# the ruled shape the copy sees the catalog's Gone verdict (the remove, as consumer, transitioned the entry);
+# until #585 it rediscovers the loss through its own I/O; the failure unwinds and the delete's receipt restores
+# the file. The graph says what
+# must be true; the trace says what happened; the gap between them is the run's story.
+
+src = t.tmp("data.txt")
+dst = t.tmp("copy.txt")
+doc = t.tmp("graph.json")
+
+t.write(src, "the original bytes")
+
+deleted = plan.file.remove(path=src, prune=False, boundary="")
+copied  = plan.file.copy(source=src, destination_path=dst, mode=0o600)
+
+graph = plan.assemble_definition([deleted, copied])
+plan.save_definition(graph, doc)
+
+# The stored catalog is input intent: exactly one entry, the source, pending; the destination — a product —
+# is absent.
+document = json.decode(data=file.read_text(resource=doc))
+entries = document["resources"]
+t.expect_equal(len([e for e in entries if "data.txt" in str(e) and e["state"] == "pending"]), 1)
+t.expect_equal(len([e for e in entries if "copy.txt" in str(e)]), 0)
+
+# The run: the copy fails on the gone source; compensation restores the deleted file; the never-produced
+# destination does not exist.
+t.expect_error("file.copy")
+t.expect_file(src, content="the original bytes")
+t.expect_no_file(dst)
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -430,3 +430,16 @@ func TestWritAdoptSubgraph(t *testing.T) {
 func TestWritAdoptTypeMismatch(t *testing.T) {
 	runScript(t, "test_writ_adopt_type_mismatch.star")
 }
+
+// --- Judgment scenarios (docs/plans/resource-construction.md) ---
+//
+// Predictions authored before implementation; the implementation is correct when the harness observes
+// exactly the prediction. These run in CI as the standing evidence the rulings require.
+
+func TestGraphCatalogContract(t *testing.T) {
+	runScript(t, "test_graph_catalog_contract.star")
+}
+
+func TestJudgmentScenario1_DeleteThenCopy(t *testing.T) {
+	runScript(t, "test_judgment_1_delete_then_copy.star")
+}

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -3,7 +3,7 @@
 > **Status:** rewritten 2026-07-22 (phase-8 step 51, slice 3) onto the landed `pkg/op` model; **revised
 > 2026-08-20 onto the resource-construction rulings** ([plan](../plans/resource-construction.md), feature
 > [#581](https://github.com/NobleFactor/devlore-cli/issues/581)): the catalog is input intent and travels with
-> the graph (§5), plan-space paths follow the git model, identity is root-relative, and **the
+> the graph (§5), plan-space file paths follow the git model, file identity is root-relative, and **the
 > declared-output-spec proposal is rejected** — products are runtime facts, so the former Appendix A is
 > removed rather than preserved (§9 item 8). Implementation is staged in
 > [#582–#587](https://github.com/NobleFactor/devlore-cli/issues/581); until those land, the tree carries the
@@ -47,9 +47,10 @@ executed on many machines:
 - **Plan time** — pure, no I/O: a resource-typed parameter's string value mints a **pending** entry (no
   existence check); a promise value records the promise and nothing else; a **product is a runtime fact**
   with no plan-time presence (§5). String-typed parameters stay plain values.
-- **Execution time** — the executor's pre-flight resolve pass verifies every pending rel under the run's
-  root and applies state transitions; dispatch results — products included — become catalog facts on the
-  per-run clone, recorded by the trace.
+- **Execution time** — the executor's pre-flight resolve pass verifies every pending resource by its
+  scheme's existence predicate (for file resources: the rel under the run's root) and applies state
+  transitions; dispatch results — products included — become catalog facts on the per-run clone, recorded
+  by the trace.
 
 **`Resource`** (`pkg/op/resource.go`) — an interface sealed by an unexported method; only types embedding
 `ResourceBase` implement it. The base carries identity (`uri`, catalog `id`, `producerID` — empty for discovered,
@@ -81,7 +82,9 @@ Three states (`pkg/op/resource_state.go` — `ResourceState`, renamed from `op.S
 
 - **Pending** — the URI is claimed but not yet observed or produced. Plan-time entries are born here.
 - **Active** — observed-as-existing (discovery) or freshly created (production). Metadata is trustworthy.
-- **Gone** — reactive: an existence check failed. Terminal for the entry; reviving a URI appends a fresh entry.
+- **Gone** — the resource is no longer there: an existence check failed (reactive), or a mutating consumer
+  destroyed the resource and reported it (ruled 2026-08-20 — the remove is the authority; its receipt carries the
+  undo). Terminal for the entry; reviving a URI appends a fresh entry.
 
 **The catalog owns transitions.** The existence verdict is the resource's `Exists()` predicate; the catalog applies
 the transition through `VerifyExistence`, driven from the **executor's pre-flight resolve pass** over the per-run
@@ -100,23 +103,66 @@ stubs and stay `Pending` until their per-type step.
    │  Active  │ │  Gone  │ ◀── terminal; revival = a fresh shadowing entry
    └──────────┘ └────────┘
           │        ▲
-          └────────┘  (a later failed check on an Active entry → Gone)
+          └────────┘  (a later failed check, or a mutating consumer's destruction → Gone)
 ```
 
-#### Catalog behavior matrix (ruled 2026-07-14; step 22)
+#### Catalog behavior matrix
 
-| Op | Cache state | `Exists()` | Content-addressable | Location-based |
-|---|---|---|---|---|
-| `DiscoverResource` | miss | success | append `Pending` → `Active`; no `producerID` | same |
-| `DiscoverResource` | miss | failure | append `Pending` → `Gone`; return error | same |
-| `DiscoverResource` | hit, `Pending` | success | in-place `Pending` → `Active`; discard input | same |
-| `DiscoverResource` | hit, `Pending` | failure | in-place `Pending` → `Gone`; return error | same |
-| `DiscoverResource` | hit, `Active` | (not called) | return existing | same |
-| `DiscoverResource` | hit, `Gone` | (not called) | return error | same |
-| `DiscoverResource` | (any) | (any) | **never shadows** | **never shadows** |
-| `NewResource` | miss | (not called) | append `Pending` → `Active`; stamp `producerID` | same |
-| `NewResource` | hit, `Pending`/`Active` | (not called) | return existing (singleton) | **shadow**: new entry, stamp `producerID`; old entry stays as history |
-| `NewResource` | hit, `Gone` | (not called) | **shadow** (revives the URI) | same |
+Ruled 2026-07-14 (step 22); **re-stated 2026-08-20 (Q1 ruling)** to agree with §5.1 and the code: the
+2026-07-14 rendering folded pre-flight's existence outcomes into the `Discover` rows, which read as
+discover-time I/O — `Discover` performs none, and existence belongs to pre-flight alone.
+
+**Claiming (plan time — no I/O anywhere in this table):**
+
+| Op | Cache state | Content-addressable | Location-based |
+|---|---|---|---|
+| `Discover` | miss | append `Pending`; no `producerID` | same |
+| `Discover` | hit, `Pending` | return existing; discard input | same |
+| `Discover` | hit, `Active` | return existing | same |
+| `Discover` | hit, `Gone` | return error | same |
+| `Discover` | (any) | **never shadows** | **never shadows** |
+
+**Verification (pre-flight, over the per-run clone — `VerifyExistence`, the only place `Exists()` runs):**
+
+| Entry state | `Exists()` | Result |
+|---|---|---|
+| `Pending` | true | `Pending` → `Active` |
+| `Pending` | false | **the transition fails**: `Pending` → `Gone`, and pre-flight fails the run — a pending resource that fails its scheme's existence predicate (for **file resources**: the rel does not exist relative to the run's fsroot) is unmet intent (§5.5) |
+| `Active` | false (a later re-check) | `Active` → `Gone` |
+
+**Production (dispatch time — products are runtime facts, §5.1):**
+
+| Op | Cache state | Content-addressable | Location-based |
+|---|---|---|---|
+| `NewResource` | miss | append `Pending` → `Active`; stamp `producerID` | same |
+| `NewResource` | hit, `Pending`/`Active` | return existing (singleton) | **shadow**: new entry, stamp `producerID`; old entry stays as history |
+| `NewResource` | hit, `Gone` | **shadow** (revives the URI) | same |
+
+**Consumption (dispatch time — ruled 2026-08-20, judgment scenario 1):**
+
+| Consumed entry state | Result |
+|---|---|
+| `Active` | dispatch proceeds; a mutating consumer that destroys the resource transitions the entry `Active` → `Gone`, and its receipt carries the undo |
+| `Gone` | **the consumer fails on the catalog's verdict** — it sees the state; it does not rediscover the loss through its own I/O |
+| `Pending` | unreachable — pre-flight has already activated the entry or failed the run |
+
+Where the guard lives (ruled 2026-08-20): **the action dispatch seam** — `Method.Invoke` converts slot values
+to Go arguments via `Convert`, and the check runs **after conversion, before the forward method is called**.
+After conversion is the earliest point the complete consumed set exists: promise-fed and defaulted slots
+resolve only at slot-fill, so a purely static executor-side guard would miss promise-fed consumption. The
+seam is also shared by graph dispatch and starlark immediate dispatch, so the verdict holds on both surfaces.
+The guard closes a live asymmetry: `Discover` errors on a hit-`Gone` entry (the claiming table), but
+`Convert`'s catalog hit (`Current`/`Lookup`) screens no state — today it hands a consumer the `Gone`
+generation silently. The guard's error is typed; the executor classifies it into the run-status reason
+(the failure is structural — the forward method never ran, so there is nothing to compensate for this unit).
+The catalog-resolve verdict remains the in-flight backstop, and provider I/O errors still catch losses the
+catalog cannot know (out-of-band deletion mid-run). The `Gone` transition stamps the destroying unit —
+symmetric with `producerID` — so the verdict names both units: *consumed by unit 1 before unit 2 could run*.
+
+Staged rollout: today `file.remove` is path-typed (no consumer link, no transition — scenario 1's receipt shows
+the entry still `pending` after the failed run) and the copy rediscovers the loss as a dispatch-time filesystem
+error. #585 closes both halves: the remove becomes a consumer that transitions the entry, and the second
+consumer's failure becomes the catalog's verdict.
 
 **Why the asymmetry:** a content-addressable URI encodes its identity, so re-producing it is provably the same
 resource (the CAS types: mem, function, json, yaml — [4.2](4.2-mem-resource.md),
@@ -195,18 +241,18 @@ input intent — it is, in effect, what must exist when the graph runs.**
   declaration of any kind (the declared-output-spec proposal is rejected — §9 item 8).
 - **String-typed parameters** (`destination_path`, `mode`, `user`, …) stay plain values.
 
-### 5.2 Plan-space paths — the git model
+### 5.2 Plan-space paths — the git model (file resources)
 
-Plan-authored paths are a small portable language: a **leading slash anchors at the fsroot** (as in
+Plan-authored **file paths** are a small portable language: a **leading slash anchors at the fsroot** (as in
 `.gitignore`), so `/foo/bar` ≡ `foo/bar`, both naming rel `foo/bar`. Machine-absoluteness is
 **inexpressible in a plan** — it arises only from the run's root choice: a home-scope graph binds to the
 account running it (`/Users/a`, `/home/b`, `C:\Users\c` — same graph, different accounts); a system-scope
 graph binds to the host (`%SystemDrive%\` on Windows, `/` on unix). Volume and drive-letter spellings, and
 rels that escape (`../`), are plan-time refusals — the latter is intent confinement can never satisfy.
 
-### 5.3 Identity is rel; the fsroot binds at run
+### 5.3 File identity is rel; the fsroot binds at run
 
-Resource identity is the **slash-canonical root-relative path** — the `fsroot.Path` serialization doctrine
+**File-resource** identity is the **slash-canonical root-relative path** — the `fsroot.Path` serialization doctrine
 (`rel` is the half that serializes) applied to the catalog. The fsroot is a **run parameter**, unknown until
 execution. Activation (pre-flight's Pending → Active) is a *state and binding* event, never an identity
 event: afterward the identity is the same rel it was as pending, and the `SourcePath` is the fully bound
@@ -227,7 +273,7 @@ documents simply fail to load and are rewritten by re-planning.
 
 The graph document never records observation. The trace's ledger snapshot (step 48) records what the run
 saw: activations with captured content identity, products, transitions, compensations. Pre-flight in one
-sentence: **every pending rel must exist under the run's root.** The judgment scenarios that pin this split
+sentence: **every pending resource must satisfy its scheme's existence predicate — for file resources, the rel must exist under the run's root.** The judgment scenarios that pin this split
 live in the plan's "Judgment scenarios" section.
 
 ## 6. Recovery — Receipts and the Recovery Site

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -14,9 +14,10 @@ Implement the resource-construction design as ruled: **the graph's resource cata
 it is, in effect, what must exist when the graph runs.** The catalog serializes with the graph (mandatory
 section, even when empty; absence is a hard pre-flight failure). At plan time, resource-typed parameters with
 string values mint **pending** entries — no existence check, no disk contact; promise values record the
-promise and nothing else; products are runtime facts with no plan-time presence. Identity is the
-slash-canonical **root-relative** path — plan-space paths follow the git model (a leading slash anchors at
-the fsroot), and the fsroot itself is a run parameter, unknown until execution. No string-to-resource
+promise and nothing else; products are runtime facts with no plan-time presence. **File-resource** identity is the
+slash-canonical **root-relative** path — plan-space file paths follow the git model (a leading slash anchors
+at the fsroot), and the fsroot itself is a run parameter, unknown until execution; other schemes keep their
+own identity forms (purl, service name, opaque, digest) and existence predicates. No string-to-resource
 conversion happens at run time. The design integrates into `docs/architecture/4-resource-management.md` as
 the body (Appendix A deleted as rejected; the transport plan's content-only narrowing superseded), and the
 sketches retire when integration is complete.
@@ -30,9 +31,10 @@ sketches retire when integration is complete.
 2. **Pre-flight fails hard when a graph has no resource catalog — even an empty one is mandatory.** The
    serialized section is always present; a document without it does not load, and a graph without a catalog
    does not dispatch.
-3. **Identity is rel; the fsroot binds at run.** Plan-space paths follow the git model: a leading slash
-   anchors at the fsroot; machine-absoluteness is inexpressible in a plan and arises only from the run's
-   root choice.
+3. **File identity is rel; the fsroot binds at run.** This ruling is scoped to **file resources** — the
+   full panoply (pkg, svc, git, appnet, the CAS types) keeps its own identity forms and existence
+   predicates. Plan-space file paths follow the git model: a leading slash anchors at the fsroot;
+   machine-absoluteness is inexpressible in a plan and arises only from the run's root choice.
 4. **Activation never changes identity.** The graph is the only place pending resources are *stored*; a run
    activates them on the clone (the graph document is never mutated by a run). Pre-flight transitions
    Pending → Active by verifying each rel under the bound fsroot — a *state and binding* event, never an
@@ -132,7 +134,7 @@ Windows known-failures.
 4. Round-trip pin: pack → unpack → pack byte-identical, including the empty section.
 5. Windows baseline expectation: unchanged (3).
 
-### Phase 2 — portable identity: rel, bound to the run's root (#546/#547) — status: pending
+### Phase 2 — portable file identity: rel, bound to the run's root (#546/#547) — status: pending
 
 **RULED 2026-08-20: named resources are computed relative to some fsroot, and the fsroot is not known until
 the run.** The motivating cases are the product's own scopes: a **home**-scope graph binds to the account
@@ -194,9 +196,10 @@ the catalog at plan time. The plan-time catalog is the graph's *input intent*, a
    `original.txt` (pending), and asserts `duplicate.txt` **absent**, pinning the product ruling in both
    directions. **Delivered early — the pins flipped with phase 1**: planning already interned the
    resource-typed source, so serialization was the missing half and the destination's absence was already
-   true. Phase 3's remaining substance is the claiming discipline itself: plan-time minting must be
-   pending-only with no existence I/O (today's Discover can still resolve at plan time), and the promise
-   grammar verified.
+   true. Phase 3's remaining substance shrank on audit (2026-08-20): `Discover` already performs no
+   existence I/O — its body says so and the executor's pre-flight owns transitions — so phase 3 is the
+   promise grammar verified plus pins for the no-I/O rule and the pre-flight transition-failure semantics
+   (a pending resource that does not exist under the run's root fails the run — Q1 ruling).
 
 ### Phase 4 — run time consumes the catalog, never strings — status: pending
 
@@ -254,6 +257,24 @@ product entry** — the copy never produced; the trace records the node's failur
 **The sentence the scenario proves:** the graph says what must be true; the trace says what happened; the
 gap between them is the run's story.
 
+**Evidence (2026-08-20):** `test_judgment_1_delete_then_copy.star`, wired into the CI suite
+(`TestJudgmentScenario1_DeleteThenCopy`) — five expectations, passing on the first run against phase 1. One
+precision recorded during authoring: `file.remove` takes `path string` by step-23 ruling 2 (only content
+reads take the resource), so the single catalog entry comes from the copy's resource-typed source — the
+count prediction held; the phrasing "delete a named regular file resource" surfaced Remove's typing, and the
+ruling followed (2026-08-20): **mutation targets are resource-typed consumers** — one pending entry, two
+consumers; the remove transitions the entry to Gone at runtime and its receipt relocates the bytes for undo.
+Step-23 ruling 2's path-typed mutation targets are overruled; the `file.remove` signature migration is
+phase-3 claiming-grammar work (#585), after which this scenario's single entry carries both consumer
+links. Refined the same day: **the second consumer sees Gone** — the copy fails on the catalog's verdict, not
+by rediscovering the loss through its own I/O. Evidence of today's gap: the manual run's receipt shows the
+entry still `pending` after the failed run — nothing transitions it yet; #585 closes both halves (the
+behavior-matrix consumption table in 4-resource-management.md §3 records the ruled semantics). Placement
+ruled the same day: the guard lives in the action dispatch seam — after `Method.Invoke`'s slot-to-argument
+conversion, before the forward method call — the earliest point the complete consumed set exists (promises
+resolve only at slot-fill), shared by graph and immediate dispatch; the catalog-resolve verdict is the
+in-flight backstop, and the Gone transition stamps the destroying unit.
+
 ### Scenario 2 — relocate the tree, reconcile the graph
 
 **Setup.** Create a graph; run it at fsroot location A. Copy the **entire tree** to a new fsroot location B
@@ -264,6 +285,9 @@ binding to B is fully defined: nothing in identity remembers A. Every rel exists
 mismatches on every entry** — Etags are stat tuples, and relocation mints new inodes — which is by design:
 the cheap screen escalates to the honest check. **Digests match**, so every entry classifies as **touch
 drift**: Etag refreshed against B, no shadow, no repair, clean report. The graph is at home in its new root.
+
+**Evidence:** deferred — the scenario needs a drivable reconcile surface (phase 4/closure era); it stays a
+recorded prediction until then.
 
 **The contrast that gives the scenario teeth:** under absolute identity, reconciliation at B finds zero
 corresponding resources — every entry "missing," the graph unreconcilable without rewriting it. Scenario 2

--- a/pkg/op/resource_state.go
+++ b/pkg/op/resource_state.go
@@ -16,11 +16,12 @@ import (
 //
 // Three states: Pending (initial — entry exists in the namespace but the underlying resource has not yet been
 // observed or produced), Active (observation succeeded or the producer created the resource; metadata is
-// populated), Gone (the catalog attempted to access the underlying resource via Resolve and it failed; Gone is
-// reactive, not driven by explicit "delete" calls).
+// populated), Gone (the resource is no longer there — an existence check failed, or a mutating consumer
+// destroyed the resource and reported it; a later consumer of a Gone entry sees the state rather than
+// rediscovering the loss).
 //
 // The state field is mutated by catalog code only; provider implementations have no setter. See
-// docs/architecture/4-resource-management.md §3.1 and §6.2 for the full lifecycle spec.
+// docs/architecture/4-resource-management.md §3 (states + the behavior matrix) for the full lifecycle spec.
 type ResourceState int
 
 const (
@@ -30,8 +31,9 @@ const (
 	// Active means the resource has been observed (discovery path) or freshly created (production path).
 	Active
 
-	// Gone means a call to Resolve has failed on this entry; the catalog has tried and the resource is not
-	// where it should be.
+	// Gone means the resource is no longer there: an existence check failed, or a mutating consumer
+	// destroyed the resource and reported it. A later consumer sees Gone from the catalog rather than
+	// rediscovering the loss.
 	Gone
 )
 


### PR DESCRIPTION
Two rulings applied and one scenario proven, under the new definition of clean (CI green + design↔code
evidence).

## Q1 — the matrix agrees with the design and the code

The 2026-07-14 matrix folded pre-flight's existence outcomes into the `Discover` rows — reading as
discover-time I/O that neither the code (`Discover` performs none, by its own comment) nor §3's prose
performs. Re-stated as three tables: **claiming** (plan time, zero I/O), **verification** (pre-flight, the
only home of `Exists()`, with the ruled failure semantics — *a pending resource that fails its scheme's
existence predicate is unmet intent and fails the run*), **production** (dispatch time).

## Precision — these are file-resource rules

The rel-identity and fsroot-binding rulings are the **file scheme's**; pkg/svc/git/appnet/CAS keep their own
identity forms and existence predicates. Scoped through the design doc and the plan. Also corrected on
audit: the plan claimed `Discover` "can still resolve at plan time" — false; phase 3 shrinks accordingly.

## Judgment scenario 1 — proven

`test_judgment_1_delete_then_copy.star`: five expectations, **passing on the first run** against phase 1 —
stored catalog = one pending source entry, destination absent, run fails at the copy, compensation restores
the file. Wired into CI (`TestJudgmentScenario1_DeleteThenCopy`, plus `TestGraphCatalogContract`) so the
scenarios are standing evidence.

## Ruled during authoring: mutation targets are resource-typed consumers

Scenario 1's shape is one pending entry with **two consumers** — the remove transitions it to Gone at
runtime; its receipt relocates the bytes for undo. Step-23 ruling 2's path-typed mutation targets
(`file.Remove(path string, …)`) are **overruled**, and the matrix gains a **consumption table**: a mutating
consumer transitions its entry `Active` → `Gone`; a later consumer of a Gone entry **fails on the catalog's
verdict** — it sees the state, it does not rediscover the loss through its own I/O. Evidence of today's gap:
the manual run's receipt still shows the entry `pending` after the failed run. Placement is ruled as well:
the guard lives in the **action dispatch seam** — after `Method.Invoke`'s slot-to-argument conversion, before
the forward method call — the earliest point the complete consumed set exists (promises resolve only at
slot-fill), shared by graph and immediate dispatch; `Convert`'s catalog hit screens no state today, so the
guard closes a live hole `Discover`'s hit-Gone error never covered. The catalog-resolve verdict stays the
in-flight backstop, and the Gone transition stamps the destroying unit. Both halves ride #585, after which a
delete-only graph also carries its target as pending intent instead of an empty section. The scenario's five
expectations are green under both the interim and the ruled shape.

## Verified

- `make check` — 103 ok, 0 failures (scenario 1 inside the suite)
- `make vet` GOOS=windows
- Windows expectation: identical to baseline 3

Refs #581, #585, #444.
