### PR TITLE
feat(op): scoped pre-flight — each subgraph verifies its own claims, and unmet required intent fails

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_preflight_fail_fast.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_preflight_fail_fast.star
@@ -7,8 +7,8 @@
 # prediction, authored from the ruled design (Q1, 2026-08-20): pre-flight's verification pass finds the
 # pending file resource missing relative to the run's fsroot — unmet intent — and FAILS THE RUN before any
 # unit dispatches; the error is the catalog's verdict ("verify existence"), not a rediscovered copy error,
-# and the destination is never created. Until phase 3 (#585) lands, resolvePendingResources marks Gone
-# without failing, so this scenario is the phase's acceptance pin.
+# and the destination is never created. Phase 3's scoped pre-flight delivered the
+# consequence (2026-08-22); this scenario un-skipped as the phase's acceptance evidence.
 
 src = t.tmp("vanishes.txt")
 dst = t.tmp("never.txt")
@@ -23,7 +23,8 @@ plan.save_definition(graph, doc)
 # The claim is intent: exactly one pending entry for the source.
 document = json.decode(data=file.read_text(resource=doc))
 entries = document["resources"]
-t.expect_equal(len([e for e in entries if "vanishes.txt" in str(e) and e["state"] == "pending"]), 1)
+t.expect_equal(len([e for e in entries if "vanishes.txt" in str(e)]), 1)
+t.expect_equal(len([e for e in entries if "state" in e]), 0)  # stateless rows: presence IS the pending claim
 
 # Intent breaks before the run starts.
 file.remove(path=src, prune=False, boundary="")

--- a/cmd/devlore-test/devloretest/data/test_judgment_scoped_claims.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_scoped_claims.star
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_scoped_claims.star — judgment scenario: scoped claims (docs/plans/resource-construction.md).
+#
+# A choose case claims a file that never exists — and the case is never reached, because its when-predicate
+# is falsy. The prediction, authored from the ruled design (2026-08-22): claims verification is per subgraph
+# executor, and a choose case is a subgraph, so its claims are judged only when the case is hit. The run
+# routes to the default and SUCCEEDS; the unreached case's missing claim is inconsequential — its existence
+# was never this run's business. (The reached-direction consequence is pinned by the pre-flight fail-fast
+# scenario: a required claim in a scope that DOES start fails that scope with the catalog's verdict.)
+
+phantom = t.tmp("phantom.txt")     # never created — the when-predicate probes it (a path query, no claim)
+unclaimed = t.tmp("never_made.txt")  # never created — the unreached case CLAIMS it
+status = t.tmp("choose_status.txt")
+
+exists_inv = plan.file.exists(path=phantom)
+choice = plan.choose(
+    plan.case(when=exists_inv, then=plan.file.read_text(resource=unclaimed)),
+    default=lambda: "case not taken",
+)
+status_inv = plan.file.write_text(destination_path=status, content=choice, mode=0o644)
+
+graph = plan.assemble_definition([choice, status_inv])
+
+# The claim IS in the stored catalog — intent is declared regardless of reachability — as a stateless row.
+doc = t.tmp("graph.json")
+plan.save_definition(graph, doc)
+document = json.decode(data=file.read_text(resource=doc))
+entries = document["resources"]
+t.expect_equal(len([e for e in entries if "never_made.txt" in str(e)]), 1)
+
+# The run succeeds: the scope that claimed the missing file never started, so the claim was never judged.
+t.expect_file(status, content="case not taken")
+t.expect_no_file(unclaimed)
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_source.star
+++ b/cmd/devlore-test/devloretest/data/test_source.star
@@ -3,24 +3,21 @@
 
 # test_source.star — Use plan.file.read_text to read an existing file.
 #
-# 1. Write a file (via shell to avoid plan.file edge coupling)
-# 2. Read it back via plan.file.read_text
+# The file exists BEFORE the run (written by the harness, outside the graph), so the read's claim is honest
+# required intent: pre-flight verifies it under the run's root and the read consumes it. The former shape —
+# a shell unit creating the file for a later read by name, with no promise between them — is refused by
+# scoped pre-flight, by design (§3: ordering-by-coincidence).
 #
 # Validates: plan.file.read_text
 
 dest = t.tmp("source_input.txt")
+t.write(dest, "source test")
 
-# Use shell to create the file outside the graph's file provider,
-# so plan.file.read_text reads it independently.
-# The destination is single-quoted for the shell, but passed raw to file.read_text: the first is a command
-# string sh will parse, where a native path's backslashes read as escapes, and the second is a path argument
-# that must stay in the platform's own form.
 graph = plan.assemble_definition([
-    plan.shell.exec(command="printf 'source test' > '" + dest + "'"),
     plan.file.read_text(resource=dest),
 ])
 
 t.expect_file(dest, content="source test")
-t.expect_unit_count(2)  # shell.exec + file.read_text
+t.expect_unit_count(1)  # file.read_text
 
 t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_write_and_read.star
+++ b/cmd/devlore-test/devloretest/data/test_write_and_read.star
@@ -2,12 +2,14 @@
 # Copyright Noble Factor. All rights reserved.
 
 # test_write_and_read.star — Write then read the same path.
