### PR TITLE
feat(op): intent rows are {id, uri} — presence IS the claim; document vocabulary follows the rulings

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_graph_catalog_contract.star
+++ b/cmd/devlore-test/devloretest/data/test_graph_catalog_contract.star
@@ -35,7 +35,8 @@ entries = document["resources"]
 
 # 2 — the source is present, as pending intent.
 t.expect_equal(len([e for e in entries if "original.txt" in str(e)]), 1)
-t.expect_equal(len([e for e in entries if "original.txt" in str(e) and e["state"] == "pending"]), 1)
+t.expect_equal(len([e for e in entries if "original.txt" in str(e)]), 1)
+t.expect_equal(len([e for e in entries if "state" in e]), 0)  # stateless rows: presence IS the pending claim
 
 # 3 — the destination is ABSENT: a product is a runtime fact, not intent.
 t.expect_equal(len([e for e in entries if "duplicate.txt" in str(e)]), 0)

--- a/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
@@ -29,7 +29,8 @@ plan.save_definition(graph, doc)
 # is absent.
 document = json.decode(data=file.read_text(resource=doc))
 entries = document["resources"]
-t.expect_equal(len([e for e in entries if "data.txt" in str(e) and e["state"] == "pending"]), 1)
+t.expect_equal(len([e for e in entries if "data.txt" in str(e)]), 1)
+t.expect_equal(len([e for e in entries if "state" in e]), 0)  # stateless rows: presence IS the pending claim
 t.expect_equal(len([e for e in entries if "copy.txt" in str(e)]), 0)
 
 # The run: the copy fails on the gone source; compensation restores the deleted file; the never-produced

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -122,13 +122,45 @@ discover-time I/O — `Discover` performs none, and existence belongs to pre-fli
 | `Discover` | hit, `Gone` | return error | same |
 | `Discover` | (any) | **never shadows** | **never shadows** |
 
-**Verification (pre-flight, over the per-run clone — `VerifyExistence`, the only place `Exists()` runs):**
+**Verification (scoped pre-flight — `VerifyExistence`, the only place `Exists()` runs). Ruled 2026-08-22:
+verification is per subgraph executor.** A graph is an object holding a root subgraph — there is only
+subgraph execution — so each executor verifies, when its scope starts, the claims its own units consume.
+The root executor verifies unconditional claims at the run's starting line; a choose case (itself a
+subgraph) verifies its claims only when it is hit, by which point mid-run production may already have
+satisfied them. Unreached scopes never judge their claims.
 
 | Entry state | `Exists()` | Result |
 |---|---|---|
 | `Pending` | true | `Pending` → `Active` |
-| `Pending` | false | **the transition fails**: `Pending` → `Gone`, and pre-flight fails the run — a pending resource that fails its scheme's existence predicate (for **file resources**: the rel does not exist relative to the run's fsroot) is unmet intent (§5.5) |
+| `Pending` | false | **the transition fails**: `Pending` → `Gone`, with a warning always produced. Under `MissingResourcePolicyStop` (the default) the consuming scope fails — a pending resource that fails its scheme's existence predicate (for **file resources**: the rel does not exist relative to the run's fsroot) is unmet intent (§5.5). Under `Ignore`/`Skip` the scope proceeds and the consumer applies its policy at dispatch. |
 | `Active` | false (a later re-check) | `Active` → `Gone` |
+
+**The claims taxonomy (ruled 2026-08-22; policy model ruled the same day).** Every literal claim is
+**required** by default — all resources named as literals are expected to exist when their consuming scope
+starts. Per-consumption tolerance is expressed by **`MissingResourcePolicy`**, an enumeration with explicit
+values (never iota) and a fail-safe zero:
+
+- `MissingResourcePolicyStop` (**0 — the zero value and the default**): a missing resource fails the
+  consuming scope — unmet intent.
+- `MissingResourcePolicyIgnore`: the call is **made anyway** — the provider sees the absence and handles it
+  (a remove no-ops; the receipt records "target was already absent" so compensation of the no-op is a
+  no-op).
+- `MissingResourcePolicySkip`: the call is **skipped** — the unit does not dispatch, recorded as skipped.
+
+**A warning is produced whenever a missing resource is detected, under every policy.** The parameter's TYPE
+is the declaration — no directive: at announcement, a method with a `MissingResourcePolicy`-typed parameter
+and exactly one consumed (resource-typed) parameter links the two; more than one consumed parameter beside
+one policy is ambiguous and refuses at announcement. The claim still enters the catalog under every policy
+(identity, compensation, and drift all want the entry). Aggregation across consumers of one entry: **Stop
+wins** — any Stop consumer in the verifying scope fails it; otherwise each non-Stop consumer applies its
+own policy at dispatch. Open consequence, owned by the implementing PR: the promise of a *skipped* unit is
+unresolved for downstream consumers — the skip semantics must say what they see.
+
+**Conditionality is structural, never declared**: a claim consumed only inside a conditional subgraph is
+verified by that subgraph's executor when the branch is hit. The one deliberately strict case: an
+*unconditional* consumer of a file that an earlier unit creates with no promise edge stays a pre-flight
+failure — ordering-by-coincidence is what "ordering comes from promises" forbids; consume the producer's
+promise and no pending entry exists to check at all.
 
 **Production (dispatch time — products are runtime facts, §5.1):**
 
