### PR TITLE
feat(file): the plan-space path grammar, and every authoring surface speaks it

### DIFF
--- a/cmd/devlore-test/devloretest/test_context.go
+++ b/cmd/devlore-test/devloretest/test_context.go
@@ -361,15 +361,34 @@ func (tc *TestContext) checkNoFile(exp Expectation) *Failure {
 	return nil
 }
 
+// resolve maps a script-supplied path onto the disk: a plan-space rel resolves against the scoping root's
+// anchor; an absolute path passes through.
+//
+// Parameters:
+//   - `path`: the script-supplied path — a plan-space rel (t.tmp's form) or an absolute path.
+//
+// Returns:
+//   - `string`: the absolute path.
+func (tc *TestContext) resolve(path string) string {
+
+	if filepath.IsAbs(path) || tc.root == nil {
+		return path
+	}
+
+	return filepath.Join(tc.root.Name(), filepath.FromSlash(path))
+}
+
 // readFile reads a file, using root-scoped I/O when root is available. Falls back to os.ReadFile otherwise.
 //
 // Parameters:
-//   - `abs`: absolute path to the file.
+//   - `path`: the script-supplied path; resolved via [TestContext.resolve].
 //
 // Returns:
 //   - []byte: file contents.
 //   - `error`: any read error.