-# Both nodes target the same path. Nodes without edges are sorted by
-# insertion order within the same path depth, so write runs first.
+# The read consumes the write's PROMISE: ordering comes from the edge, and a promise-fed slot claims
+# nothing — the file need not exist when the run starts because the graph itself creates it (§3: the
+# promise-less name-coincidence form of this plan is refused by scoped pre-flight, by design).
 dest = t.tmp("readback.txt")
+written = plan.file.write_text(destination_path=dest, content="read me back", mode=0o644)
 graph = plan.assemble_definition([
-    plan.file.write_text(destination_path=dest, content="read me back", mode=0o644),
-    plan.file.read_text(resource=dest),
+    written,
+    plan.file.read_text(resource=written),
 ])
 t.expect_file(dest, content="read me back")
 t.expect_unit_count(2)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -445,9 +445,11 @@ func TestJudgmentScenario1_DeleteThenCopy(t *testing.T) {
 }
 
 func TestJudgmentPreflightFailFast(t *testing.T) {
-	t.Skip("phase-3 acceptance pin (#585): resolvePendingResources marks Gone without failing the run; " +
-		"un-skip when pre-flight fails on unmet intent")
 	runScript(t, "test_judgment_preflight_fail_fast.star")
+}
+
+func TestJudgmentScopedClaims(t *testing.T) {
+	runScript(t, "test_judgment_scoped_claims.star")
 }
 
 func TestJudgmentPromiseOrdering(t *testing.T) {

--- a/cmd/lore/lore/builder.go
+++ b/cmd/lore/lore/builder.go
@@ -146,7 +146,11 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 		"settings": cfg.Settings,
 	}))
 
-	graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(phases...))
+	// The catalog travels with the graph (§5.4): the planning session interned this graph's claims
+	// into the environment's catalog — a fresh one here would strand them (the empty-section defect
+	// scoped verification exposed, 2026-08-22).
+	graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(phases...).
+		WithResourceCatalog(sharedEnvironment.ResourceCatalog))
 	if err != nil {
 		return nil, fmt.Errorf("lore.Build: %w", err)
 	}

--- a/cmd/writ/writ/decommission/decommission.go
+++ b/cmd/writ/writ/decommission/decommission.go
@@ -217,7 +217,11 @@ func buildScopeGraph(
 			"files":       fileMetas,
 		}))
 
-		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...))
+		// The catalog travels with the graph (§5.4): the planning session interned this graph's claims
+		// into the environment's catalog — a fresh one here would strand them (the empty-section defect
+		// scoped verification exposed, 2026-08-22).
+		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...).
+			WithResourceCatalog(environment.ResourceCatalog))
 		if err != nil {
 			return nil, fmt.Errorf("assemble scope %q: %w", scope, err)
 		}

--- a/cmd/writ/writ/deploy/plan.go
+++ b/cmd/writ/writ/deploy/plan.go
@@ -349,7 +349,11 @@ func buildScopeGraph(
 			"files":         fileMetas,
 		}))
 
-		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...))
+		// The catalog travels with the graph (§5.4): the planning session interned this graph's claims
+		// into the environment's catalog — a fresh one here would strand them (the empty-section defect
+		// scoped verification exposed, 2026-08-22).
+		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...).
+			WithResourceCatalog(environment.ResourceCatalog))
 		if err != nil {
 			return nil, fmt.Errorf("assemble scope %q: %w", scope, err)
 		}

--- a/cmd/writ/writ/secret/encrypt.go
+++ b/cmd/writ/writ/secret/encrypt.go
@@ -191,7 +191,11 @@ func buildLayerGraph(ctx context.Context, cfg *EncryptConfig, group *layerGroup)
 			"files":    fileMetas,
 		}))
 
-		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...))
+		// The catalog travels with the graph (§5.4): the planning session interned this graph's claims
+		// into the environment's catalog — a fresh one here would strand them (the empty-section defect
+		// scoped verification exposed, 2026-08-22).
+		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...).
+			WithResourceCatalog(environment.ResourceCatalog))
 		if err != nil {
 			return nil, fmt.Errorf("assemble layer %q: %w", group.name, err)
 		}

--- a/cmd/writ/writ/upgrade/upgrade.go
+++ b/cmd/writ/writ/upgrade/upgrade.go
@@ -493,7 +493,11 @@ func buildScopeGraph(
 			"files":       fileMetas,
 		}))
 
