### PR TITLE
feat(file): identity is the rel — the mint flips, and the trace records the binding

### DIFF
--- a/cmd/writ/writ/readback/readback.go
+++ b/cmd/writ/writ/readback/readback.go
@@ -417,9 +417,10 @@ type contentIdentity struct {
 
 // recordedIdentity extracts the per-path content identity a run's ledger snapshot recorded (step 48).
 //
-// File-form entries (URIs whose tag-specific payload is `file://<path>`) map by absolute path; later
-// generations of the same path win (append order). A nil catalog — a pre-capture trace — yields an empty map,
-// and consumers treat the absent identity as indeterminate.
+// File-form entries (URIs whose tag-specific payload is `file:<rel>`) carry root-relative identity
+// (#584); the native key is derived by joining the snapshot's recorded run root with the rel — identity is
+// never parsed for a native form. Later generations of the same path win (append order). A nil catalog — a
+// pre-capture trace — yields an empty map, and consumers treat the absent identity as indeterminate.
 //
 // Parameters:
 //   - `catalog`: the trace's ledger snapshot, or nil.
@@ -441,11 +442,11 @@ func recordedIdentity(catalog *op.ResourceLedgerSnapshot) map[string]contentIden
 		if err != nil {
 			continue
 		}
-		path, ok := strings.CutPrefix(specific, "file://")
+		rel, ok := strings.CutPrefix(specific, "file:")
 		if !ok {
 			continue
 		}
-		recorded[path] = contentIdentity{etag: entry.Etag, digest: entry.Digest}
+		recorded[filepath.Join(catalog.Root, filepath.FromSlash(rel))] = contentIdentity{etag: entry.Etag, digest: entry.Digest}
 	}
 
 	return recorded

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -272,7 +272,11 @@ documents simply fail to load and are rewritten by re-planning.
 ### 5.5 Graph = intent; trace = observation
 
 The graph document never records observation. The trace's ledger snapshot (step 48) records what the run
-saw: activations with captured content identity, products, transitions, compensations. Pre-flight in one
+saw: activations with captured content identity, products, transitions, compensations — and **the binding**:
+the snapshot names the root the run bound (its `root` field, stamped by the executor at capture), because
+file identities are rels and a recorded rel is interpretable only against the root that ran it. Consumers
+derive an entry's native path by joining the recorded root with the URI's rel payload — identity is never
+parsed for a native form (the #547 rule). Pre-flight in one
 sentence: **every pending resource must satisfy its scheme's existence predicate — for file resources, the rel must exist under the run's root.** The judgment scenarios that pin this split
 live in the plan's "Judgment scenarios" section.
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -206,6 +206,16 @@ re-asserts against the rel form (`file:https:/example.com/x`), which also makes 
 expected to clear on Windows. Escaping rels (`../…`) still mint until PR 2's grammar refuses authoring them.
 Gate: make check 103 ok / 0 fail, GOOS=windows vet clean.
 
+**Run-from-elsewhere caveat (USER, 2026-08-21): PR 3 is load-bearing, not closure hygiene.** The existence
+check reads `r.RuntimeEnvironment().Root()` — the environment the resource object was *constructed*
+against — and feeds `SourcePath.Abs()`, the construction-time absolute (`file.Resource.Exists`/`Resolve`;
+`Resolve` even re-binds abs-first). Plan-and-run-in-one-session flows hide this because the roots coincide;
+**save the graph and run later from elsewhere and they don't** — the run verifies against the load
+environment's root, never the run's. PR 1 made the identity payload relocatable; PR 3 must make the
+*verification* relocatable: pre-flight binds every pending rel against the run's root (rel-first activation
+binding at the executor's resolve pass, where the run environment is in scope), and Abs derives from that
+binding.
+
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 
 **RULED 2026-08-20, superseding the sketch's output section (:21–27) and rejecting Appendix A outright:**

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -193,7 +193,9 @@ actual shape) and what #571's declared-roots direction extends naturally into `(
 **PR slicing:** PR 1 — the identity mint (URI specific part carries `SourcePath.Rel()`), the 4.1 amendment,
 re-pinned format-identity tests; Windows 3 → 2. PR 2 — the plan-space grammar with both refusals plus the
 full authoring migration (`t.tmp`, writ deploy, tests) and the re-diagnosed fixes for the two path-as-text
