### PR TITLE
feat(op): pre-flight binds pending resources to the run's root — phase 2 closes

### DIFF
--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -280,9 +280,13 @@ saw: activations with captured content identity, products, transitions, compensa
 the snapshot names the root the run bound (its `root` field, stamped by the executor at capture), because
 file identities are rels and a recorded rel is interpretable only against the root that ran it. Consumers
 derive an entry's native path by joining the recorded root with the URI's rel payload — identity is never
-parsed for a native form (the #547 rule). Pre-flight in one
-sentence: **every pending resource must satisfy its scheme's existence predicate — for file resources, the rel must exist under the run's root.** The judgment scenarios that pin this split
-live in the plan's "Judgment scenarios" section.
+parsed for a native form (the #547 rule). **The binding is enforced at the executor's pre-flight resolve
+pass** (implemented 2026-08-21, #584 PR 3): every pending entry re-bases onto the run's environment, and a
+root-relative scheme re-binds its path rel-first through the `op.RootBinder` seam (`file` implements it) —
+so existence, Etag, Digest, and I/O all read the run's world, never the environment that constructed or
+rehydrated the object. Pre-flight in one sentence: **every pending resource must satisfy its scheme's
+existence predicate — for file resources, the rel must exist under the run's root.** The judgment scenarios
+that pin this split live in the plan's "Judgment scenarios" section.
 
 ## 6. Recovery — Receipts and the Recovery Site
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -134,7 +134,7 @@ Windows known-failures.
 4. Round-trip pin: pack → unpack → pack byte-identical, including the empty section.
 5. Windows baseline expectation: unchanged (3).
 
-### Phase 2 — portable file identity: rel, bound to the run's root (#546/#547) — status: in progress (PR 1 merged `92c18eb1`; PR 2 in review)
+### Phase 2 — portable file identity: rel, bound to the run's root (#546/#547) — status: complete 2026-08-21 (PR 1 `92c18eb1`; PR 2 `2c5f6e6a`; PR 3 in review — the completing PR)
 
 **RULED 2026-08-20: named resources are computed relative to some fsroot, and the fsroot is not known until
 the run.** The motivating cases are the product's own scopes: a **home**-scope graph binds to the account
@@ -256,6 +256,18 @@ constraint demanded.
   subject. `TestSourceFile_StarlarkIntegration`'s escape failure was CURED by the slash-form fix — the
   residue was a Windows handle leak: the test never called the documented `Application.Close`, so the
   session root pinned the temp dir at cleanup (the same class as the TestLintCopyright fix).
+
+**PR 3 record (2026-08-21) — the activation binding; phase 2 closes.** The run-from-elsewhere caveat is
+implemented: the executor's pre-flight resolve pass re-bases every pending entry onto the run's environment
+and re-binds root-relative schemes rel-first through the new `op.RootBinder` seam (`file.Resource.BindRoot`;
+`Resolve`'s abs-first rebind — the documented inverse — flips rel-first). The consequence stays
+mark-don't-fail; phase 3 owns the transition-failure semantics. Pinned in both directions
+(`TestRun_BindsPendingResourcesToTheRunRoot`, `TestRun_APendingRelAbsentUnderTheRunRootIsGone`): a graph
+planned under root A and executed under root B verifies and observes under B — the trace records B as the
+binding, the rel is Active when the file exists only under B, Gone when only under A. Step 4's consumer
+sweep completed across PRs 1–3: readback (PR 1), providers already on the accessor, and Resolve's rebind
+(this PR). Windows expectation: green stays green — the baseline is now zero. **The Windows CI leg went
+28 → 0 during this phase; #547 closed.**
 
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1092,10 +1092,22 @@ func (e *GraphExecutor) resolvePendingResources() {
 	}
 
 	for _, resource := range catalog.pendingEntries() {
+
+		// The activation binding (§5.5): the run, not the construction session, owns location. Every
+		// pending entry re-bases onto the run's environment, and a root-relative scheme re-binds its path
+		// rel-first against the run's root through the [RootBinder] seam — so the existence check below,
+		// and every later observation, read the run's world rather than the environment that happened to
+		// construct or rehydrate the object (the run-from-elsewhere defect).
+		resource.resourceBase().runtimeEnvironment = e.environment
+		if binder, ok := resource.(RootBinder); ok && e.environment.HasRoot() {
+			binder.BindRoot(e.environment.Root())
+		}
+
 		if !participatesInExistenceVerification(resource) {
 			continue
 		}
-		// Mark, don't fail: VerifyExistence records Gone on a missing resource; the error is informational here.
+		// Mark, don't fail: VerifyExistence records Gone on a missing resource; the error is informational
+		// here (phase 3 of the resource-construction plan owns the transition-failure consequence).
 		//nolint:errcheck // diagnose-ignored-error: records Gone; see docs/architecture/2.8-eventing-infrastructure.md
 		_ = catalog.VerifyExistence(resource)
 	}

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -27,10 +27,24 @@ import (
 type Resource struct {
 	op.ResourceBase
 
-	// SourcePath is the canonicalized absolute path on the disk. Set at construction by [buildCandidate] (which routes
-	// the input through `RuntimeEnvironment.Root.NewPath`); rebound to the live execution fsroot by [Resource.Resolve]
-	// when the run-time fsroot differs from the construction-time fsroot.
+	// SourcePath is the bound location triad (§5.5): Rel() is the identity verbatim, Root() the bound
+	// fsroot, Abs() derived and OS-native for I/O. Set at construction against the constructing session's
+	// root; re-bound REL-FIRST to the run's root by [Resource.BindRoot] at the executor's pre-flight
+	// resolve pass (the op.RootBinder seam) and by [Resource.Resolve].
 	SourcePath fsroot.Path
+}
+
+// BindRoot re-binds this resource's location to `root`, rel-first — the activation binding (§5.5), driven
+// from the executor's pre-flight resolve pass through the [op.RootBinder] seam.
+//
+// Identity (the rel) is unchanged; the root becomes the run's; the native form derives. The environment
+// re-base happens executor-side, so after binding every observation — existence, Etag, Digest, I/O — reads
+// the run's world.
+//
+// Parameters:
+//   - `root`: the run's bound fsroot.
+func (r *Resource) BindRoot(root fsroot.Dir) {
+	r.SourcePath = root.NewPath(r.SourcePath.Rel())
 }
 
 // discoverResource registers a catch-all base handle via [op.ResourceCatalog.Discover] without claiming production.
@@ -346,7 +360,9 @@ func (r *Resource) Resolve() error {
 
 	root := r.RuntimeEnvironment().Root()
 
-	r.SourcePath = root.NewPath(r.SourcePath.Abs())
+	// Rel-first (§5.5): identity is the rel and location derives from the live root. The abs-first form
+	// this replaces preserved the construction-time machine location — the run-from-elsewhere defect.
+	r.SourcePath = root.NewPath(r.SourcePath.Rel())
 
 	_, err := root.Stat(r.SourcePath)
 	if err != nil {

--- a/pkg/op/provider/plan/root_binding_test.go
+++ b/pkg/op/provider/plan/root_binding_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package plan_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
+
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/file/gen"
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/plan/gen"
+)
+
+// TestRun_BindsPendingResourcesToTheRunRoot pins the activation binding (4-resource-management.md §5.5,
+// the run-from-elsewhere ruling, 2026-08-21): a graph planned under one root and executed under another
+// verifies and observes its pending resources against the RUN's root — never the environment that
+// constructed them.
+//
+// The sharp assertion is the trace: the ledger snapshot records the run's root as the binding, and the
+// claimed rel is Active because it exists under the RUN root — the plan root never held the file at all.
+func TestRun_BindsPendingResourcesToTheRunRoot(t *testing.T) {
+
+	planRoot := t.TempDir() // the file NEVER exists here
+	runRoot := t.TempDir()  // it exists here, under the claimed rel
+
+	if err := os.WriteFile(filepath.Join(runRoot, "data.txt"), []byte("found under the run root"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := planReadText(t, planRoot)
+
+	executor := op.NewGraphExecutor(graph, runSpec(runRoot))
+
+	result, err := executor.Run(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Run under the run root: %v", err)
+	}
+	if got, ok := result.(string); !ok || got != "found under the run root" {
+		t.Fatalf("result = %#v, want the run root's content", result)
+	}
+
+	assertTraceBinding(t, executor, runRoot, op.Active)
+}
+
+// TestRun_APendingRelAbsentUnderTheRunRootIsGone pins the inverse: the rel exists only under the PLAN
+// root, so the run marks the entry Gone (pre-flight marks, phase 3 owns the failing consequence) and the
+// dispatch fails to find it.
+func TestRun_APendingRelAbsentUnderTheRunRootIsGone(t *testing.T) {
+
+	planRoot := t.TempDir()
+	runRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(planRoot, "data.txt"), []byte("only where it was planned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := planReadText(t, planRoot)
+
+	executor := op.NewGraphExecutor(graph, runSpec(runRoot))
+
+	if _, err := executor.Run(context.Background(), nil); err == nil {
+		t.Fatal("Run succeeded although the claimed rel does not exist under the run root")
+	}
+
+	assertTraceBinding(t, executor, runRoot, op.Gone)
+}
+
+// planReadText plans a one-node file.read_text graph claiming the rel "data.txt" under `planRoot`.
+func planReadText(t *testing.T, planRoot string) *op.Graph {
+
+	t.Helper()
+
+	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}).
+		WithRoot(planRoot))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = environment.Close() })
+
+	provider := plan.NewProvider(environment)
+
+	invocation, err := provider.Plan(file.ReadText, nil, map[string]any{"resource": "data.txt"})
+	if err != nil {
+		t.Fatalf("provider.Plan: %v", err)
+	}
+
+	graph, err := provider.AssembleDefinition([]*op.Invocation{invocation}, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("provider.AssembleDefinition: %v", err)
+	}
+
+	return graph
+}
+
+// runSpec builds a run spec rooted at `runRoot`.
+func runSpec(runRoot string) *op.RuntimeEnvironmentSpec {
+
+	return op.NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}).
+		WithRoot(runRoot)
+}
+
+// assertTraceBinding asserts the trace's ledger snapshot records `runRoot` as the binding and holds the
+// claimed rel in `state`.
+func assertTraceBinding(t *testing.T, executor *op.GraphExecutor, runRoot string, state op.ResourceState) {
+
+	t.Helper()
+
+	trace := executor.Trace()
+	if trace == nil || trace.Catalog == nil {
+		t.Fatal("trace carries no ledger snapshot")
+	}
+
+	if trace.Catalog.Root != runRoot {
+		t.Fatalf("trace binding root = %q, want the run root %q", trace.Catalog.Root, runRoot)
+	}
+
+	for _, entry := range trace.Catalog.Entries {
+		if strings.Contains(entry.URI, "data.txt") {
+			if entry.State != state {
+				t.Fatalf("entry %s state = %v, want %v", entry.URI, entry.State, state)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("trace carries no entry for the claimed rel; entries: %+v", trace.Catalog.Entries)
+}

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
 // tagURIPrefix is the fixed prefix of every canonical [Resource] URI.
@@ -29,6 +30,24 @@ var (
 	// [ResourceBase.Convert] to decide whether the URI projection applies to a given conversion target.
 	stringType = reflect.TypeFor[string]()
 )
+
+// RootBinder is the activation-binding seam (4-resource-management.md §5.5): a resource whose identity is
+// root-relative re-binds its location to the run's root at the executor's pre-flight resolve pass.
+//
+// The run, not the construction session, owns location: a resource is constructed (or rehydrated) in
+// whatever environment planned or loaded the graph, but every location fact about it — existence, content
+// identity, I/O — belongs to the root the run binds. A scheme whose identity is a rel implements BindRoot
+// to re-derive its path rel-first against the run's root; Abs derives from that binding and never survives
+// from construction. The inverse — verifying against the construction environment's root — was the
+// run-from-elsewhere defect: a graph saved on one machine verified against the environment that loaded it,
+// never the root that ran it. Schemes without location (the content-addressed types) simply do not
+// implement the interface.
+type RootBinder interface {
+
+	// BindRoot re-binds the resource's location to `root`, rel-first: identity (the rel) is unchanged;
+	// the root is the run's; the native form derives.
+	BindRoot(root fsroot.Dir)
+}
 
 // Resource is the interface for all resource receiverTypes.
 //


### PR DESCRIPTION
Phase 2, PR 3 of [resource-construction](docs/plans/resource-construction.md) — the activation binding
(§5.5), ruled load-bearing by the run-from-elsewhere caveat. **Closes #584.**

## The binding

The executor's pre-flight resolve pass re-bases every pending entry onto the run's environment and
re-binds root-relative schemes rel-first through the new **`op.RootBinder`** seam: identity (the rel)
unchanged, root becomes the run's, native form derives. `file.Resource` implements `BindRoot`;
`Resolve`'s abs-first rebind — the documented inverse — flips rel-first. Verification stays
mark-don't-fail; phase 3 owns the transition-failure consequence.

## The proof

Two pins, both sharp: a graph planned under root A, executed under root B. The trace records **B** as the
binding; the claimed rel is **Active** when the file exists only under B (the plan root never held it),
and **Gone** when it exists only under A, with the dispatch failing. PR 1 made the identity payload
relocatable; this PR makes the *verification* relocatable — the two halves of "one graph, any machine."

## Phase 2 closes

Rel identity (#596) + the plan-space grammar and authoring migration (#600) + the binding (here). During
this phase the Windows CI leg went **28 known failures → 0** and #547 closed. Step 4's consumer sweep
completed across the three PRs.

## Verified

- `make check` — 103 ok, 0 failures (both binding pins, every scenario star)
- `make vet` GOOS=windows
- gofmt clean; Windows expectation: green stays green

Refs #546, #585.