-		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...))
+		// The catalog travels with the graph (§5.4): the planning session interned this graph's claims
+		// into the environment's catalog — a fresh one here would strand them (the empty-section defect
+		// scoped verification exposed, 2026-08-22).
+		graph, err := op.NewGraph(op.NewGraphSpec().WithOrigin(origin).WithUnits(units...).
+			WithResourceCatalog(environment.ResourceCatalog))
 		if err != nil {
 			return nil, fmt.Errorf("assemble scope %q: %w", scope, err)
 		}

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -319,6 +319,35 @@ Items 1–3 of the original docket (string → pending, promise → recorded, st
 
 Surviving directive set: `+devlore:defaults`, `+devlore:property`, `+devlore:root` — everything else
 derives from types, signatures, names, and graph structure.
+
+**PR B record (2026-08-22) — scoped verification lands; the fail-fast scenario flips green; a stranded
+catalog exposed.**
+
+- `MissingResourcePolicy` ships (`pkg/op/missing_resource_policy.go`): explicit values, Stop = 0 fail-safe,
+  canonical lowercase document forms, `UnmarshalText` for authored strings; round-trip pinned.
+- The pre-flight pass splits: `bindPendingResources` (binding only, every entry) stays at Run's start;
+  **verification moved to `Subgraph.Execute`** — `verifyScopeClaims` walks the scope's own units' immediate
+  resource slots, warns on every detection, and fails the scope under Stop with a reason-carrying failure
+  (`ReasonPreflightFailed`). The root graph passes through the same seam — one starting line for every
+  scope, exactly the ruled uniformity.
+- **Acceptance delivered: `TestJudgmentPreflightFailFast` un-skipped and green** — the copy's missing
+  source fails the run with the catalog's verdict before any dispatch. The new scoped-claims scenario
+  (`test_judgment_scoped_claims.star`) pins the other direction: an unreached choose case's missing claim
+  is never judged and the run succeeds.
+- **The headline catch: five Go-side assemblers stranded their catalogs.** writ deploy/upgrade/
+  decommission/encrypt and lore's builder assembled via `op.NewGraph(...)`, which supplies a FRESH catalog
+  — every claim interned during planning stayed in the environment's catalog, and the serialized graphs
+  carried empty `resources` sections since phase 1. Scoped verification exposed it (verify saw slot
+  resources the binding pass never touched: "file already closed"). All five now attach the planning
+  environment's catalog; writ and lore graphs finally travel with their claims.
+- The deliberately strict case bit two star fixtures authored as promise-less name-coincidence ordering
+  (`test_source.star`, `test_write_and_read.star`) — both re-authored legal (pre-existing file; promise-fed
+  read), each carrying the refusal's why.
+- The old global-pass pin split into two ruled pins: claim-driven probing (consumed probed once; unconsumed
+  never; unenrolled never) and the Stop consequence (unmet intent, `preflight_failed` terminal, pristine
+  planning catalog).
+- Gate: make check 103 ok / 0 fail, GOOS=windows vet clean. Skip/Ignore behavior at dispatch is PR C/D
+  work (the mutators gain the policy parameter in C; the guard honors it in D).
 4. Consequence for phase 1's stored section: every stored entry is Pending by construction. **RULED
    2026-08-21: the stored row drops `state` entirely** — the intent row becomes its own `{id, uri}` type
    (presence IS the pending claim), splitting from the trace's `LedgerEntrySnapshot`, whose

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -530,11 +530,11 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 		e.stack = NewRecoveryStack()
 	}
 
-	// The pre-flight resolve pass (phase-8 step 22): plan-time resources were introduced as [Pending]; now that the
-	// catalog is live on the per-run environment, verify each participating entry's existence and drive the
-	// [Pending] → [Active]/[Gone] transition. Runs for fresh and resumed runs alike, and in dry-run too — the probes
-	// are read-only (stat-class).
-	e.resolvePendingResources()
+	// The pre-flight binding pass: every pending entry re-bases onto the run's environment and binds
+	// rel-first to the run's root. VERIFICATION is not here — it is scoped (§3, ruled 2026-08-22): each
+	// subgraph executor verifies the claims its own units consume when its scope starts, the root subgraph
+	// included, inside [Subgraph.Execute]. Runs for fresh and resumed runs alike, and in dry-run too.
+	e.bindPendingResources()
 
 	// preparing → running: construction + environment build + variable binding (the preflight) run in
 	// [PhasePreparing]; the phase enters [PhaseRunning] here, at the first dispatch. A preflight failure above lands a