-failures; Windows 2 → 0. PR 3 — the four consumers onto `SourcePath.Abs()`, pre-flight as the one sentence,
+failures; Windows 2 → 0. The grammar also **reserves the root-qualification spelling** (#597 — named
+multi-root design, filed 2026-08-21): a shape like `@name/rel` that cannot collide with the drive-letter
+refusal, decided now so the little language does not break when multi-root lands. PR 3 — the four consumers onto `SourcePath.Abs()`, pre-flight as the one sentence,
 closure.
 
 **PR 1 record (2026-08-21):** the mint flips to the ruled opaque form — `"file:" + SourcePath.Rel()`
@@ -215,6 +217,14 @@ environment's root, never the run's. PR 1 made the identity payload relocatable;
 *verification* relocatable: pre-flight binds every pending rel against the run's root (rel-first activation
 binding at the executor's resolve pass, where the run environment is in scope), and Abs derives from that
 binding.
+
+**The sixth discovery (2026-08-21, caught by the foreign-scheme pin on Windows):** `fsroot.makePath`'s rel
+half was not platform-neutral — Windows `filepath.Clean` guards a colon-bearing first segment with a
+leading `./` (drive-relative disambiguation), so the same input minted `./https:/example.com/x` on Windows
+and `https:/example.com/x` elsewhere. Fixed where the capability lives: `fsroot.canonicalRel` (slash-path
+Clean after separator normalization) renders every rel in both `makePath` branches and `fsroot.NewPath`,
+with a platform-neutrality pin in the fsroot suite. Exactly the class #547 predicted ("the sixth is
+waiting"); recorded on #547.
 
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -176,6 +176,36 @@ actual shape) and what #571's declared-roots direction extends naturally into `(
    **3 → 0** if all three prove to be pure identity-form failures; any remainder is re-diagnosed, not
    assumed.
 
