### PR TITLE
test(scenario): promise-ordering proven; pre-flight fail-fast pinned red for phase 3

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_preflight_fail_fast.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_preflight_fail_fast.star
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_preflight_fail_fast.star — judgment scenario: pre-flight fail-fast (docs/plans/resource-construction.md).
+#
+# A graph claims an existing file as pending intent; the file is deleted AFTER planning, BEFORE the run. The
+# prediction, authored from the ruled design (Q1, 2026-08-20): pre-flight's verification pass finds the
+# pending file resource missing relative to the run's fsroot — unmet intent — and FAILS THE RUN before any
+# unit dispatches; the error is the catalog's verdict ("verify existence"), not a rediscovered copy error,
+# and the destination is never created. Until phase 3 (#585) lands, resolvePendingResources marks Gone
+# without failing, so this scenario is the phase's acceptance pin.
+
+src = t.tmp("vanishes.txt")
+dst = t.tmp("never.txt")
+doc = t.tmp("graph.json")
+
+t.write(src, "gone before the run")
+
+copied = plan.file.copy(source=src, destination_path=dst, mode=0o600)
+graph = plan.assemble_definition([copied])
+plan.save_definition(graph, doc)
+
+# The claim is intent: exactly one pending entry for the source.
+document = json.decode(data=file.read_text(resource=doc))
+entries = document["resources"]
+t.expect_equal(len([e for e in entries if "vanishes.txt" in str(e) and e["state"] == "pending"]), 1)
+
+# Intent breaks before the run starts.
+file.remove(path=src, prune=False, boundary="")
+
+t.expect_error("verify existence")
+t.expect_no_file(dst)
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_judgment_promise_ordering.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_promise_ordering.star
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_promise_ordering.star — judgment scenario: promise ordering (docs/plans/resource-construction.md).
+#
+# One unit produces a file; a second consumes it through the producer's promise, and the list hands the
+# consumer to assemble_definition FIRST. The prediction, authored from the ruled design: ordering comes from
+# promises, so the write still runs before the copy; the promise-fed source mints NO pending entry (a promise
+# is recorded, not claimed) and the products are runtime facts — the stored catalog section is present and
+# EMPTY; the content flows through the promise into the copy.
+
+out = t.tmp("produced.txt")
+dst = t.tmp("copied.txt")
+doc = t.tmp("graph.json")
+
+written = plan.file.write_text(destination_path=out, content="flows through the promise", mode=0o600)
+copied  = plan.file.copy(source=written, destination_path=dst, mode=0o600)
+
+# Consumer first: if ordering were positional, the copy would dispatch before its source exists.
+graph = plan.assemble_definition([copied, written])
+plan.save_definition(graph, doc)
+
+# The mandatory catalog section is present and empty: no claims, only a promise and two products.
+document = json.decode(data=file.read_text(resource=doc))
+t.expect_equal(len(document["resources"]), 0)
+
+t.expect_unit_count(2)
+t.expect_file(out, content="flows through the promise")
+t.expect_file(dst, content="flows through the promise")
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -443,3 +443,13 @@ func TestGraphCatalogContract(t *testing.T) {
 func TestJudgmentScenario1_DeleteThenCopy(t *testing.T) {
 	runScript(t, "test_judgment_1_delete_then_copy.star")
 }
+
+func TestJudgmentPreflightFailFast(t *testing.T) {
+	t.Skip("phase-3 acceptance pin (#585): resolvePendingResources marks Gone without failing the run; " +
+		"un-skip when pre-flight fails on unmet intent")
+	runScript(t, "test_judgment_preflight_fail_fast.star")
+}
+
+func TestJudgmentPromiseOrdering(t *testing.T) {
+	runScript(t, "test_judgment_promise_ordering.star")
+}

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -294,6 +294,39 @@ corresponding resources — every entry "missing," the graph unreconcilable with
 is the relocation proof — the direct payoff of rel identity — and it exercises the reconciler's two-tier
 cascade (Etag screen → Digest verdict) exactly as designed.
 
+### Scenario — promise ordering
+
+**Setup.** One unit produces a file; a second consumes it through the producer's promise. The list hands the
+**consumer first** to `assemble_definition` — if ordering were positional, the copy would dispatch before its
+source exists.
+
+**Predictions.** Ordering comes from promises, so the write runs before the copy regardless of list
+position; the promise-fed source mints **no** pending entry (a promise is recorded, not claimed); the
+products are runtime facts — the stored catalog section is present and **empty**; the produced content flows
+through the promise into the copy.
+
+**Evidence (2026-08-20):** `test_judgment_promise_ordering.star`, wired into the CI suite
+(`TestJudgmentPromiseOrdering`) — four expectations, passing on the first run. The consumer-first list is the
+sharp assertion: execution ordered by the promise edge, not by position.
+
+### Scenario — pre-flight fail-fast
+
+**Setup.** A graph claims an existing file as pending intent; the file is deleted **after planning, before
+the run**.
+
+**Predictions (from the Q1 ruling).** Pre-flight's verification pass finds the pending file resource missing
+relative to the run's fsroot — unmet intent — and **fails the run before any unit dispatches**; the error is
+the catalog's verdict (`verify existence: resource … does not exist`), not a rediscovered copy error; the
+destination is never created.
+
+**Evidence (2026-08-20): red, exactly as predicted — this is phase 3's acceptance pin.**
+`test_judgment_preflight_fail_fast.star`: two of three expectations pass (one pending entry claimed; the
+destination never created); the error-shape expectation fails because today's run produced
+`file.copy: openat vanishes.txt: no such file or directory` — the copy **dispatched** and rediscovered the
+loss through its own I/O. `resolvePendingResources` says so itself: "Mark, don't fail." Wired as
+`TestJudgmentPreflightFailFast` with a `t.Skip` naming the gap; #585 un-skips it, and the scenario flipping
+green is the phase's acceptance evidence.
+
 ## Open questions — all ruled 2026-08-20
 
 1. ~~Which string parameters are output-naming?~~ — **RULED: none.** Products are runtime-created; nothing

--- a/scripts/Get-EpicReport
+++ b/scripts/Get-EpicReport
@@ -5,8 +5,9 @@
 
 # Get-EpicReport - render the epic / feature / task tree as markdown
 #
-# GitHub is the index. Four kinds across three tiers: `epic` -> `feature` -> {`task` | `bug`}. A task
-# implements part of a feature; a bug repairs one. They are peers and mutually exclusive. Every issue also
+# GitHub is the index. Five kinds across three tiers: `epic` -> `feature` -> {`task` | `bug`}, plus `chore`
+# for maintenance work on the repo itself (adopted by #574). A task implements part of a feature; a bug
+# repairs one. They are peers and mutually exclusive. Every issue also
 # carries its epic's `Epic:<Name>` label, and every tier-three issue states its parent in its body as
 # `**Feature:** #<number>`; those without the marker are reported under "Unfiled" rather than silently
 # attached to something.
@@ -112,7 +113,7 @@ gh issue list \
         --arg debtOnly "$debt_only" --argjson exempt "$exempt" '
     def names: [.labels[].name];
     def tagged($l): (names | index($l)) != null;
-    def kinds: (names | map(select(. == "epic" or . == "feature" or . == "task" or . == "bug")));
+    def kinds: (names | map(select(. == "epic" or . == "feature" or . == "task" or . == "bug" or . == "chore")));
     def epicTags: (names | map(select(startswith("Epic:"))));
     def epicTag: (epicTags | first // "");
     def mark: if .state == "CLOSED" then "~~" else "" end;
@@ -149,7 +150,7 @@ gh issue list \
 
     def faults:
       if awaitingTriage then [] else
-      [ (if (kinds | length) == 0 then "no kind label (epic/feature/task/bug)" else empty end),
+      [ (if (kinds | length) == 0 then "no kind label (epic/feature/task/bug/chore)" else empty end),
         (if (kinds | length) > 1 then "multiple kind labels: \(kinds | join(", "))" else empty end),
         (if (epicTags | length) == 0 then "no Epic:<Name> label" else empty end),
         (if (epicTags | length) > 1 then "multiple epics: \(epicTags | join(", "))" else empty end) ] end;

--- a/scripts/Get-EpicReport
+++ b/scripts/Get-EpicReport
@@ -123,6 +123,8 @@ gh issue list \
     def isBug: tagged("bug");
     def severity: (names | map(select(startswith("Severity:"))) | first // "");
     def priority: (names | map(select(startswith("Priority:"))) | first // "");
+    def taskRow:
+      "| \(if .state == "CLOSED" then "✅" else "" end) | [#\(.number)](\(.url)) | \(mark)\(.title | gsub("\\|"; "\\\\|"))\(mark) | \(if isBug then "bug" else "task" end) | \(severity | ltrimstr("Severity:")) | \(priority | ltrimstr("Priority:")) |";
     def severityRank:
       severity
       | if . == "Severity:Critical" then 0
@@ -130,12 +132,6 @@ gh issue list \
         elif . == "Severity:Medium" then 2
         elif . == "Severity:Low" then 3
         else 4 end;
-    def triage:
-      [ (if isBug then "bug" else empty end),
-        (if severity != "" then severity else empty end),
-        (if priority != "" then priority else empty end) ]
-      | if length == 0 then "" else " — **" + join("** · **") + "**" end;
-
     # A tier-three issue is a task or a bug; they are peers under a feature.
     def isChild: tagged("task") or isBug;
 
@@ -209,23 +205,27 @@ gh issue list \
                     | [ $all[] | select(isChild          and epicTag == $tag) ] as $tasks
                     | ([ $features[].number ]) as $featureNumbers
                     | (
-                        "\n# \($e | line)",
+                        "\n## \($e | line)",
                         "\n_\($features | length) feature(s), \([$tasks[] | select(isBug | not)] | length) task(s), \([$tasks[] | select(isBug)] | length) bug(s)._",
                         ( $features
                           | sort_by(.number)
                           | .[] as $f
-                          | ( "\n## \($f | line)",
+                          | ( "\n### \($f | line)",
                               ( [ $tasks[] | select(parentFeature == $f.number) ]
                                 | sort_by(.number)
                                 | if length == 0 then "\n_No tasks filed._"
-                                  else (.[] | "\n### \(line)\(triage)") end ) ) ),
+                                  else ( "\n| Done | Issue | Title | Kind | Severity | Priority |",
+                                         "|---|---|---|---|---|---|",
+                                         (.[] | taskRow) ) end ) ) ),
                         ( [ $tasks[]
                             | select(parentFeature == null
                                      or (parentFeature as $p | $featureNumbers | index($p) | not)) ]
                           | sort_by(.number)
                           | if length == 0 then empty
-                            else ( "\n## Unfiled — no parent feature stated",
-                                   (.[] | "\n### \(line)\(triage)") ) end )
+                            else ( "\n### Unfiled — no parent feature stated",
+                                   "\n| Done | Issue | Title | Kind | Severity | Priority |",
+                                   "|---|---|---|---|---|---|",
+                                   (.[] | taskRow) ) end )
                       ) ) )
               end )
         end )