-func (tc *TestContext) readFile(abs string) ([]byte, error) {
+func (tc *TestContext) readFile(path string) ([]byte, error) {
+
+	abs := tc.resolve(path)
 
 	if tc.root != nil {
 		return tc.root.ReadFile(tc.root.NewPath(abs))
@@ -515,7 +534,7 @@ func (tc *TestContext) starMkdir(
 		return nil, err
 	}
 
-	if err := os.MkdirAll(path, 0o750); err != nil {
+	if err := os.MkdirAll(tc.resolve(path), 0o750); err != nil {
 		return nil, fmt.Errorf("t.mkdir: %w", err)
 	}
 
@@ -535,12 +554,13 @@ func (tc *TestContext) starWrite(
 		return nil, err
 	}
 
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return nil, fmt.Errorf("t.write: %w", err)
+	abs := tc.resolve(path)
+
+	if err := os.MkdirAll(filepath.Dir(abs), 0o750); err != nil {
+		return nil, fmt.Errorf("t.mkdir: %w", err)
 	}
 
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+	if err := os.WriteFile(abs, []byte(content), 0o600); err != nil {
 		return nil, fmt.Errorf("t.write: %w", err)
 	}
 
@@ -565,6 +585,16 @@ func (tc *TestContext) starTmp(
 		return nil, fmt.Errorf("t.tmp: path traversal not allowed: %s", relative)
 	}
 
+	// Plan-space names (#584 phase 2): with a scoping root, t.tmp returns the slash-canonical rel of the
+	// name under the run's root — the same value works as authored plan input, immediate-mode I/O, and a
+	// harness expectation, because every consumer resolves rels against the one root. Without a root the
+	// context falls back to the historical absolute form.
+	if tc.root != nil {
+		if rel, err := filepath.Rel(tc.root.Name(), filepath.Join(tc.tmpDir, relative)); err == nil {
+			return starlark.String(filepath.ToSlash(rel)), nil
+		}
+	}
+
 	return starlark.String(filepath.Join(tc.tmpDir, relative)), nil
 }
 
@@ -576,7 +606,9 @@ func (tc *TestContext) starTmp(
 // Returns:
 //   - os.FileInfo: file metadata.
 //   - `error`: any stat error.
-func (tc *TestContext) stat(abs string) (os.FileInfo, error) {
+func (tc *TestContext) stat(path string) (os.FileInfo, error) {
+
+	abs := tc.resolve(path)
 
 	if tc.root != nil {
 		return tc.root.Stat(tc.root.NewPath(abs))
@@ -839,9 +871,17 @@ func (tc *TestContext) buildSpec() (*op.RuntimeEnvironmentSpec, error) {
 		Config:    tc.sources.Config,
 	}
 
+	// One root everywhere (#584 phase 2): the run anchors where the script session anchors — the scoping
+	// root's own name — so plan-space rels mean the same disk locations at plan time, immediate dispatch,
+	// and run dispatch. The .devlore/tmp prefix lives in the rels t.tmp returns, not in the root.
+	anchor := tc.tmpDir
+	if tc.root != nil {
+		anchor = tc.root.Name()
+	}
+
 	return op.NewRuntimeEnvironmentSpec(programName).
 		WithStatus(cli.UI()).
-		WithRoot(tc.tmpDir).
+		WithRoot(anchor).
 		WithPlatform(hostPlatform).
 		WithApplication(app), nil
 }

--- a/cmd/lore/lore/commands.go
+++ b/cmd/lore/lore/commands.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -799,7 +800,7 @@ func reportOnboardResult(result *onboard.Result) {
 //   - `error`: non-nil when the manifest cannot be written.
 func writeOnboardManifest(outputDir string, result *onboard.Result) error {
 
-	manifestPath := outputDir + "/packages-manifest.yaml"
+	manifestPath := filepath.Join(outputDir, "packages-manifest.yaml")
 	if err := os.WriteFile(manifestPath, []byte(result.Manifest), 0o600); err != nil {
 		return fmt.Errorf("writing manifest: %w", err)
 	}

--- a/cmd/star/star/sourcefile_integration_test.go
+++ b/cmd/star/star/sourcefile_integration_test.go
@@ -215,6 +215,7 @@ var MaxRetries = 3
 	t.Cleanup(func() { os.Chdir(origDir) })
 
 	r := NewApplication(&cobra.Command{Use: "star"})
+	t.Cleanup(func() { _ = r.Close() })
 
 	// Load the test extension.
 	if err := r.LoadExtensionsFrom(filepath.Join(dir, "star", "extensions")); err != nil {

--- a/cmd/star/star/sourcefile_integration_test.go
+++ b/cmd/star/star/sourcefile_integration_test.go
@@ -109,8 +109,10 @@ var MaxRetries = 3
 		t.Fatal(err)
 	}
 
+	// The path rides inside double-quoted starlark source, so it must be slash-form — a native Windows
+	// spelling's backslashes read as escape sequences there (#547: path-as-text is neutral text).
 	starScript := `def run(command, ctx):
-    ast = goast.load_source_file("` + testGoPath + `")
+    ast = goast.load_source_file("` + filepath.ToSlash(testGoPath) + `")
 
     # --- PkgPath name (string return = eagerly evaluated property) ---
     if ast.package_name != "example":

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -139,6 +139,24 @@ func BuildGraphs(ctx context.Context, cfg *Config, pin *PinInfo) (*BuildResult, 
 //   - `error`: non-nil when the pipeline is unknown or a planning call fails.
 func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]any) (*op.Invocation, string, error) {
 
+	// The plan carries rels (#584 phase 2): every path the chain authors renders in plan space against the
+	// planning environment's root — writ chose that root (the common ancestor of sources and targets), and
+	// a graph of rels relocates with it. The origin is converted only when the entry carries one.
+	source, err := PlanSpacePath(provider.RuntimeEnvironment(), f.Source)
+	if err != nil {
+		return nil, "", err
+	}
+	target, err := PlanSpacePath(provider.RuntimeEnvironment(), f.Target)
+	if err != nil {
+		return nil, "", err
+	}
+	origin := ""
+	if f.Origin != "" {
+		if origin, err = PlanSpacePath(provider.RuntimeEnvironment(), f.Origin); err != nil {
+			return nil, "", err
+		}
+	}
+
 	pipeline := strings.Join(f.Operations, "+")
 
 	switch pipeline {
@@ -147,20 +165,20 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 		// The link targets the ORIGIN path: the snapshot this entry was read from is removed when the
 		// run ends, so a durable link must point at the layer repo itself (ruled 2026-08-08).
 		invocation, err := provider.Plan(file.Link, nil, map[string]any{
-			"source_path": f.Origin,
-			"target_path": f.Target,
+			"source_path": origin,
+			"target_path": target,
 		})
 		return invocation, string(file.Link), err
 
 	case "encryption.decrypt+file.copy":
 		invocation, err := provider.Plan(encryption.DecryptSopsFile, nil, map[string]any{
-			"source":           f.Source,
-			"destination_path": f.Target,
+			"source":           source,
+			"destination_path": target,
 		})
 		return invocation, string(encryption.DecryptSopsFile), err
 
 	case "template.render_bytes+file.copy":
-		content, err := provider.Plan(file.ReadText, nil, map[string]any{"resource": f.Source})
+		content, err := provider.Plan(file.ReadText, nil, map[string]any{"resource": source})
 		if err != nil {
 			return nil, "", err
 		}
@@ -176,7 +194,7 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 			mode = 0o644
 		}
 		invocation, err := provider.Plan(file.WriteText, nil, map[string]any{
-			"destination_path": f.Target,
+			"destination_path": target,
 			"content":          rendered,
 			"mode":             mode,
 			"user":             "", "group": "",
@@ -185,8 +203,8 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 
 	case "encryption.decrypt+template.render_bytes+file.copy":
 		decrypted, err := provider.Plan(encryption.DecryptSopsFile, nil, map[string]any{
-			"source":           f.Source,
-			"destination_path": f.Target,
+			"source":           source,
+			"destination_path": target,
 		})
 		if err != nil {
 			return nil, "", err
@@ -203,7 +221,7 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 			return nil, "", err
 		}
 		invocation, err := provider.Plan(file.WriteText, nil, map[string]any{
-			"destination_path": f.Target,
+			"destination_path": target,
 			"content":          rendered,
 			"mode":             os.FileMode(0o600),
 			"user":             "", "group": "",
@@ -213,6 +231,37 @@ func PlanFileChain(provider *plan.Provider, f *tree.FileEntry, data map[string]a
 	default:
 		return nil, "", fmt.Errorf("unknown pipeline %q", pipeline)
 	}
+}
+
+// PlanSpacePath renders the machine-absolute `abs` in plan space: the slash-canonical rel against the
+// planning environment's root.
+//
+// writ's planners choose their run root as the common ancestor of every involved path ([runRootFor] and the
+// per-command equivalents), so a path outside the root is a planning defect, not an input case.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the planning environment; its root is the run root the rel binds to.
+//   - `abs`: the machine-absolute path to render.
+//
+// Returns:
+//   - `string`: the slash-canonical rel.
+//   - `error`: non-nil when `abs` cannot be made relative to the root, or escapes it.
+func PlanSpacePath(runtimeEnvironment *op.RuntimeEnvironment, abs string) (string, error) {
+
+	root := runtimeEnvironment.Root().Name()
+
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return "", fmt.Errorf("plan space: %q against root %q: %w", abs, root, err)
+	}
+
+	slash := filepath.ToSlash(rel)
+
+	if slash == ".." || strings.HasPrefix(slash, "../") {
+		return "", fmt.Errorf("plan space: %q escapes the run root %q — widen the root before planning", abs, root)
+	}
+
+	return slash, nil
 }
 
 // CommonAncestor returns the deepest directory containing both `a` and `b`.

--- a/cmd/writ/writ/secret/encrypt.go
+++ b/cmd/writ/writ/secret/encrypt.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
 	"github.com/NobleFactor/devlore-cli/cmd/internal/devlore"
+	"github.com/NobleFactor/devlore-cli/cmd/writ/writ/deploy"
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -156,9 +157,14 @@ func buildLayerGraph(ctx context.Context, cfg *EncryptConfig, group *layerGroup)
 
 		for _, source := range group.files {
 
-			destination := source + sopsSuffix
+			rel, err := deploy.PlanSpacePath(environment, source)
+			if err != nil {
+				return nil, err
+			}
+
+			destination := rel + sopsSuffix
 			invocation, err := provider.Plan(encryption.EncryptFile, nil, map[string]any{
-				"source":           source,
+				"source":           rel,
 				"destination_path": destination,
 			})
 			if err != nil {
@@ -167,7 +173,7 @@ func buildLayerGraph(ctx context.Context, cfg *EncryptConfig, group *layerGroup)
 
 			fileMetas[invocation.Target.ID()] = map[string]any{
 				"source":      source,
-				"destination": destination,
+				"destination": source + sopsSuffix,
 				"layer":       group.name,
 			}
 		}

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -263,11 +263,15 @@ without letting them trade places.
 ### 5.4 The serialized section — mandatory, even when empty
 
 Every graph document carries a `resources` section: one row per current-generation entry, as intent —
-`{id, uri, state: pending}` (all pending by construction: no producers, no Etag/Digest — those are trace
-material). Content-addressed entries additionally carry their packed bytes (the content transport, step 25).
-The section is present even when empty. **A document without it does not load, and a graph without a catalog
-fails pre-flight hard** (`ReasonPreflightFailed`, before any dispatch). `schema_version` stays 1: pre-ruling
-documents simply fail to load and are rewritten by re-planning.
+**`{id, uri}` and nothing else** (ruled 2026-08-21; implementation rides #585). Intent needs no state
+field: presence in the section IS the pending claim — pending is definitional, not recorded — and
+producers, Etag/Digest, and state are trace vocabulary (§5.5), so the intent row is its own type rather
+than a borrowed trace row. Content-addressed entries additionally carry their packed bytes (the content
+transport, step 25). The section is present even when empty. **A document without it does not load, and a
+graph without a catalog fails pre-flight hard** (`ReasonPreflightFailed`, before any dispatch).
+`schema_version` stays 1: pre-ruling documents simply fail to load and are rewritten by re-planning. Known
+boundary, accepted: today's decoders are lenient, so a stray field (e.g. a hand-edited `state:`) is ignored
+rather than refused — strict decoding is a codec-wide property, not this section's.
 
 ### 5.5 Graph = intent; trace = observation
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -134,7 +134,7 @@ Windows known-failures.
 4. Round-trip pin: pack → unpack → pack byte-identical, including the empty section.
 5. Windows baseline expectation: unchanged (3).
 
-### Phase 2 — portable file identity: rel, bound to the run's root (#546/#547) — status: pending
+### Phase 2 — portable file identity: rel, bound to the run's root (#546/#547) — status: in progress (PR 1 merged `92c18eb1`; PR 2 in review)
 
 **RULED 2026-08-20: named resources are computed relative to some fsroot, and the fsroot is not known until
 the run.** The motivating cases are the product's own scopes: a **home**-scope graph binds to the account
@@ -225,6 +225,31 @@ and `https:/example.com/x` elsewhere. Fixed where the capability lives: `fsroot.
 Clean after separator normalization) renders every rel in both `makePath` branches and `fsroot.NewPath`,
 with a platform-neutrality pin in the fsroot suite. Exactly the class #547 predicted ("the sixth is
 waiting"); recorded on #547.
+
+**PR 2 record (2026-08-21):** the plan-space grammar and the full co-landing, one PR as the sequencing
+constraint demanded.
+
+- **The grammar** (`file.NormalizePlanSpacePath`, registered per resource type via
+  `op.RegisterPlanPathNormalizer`, applied at the planner's claiming seam — `normalizePlanSpaceValue` in
+  `bindPresentValue`): `foo/bar` ≡ `/foo/bar`; volume/UNC/backslash spellings refuse; `@name/…` refuses
+  as reserved for #597; escapes and the bare root refuse. One table pin covers every rule. Immediate-mode
+  and programmatic construction are untouched — the grammar governs what a plan may say.
+- **One root everywhere in devlore-test**: `t.tmp` returns plan-space rels (`.devlore/tmp/<name>`), the
+  run anchors at the same workspace root as the script session, and the harness's Go-side helpers resolve
+  rels through one `resolve` seam. Machine-absolute authored paths died by double-prefix exactly as
+  predicted — the migration was forced, visible, and complete.
+- **writ emits rels**: `PlanFileChain` renders source/origin/target through the new `deploy.PlanSpacePath`
+  (rel against the planning environment's root — the run root writ already chooses); the encrypt planner
+  follows; graph-origin annotations keep machine-absolute paths for the readback fold's keying.
+- **Process-cwd leaks fixed as discovered**: `shell.exec`/`powershell.exec` anchor the command's cwd at
+  the run root; `file.glob` resolves relative patterns against the root; `plan.save_definition`/
+  `load_definition` resolve relative document paths against the session root.
+- **The two Windows surfaces fixed**: the star integration fixture interpolates its path slash-form into
+  starlark source (paths-in-text are neutral text); lore's onboard manifest path uses a native join
+  instead of string concatenation.
+- Gate: make check 103 ok / 0 fail (grammar pins + all scenario stars green), GOOS=windows vet clean.
+  **Windows expectation: 2 → 0 — the first fully green CI of the campaign.** Any Windows remainder is
+  re-diagnosed, not assumed.
 
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -250,6 +250,12 @@ constraint demanded.
 - Gate: make check 103 ok / 0 fail (grammar pins + all scenario stars green), GOOS=windows vet clean.
   **Windows expectation: 2 → 0 — the first fully green CI of the campaign.** Any Windows remainder is
   re-diagnosed, not assumed.
+- **First CI re-diagnosis (2026-08-21):** two names, neither assumed. `TestPlannedCopy_…` was the last
+  unswept authoring surface — the Go judgment pin interpolated machine-absolutes into its star fixture and
+  the grammar refused them on Windows exactly as designed; it now authors rels, which is also truer to its
+  subject. `TestSourceFile_StarlarkIntegration`'s escape failure was CURED by the slash-form fix — the
+  residue was a Windows handle leak: the test never called the documented `Application.Close`, so the
+  session root pinned the temp dir at cleanup (the same class as the TestLintCopyright fix).
 
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 
@@ -264,9 +270,15 @@ the catalog at plan time. The plan-time catalog is the graph's *input intent*, a
    arrives when the producer runs.
 3. String-typed parameters (`destination_path`, `mode`, `user`, …) stay plain values. No output-naming
    convention, no `+devlore:output` — there is nothing to declare because there is nothing tracked.
-4. Consequence for phase 1's stored section: every stored entry is Pending by construction — `{id, uri,
-   state: pending}` rows, no producer stamps, no Etag/Digest. **Graph = intent; trace = observation** (the
-   step-48 snapshot keeps the observed side).
+4. Consequence for phase 1's stored section: every stored entry is Pending by construction. **RULED
+   2026-08-21: the stored row drops `state` entirely** — the intent row becomes its own `{id, uri}` type
+   (presence IS the pending claim), splitting from the trace's `LedgerEntrySnapshot`, whose
+   state/etag/digest/producer vocabulary stays where observation lives. **Graph = intent; trace =
+   observation** (the step-48 snapshot keeps the observed side). Fallout, small and known: the
+   round-trip pins re-pin (bytes change; old documents die, schema stays 1); the star pins asserting
+   `state == "pending"` flip to asserting the field's absence; the Go catalog pin keeps presence/absence
+   and drops its state assertion; writ readback is untouched (it reads the trace). Known boundary: lenient
+   decoding means a stray hand-edited `state:` is ignored, not refused — a codec-wide property, noted.
 5. Acceptance: **both pins flip green with corrected assertions** — the stored document carries
    `original.txt` (pending), and asserts `duplicate.txt` **absent**, pinning the product ruling in both
    directions. **Delivered early — the pins flipped with phase 1**: planning already interned the

--- a/pkg/op/plan_path.go
+++ b/pkg/op/plan_path.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"reflect"
+	"sync"
+)
+
+// PlanPathNormalizer renders an authored plan-space path into its canonical rel form, or refuses it.
+//
+// The plan-space grammar belongs to the scheme that owns the resource type (the file scheme's git model:
+// docs/architecture/4-resource-management.md §5.2), so the framework carries only this seam: a resource type
+// registers its normalizer, and [ActionPlanner] applies it to string values bound to that type's parameters
+// at plan time. Immediate-mode construction and programmatic Go callers are untouched — the little language
+// governs what a PLAN may say, not what a session may do.
+type PlanPathNormalizer func(path string) (string, error)
+
+var (
+	// planPathNormalizersMu guards planPathNormalizers. Registration happens in provider init functions;
+	// lookups run on every plan-time slot bind.
+	planPathNormalizersMu sync.RWMutex
+
+	// planPathNormalizers maps a resource's reflect.Type to its plan-space normalizer.
+	planPathNormalizers = make(map[reflect.Type]PlanPathNormalizer)
+)
+
+// RegisterPlanPathNormalizer registers `normalize` as the plan-space grammar for resource type `t`.
+//
+// Called from provider init alongside the type's announcement. Registering the value type covers the
+// pointer spelling and vice versa — lookup tries both forms.
+//
+// Parameters:
+//   - `t`: the resource's reflect.Type (value or pointer form).
+//   - `normalize`: the scheme's plan-space normalizer.
+func RegisterPlanPathNormalizer(t reflect.Type, normalize PlanPathNormalizer) {
+
+	planPathNormalizersMu.Lock()
+	defer planPathNormalizersMu.Unlock()
+
+	planPathNormalizers[t] = normalize
+}
+
+// planPathNormalizerFor returns the registered normalizer for `t`, trying the exact type, its element form,
+// and its pointer form — the same fallback ladder the registry's type lookups use.
+//
+// Parameters:
+//   - `t`: the parameter's reflect.Type.
+//
+// Returns:
+//   - `PlanPathNormalizer`: the registered normalizer, or nil.
+//   - `bool`: true when a normalizer is registered for `t` in any spelling.
+func planPathNormalizerFor(t reflect.Type) (PlanPathNormalizer, bool) {
+
+	planPathNormalizersMu.RLock()
+	defer planPathNormalizersMu.RUnlock()
+
+	if normalize, ok := planPathNormalizers[t]; ok {
+		return normalize, true
+	}
+
+	if t.Kind() == reflect.Pointer {
+		if normalize, ok := planPathNormalizers[t.Elem()]; ok {
+			return normalize, true
+		}
+	} else {
+		if normalize, ok := planPathNormalizers[reflect.PointerTo(t)]; ok {
+			return normalize, true
+		}
+	}
+
+	return nil, false
+}

--- a/pkg/op/planner.go
+++ b/pkg/op/planner.go
@@ -381,6 +381,11 @@ func bindPresentValue(invocator PlanInvocator, spec *NodeSpec, actionName string
 
 	default:
 
+		value, err := normalizePlanSpaceValue(actionName, param, value)
+		if err != nil {
+			return err
+		}
+
 		// A builtin value may be the Go form of a content resource (e.g. a *starlark.Function). The provider
 		// keys its constructor by the source type; if the registry has one, build the resource here so the
 		// addressing switch below takes over — naming only op + reflect, never the provider.
@@ -409,6 +414,40 @@ func bindPresentValue(invocator PlanInvocator, spec *NodeSpec, actionName string
 	}
 
 	return nil
+}
+
+// normalizePlanSpaceValue renders an authored string bound to a resource-typed parameter through the
+// owning scheme's plan-space grammar — the claiming seam of the little language (§5.2).
+//
+// Non-string values and parameter types without a registered normalizer pass through untouched: the grammar
+// governs what a plan may say, not what a session may do.
+//
+// Parameters:
+//   - `actionName`: the action name, for error messages.
+//   - `param`: the parameter being bound.
+//   - `value`: the supplied value.
+//
+// Returns:
+//   - `any`: the canonical value (normalized when the grammar applied; the input otherwise).
+//   - `error`: non-nil when the grammar refuses the authored path.
+func normalizePlanSpaceValue(actionName string, param Parameter, value any) (any, error) {
+
+	s, isString := value.(string)
+	if !isString || param.Type == nil {
+		return value, nil
+	}
+
+	normalize, ok := planPathNormalizerFor(param.Type)
+	if !ok {
+		return value, nil
+	}
+
+	normalized, err := normalize(s)
+	if err != nil {
+		return nil, fmt.Errorf("op.ActionPlanner.Plan: %s: param %q: %w", actionName, param.Name, err)
+	}
+
+	return normalized, nil
 }
 
 // bindResourceValue binds a resource-valued argument per its addressing.

--- a/pkg/op/provider/file/planspace.go
+++ b/pkg/op/provider/file/planspace.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package file
+
+import (
+	"fmt"
+	"reflect"
+
+	// Aliased: plan-space paths are a slash-form language on every platform; their canonical form comes
+	// from the slash-path Clean, never the OS one.
+	slashpath "path"
+	"strings"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// init registers the file scheme's plan-space grammar for every taxonomy variant, beside the generated
+// announcements — an authored string bound to a file-resource parameter at plan time passes through
+// [NormalizePlanSpacePath] before construction.
+func init() {
+	for _, t := range []reflect.Type{
+		reflect.TypeFor[*Regular](),
+		reflect.TypeFor[*Directory](),
+		reflect.TypeFor[*SymbolicLink](),
+		reflect.TypeFor[*Resource](),
+	} {
+		op.RegisterPlanPathNormalizer(t, NormalizePlanSpacePath)
+	}
+}
+
+// NormalizePlanSpacePath renders an authored plan path into its canonical rel, or refuses it.
+//
+// The git model (#584, ruled 2026-08-20; docs/architecture/4-resource-management.md §5.2): plan-space paths
+// are a portable little language. `foo/bar` and `/foo/bar` both name rel `foo/bar` — the leading slash is
+// the anchored spelling; machine-absoluteness is inexpressible in a plan (it arises only from the run's root
+// choice). The refusals:
+//
+//   - a volume or drive-letter spelling (`C:\x`, `C:/x`) — malformed plan input;
+//   - a UNC spelling (`//server/share`, `\\server\share`) — malformed plan input;
+//   - any backslash — plan space is slash-form on every platform; a backslash is a native-spelling leak;
+//   - a root-qualified spelling (`@name/…`) — reserved for the named multi-root design (#597);
+//   - a rel that escapes (`../…`) or names the root itself — intent confinement can never satisfy.
+//
+// Parameters:
+//   - `path`: the authored plan path.
+//
+// Returns:
+//   - `string`: the slash-canonical rel.
+//   - `error`: non-nil for every refusal above.
+func NormalizePlanSpacePath(path string) (string, error) {
+
+	if len(path) >= 2 && path[1] == ':' && isASCIILetter(path[0]) {
+		return "", fmt.Errorf(
+			"file: plan path %q carries a volume spelling — machine-absoluteness is inexpressible in a plan; "+
+				"name the path relative to the run's root", path)
+	}
+
+	if strings.HasPrefix(path, "//") || strings.HasPrefix(path, `\\`) {
+		return "", fmt.Errorf(
+			"file: plan path %q carries a UNC spelling — machine-absoluteness is inexpressible in a plan; "+
+				"name the path relative to the run's root", path)
+	}
+
+	if strings.Contains(path, `\`) {
+		return "", fmt.Errorf(
+			"file: plan path %q carries a backslash — plan-space paths are slash-form on every platform", path)
+	}
+
+	if strings.HasPrefix(path, "@") {
+		return "", fmt.Errorf(
+			"file: plan path %q is root-qualified — the @name spelling is reserved for the named multi-root "+
+				"design; only run-root-relative paths are expressible today", path)
+	}
+
+	// The anchored spelling: a leading slash names the same rel.
+	cleaned := slashpath.Clean(strings.TrimPrefix(path, "/"))
+
+	if cleaned == "." || cleaned == "" {
+		return "", fmt.Errorf("file: plan path %q names the run's root itself, not a resource under it", path)
+	}
+
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf(
+			"file: plan path %q escapes the run's root — intent confinement can never satisfy it", path)
+	}
+
+	return cleaned, nil
+}
+
+// isASCIILetter reports whether b is an ASCII letter — the drive-letter half of a volume spelling.
+//
+// Parameters:
+//   - `b`: the byte to test.
+//
+// Returns:
+//   - `bool`: true for A-Z and a-z.
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/pkg/op/provider/file/planspace_test.go
+++ b/pkg/op/provider/file/planspace_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package file
+
+import (
+	"strings"
+	"testing"
+)
+
+// The plan-space little language (#584, ruled 2026-08-20): `foo/bar` ≡ `/foo/bar`; volume, UNC, and
+// backslash spellings refuse; `@name/…` is reserved for the named multi-root design; escapes and the bare
+// root refuse. One table, every rule.
+
+func TestNormalizePlanSpacePath_TheLittleLanguage(t *testing.T) {
+
+	accepted := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare rel", "foo/bar", "foo/bar"},
+		{"anchored spelling names the same rel", "/foo/bar", "foo/bar"},
+		{"dot segments collapse", "a/./b/../c.txt", "a/c.txt"},
+		{"duplicate slashes collapse", "a//b", "a/b"},
+		{"colon beyond the drive position rides as a path", "https://example.com/x", "https:/example.com/x"},
+	}
+
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizePlanSpacePath(tc.in)
+			if err != nil {
+				t.Fatalf("NormalizePlanSpacePath(%q): unexpected refusal: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("NormalizePlanSpacePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	refused := []struct {
+		name   string
+		in     string
+		reason string
+	}{
+		{"drive letter, backslash form", `C:\x`, "volume"},
+		{"drive letter, slash form", "C:/x", "volume"},
+		{"drive-relative", "C:x", "volume"},
+		{"UNC, backslash form", `\\server\share`, "UNC"},
+		{"UNC, slash form", "//server/share", "UNC"},
+		{"bare backslash separator", `foo\bar`, "backslash"},
+		{"root-qualified is reserved", "@config/foo", "root-qualified"},
+		{"escape", "../secrets", "escapes"},
+		{"escape after cleaning", "a/../../secrets", "escapes"},
+		{"the root itself", "/", "root"},
+		{"empty", "", "root"},
+		{"dot", ".", "root"},
+	}
+
+	for _, tc := range refused {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NormalizePlanSpacePath(tc.in)
+			if err == nil {
+				t.Fatalf("NormalizePlanSpacePath(%q): expected refusal, got acceptance", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.reason) {
+				t.Fatalf("NormalizePlanSpacePath(%q): refusal %q does not name %q", tc.in, err, tc.reason)
+			}
+		})
+	}
+}

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -1199,6 +1199,11 @@ func (p *Provider) findWalkFunc(
 // +devlore:defaults includeGitignored=false
 func (p *Provider) Glob(pattern string, includeGitignored bool) ([]Entry, error) {
 
+	// A relative pattern is root-relative (#584 phase 2), never process-cwd-relative.
+	if !filepath.IsAbs(pattern) && p.RuntimeEnvironment().HasRoot() {
+		pattern = filepath.Join(p.Root(), filepath.FromSlash(pattern))
+	}
+
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, err

--- a/pkg/op/provider/plan/catalog_contract_test.go
+++ b/pkg/op/provider/plan/catalog_contract_test.go
@@ -5,7 +5,6 @@ package plan_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,12 +43,14 @@ func TestPlannedCopy_TheStoredCatalogIsInputIntent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Plan — not run — a one-node copy from Starlark, and save the graph document.
-	script := fmt.Sprintf(`
-node  = plan.file.copy(source = %q, destination_path = %q, mode = 0o600, user = "", group = "")
+	// Plan — not run — a one-node copy from Starlark, and save the graph document. The script authors
+	// plan-space rels (#584 phase 2): the session root is the run root here, so the names resolve to the
+	// files written above, and the same script text is valid on every platform.
+	script := `
+node  = plan.file.copy(source = "original.txt", destination_path = "duplicate.txt", mode = 0o600, user = "", group = "")
 graph = plan.assemble_definition([node])
-plan.save_definition(graph, %q)
-`, sourcePath, destinationPath, graphPath)
+plan.save_definition(graph, "graph.json")
+`
 
 	scriptPath := filepath.Join(root, "catalog.star")
 	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -343,7 +343,13 @@ func (p *Provider) Clear() error {
 //   - `error`: non-nil when the file cannot be read, the format is unsupported, or decoding fails.
 func (p *Provider) LoadDefinition(path string) (*op.Graph, error) {
 
-	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree resources.
+	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree
+	// resources. A relative caller-named path resolves against the session root (#584 phase 2) — never the
+	// process cwd.
+	if !filepath.IsAbs(path) && p.RuntimeEnvironment().HasRoot() {
+		path = filepath.Join(p.RuntimeEnvironment().Root().Name(), filepath.FromSlash(path))
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("plan.Provider.LoadDefinition: %w", err)
@@ -386,7 +392,13 @@ func (p *Provider) SaveDefinition(graph *op.Graph, path string) (err error) {
 
 	var file *os.File
 
-	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree resources.
+	// Confinement: plan documents are store/CLI documents at caller-named paths, not confined-tree
+	// resources. A relative caller-named path resolves against the session root (#584 phase 2) — never the
+	// process cwd.
+	if !filepath.IsAbs(path) && p.RuntimeEnvironment().HasRoot() {
+		path = filepath.Join(p.RuntimeEnvironment().Root().Name(), filepath.FromSlash(path))
+	}
+
 	file, err = os.Create(path)
 	if err != nil {
 		return fmt.Errorf("plan.Provider.SaveDefinition: %w", err)

--- a/pkg/op/provider/powershell/provider.go
+++ b/pkg/op/provider/powershell/provider.go
@@ -62,6 +62,12 @@ func (p *Provider) Exec(command string) (*Result, error) {
 		return nil, fmt.Errorf("no command specified")
 	}
 	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "pwsh", "-NoLogo", "-NoProfile", "-Command", command) //nolint:gosec // G204: command built from provider inputs
+
+	// The command's world is the run's root (#584 phase 2): plan-space paths are root-relative, so a
+	// planned command's relative paths must resolve against the run's root, not the host process's cwd.
+	if p.RuntimeEnvironment().HasRoot() {
+		cmd.Dir = p.RuntimeEnvironment().Root().Name()
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/op/provider/shell/provider.go
+++ b/pkg/op/provider/shell/provider.go
@@ -53,6 +53,12 @@ func (p *Provider) Exec(command string) (*Result, error) {
 		return nil, fmt.Errorf("no command specified")
 	}
 	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "sh", "-c", command) //nolint:gosec // G204: command built from provider inputs
+
+	// The command's world is the run's root (#584 phase 2): plan-space paths are root-relative, so a
+	// planned command's relative paths must resolve against the run's root, not the host process's cwd.
+	if p.RuntimeEnvironment().HasRoot() {
+		cmd.Dir = p.RuntimeEnvironment().Root().Name()
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
Phase 2, PR 2 of [resource-construction](docs/plans/resource-construction.md) (#584) — the co-landing: the
grammar's semantics and the authoring surfaces flip together, because once a leading slash means "anchored
at the run's root," every machine-absolute authored path double-prefixes and dies.

## The little language

`file.NormalizePlanSpacePath`, applied at the planner's claiming seam via `op.RegisterPlanPathNormalizer` —
op stays generic, the file scheme owns its grammar. `foo/bar` ≡ `/foo/bar`; volume/UNC/backslash spellings
refuse; **`@name/…` refuses as reserved for #597**; escapes and the bare root refuse. One table pin per
rule. Immediate-mode and programmatic construction untouched: the grammar governs what a *plan* may say.

## The authoring surfaces

- **devlore-test**: `t.tmp` returns plan-space rels; `t.run` anchors at the same workspace root as the
  script session (one root everywhere); the harness's Go helpers resolve rels through one seam. The
  machine-absolute forms died by double-prefix exactly as the plan predicted.
- **writ**: `PlanFileChain` and the encrypt planner emit rels via the new `deploy.PlanSpacePath` against
  the run root writ already chooses; graph-origin annotations keep absolutes for the readback fold.
- **Process-cwd leaks fixed as discovered**: `shell.exec`/`powershell.exec` cwd anchors at the run root;
  `file.glob` patterns and `plan.save_definition`/`load_definition` paths resolve against the root.

## Windows: 2 → 0

Both remaining baseline failures fixed at their surfaces: the star fixture interpolates its path
slash-form into generated starlark source (the `\U` escape failure), and lore's onboard manifest narration
uses a native join (the mixed-separator path). **Expectation: the first fully green CI of the campaign.**
Any remainder is re-diagnosed, not assumed.

## Verified

- `make check` — 103 ok, 0 failures (grammar pins, every scenario star, writ drift attribution)
- `make vet` GOOS=windows
- gofmt clean

Refs #584, #547, #546, #597.