+**Review findings (2026-08-21, from the live CI logs and the code):**
+
+- Failure diagnosis: `TestDiscoverRegular_ForeignSchemeString_IsAPath` is **pure identity-form** (the tag
+  URI embeds the backslashed machine-absolute path) — the identity mint fixes it directly.
+  `TestSourceFile_StarlarkIntegration` is a machine path **interpolated into generated Starlark source**
+  (`\U` reads as an invalid escape) and `TestWriteOnboardManifest…` is **mixed-separator narration**
+  (`C:\…\001/packages-manifest.yaml`) — both are path-as-text at their surfaces, cured in the
+  authoring-migration step, not by the mint.
+- Sequencing constraint: **the grammar refusals and the harness migration must co-land** — once volume
+  spellings are plan-time refusals, every `t.tmp`-authored script fails to plan (`t.tmp` returns
+  `filepath.Join(tmpDir, name)`, machine-absolute). The identity mint has no such coupling: `SourcePath`
+  already carries `Rel()`, so the mint lands first and alone.
+- Providers already use `SourcePath.Abs()` at their I/O sites; step 4's four consumers are a bounded hunt.
+
+**PR slicing:** PR 1 — the identity mint (URI specific part carries `SourcePath.Rel()`), the 4.1 amendment,
+re-pinned format-identity tests; Windows 3 → 2. PR 2 — the plan-space grammar with both refusals plus the
+full authoring migration (`t.tmp`, writ deploy, tests) and the re-diagnosed fixes for the two path-as-text
+failures; Windows 2 → 0. PR 3 — the four consumers onto `SourcePath.Abs()`, pre-flight as the one sentence,
+closure.
+
+**PR 1 record (2026-08-21):** the mint flips to the ruled opaque form — `"file:" + SourcePath.Rel()`
+(4.1's amended row and sketch, already landed in phase 0). The empirical consumer hunt found ONE seam, not
+four: writ's readback (`recordedIdentity`) parsed the URI's embedded path and keyed drift attribution by it;
+everything else already used `SourcePath.Abs()`. The fix is design-true: `ResourceLedgerSnapshot` gains
+`Root` — the run's bound fsroot, stamped by the executor at capture (§5.5: the trace records the binding) —
+and readback joins the recorded root with the rel to derive its native keys. The foreign-scheme pin
+re-asserts against the rel form (`file:https:/example.com/x`), which also makes it platform-neutral —
+expected to clear on Windows. Escaping rels (`../…`) still mint until PR 2's grammar refuses authoring them.
+Gate: make check 103 ok / 0 fail, GOOS=windows vet clean.
+
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 
 **RULED 2026-08-20, superseding the sketch's output section (:21–27) and rejecting Appendix A outright:**

--- a/pkg/fsroot/fsroot.go
+++ b/pkg/fsroot/fsroot.go
@@ -16,6 +16,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+
+	// Aliased: the rel half of a Path is a slash-form value on every platform, and its canonical form
+	// comes from the slash-path Clean, not the OS one.
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -578,7 +582,7 @@ type Path struct {
 // Returns:
 //   - `Path`: the constructed path, with `rel` canonicalized to slash form.
 func NewPath(root, rel string) Path {
-	return Path{root: root, rel: filepath.ToSlash(rel), abs: filepath.Join(root, rel)}
+	return Path{root: root, rel: canonicalRel(rel), abs: filepath.Join(root, rel)}
 }
 
 // region EXPORTED METHODS
@@ -773,13 +777,31 @@ func makePath(rootName string, name []string) Path {
 
 	if filepath.IsAbs(path) {
 		rel := assert.Must(filepath.Rel(rootName, path))
-		return Path{root: rootName, rel: filepath.ToSlash(rel), abs: filepath.Clean(path)}
+		return Path{root: rootName, rel: canonicalRel(rel), abs: filepath.Clean(path)}
 	}
 	return Path{
 		root: rootName,
-		rel:  filepath.ToSlash(filepath.Clean(path)),
+		rel:  canonicalRel(path),
 		abs:  filepath.Join(rootName, path),
 	}
+}
+
+// canonicalRel renders `rel` in the slash-canonical form that is identical on every platform.
+//
+// The OS-form Clean is not neutral: on Windows it guards a first segment containing a colon with a leading
+// ".\" so the result cannot be misread as drive-relative (the CVE-2022-41722 rule), and that guard would
+// otherwise ride into the rel — the identity half of a [Path] — making the same input mint different
+// identities per platform (#547's sixth discovery, caught by the foreign-scheme identity pin). The slash-path
+// Clean owns the canonical form: OS separators normalize first, then slash semantics collapse duplicate
+// slashes, dot segments, and the guard alike.
+//
+// Parameters:
+//   - `rel`: the relative path in any separator form.
+//
+// Returns:
+//   - `string`: the slash-canonical relative path.
+func canonicalRel(rel string) string {
+	return slashpath.Clean(filepath.ToSlash(rel))
 }
 
 // createTempIn creates a uniquely named file under `dir`, mirroring [os.CreateTemp] inside a root.

--- a/pkg/fsroot/fsroot_test.go
+++ b/pkg/fsroot/fsroot_test.go
@@ -94,6 +94,25 @@ func TestRoot_NewPath_CleansDotSegments(t *testing.T) {
 	}
 }
 
+func TestRoot_NewPath_ColonSegmentRelIsPlatformNeutral(t *testing.T) {
+
+	// A first segment containing a colon trips Windows filepath.Clean into guarding the result with a
+	// leading ".\" (the drive-relative disambiguation), and that guard must never reach the rel — the
+	// identity half of a Path is slash-canonical and identical on every platform (#547's sixth discovery:
+	// the same input minted "./https:/example.com/x" on Windows and "https:/example.com/x" elsewhere).
+	dir := t.TempDir()
+	roots := allRoots(t, dir)
+
+	for _, tc := range roots {
+		t.Run(tc.name, func(t *testing.T) {
+			p := tc.root.NewPath("https://example.com/x")
+			if p.Rel() != "https:/example.com/x" {
+				t.Errorf("Rel() = %q, want %q", p.Rel(), "https:/example.com/x")
+			}
+		})
+	}
+}
+
 func TestPath_MarshalJSON(t *testing.T) {
 
 	p := fsroot.NewPath("/project", "src/main.go")

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -310,9 +310,7 @@ func (e *GraphExecutor) ResumeUnwind(ctx context.Context) error {
 	}
 	e.environment = environment
 	defer func() {
-		if e.environment.ResourceCatalog != nil {
-			e.ledgerSnapshot = e.environment.ResourceCatalog.Snapshot()
-		}
+		e.captureLedgerSnapshot()
 		//nolint:errcheck // diagnose-ignored-error: cleanup close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = e.environment.Close()
 		e.environment = nil
@@ -512,9 +510,7 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 		// after Run returns) can project it into [Trace.Catalog]: a paused run's trace becomes resumable, and a
 		// completed run's trace records the as-deployed content identity — the ledger's Etag/Digest capture
 		// (phase-8 step 48) — that drift attribution reads back.
-		if e.environment.ResourceCatalog != nil {
-			e.ledgerSnapshot = e.environment.ResourceCatalog.Snapshot()
-		}
+		e.captureLedgerSnapshot()
 		//nolint:errcheck // diagnose-ignored-error: cleanup close; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = e.environment.Close()
 		e.environment = nil
@@ -1071,6 +1067,23 @@ func (e *GraphExecutor) bindVariables(graph *Graph, callerVariables map[string]V
 // operations against a not-yet-existent path is legitimate (`file.exists` on a missing file answers false; a producer
 // revives a [Gone] URI via shadow), and consumers of a genuinely missing resource fail at their own dispatch (the Q2
 // "dependents fail on their own" precedent). The probes are read-only (stat-class), so the pass also runs in dry-run.
+// captureLedgerSnapshot records the resource ledger and the run's bound root for the trace.
+//
+// The binding half of the trace record: file identities are root-relative (#584), so the snapshot names
+// the root this run bound them to. A nil catalog leaves the snapshot untouched.
+func (e *GraphExecutor) captureLedgerSnapshot() {
+
+	if e.environment.ResourceCatalog == nil {
+		return
+	}
+
+	e.ledgerSnapshot = e.environment.ResourceCatalog.Snapshot()
+
+	if e.environment.HasRoot() {
+		e.ledgerSnapshot.Root = e.environment.Root().Name()
+	}
+}
+
 func (e *GraphExecutor) resolvePendingResources() {
 
 	catalog := e.environment.ResourceCatalog

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -101,17 +101,18 @@ func buildCandidateAs(
 	}
 
 	// The input is a filesystem path. One internal round-trip also lands here: catalog rehydration hands
-	// back this provider's own emitted identity specific ("file://" + path) — strip our own prefix and it
-	// is a path again. No URI parsing: the provider decodes only what it mints (readback does the same).
-	path = strings.TrimPrefix(path, "file://")
+	// back this provider's own emitted identity specific ("file:" + rel) — strip our own prefix and it is
+	// a path again. No URI parsing: the provider decodes only what it mints (readback does the same).
+	path = strings.TrimPrefix(path, "file:")
 	sourcePath := runtimeEnvironment.Root().NewPath(path)
 	var base op.ResourceBase
 
-	// NOTE: this identity is OS-native, so on Windows it carries backslashes inside a URI — see #547.
-	// Normalizing HERE was tried on 2026-08-18 and reverted: it fixed the identity string and broke four
-	// consumers that key on the native form, because the transform belongs at resource construction with
-	// the resource owning both forms, not at one site along the way.
-	base, err = op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), resourceType)
+	// Identity is the slash-canonical root-relative path (#584, ruled 2026-08-20): the fsroot is a run
+	// parameter, so the rel half is what serializes and the same graph relocates across prefixes. The
+	// native form is access, not identity — consumers reach it through SourcePath.Abs(), never by parsing
+	// the URI. A rel that escapes the root ("../…") still mints here until the plan-space grammar (PR 2 of
+	// phase 2) refuses authoring it.
+	base, err = op.NewResourceBase(runtimeEnvironment, "file:"+sourcePath.Rel(), resourceType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/op/provider/file/resource_input_test.go
+++ b/pkg/op/provider/file/resource_input_test.go
@@ -64,8 +64,9 @@ func TestDiscoverRegular_ForeignSchemeString_IsAPath(t *testing.T) {
 	}
 
 	// Path canonicalization collapses the "//" — the string rides as the relative path
-	// "https:/example.com/x" under the root, proving no scheme grammar intervened.
-	if !strings.Contains(resource.URI(), "/https:/example.com/x") {
+	// "https:/example.com/x" under the root, proving no scheme grammar intervened. Identity is the rel
+	// itself (#584), so it sits immediately after the file: marker, slash-canonical on every platform.
+	if !strings.Contains(resource.URI(), "file:https:/example.com/x") {
 		t.Fatalf("expected the string carried as a path in the identity, got %s", resource.URI())
 	}
 }

--- a/pkg/op/provider/file/resource_input_test.go
+++ b/pkg/op/provider/file/resource_input_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // The constructor input domain (paths-only ruling, 2026-08-09): the input is a filesystem path, plus the one
-// internal round-trip — the provider's own emitted identity specific ("file://" + path) handed back by
+// internal round-trip — the provider's own emitted identity specific ("file:" + rel, #584) handed back by
 // catalog rehydration. No URI grammar exists on the input side.
 
 func TestDiscoverRegular_PathAndOwnSpecific_SameIdentity(t *testing.T) {
@@ -24,7 +24,10 @@ func TestDiscoverRegular_PathAndOwnSpecific_SameIdentity(t *testing.T) {
 		t.Fatalf("DiscoverRegular(path): %v", err)
 	}
 
-	fromSpecific, err := DiscoverRegular(p.RuntimeEnvironment(), "file://"+path)
+	// The provider's OWN specific, asked of the resource rather than spelled here — the pin follows the
+	// mint instead of freezing a retired form (the defect this test caught on Windows when it hardcoded
+	// "file://" + abs).
+	fromSpecific, err := DiscoverRegular(p.RuntimeEnvironment(), fromPath.ReachabilityURI())
 	if err != nil {
 		t.Fatalf("DiscoverRegular(own specific): %v", err)
 	}

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -831,6 +831,12 @@ func stripFragment(uri string) string {
 // receipt references resolve against the rehydrated ledger by id.
 type ResourceLedgerSnapshot struct {
 
+	// Root is the run's bound fsroot, stamped by the executor at capture time (empty on a snapshot taken
+	// outside a run). File identities are root-relative (#584), so the trace must record which root the run
+	// bound — consumers derive an entry's native path by joining Root with the URI's rel payload, never by
+	// parsing a native form out of identity.
+	Root string `json:"root" yaml:"root"`
+
 	// Entries is every ledger generation in append order. Replaying that order reproduces the URI→id namespace's
 	// current-generation pointer (last writer for a URI wins).
 	Entries []LedgerEntrySnapshot `json:"entries" yaml:"entries"`


### PR DESCRIPTION
Phase 2, PR 1 of [resource-construction](docs/plans/resource-construction.md) (#584).

## The mint

File identity mints from `SourcePath.Rel()` in the ruled opaque form — `"file:" + rel`, slash-canonical on
every platform (4.1's amended row and sketch). The fsroot is a run parameter, so the rel half is what
serializes and one graph relocates across prefixes. The native form is access, not identity: consumers use
`SourcePath.Abs()`, never URI parsing (the #547 rule). Escaping rels (`../…`) still mint until PR 2's
grammar refuses authoring them.

## The binding

The 2026-08-18 revert's "four consumers" resolved empirically to **one seam**: writ's readback parsed the
URI's embedded absolute path and keyed drift attribution by it. Design-true fix: `ResourceLedgerSnapshot`
gains `Root` — the run's bound fsroot, stamped by the executor at capture — and `recordedIdentity` joins
the recorded root with each entry's rel to derive its native keys. §5.5 records the doctrine: the graph
stays root-free (intent); the trace records the binding (observation).

## Windows expectation: 3 → 2

`TestDiscoverRegular_ForeignSchemeString_IsAPath` pins the rel form (`file:https:/example.com/x`), which is
platform-neutral — expected to clear. The remaining two (`TestSourceFile_StarlarkIntegration`,
`TestWriteOnboardManifest…`) are path-as-text at their authoring/narration surfaces — PR 2's work, per the
review diagnosis now recorded in the plan.

## Verified

- `make check` — 103 ok, 0 failures (the full suite, writ drift attribution included)
- `make vet` GOOS=windows
- gofmt clean

Refs #584, #547, #546.