@@ -1067,6 +1067,89 @@ func (e *GraphExecutor) bindVariables(graph *Graph, callerVariables map[string]V
 // operations against a not-yet-existent path is legitimate (`file.exists` on a missing file answers false; a producer
 // revives a [Gone] URI via shadow), and consumers of a genuinely missing resource fail at their own dispatch (the Q2
 // "dependents fail on their own" precedent). The probes are read-only (stat-class), so the pass also runs in dry-run.
+// verifyScopeClaims verifies the claims a scope's own units consume — the scoped pre-flight (§3, ruled
+// 2026-08-22).
+//
+// A claim is an immediate resource-valued slot on one of the scope's direct units (a promise-fed slot is
+// not a claim, and deeper units belong to deeper scopes). Verification drives the [Pending] → [Active] /
+// [Gone] transition through [ResourceCatalog.VerifyExistence]; a warning is produced on every detection of
+// a missing resource, under every policy. The consequence follows the unit's [MissingResourcePolicy]
+// (fail-safe default [MissingResourcePolicyStop]): Stop fails the scope with [ReasonPreflightFailed];
+// Ignore and Skip let the scope proceed — their behavior applies at the consumer's dispatch.
+//
+// Parameters:
+//   - `scopeID`: the verifying scope's unit id, for the warning and the failure.
+//   - `units`: the scope's direct units.
+//
+// Returns:
+//   - `error`: a reason-carrying dispatch failure for the first unmet required claim; nil otherwise.
+func (e *GraphExecutor) verifyScopeClaims(scopeID string, units []ExecutableUnit) error {
+
+	catalog := e.environment.ResourceCatalog
+	if catalog == nil {
+		return nil
+	}
+
+	for _, unit := range units {
+
+		policy := unitMissingResourcePolicy(unit)
+
+		for _, binding := range unit.Slots() {
+
+			immediate, ok := binding.(ImmediateBinding)
+			if !ok {
+				continue
+			}
+
+			resource, ok := immediate.Resolve(nil, nil).(Resource)
+			if !ok || !participatesInExistenceVerification(resource) {
+				continue
+			}
+
+			verifyErr := catalog.VerifyExistence(resource)
+			if verifyErr == nil {
+				continue
+			}
+
+			if e.environment.Status != nil {
+				e.environment.Status.Warn(fmt.Sprintf(
+					"%s: %s: missing resource (policy %s): %v", scopeID, unit.ID(), policy, verifyErr))
+			}
+
+			if policy == MissingResourcePolicyStop {
+				return &dispatchFailure{reason: ReasonPreflightFailed,
+					cause: fmt.Errorf("%s: unmet intent: %w", unit.ID(), verifyErr)}
+			}
+		}
+	}
+
+	return nil
+}
+
+// unitMissingResourcePolicy returns the unit's declared [MissingResourcePolicy] — its immediate
+// policy-typed slot value — or the fail-safe default [MissingResourcePolicyStop].
+//
+// The parameter's type is the declaration (§3): no directive names the slot, so the policy is found by
+// its type among the unit's immediate bindings.
+//
+// Parameters:
+//   - `unit`: the unit whose policy is read.
+//
+// Returns:
+//   - `MissingResourcePolicy`: the declared policy, or Stop when none is declared.
+func unitMissingResourcePolicy(unit ExecutableUnit) MissingResourcePolicy {
+
+	for _, binding := range unit.Slots() {
+		if immediate, ok := binding.(ImmediateBinding); ok {
+			if policy, ok := immediate.Resolve(nil, nil).(MissingResourcePolicy); ok {
+				return policy
+			}
+		}
+	}
+
+	return MissingResourcePolicyStop
+}
+
 // captureLedgerSnapshot records the resource ledger and the run's bound root for the trace.
 //
 // The binding half of the trace record: file identities are root-relative (#584), so the snapshot names
@@ -1084,7 +1167,7 @@ func (e *GraphExecutor) captureLedgerSnapshot() {
 	}
 }
 