@@ -143,7 +175,7 @@ discover-time I/O — `Discover` performs none, and existence belongs to pre-fli
 | Consumed entry state | Result |
 |---|---|
 | `Active` | dispatch proceeds; a mutating consumer that destroys the resource transitions the entry `Active` → `Gone`, and its receipt carries the undo |
-| `Gone` | **the consumer fails on the catalog's verdict** — it sees the state; it does not rediscover the loss through its own I/O |
+| `Gone` | **a `Stop` consumer fails on the catalog's verdict** — it sees the state; it does not rediscover the loss through its own I/O. An `Ignore` consumer makes the call (its provider handles the absence; the receipt records it); a `Skip` consumer does not dispatch, recorded as skipped. A warning is produced in every case. |
 | `Pending` | unreachable — pre-flight has already activated the entry or failed the run |
 
 Where the guard lives (ruled 2026-08-20): **the action dispatch seam** — `Method.Invoke` converts slot values
@@ -284,9 +316,10 @@ parsed for a native form (the #547 rule). **The binding is enforced at the execu
 pass** (implemented 2026-08-21, #584 PR 3): every pending entry re-bases onto the run's environment, and a
 root-relative scheme re-binds its path rel-first through the `op.RootBinder` seam (`file` implements it) —
 so existence, Etag, Digest, and I/O all read the run's world, never the environment that constructed or
-rehydrated the object. Pre-flight in one sentence: **every pending resource must satisfy its scheme's
-existence predicate — for file resources, the rel must exist under the run's root.** The judgment scenarios
-that pin this split live in the plan's "Judgment scenarios" section.
+rehydrated the object. Pre-flight in one sentence (scoped per the 2026-08-22 ruling): **every required pending resource must
+satisfy its scheme's existence predicate when its consuming scope starts — for file resources, the rel must
+exist under the run's root.** The judgment scenarios that pin this split live in the plan's "Judgment
+scenarios" section.
 
 ## 6. Recovery — Receipts and the Recovery Site
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -271,17 +271,54 @@ sweep completed across PRs 1–3: readback (PR 1), providers already on the acce
 
 ### Phase 3 — plan-time claiming: inputs only, pending only — status: pending
 
+**NOTE (USER, 2026-08-22): two e2e lore scenarios join this phase's development — Docker and Go Toolchain,
+each covering deployment, upgrade, reconcile, and decommission. Docker first. Expected to take many passes;
+development starts right away alongside the phase-3 design work. Parts were previously spec'd — locate and
+fold in when the work begins.**
+
 **RULED 2026-08-20, superseding the sketch's output section (:21–27) and rejecting Appendix A outright:**
 products are runtime facts. A method that returns a resource creates it at execution; nothing about it enters
 the catalog at plan time. The plan-time catalog is the graph's *input intent*, and it never touches the disk.
 
-1. Resource-typed parameter, **string value** → mint a **pending** resource from the string into the catalog.
-   No existence check at plan time; pending, never resolved (the executor's pre-flight owns transitions —
-   [4-resource-management.md](../architecture/4-resource-management.md) §78–81 already rules this).
-2. Resource-typed parameter, **promise value** → record the promise binding; **no catalog entry** — identity
-   arrives when the producer runs.
-3. String-typed parameters (`destination_path`, `mode`, `user`, …) stay plain values. No output-naming
-   convention, no `+devlore:output` — there is nothing to declare because there is nothing tracked.
+Items 1–3 of the original docket (string → pending, promise → recorded, strings stay plain) were
+**delivered by phases 1–2 and are pinned green**. The live docket, consolidated from the #585 rulings:
+
+1. **The claims taxonomy + scoped verification (RULED 2026-08-22).** Required by default; per-consumption
+   tolerance via **`MissingResourcePolicy`** — `Stop` (0, the fail-safe zero value and default: missing
+   fails the scope), `Ignore` (make the call; the provider handles absence, the receipt records it),
+   `Skip` (do not dispatch; recorded as skipped) — **a warning always produced on detection**. The
+   parameter's TYPE is the declaration (announce-time linkage to the single consumed parameter; ambiguity
+   refuses) — no directive. Aggregation: Stop wins. Conditionality is **structural** — a graph is an
+   object holding a root subgraph, there is only subgraph execution, and **each subgraph executor verifies
+   the claims its own units consume when its scope starts** (a choose case verifies only when hit). Strict
+   case stays: promise-less unconditional consumption of a mid-run product fails pre-flight. Open
+   consequence for the implementing PR: what a skipped unit's promise consumers see.
+2. **Pre-flight fails on unmet required intent** — the Q1 consequence, implemented per the taxonomy.
+   Acceptance: `TestJudgmentPreflightFailFast` un-skips and flips green; the binding pin's Gone direction
+   updates from dispatch-failure to the pre-flight verdict.
+3. **Mutation targets go resource-typed** (Remove, Unlink; Move's source and RemoveAll sized at execution)
+   with a `MissingResourcePolicy` parameter on the mutators; the authoring sweep renames `path` → `target`;
+   writ decommission authors a non-Stop policy — a vanished target decommissions as a recorded no-op
+   (ruled; the exact constant, Ignore vs Skip, chosen at this PR).
+4. **The consumed-Gone guard** at the dispatch seam (post-conversion, pre-forward-call), honoring
+   tolerance, with the **destroyer stamp** on `MarkGone` so the verdict names both units.
+5. **Stateless intent rows** — `IntentEntry{ID, URI}`; presence IS the claim (ruled 2026-08-21).
+
+**Directive-inventory rulings (USER, 2026-08-22), chartered here and sized at execution:**
+
+- `+devlore:planner` **retires — inferred**: a package type named `<MethodName>Planner` implementing
+  `op.Planner` links by convention (verified 4/4 on today's uses). No directive required.
+- `+devlore:struct_param` **removed**: consumed by nothing (two declaration sites, zero readers), and
+  `Convert`'s struct hydration already performs the conversion.
+- `+devlore:lifetime` **removed**, with the dormant `Lifetime` machinery (`pkg/op/provider/lifetime.go`).
+- `+devlore:access` retires separately per `3.6-method-classification.md` (its own design; no shim,
+  removed in one pass, per the governing principle).
+- Tolerance carries **no directive** — the `MissingResourcePolicy` parameter type is the declaration.
+- The "wire" comment vocabulary ("wire parameter token" etc.) renames to parameter-token/announce
+  vocabulary — cleanup pass run 2026-08-22 (background).
+
+Surviving directive set: `+devlore:defaults`, `+devlore:property`, `+devlore:root` — everything else
+derives from types, signatures, names, and graph structure.
 4. Consequence for phase 1's stored section: every stored entry is Pending by construction. **RULED
    2026-08-21: the stored row drops `state` entirely** — the intent row becomes its own `{id, uri}` type
    (presence IS the pending claim), splitting from the trace's `LedgerEntrySnapshot`, whose

--- a/pkg/op/action.go
+++ b/pkg/op/action.go
@@ -64,7 +64,7 @@ type Compensator interface {
 
 // Parameter describes a single parameter accepted by an Action's Do method.
 //
-// Parameter is the runtime-typed form of a wire parameter token produced by codegen. The wire token (e.g.,
+// Parameter is the runtime-typed form of a parameter token produced by codegen. The parameter token (e.g.,
 // "destination_path", "mode?", "mode?=0o666", "*parts", "**kwargs") is cracked at the announce boundary by
 // parseParameterToken, which populates every field below. Downstream consumers — Method.Invoke, slot-fill in the
 // starlark bridge, error reporting — read these fields directly and never re-parse the token.
@@ -73,8 +73,8 @@ type Compensator interface {
 //   - Name is the bare parameter name with no decoration (no leading "*"/"**", no trailing "?", no "=value"
 //     suffix). It is the canonical key for slots[Name] lookups and for kwarg matching.
 //   - Type is the Go reflect.Type the dispatch site projects values into via op.Convert.
-//   - Optional is true when the caller may omit this slot. Set by parseParameterToken in three cases: the wire
-//     token carries "?", or the parameter is Variadic, or the parameter is Kwargs. Variadic and Kwargs are
+//   - Optional is true when the caller may omit this slot. Set by parseParameterToken in three cases: the
+//     parameter token carries "?", or the parameter is Variadic, or the parameter is Kwargs. Variadic and Kwargs are
 //     inherently "zero or more" — the caller may always omit positional overflow or extra keyword args — so
 //     Optional being true for them lets consumers ask one question ("may caller omit this slot?") without
 //     special-casing the Variadic / Kwargs flags. If Default is non-nil, slot-fill substitutes it.
@@ -87,7 +87,7 @@ type Compensator interface {
 //     to Type's named form (e.g., os.FileMode(0o666), not uint32(0o666)). Default is never a starlark.Value and
 //     never a raw string at the runtime layer.
 //
-// Variadic and Kwargs cannot carry an explicit "?" or "=value" at the wire level — the grammar rejects
+// Variadic and Kwargs cannot carry an explicit "?" or "=value" at the token level — the grammar rejects
 // "*parts?" and "**kwargs?=foo" at parse time. Their Optional bit is set by parseParameterToken on the basis
 // of the marker alone, and Default is always nil for them.
 type Parameter struct {

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -513,7 +513,7 @@ func assembleGraph(env *RuntimeEnvironment, p *graphData) (*Graph, error) {
 //   - `*ResourceCatalog`: the reconstructed catalog, ids preserved, every entry Pending.
 //   - `error`: non-nil on a malformed URI, an unresolvable type id, an Unpack or construction failure, or an
 //     orphan content blob.
-func unpackCatalog(env *RuntimeEnvironment, rows []LedgerEntrySnapshot, content []contentEntry) (*ResourceCatalog, error) {
+func unpackCatalog(env *RuntimeEnvironment, rows []IntentEntry, content []contentEntry) (*ResourceCatalog, error) {
 
 	blobs := make(map[string][]byte, len(content))
 	for _, entry := range content {
@@ -570,7 +570,7 @@ func unpackCatalog(env *RuntimeEnvironment, rows []LedgerEntrySnapshot, content 
 // Returns:
 //   - `Resource`: the reconstructed resource.
 //   - `error`: a malformed URI, an unresolvable type id, or an Unpack/construction failure.
-func reconstructIntentRow(env *RuntimeEnvironment, row LedgerEntrySnapshot, blobs map[string][]byte) (Resource, error) {
+func reconstructIntentRow(env *RuntimeEnvironment, row IntentEntry, blobs map[string][]byte) (Resource, error) {
 
 	specific, typeID, err := ExtractTagSpecific(row.URI)
 	if err != nil {
@@ -1231,7 +1231,7 @@ type graphData struct {
 	// `{id, uri, state: pending}`, in ledger append order. Deliberately NOT omitempty: the section is
 	// mandatory even when empty, and [LoadGraph] refuses a document without it. Like the content section it
 	// sits outside [Graph.CanonicalContent].
-	Resources []LedgerEntrySnapshot `json:"resources"            yaml:"resources"`
+	Resources []IntentEntry `json:"resources"            yaml:"resources"`
 
 	Subgraphs []subgraphData `json:"subgraphs,omitempty"  yaml:"subgraphs,omitempty"`
 }

--- a/pkg/op/graph_catalog_section_test.go
+++ b/pkg/op/graph_catalog_section_test.go
@@ -141,9 +141,12 @@ func TestGraphDocument_IntentRowsRoundTrip(t *testing.T) {
 		if !strings.Contains(rows[i].URI, want) {
 			t.Errorf("row %d URI = %q, want it to name %q", i, rows[i].URI, want)
 		}
-		if rows[i].State != Pending {
-			t.Errorf("row %d state = %v, want Pending — the stored catalog is intent", i, rows[i].State)
-		}
+	}
+
+	// The stateless-row ruling (§5.4, 2026-08-21): an intent row is {id, uri} and nothing else — pending
+	// is definitional, so no state field exists to assert. The serialized document must not carry one.
+	if strings.Contains(string(document), `"state"`) {
+		t.Errorf("the graph document carries a state field — intent rows are {id, uri}:\n%s", document)
 	}
 
 	repacked := serializeGraph(t, loaded, "json")

--- a/pkg/op/helpers.go
+++ b/pkg/op/helpers.go
@@ -221,10 +221,10 @@ func newRecoveryStack(parent *RecoveryStack) *RecoveryStack {
 	return &RecoveryStack{parent: parent}
 }
 
-// parseParameters walks the `announce` map and converts wire-form tokens to fully typed Parameter values.
+// parseParameters walks the `announce` map and converts parameter tokens to fully typed Parameter values.
 //
-// The wire form arrives at AnnounceProvider, AnnounceResource, and AnnounceType as a map[string][]string of
-// codegen-emitted parameter-name tokens. parseParameters is the boundary that converts that wire form into
+// The token form arrives at AnnounceProvider, AnnounceResource, and AnnounceType as a map[string][]string of
+// codegen-emitted parameter-name tokens. parseParameters is the boundary that converts that token form into
 // runtime-typed Parameter values, so ReceiverType construction and everything below it consume Parameter values
 // directly and never see raw tokens. For each method, the function looks up the corresponding `[reflect.Method]` on
 // providerType to source per-parameter reflect.Type info, then calls parseParameterToken once per token.
@@ -234,9 +234,9 @@ func newRecoveryStack(parent *RecoveryStack) *RecoveryStack {
 // Parameters:
 //   - `providerType`: the announced type's `[reflect.Type]`. Used to resolve per-method reflect.Method values via
 //     MethodByName so each parameter token can be paired with its Go parameter type.
-//   - `methodParameters`: the codegen-emitted wire map. Each value is a list of parameter-name tokens for one
+//   - `methodParameters`: the codegen-emitted token map. Each value is a list of parameter-name tokens for one
 //     method, in the same order as the Go method's non-receiver parameters (a leading context.Context, if
-//     present, is implicit and not represented in the wire list).
+//     present, is implicit and not represented in the token list).
 //
 // Returns:
 //   - `map[string][]Parameter`: the parsed map, ready to be passed to NewProviderReceiverType, NewResourceReceiverType,
@@ -300,7 +300,7 @@ func parseParameters(providerType reflect.Type, methodParameters map[string][]st
 	return out, nil
 }
 
-// resolvePayloadAction resolves a wire-payload action name through the registry to its bound [Action].
+// resolvePayloadAction resolves a document-payload action name through the registry to its bound [Action].
 //
 // Shared by [assembleNode] and [assembleSubgraph] on the deserialization path.
 //
@@ -315,7 +315,7 @@ func parseParameters(providerType reflect.Type, methodParameters map[string][]st
 func resolvePayloadAction(name, kind, id string) (Action, error) {
 
 	if name == "" {
-		return nil, fmt.Errorf("op.LoadGraph: %s %q has no action_name in wire form", kind, id)
+		return nil, fmt.Errorf("op.LoadGraph: %s %q has no action_name in the document", kind, id)
 	}
 	action, err := ReceiverRegistry().BuildAction(ActionName(name))
 	if err != nil {

--- a/pkg/op/marshalers_test.go
+++ b/pkg/op/marshalers_test.go
@@ -18,10 +18,10 @@ import (
 
 // TestGraph_Marshal_WritAdopt_YAML and TestGraph_Marshal_WritAdopt_JSON build an adopt-shaped graph
 // (two adopt subgraphs, each with mkdir → move → link), serialize via the named encoder, decode the
-// bytes back into a [graphPayload] directly, and verify the wire-form structure preserves all IDs,
+// bytes back into a [graphPayload] directly, and verify the document-form structure preserves all IDs,
 // edges, names, and action labels.
 //
-// Under step 18.b, Graph / Node / Subgraph no longer implement [json.Unmarshaler] — the wire form
+// Under step 18.b, Graph / Node / Subgraph no longer implement [json.Unmarshaler] — the document form
 // decodes into payload structs, and [LoadGraph] is the registry-aware path that converts payloads
 // to in-memory units. This test asserts on the payload structure directly, which doesn't require a
 // registry; coverage of the registry-aware decode path lives alongside [plan.Provider.Load].
@@ -37,7 +37,7 @@ func TestGraph_Marshal_WritAdopt_JSON(t *testing.T) {
 }
 
 // runMarshalRoundTrip marshals an adopt-shaped graph, decodes the bytes into a [graphPayload], and
-// verifies the projected wire structure.
+// verifies the projected document structure.
 func runMarshalRoundTrip(
 	t *testing.T,
 	name string,
@@ -290,7 +290,7 @@ func buildAdoptSubgraph(id string) *Subgraph {
 	return sg
 }
 
-// newAdoptNode constructs a Node carrying the given ID, bound to a stub [Action]. The wire-format
+// newAdoptNode constructs a Node carrying the given ID, bound to a stub [Action]. The document-format
 // round-trip test exercises only the symbol-table / containment layer (IDs, children, edges).
 func newAdoptNode(id string) *Node {
 

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -90,7 +90,7 @@ type Method struct {
 //
 // Parameters:
 //   - `do`: the reflected Go method to wrap.
-//   - `parameters`: parsed Parameter values matching the method's non-receiver parameters. Wire-form parsing happens
+//   - `parameters`: parsed Parameter values matching the method's non-receiver parameters. Token-form parsing happens
 //     upstream in parseParameters at the announcement boundary; NewMethod consumes typed Parameters only.
 //   - `plan`: the Plan<Name> companion method, or nil if the method has no plan companion.
 //   - `undo`: the Compensate companion method, or nil for non-compensable methods.
@@ -734,7 +734,7 @@ func methodSignature(m *reflect.Method) string {
 // endregion
 
 // validateParameterPositions checks the variadic / kwargs position rules: each flag implies the
-// parameter sits in the last (or last-before-kwargs) slot. The wire grammar already enforces that
+// parameter sits in the last (or last-before-kwargs) slot. The token grammar already enforces that
 // variadic / kwargs cannot also carry ?/=; only cross-parameter position is validated here.
 //
 // Parameters:

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -27,7 +27,7 @@ type Node struct {
 // The spec's ID, action, annotations, slots, elevation offer, error action, and retry policy are applied here; the
 // returned Node exposes no public setters and is immutable thereafter (the graph-immutability seal).
 //
-// Wire-form deserialization reaches the same result through [LoadGraph]: it decodes the stream into [nodeData] values
+// Document deserialization reaches the same result through [LoadGraph]: it decodes the stream into [nodeData] values
 // and rebuilds each Node with its registry-resolved [Action], never leaving a Node in an action-less transient state.
 //
 // Parameters:
@@ -188,17 +188,17 @@ func (n *Node) Execute(
 	return result, nil
 }
 
-// MarshalJSON projects the node to its [nodeData] wire shape and JSON-encodes it.
+// MarshalJSON projects the node to its [nodeData] document shape and JSON-encodes it.
 //
 // Returns:
-//   - []byte: the JSON encoding of the node's wire form.
+//   - []byte: the JSON encoding of the node's document form.
 //   - `error`: non-nil if JSON marshaling fails.
 func (n *Node) MarshalJSON() ([]byte, error) { return json.Marshal(n.marshalData()) }
 
-// MarshalYAML returns the node's [nodeData] wire shape for the YAML encoder to serialize.
+// MarshalYAML returns the node's [nodeData] document shape for the YAML encoder to serialize.
 //
 // Returns:
-//   - `any`: the [nodeData] wire-form value.
+//   - `any`: the [nodeData] document-form value.
 //   - `error`: always nil; present only to satisfy the yaml.Marshaler signature.
 func (n *Node) MarshalYAML() (any, error) { return n.marshalData(), nil }
 
@@ -247,8 +247,8 @@ func (n *Node) Parameters() ([]Parameter, error) {
 	return out, nil
 }
 
-// Node intentionally has no [json.Unmarshaler] / yaml.Unmarshaler. The wire form decodes into [nodeData] structs (held
-// inside [graphData]); [LoadGraph] then walks those payloads and constructs each Node via [NewNode] with the
+// Node intentionally has no [json.Unmarshaler] / yaml.Unmarshaler. The document form decodes into [nodeData] structs
+// (held inside [graphData]); [LoadGraph] then walks those payloads and constructs each Node via [NewNode] with the
 // registry-resolved [Action] in one pass — so a Node never exists in an action-less transient state outside
 // [LoadGraph]'s internals.
 

--- a/pkg/op/parameter.go
+++ b/pkg/op/parameter.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// parseParameterToken cracks one wire-form parameter token into a fully typed Parameter.
+// parseParameterToken cracks one parameter token into a fully typed Parameter.
 //
 // The token grammar emitted by codegen is:
 //
@@ -32,7 +32,7 @@ import (
 // documents the deferred path.
 //
 // Parameters:
-//   - `raw`: the wire token to parse (e.g., "destination_path", "mode?", "mode?=0o666", "*parts", "**kwargs").
+//   - `raw`: the parameter token to parse (e.g., "destination_path", "mode?", "mode?=0o666", "*parts", "**kwargs").
 //   - `paramType`: the Go-method parameter type the token corresponds to. Used to type-check the default
 //     expression and to detect Resource-typed parameters.
 //

--- a/pkg/op/provider/plan/catalog_contract_test.go
+++ b/pkg/op/provider/plan/catalog_contract_test.go
@@ -85,11 +85,13 @@ plan.save_definition(graph, "graph.json")
 	rows := loaded.ResourceCatalog().IntentEntries()
 
 	// 2 — the source: pending intent in the stored catalog.
-	sourceRow, found := rowNaming(rows, filepath.Base(sourcePath))
-	if !found {
+	if _, found := rowNaming(rows, filepath.Base(sourcePath)); !found {
 		t.Errorf("stored catalog carries no entry for the source %q\n  rows: %s", sourcePath, describeRows(rows))
-	} else if sourceRow.State != op.Pending {
-		t.Errorf("source entry state = %v, want Pending — the stored catalog is intent", sourceRow.State)
+	}
+
+	// Stateless rows (§5.4): presence IS the pending claim; the document must not carry a state field.
+	if strings.Contains(string(data), `"state"`) {
+		t.Errorf("the stored document carries a state field — intent rows are {id, uri}")
 	}
 
 	// 3 — the destination: absent, pinning the product ruling in both directions.
@@ -100,7 +102,7 @@ plan.save_definition(graph, "graph.json")
 }
 
 // rowNaming returns the first intent row whose URI names `needle`.
-func rowNaming(rows []op.LedgerEntrySnapshot, needle string) (op.LedgerEntrySnapshot, bool) {
+func rowNaming(rows []op.IntentEntry, needle string) (op.IntentEntry, bool) {
 
 	for _, row := range rows {
 		if strings.Contains(row.URI, needle) {
@@ -108,11 +110,11 @@ func rowNaming(rows []op.LedgerEntrySnapshot, needle string) (op.LedgerEntrySnap
 		}
 	}
 
-	return op.LedgerEntrySnapshot{}, false
+	return op.IntentEntry{}, false
 }
 
 // describeRows renders the rows for a failure message.
-func describeRows(rows []op.LedgerEntrySnapshot) string {
+func describeRows(rows []op.IntentEntry) string {
 
 	if len(rows) == 0 {
 		return "(none)"

--- a/pkg/op/receipt.go
+++ b/pkg/op/receipt.go
@@ -480,11 +480,11 @@ func (b *ReceiptBase) MarshalJSON() ([]byte, error) {
 
 // MarshalYAML returns the receipt's base state as a [ReceiptData] value the YAML encoder serializes.
 //
-// Per phase-8 13.0(d), Resource is projected to its [Resource.URI] string on the wire — not embedded as a full Resource
-// document — so the envelope stays flat and the Unmarshal side can rehydrate the concrete Resource via each
+// Per phase-8 13.0(d), Resource is projected to its [Resource.URI] string in the document — not embedded as a full
+// Resource document — so the envelope stays flat and the Unmarshal side can rehydrate the concrete Resource via each
 // derivative's NewResource without nested-decoder context plumbing. TransactionID serializes as the canonical 36-char
 // UUIDv7 string already produced by [ReceiptBase.TransactionID]. Err round-trips as a `status` string (the error
-// message); empty restores as nil. [ReceiptData] is the single source of truth for the wire shape: its `json:` and
+// message); empty restores as nil. [ReceiptData] is the single source of truth for the document shape: its `json:` and
 // `yaml:` tags drive both encoders, and [ReceiptBase.MarshalJSON] delegates here for the value before running
 // [json.Marshal].
 //
@@ -504,15 +504,15 @@ func (b *ReceiptBase) MarshalYAML() (any, error) {
 // Restore rebuilds this receipt's base state from a [ReceiptData].
 //
 // [Snapshot] and Restore form the encapsulation-respecting path to read or write the embedded base state from outside
-// [op]. Concrete receipt types in other packages embed [ReceiptData] in their own wire-shape struct, extract the
+// [op]. Concrete receipt types in other packages embed [ReceiptData] in their own document-shape struct, extract the
 // embedded value during unmarshal, and pass it here. The boundary conversions ([Resource] -> URI, UUID -> 36-char
 // string, error -> status string) run at the Snapshot / Restore boundary so downstream encoders see plain field values
 // and skip reflection-driven method dispatch on the embedded base.
 //
 // The receiver MUST be pre-seeded with a [Resource] before Restore is called — typically by reconstructing the
 // receipt's base via [NewReceiptBase] with a freshly-built concrete Resource. Restore validates that the pre-seeded
-// resource's URI matches snapshot.ResourceURI (sanity check against malformed wire input), parses the transaction ID,
-// then writes every base field from the snapshot. The Resource itself is not mutated — its identity was fixed at
+// resource's URI matches snapshot.ResourceURI (sanity check against malformed document input), parses the transaction
+// ID, then writes every base field from the snapshot. The Resource itself is not mutated — its identity was fixed at
 // construction.
 //
 // Restore is one-shot: it errors if the receipt has already been committed or restored. Callers that need to re-bind a
@@ -608,9 +608,9 @@ func (b *ReceiptBase) RestoreEncoded(_ *RuntimeEnvironment, base ReceiptData, _ 
 //
 // Snapshot is the read side of the encapsulation boundary. Marshalers can return Snapshot's value directly or embed it
 // alongside derivative-specific fields — concrete receipt types in other packages compose [ReceiptData] with their
-// provider fields in a single wire-shape struct. The boundary conversions ([Resource] -> URI, UUID -> 36-char string,
-// error -> status string) run once here, so downstream encoders see plain field values and skip reflection-driven
-// method dispatch on the embedded base.
+// provider fields in a single document-shape struct. The boundary conversions ([Resource] -> URI, UUID -> 36-char
+// string, error -> status string) run once here, so downstream encoders see plain field values and skip
+// reflection-driven method dispatch on the embedded base.
 //
 // Returns:
 //   - ReceiptData: the receipt's base state with ResourceURI empty when no resource is attached, TransactionID the
@@ -687,17 +687,17 @@ type Attempt struct {
 	Timestamp string `json:"timestamp" yaml:"timestamp"`
 }
 
-// ReceiptData is the canonical wire shape for [ReceiptBase].
+// ReceiptData is the canonical document shape for [ReceiptBase].
 //
 // [ReceiptBase.Snapshot] and [ReceiptBase.Restore] form the encapsulation-respecting path to read or write the base
-// state from outside [op]. Concrete receipt types in other packages embed ReceiptData in their own wire-shape
+// state from outside [op]. Concrete receipt types in other packages embed ReceiptData in their own document-shape
 // struct (combining base and provider-specific fields) and pass the embedded value to [ReceiptBase.Restore] during
 // unmarshal. The named type avoids the verbose anonymous-struct repetition a 12-field shape would otherwise demand at
 // every call site.
 //
 // Field-level encoding choices:
 //   - Status holds the dispatch error's message; non-empty restores as errors.New(status) so Err()-presence and the
-//     human-readable reason survive the wire trip (typed/joined errors collapse into a single error on reload).
+//     human-readable reason survive the round trip (typed/joined errors collapse into a single error on reload).
 //   - CompensationError holds the message of the error this receipt's Compensate returned on a failed unwind (empty
 //     when the undo succeeded or never ran); like Status it restores as errors.New(...). Distinct from Status, which
 //     is the forward dispatch error — a receipt on a failed-unwind journal can carry both.

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -226,7 +226,7 @@ type providerReceiverType struct {
 //   - providerType: the provider's reflect.Type.
 //   - construct: creates a provider instance from RuntimeEnvironment.
 //   - roles: the provider's declared roles (RoleModule, RoleAction, or both).
-//   - methodParameters: parsed Parameter values per Go method. The wire-form parameter tokens are cracked into
+//   - methodParameters: parsed Parameter values per Go method. The parameter tokens are cracked into
 //     Parameter values upstream by parseParameters at the announce boundary.
 //
 // Returns:
@@ -337,7 +337,7 @@ func (rt *resourceReceiverType) SourceTypes() []reflect.Type { return rt.sourceT
 //
 // Parameters:
 //   - providerType: the reflect.Type of the provider or resource.
-//   - methodParameters: parsed Parameter values per Go method, or nil for positional auto-naming. The wire
+//   - methodParameters: parsed Parameter values per Go method, or nil for positional auto-naming. The token
 //     grammar is cracked upstream by parseParameters; newReceiverType consumes typed Parameter values only.
 //   - isProvider: true if this receiver is an op.Provider (enables companion lookup).
 //

--- a/pkg/op/receiver_type_test.go
+++ b/pkg/op/receiver_type_test.go
@@ -122,8 +122,8 @@ func TestNewReceiverType_RequiredFloor_CompanionWithoutActivation(t *testing.T) 
 	}
 }
 
-// mustParseParameters cracks a wire-form methodParameters map into Parameter values for the test, failing the
-// test on parse error. Tests express their inputs in the wire form (matching codegen output); this helper drives
+// mustParseParameters cracks a token-form methodParameters map into Parameter values for the test, failing the
+// test on parse error. Tests express their inputs in the token form (matching codegen output); this helper drives
 // them through parseParameters so the receiver-construction path under test consumes typed Parameter values just
 // as production code does.
 func mustParseParameters(t *testing.T, providerType reflect.Type, m map[string][]string) map[string][]Parameter {

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -242,7 +242,7 @@ func (b *ResourceBase) Etag() (string, error) {
 	return b.uri, nil
 }
 
-// MarshalJSON marshals the resource to its JSON wire form, which is the URI as a JSON-encoded string.
+// MarshalJSON marshals the resource to its JSON form, which is the URI as a JSON-encoded string.
 //
 // The URI is the resource's identity and the only field required for a round trip through JSON: catalog rehydration
 // reconstructs the resource via [NewResource] from the stored URI. Concrete Resource types that need to persist
@@ -256,7 +256,7 @@ func (b *ResourceBase) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.uri)
 }
 
-// MarshalText marshals the resource to its text wire form, which is the URI as raw UTF-8 bytes.
+// MarshalText marshals the resource to its text form, which is the URI as raw UTF-8 bytes.
 //
 // The text form is consumed by stdlib encoders ([encoding/json] for map keys, [encoding/xml] for attributes), YAML
 // scalar emission via [yaml.v3], CLI flag ingestion via [flag.TextVar], and most env/config parsers. Round trip through

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -120,12 +120,12 @@ func (c *ResourceCatalog) Clone() *ResourceCatalog {
 // Returns:
 //   - `[]LedgerEntrySnapshot`: id, URI, and [Pending] per current generation; empty (never nil) when the
 //     ledger holds nothing — the document's section serializes even then, mandatorily.
-func (c *ResourceCatalog) IntentEntries() []LedgerEntrySnapshot {
+func (c *ResourceCatalog) IntentEntries() []IntentEntry {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	entries := make([]LedgerEntrySnapshot, 0, len(c.entries))
+	entries := make([]IntentEntry, 0, len(c.entries))
 
 	for _, resource := range c.entries {
 
@@ -134,7 +134,7 @@ func (c *ResourceCatalog) IntentEntries() []LedgerEntrySnapshot {
 			continue // a superseded generation is history, not intent
 		}
 
-		entries = append(entries, LedgerEntrySnapshot{ID: base.id, URI: resource.URI(), State: Pending})
+		entries = append(entries, IntentEntry{ID: base.id, URI: resource.URI()})
 	}
 
 	return entries
@@ -843,6 +843,21 @@ type ResourceLedgerSnapshot struct {
 
 	// NextID is the monotonic id counter, restored so post-resume production continues the id sequence.
 	NextID int `json:"next_id" yaml:"next_id"`
+}
+
+// IntentEntry is one row of the graph document's resource catalog — input intent, nothing else.
+//
+// `{id, uri}` and no more (ruled 2026-08-21, 4-resource-management.md §5.4): presence in the section IS the
+// pending claim — pending is definitional, not recorded — and state, producer, Etag, and Digest are trace
+// vocabulary ([LedgerEntrySnapshot]), where observation genuinely varies. The intent row is its own type
+// precisely so the graph document cannot say more than intent.
+type IntentEntry struct {
+
+	// ID is the catalog id (`res-N`) the claim was minted under; restored verbatim on load.
+	ID string `json:"id" yaml:"id"`
+
+	// URI is the resource's identity, from which the concrete Resource object is rebuilt on load.
+	URI string `json:"uri" yaml:"uri"`
 }
 
 // LedgerEntrySnapshot is one ledger generation's serializable identity and lifecycle state.

--- a/pkg/op/validate.go
+++ b/pkg/op/validate.go
@@ -29,7 +29,7 @@ import (
 // ValidateGraph is the single source of truth for both boundary checks:
 //
 //   - The planning path calls it as the final step of plan.Provider.Assemble.
-//   - The wire-form load path calls it after [Graph.Rebind]'s linkActions resolves pending action
+//   - The document-form load path calls it after [Graph.Rebind]'s linkActions resolves pending action
 //     references through the registry. The loader (e.g., plan.Provider.Load) orders Unmarshal ->
 //     Rebind -> ValidateGraph.
 //


### PR DESCRIPTION
Phase 3, PR A of [resource-construction](docs/plans/resource-construction.md) (#585).

## Stateless intent rows

The graph document's resource rows drop `state` (ruled 2026-08-21): the intent row becomes its own
**`IntentEntry{ID, URI}`**, split from the trace's `LedgerEntrySnapshot`. Presence in the section IS the
pending claim — pending is definitional, not recorded — and state/producer/Etag/Digest stay where
observation varies: the trace. The writer already forced Pending and the reader ignored the field; the
type now makes the document say exactly what the code means. Round-trip pins re-assert byte identity and
**refuse** a `state` field; the star pins flip to asserting the key's absence.

## The day's rulings, recorded

- **`MissingResourcePolicy`** — `Stop` (0, fail-safe zero, default) / `Ignore` / `Skip`, warning always on
  detection, the parameter TYPE as the declaration, Stop-wins aggregation, scoped verification per
  subgraph executor. (Design §3 + plan docket.)
- **Directive inventory shrinks**: `planner` inferred from `<MethodName>Planner` (4/4 conform),
  `struct_param` removed (zero consumers; `Convert` hydrates), `lifetime` removed with its dormant
  machinery, `access` retires per 3.6. Survivors: `defaults`, `property`, `root`.
- **Two e2e lore scenarios noted into the phase**: Docker first, then Go Toolchain —
  deploy/upgrade/reconcile/decommission.

## Vocabulary cleanup (background pass)

Eleven pkg/op files rename the "wire" comment vocabulary per the ruling — parameter tokens at the announce
boundary; serialized objects live in documents. OpenSSH's standard term, real network text, and "wire" as
a verb are deliberately untouched; one error string follows the ruling.

## Verified

- `make check` — 103 ok, 0 failures (both flipped star pins inside the suite)
- `make vet` GOOS=windows; gofmt clean; expectation: green stays green

Refs #585, #581.