### PR DESCRIPTION
Two judgment scenarios join the roster, both authored as predictions before touching the implementation.

## Promise ordering — green, 4/4, first run

`test_judgment_promise_ordering.star`: one unit produces a file, a second consumes it through the promise,
and the list hands the **consumer first** to `assemble_definition`. Execution ordered by the promise edge,
not list position; the promise-fed source minted **no** pending entry (a promise is recorded, not claimed);
the catalog section is present and **empty** (products are runtime facts); content flowed through the
promise. Wired as `TestJudgmentPromiseOrdering`.

## Pre-flight fail-fast — red exactly as predicted; phase 3's acceptance pin

`test_judgment_preflight_fail_fast.star`: a graph claims an existing file as pending intent; the file is
deleted after planning, before the run. Ruled prediction (Q1): pre-flight fails the run on unmet intent —
the catalog's verdict, no unit dispatches. Today: the copy **dispatched** and rediscovered the loss
(`file.copy: openat vanishes.txt: no such file or directory`) because `resolvePendingResources` marks Gone
without failing ("Mark, don't fail" — its own comment). Wired as `TestJudgmentPreflightFailFast` under a
`t.Skip` naming the gap; #585 un-skips it, and the flip to green is the phase's acceptance evidence.

## Also

`Get-EpicReport` learns the `chore` kind (adopted by #574): the audit's kind set predated it and reported
chore-classified issues as unclassified. With the fix the audit runs clean.

## Verified

- `make check` — 103 ok, 0 failures (promise scenario runs inside the suite; fail-fast pin skips with its
  reason; shell-lint covers the script edit)
- Windows expectation: identical to baseline 3

Refs #581, #585, #574.