-func (e *GraphExecutor) resolvePendingResources() {
+func (e *GraphExecutor) bindPendingResources() {
 
 	catalog := e.environment.ResourceCatalog
 	if catalog == nil {
@@ -1095,21 +1178,14 @@ func (e *GraphExecutor) resolvePendingResources() {
 
 		// The activation binding (§5.5): the run, not the construction session, owns location. Every
 		// pending entry re-bases onto the run's environment, and a root-relative scheme re-binds its path
-		// rel-first against the run's root through the [RootBinder] seam — so the existence check below,
-		// and every later observation, read the run's world rather than the environment that happened to
-		// construct or rehydrate the object (the run-from-elsewhere defect).
+		// rel-first against the run's root through the [RootBinder] seam — so scoped verification, and
+		// every later observation, read the run's world rather than the environment that happened to
+		// construct or rehydrate the object (the run-from-elsewhere defect). Existence is NOT checked
+		// here: verification is scoped per subgraph executor ([GraphExecutor.verifyScopeClaims]).
 		resource.resourceBase().runtimeEnvironment = e.environment
 		if binder, ok := resource.(RootBinder); ok && e.environment.HasRoot() {
 			binder.BindRoot(e.environment.Root())
 		}
-
-		if !participatesInExistenceVerification(resource) {
-			continue
-		}
-		// Mark, don't fail: VerifyExistence records Gone on a missing resource; the error is informational
-		// here (phase 3 of the resource-construction plan owns the transition-failure consequence).
-		//nolint:errcheck // diagnose-ignored-error: records Gone; see docs/architecture/2.8-eventing-infrastructure.md
-		_ = catalog.VerifyExistence(resource)
 	}
 }
 

--- a/pkg/op/graph_executor_test.go
+++ b/pkg/op/graph_executor_test.go
@@ -294,24 +294,26 @@ func TestRun_CleanUnwind_ReachesExecutionFailed(t *testing.T) {
 	}
 }
 
-// TestRun_PreflightResolvesPendingResources proves the pre-flight resolve pass (phase-8 step 22 slice C).
+// TestRun_ScopedPreflightVerifiesConsumedClaims proves the scoped pre-flight (§3, ruled 2026-08-22).
 //
-// Pending entries of a participating type are probed exactly once through Resource.Exists, a non-enrolled type is never
-// probed (the staged-rollout gate), a missing resource marks Gone without failing the run, and the graph's planning
-// catalog stays pristine (the pass runs on the per-run clone).
-func TestRun_PreflightResolvesPendingResources(t *testing.T) {
+// Verification is claim-driven: a scope probes exactly the resources its own units' immediate slots carry.
+// A consumed present entry is probed once and activates; an entry consumed by NOTHING is never probed —
+// even when Pending in the catalog — and neither is a non-enrolled type (the staged-rollout gate). The
+// graph's planning catalog stays pristine (the pass runs on the per-run clone). The Stop consequence for a
+// consumed MISSING claim is pinned separately below.
+func TestRun_ScopedPreflightVerifiesConsumedClaims(t *testing.T) {
 
 	presentBase, err := NewResourceBase(nil, "test:///present", reflect.TypeFor[*lifecycleResource]())
 	if err != nil {
 		t.Fatalf("NewResourceBase(present): %v", err)
 	}
-	missingBase, err := NewResourceBase(nil, "test:///missing", reflect.TypeFor[*lifecycleResource]())
+	unconsumedBase, err := NewResourceBase(nil, "test:///unconsumed", reflect.TypeFor[*lifecycleResource]())
 	if err != nil {
-		t.Fatalf("NewResourceBase(missing): %v", err)
+		t.Fatalf("NewResourceBase(unconsumed): %v", err)
 	}
 
 	present := &lifecycleResource{ResourceBase: presentBase, addressingMode: AddressingLocation, present: true}
-	missing := &lifecycleResource{ResourceBase: missingBase, addressingMode: AddressingLocation, present: false}
+	unconsumed := &lifecycleResource{ResourceBase: unconsumedBase, addressingMode: AddressingLocation, present: true}
 	unenrolled := newLifecycle("test:///unenrolled", AddressingLocation) // bare base: type id "", not enrolled
 
 	// Enroll the fixture type in the staged-rollout gate for the duration of this test.
@@ -321,14 +323,15 @@ func TestRun_PreflightResolvesPendingResources(t *testing.T) {
 
 	catalog := NewResourceCatalog()
 	catalog.Resolve(present)
-	catalog.Resolve(missing)
+	catalog.Resolve(unconsumed)
 	catalog.Resolve(unenrolled)
 
 	produceAction, err := ReceiverRegistry().BuildAction("compensationCleanFixture.produce")
 	if err != nil {
 		t.Fatalf("BuildAction(produce): %v", err)
 	}
-	producer, err := NewNode(NewNodeSpec().WithID("producer").WithAction(produceAction))
+	producer, err := NewNode(NewNodeSpec().WithID("producer").WithAction(produceAction).
+		WithSlot("claim", NewImmediateBinding(present)))
 	if err != nil {
 		t.Fatalf("NewNode(producer): %v", err)
 	}
@@ -341,15 +344,16 @@ func TestRun_PreflightResolvesPendingResources(t *testing.T) {
 		WithApplication(&application.Application{Name: "test"}))
 
 	if _, err := executor.Run(context.Background(), nil); err != nil {
-		t.Fatalf("Run: %v — a Gone resource is a recorded fact; the pass must mark, not fail", err)
+		t.Fatalf("Run: %v — a present consumed claim must verify and the scope proceed", err)
 	}
 
 	if present.existsCalls != 1 {
-		t.Errorf("present.existsCalls = %d, want 1 (a pending participating entry is probed once)", present.existsCalls)
+		t.Errorf("present.existsCalls = %d, want 1 (a consumed claim is probed once, at its scope's start)",
+			present.existsCalls)
 	}
-	if missing.existsCalls != 1 {
-		t.Errorf("missing.existsCalls = %d, want 1 (a missing resource is probed, marked Gone, and the run proceeds)",
-			missing.existsCalls)
+	if unconsumed.existsCalls != 0 {
+		t.Errorf("unconsumed.existsCalls = %d, want 0 (verification is claim-driven — an entry no unit consumes is never judged)",
+			unconsumed.existsCalls)
 	}
 	if unenrolled.existsCalls != 0 {
 		t.Errorf("unenrolled.existsCalls = %d, want 0 (the staging gate must skip non-enrolled types)",
@@ -360,6 +364,54 @@ func TestRun_PreflightResolvesPendingResources(t *testing.T) {
 	if got := catalog.State(present.ID()); got != Pending {
 		t.Errorf("planning catalog State(present) = %v, want Pending (transitions must land on the clone only)", got)
 	}
+}
+
+// TestRun_ScopedPreflightFailsOnConsumedMissingClaim proves the Stop consequence (§3, ruled 2026-08-22): a
+// consumed claim that fails its existence predicate fails the scope as unmet intent — before any dispatch —
+// and lands the preflight_failed terminal. The planning catalog stays pristine.
+func TestRun_ScopedPreflightFailsOnConsumedMissingClaim(t *testing.T) {
+
+	missingBase, err := NewResourceBase(nil, "test:///missing", reflect.TypeFor[*lifecycleResource]())
+	if err != nil {
+		t.Fatalf("NewResourceBase(missing): %v", err)
+	}
+	missing := &lifecycleResource{ResourceBase: missingBase, addressingMode: AddressingLocation, present: false}
+
+	typeID := missing.ResourceType()
+	existenceVerifiableTypes[typeID] = struct{}{}
+	t.Cleanup(func() { delete(existenceVerifiableTypes, typeID) })
+
+	catalog := NewResourceCatalog()
+	catalog.Resolve(missing)
+
+	produceAction, err := ReceiverRegistry().BuildAction("compensationCleanFixture.produce")
+	if err != nil {
+		t.Fatalf("BuildAction(produce): %v", err)
+	}
+	consumer, err := NewNode(NewNodeSpec().WithID("consumer").WithAction(produceAction).
+		WithSlot("claim", NewImmediateBinding(missing)))
+	if err != nil {
+		t.Fatalf("NewNode(consumer): %v", err)
+	}
+	graph, err := NewGraph(NewGraphSpec().WithOrigin(OriginBase{}).WithUnits(consumer).WithResourceCatalog(catalog))
+	if err != nil {
+		t.Fatalf("NewGraph: %v", err)
+	}
+
+	executor := NewGraphExecutor(graph, NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}))
+
+	_, runErr := executor.Run(context.Background(), nil)
+	if runErr == nil {
+		t.Fatal("Run succeeded although a consumed required claim is missing")
+	}
+	if !strings.Contains(runErr.Error(), "unmet intent") {
+		t.Errorf("failure does not name unmet intent: %v", runErr)
+	}
+	if got := executor.RunStatus().Reason; got != ReasonPreflightFailed {
+		t.Errorf("terminal reason = %v, want ReasonPreflightFailed", got)
+	}
+
 	if got := catalog.State(missing.ID()); got != Pending {
 		t.Errorf("planning catalog State(missing) = %v, want Pending (transitions must land on the clone only)", got)
 	}

--- a/pkg/op/missing_resource_policy.go
+++ b/pkg/op/missing_resource_policy.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/NobleFactor/devlore-cli/pkg/assert"
+)
+
+// MissingResourcePolicy is a consumer's declared response to a missing resource (ruled 2026-08-22;
+// docs/architecture/4-resource-management.md §3, the claims taxonomy).
+//
+// The parameter's TYPE is the declaration — no directive: a method with a MissingResourcePolicy-typed
+// parameter and exactly one consumed (resource-typed) parameter links the two at announcement. A warning
+// is produced whenever a missing resource is detected, under every policy. Aggregation across the
+// consumers of one entry: Stop wins.
+type MissingResourcePolicy int
+
+const (
+	// MissingResourcePolicyStop is the zero value and the default — fail-safe: a missing resource fails
+	// the consuming scope as unmet intent. An unset policy can never accidentally tolerate.
+	MissingResourcePolicyStop MissingResourcePolicy = 0
+
+	// MissingResourcePolicyIgnore makes the call anyway: the provider sees the absence and handles it
+	// (a remove no-ops), and the receipt records that the target was already absent.
+	MissingResourcePolicyIgnore MissingResourcePolicy = 1
+
+	// MissingResourcePolicySkip skips the call: the unit does not dispatch, recorded as skipped.
+	MissingResourcePolicySkip MissingResourcePolicy = 2
+)
+
+// String returns the canonical lowercase rendering of the policy.
+//
+// Returns:
+//   - `string`: "stop", "ignore", or "skip".
+func (p MissingResourcePolicy) String() string {
+
+	switch p {
+	case MissingResourcePolicyStop:
+		return "stop"
+	case MissingResourcePolicyIgnore:
+		return "ignore"
+	case MissingResourcePolicySkip:
+		return "skip"
+	}
+
+	assert.Unreachable(fmt.Sprintf("op.MissingResourcePolicy.String: invalid policy value %d", int(p)))
+	return ""
+}
+
+// MarshalJSON serializes the policy as its canonical lowercase string — a document carries "stop", never a
+// bare ordinal (the typed-value rule: no value degrades to its least-typed rendering in an artifact).
+//
+// Returns:
+//   - `[]byte`: the JSON string form.
+//   - `error`: any error from the underlying marshal.
+func (p MissingResourcePolicy) MarshalJSON() ([]byte, error) { return json.Marshal(p.String()) }
+
+// MarshalYAML serializes the policy as its canonical lowercase string, mirroring
+// [MissingResourcePolicy.MarshalJSON].
+//
+// Returns:
+//   - `any`: the string form for the YAML encoder.
+//   - `error`: always nil; present to satisfy the [yaml.Marshaler] interface.
+func (p MissingResourcePolicy) MarshalYAML() (any, error) { return p.String(), nil }
+
+// UnmarshalJSON deserializes the canonical string form.
+//
+// Parameters:
+//   - `data`: the JSON bytes to decode.
+//
+// Returns:
+//   - `error`: a malformed JSON string, or an unknown policy name.
+func (p *MissingResourcePolicy) UnmarshalJSON(data []byte) error {
+
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	return p.parse(name)
+}
+
+// UnmarshalYAML deserializes the canonical string form, mirroring [MissingResourcePolicy.UnmarshalJSON].
+//
+// Parameters:
+//   - `value`: the YAML node to decode.
+//
+// Returns:
+//   - `error`: a malformed YAML scalar, or an unknown policy name.
+func (p *MissingResourcePolicy) UnmarshalYAML(value *yaml.Node) error {
+
+	var name string
+	if err := value.Decode(&name); err != nil {
+		return err
+	}
+
+	return p.parse(name)
+}
+
+// UnmarshalText deserializes the canonical string form — the seam [Convert]'s text-unmarshal step uses to
+// turn an authored "skip" into the typed policy at slot fill.
+//
+// Parameters:
+//   - `text`: the policy name as UTF-8 bytes.
+//
+// Returns:
+//   - `error`: non-nil for an unknown name.
+func (p *MissingResourcePolicy) UnmarshalText(text []byte) error { return p.parse(string(text)) }
+
+// parse assigns the policy named by `name`.
+//
+// Parameters:
+//   - `name`: the canonical lowercase policy name.
+//
+// Returns:
+//   - `error`: non-nil for an unknown name.
+func (p *MissingResourcePolicy) parse(name string) error {
+
+	switch name {
+	case "stop":
+		*p = MissingResourcePolicyStop
+	case "ignore":
+		*p = MissingResourcePolicyIgnore
+	case "skip":
+		*p = MissingResourcePolicySkip
+	default:
+		return fmt.Errorf("op.MissingResourcePolicy: unknown policy %q", name)
+	}
+
+	return nil
+}

--- a/pkg/op/missing_resource_policy_test.go
+++ b/pkg/op/missing_resource_policy_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The policy's document form is its canonical lowercase name in both directions, and the zero value is
+// Stop — fail-safe: an unset policy can never accidentally tolerate (§3, ruled 2026-08-22).
+
+func TestMissingResourcePolicy_RoundTripAndZeroValue(t *testing.T) {
+
+	var unset MissingResourcePolicy
+	if unset != MissingResourcePolicyStop {
+		t.Fatalf("zero value = %v, want Stop — the fail-safe default", unset)
+	}
+
+	for _, tc := range []struct {
+		policy MissingResourcePolicy
+		name   string
+	}{
+		{MissingResourcePolicyStop, "stop"},
+		{MissingResourcePolicyIgnore, "ignore"},
+		{MissingResourcePolicySkip, "skip"},
+	} {
+		if tc.policy.String() != tc.name {
+			t.Errorf("String(%d) = %q, want %q", int(tc.policy), tc.policy.String(), tc.name)
+		}
+
+		data, err := json.Marshal(tc.policy)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", tc.name, err)
+		}
+		if string(data) != `"`+tc.name+`"` {
+			t.Errorf("document form = %s, want %q — never a bare ordinal", data, tc.name)
+		}
+
+		var back MissingResourcePolicy
+		if err := json.Unmarshal(data, &back); err != nil {
+			t.Fatalf("unmarshal %s: %v", data, err)
+		}
+		if back != tc.policy {
+			t.Errorf("round trip %s = %v, want %v", tc.name, back, tc.policy)
+		}
+	}
+
+	var invalid MissingResourcePolicy
+	if err := invalid.UnmarshalText([]byte("shrug")); err == nil {
+		t.Error("unknown policy name accepted — must refuse")
+	}
+}

--- a/pkg/op/provider/plan/root_binding_test.go
+++ b/pkg/op/provider/plan/root_binding_test.go
@@ -51,8 +51,8 @@ func TestRun_BindsPendingResourcesToTheRunRoot(t *testing.T) {
 }
 
 // TestRun_APendingRelAbsentUnderTheRunRootIsGone pins the inverse: the rel exists only under the PLAN
-// root, so the run marks the entry Gone (pre-flight marks, phase 3 owns the failing consequence) and the
-// dispatch fails to find it.
+// root, so the scoped pre-flight (§3, ruled 2026-08-22) marks the entry Gone and fails the scope with the
+// catalog's verdict — the required claim is unmet intent, and no unit dispatches.
 func TestRun_APendingRelAbsentUnderTheRunRootIsGone(t *testing.T) {
 
 	planRoot := t.TempDir()
@@ -66,8 +66,12 @@ func TestRun_APendingRelAbsentUnderTheRunRootIsGone(t *testing.T) {
 
 	executor := op.NewGraphExecutor(graph, runSpec(runRoot))
 
-	if _, err := executor.Run(context.Background(), nil); err == nil {
+	_, err := executor.Run(context.Background(), nil)
+	if err == nil {
 		t.Fatal("Run succeeded although the claimed rel does not exist under the run root")
+	}
+	if !strings.Contains(err.Error(), "verify existence") {
+		t.Fatalf("run failure is not the catalog's verdict: %v", err)
 	}
 
 	assertTraceBinding(t, executor, runRoot, op.Gone)

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -185,21 +185,11 @@ func (s *Subgraph) Execute(
 		return nil, err
 	}
 
-	// Resume (pseudo replay): replay or adopt against this subgraph's prior stamped stack on the parent stack. A
-	// completed stack (nil Err) prunes the whole subtree — return its cached result. An error stack is the in-progress
-	// spine (in a resumable trace the only error stacks are paused subgraphs): the stamped stack IS this subgraph's
-	// child stack, so adopt it (re-parented here) — the completed children are present and the descent resumes at the
-	// frontier — and supersede the stale entry so the fresh completion replaces it. "Has an error" is the serialize-safe
-	// signal — a reloaded error is a plain message, so errors.Is against the ErrPaused sentinel would not match. On a
-	// fresh run there is no prior stack, so this is a no-op.
-	var adoptedStack *RecoveryStack
-	if priorStack, ok := stack.NestedStackByUnitID(subgraphID); ok {
-		if priorStack.Err() == nil {
-			return priorStack.Result(), nil
-		}
-		adoptedStack = priorStack
-		adoptedStack.parent = stack
-		stack.supersede(subgraphID)
+	// Resume (pseudo replay): replay or adopt against this subgraph's prior stamped stack — see
+	// [Subgraph.adoptPriorStack]. A completed prior stack short-circuits with its cached result.
+	cached, pruned, adoptedStack := s.adoptPriorStack(stack)
+	if pruned {
+		return cached, nil
 	}
 
 	action := s.Action()
@@ -252,6 +242,17 @@ func (s *Subgraph) Execute(
 	activationRecord.Variables = variables
 	activationRecord.Slots = slots
 	activationRecord.executor = childExecutor
+
+	// Scoped pre-flight (§3, ruled 2026-08-22): before this scope dispatches, its executor verifies the
+	// claims its own units consume. The root subgraph and a choose case pass through this same seam — a
+	// graph is an object holding a root subgraph, so every starting line is a scope's starting line, and
+	// an unreached scope never judges its claims.
+	if verifyErr := childExecutor.verifyScopeClaims(subgraphID, s.Children()); verifyErr != nil {
+		verifyErr = executor.joinAuditStamp(s, stack, slots, nil, verifyErr, action)
+		executor.hooks.FireSubgraphComplete(runtimeEnvironment, subgraphID, verifyErr)
+		return nil, fmt.Errorf("subgraph %s: %w", subgraphID, verifyErr)
+	}
+
 	result, compensator, err := action.Do(activationRecord)
 
 	// Bubble-up (phase-8 step 41 slice 17b): a non-failure condition the body recorded on its child executor — a
@@ -386,6 +387,39 @@ func (s *Subgraph) addChild(child ExecutableUnit) {
 
 	s.executableUnitsByID[child.ID()] = child
 	child.stampParentID(s.ID())
+}
+
+// adoptPriorStack replays or adopts this subgraph's prior stamped stack on the parent stack.
+//
+// A completed stack (nil Err) prunes the whole subtree — the cached result returns with `pruned` true. An
+// error stack is the in-progress spine (in a resumable trace the only error stacks are paused subgraphs):
+// the stamped stack IS this subgraph's child stack, so it is adopted (re-parented here) — the completed
+// children are present and the descent resumes at the frontier — and the stale entry superseded so the
+// fresh completion replaces it. "Has an error" is the serialize-safe signal — a reloaded error is a plain
+// message, so errors.Is against the ErrPaused sentinel would not match. On a fresh run there is no prior
+// stack: all three results are zero.
+//
+// Parameters:
+//   - `stack`: the parent recovery stack carrying any prior stamped stack for this subgraph.
+//
+// Returns:
+//   - `cached`: the completed prior run's result, when `pruned`.
+//   - `pruned`: true when a completed prior stack short-circuits this subgraph.
+//   - `adopted`: the in-progress prior stack to resume into, or nil.
+func (s *Subgraph) adoptPriorStack(stack *RecoveryStack) (cached any, pruned bool, adopted *RecoveryStack) {
+
+	priorStack, ok := stack.NestedStackByUnitID(s.ID())
+	if !ok {
+		return nil, false, nil
+	}
+
+	if priorStack.Err() == nil {
+		return priorStack.Result(), true, nil
+	}
+
+	priorStack.parent = stack
+	stack.supersede(s.ID())
+	return nil, false, priorStack
 }
 
 // setEdges replaces this subgraph's edge list with `edges`.


### PR DESCRIPTION
Phase 3, PR B of [resource-construction](docs/plans/resource-construction.md) (#585) — the ruled claims
taxonomy lands.

## Scoped verification, one seam

Verification is per subgraph executor: every scope verifies the claims its own units consume when it
starts, inside `Subgraph.Execute` — the root graph passes through the same seam, so the run's starting
line and a choose case's entry are one code path. An unreached scope never judges its claims. The
Run-level pass shrinks to binding only.

## `MissingResourcePolicy`

Explicit values, fail-safe zero (`Stop`=0). A missing resource **warns under every policy**; `Stop` fails
the consuming scope as unmet intent (`preflight_failed` terminal); `Ignore`/`Skip` defer to dispatch (PR C
adds the mutator parameter; PR D the tolerance-aware guard). The parameter's *type* is the declaration.

## Acceptance delivered

**`TestJudgmentPreflightFailFast` un-skips and flips green** — the phase's ruled acceptance evidence. The
new `test_judgment_scoped_claims.star` pins the reverse: an unreached choose case's missing claim is never
judged and the run succeeds.

## The headline catch: five stranded catalogs

writ deploy/upgrade/decommission/encrypt and lore's builder assembled via `op.NewGraph(...)` — a **fresh**
catalog — while every claim interned during planning stayed behind in the environment's. Their serialized
graphs have carried empty `resources` sections since phase 1. Scoped verification exposed the strand; all
five sites now attach the planning environment's catalog. writ and lore graphs finally travel with their
claims.

## Also

The deliberately strict case caught two star fixtures authoring promise-less name-coincidence ordering —
re-authored legal, each recording the refusal's why. The old global-pass pin splits into claim-driven
probing + the Stop consequence.

## Verified

- `make check` — 103 ok, 0 failures (both scenarios, both new executor pins, writ end-to-end)
- `make vet` GOOS=windows; gofmt clean; expectation: green stays green

Refs #585, #581.
