### PR TITLE
feat(op): the consumed-Gone guard with the narrated verdict; Skip is dropped — phase 3's docket completes

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_1_delete_then_copy.star
@@ -7,10 +7,10 @@
 # prediction, authored before implementation: the stored catalog carries exactly one pending file entry with
 # two consumers (ruled 2026-08-20: mutation targets are resource-typed consumers — delivered by #585 PR C:
 # the remove's target and the copy's source both claim, deduplicating to the single entry asserted below);
-# pre-flight passes because intent was satisfied at the starting line; the run fails at the copy — under
-# the ruled shape the copy sees the catalog's Gone verdict (the remove, as consumer, transitioned the entry);
-# until #585 it rediscovers the loss through its own I/O; the failure unwinds and the delete's receipt restores
-# the file. The graph says what
+# pre-flight passes because intent was satisfied at the starting line; the run fails at the copy on the
+# catalog's NARRATED verdict — the remove transitioned the entry to Gone with the destroyer stamp, and the
+# guard at the dispatch seam names both units (delivered by #585 PR D); the failure unwinds and the delete's
+# receipt restores the file. The graph says what
 # must be true; the trace says what happened; the gap between them is the run's story.
 
 src = t.tmp("data.txt")
@@ -35,7 +35,7 @@ t.expect_equal(len([e for e in entries if "copy.txt" in str(e)]), 0)
 
 # The run: the copy fails on the gone source; compensation restores the deleted file; the never-produced
 # destination does not exist.
-t.expect_error("file.copy")
+t.expect_error("file.copy.*destroyed by")
 t.expect_file(src, content="the original bytes")
 t.expect_no_file(dst)
 

--- a/cmd/devlore-test/devloretest/data/test_judgment_gone_tolerance.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_gone_tolerance.star
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_gone_tolerance.star — judgment scenario: gone tolerance (docs/plans/resource-construction.md).
+#
+# Two removes of the same file, in order, with no promise between them. The first consumes and destroys the
+# resource (Gone, destroyer-stamped). The second declares on_missing="ignore" — the guard at the dispatch
+# seam sees the catalog's Gone state, warns, and MAKES THE CALL; the provider no-ops on the absence. The
+# run succeeds and the trace's story is one deletion plus one recorded no-op. Under the default (stop) the
+# second remove would fail on the narrated verdict — that direction is pinned by judgment scenario 1. (A
+# Skip variant was considered and dropped, ruled 2026-08-22.)
+
+f = t.tmp("twice.txt")
+t.write(f, "delete me once")
+
+first = plan.file.remove(target=f, prune=False, boundary="")
+second = plan.file.remove(target=f, on_missing="ignore", prune=False, boundary="")
+
+graph = plan.assemble_definition([first, second])
+
+t.expect_no_file(f)
+t.expect_unit_count(2)
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -452,6 +452,10 @@ func TestJudgmentScopedClaims(t *testing.T) {
 	runScript(t, "test_judgment_scoped_claims.star")
 }
 
+func TestJudgmentGoneTolerance(t *testing.T) {
+	runScript(t, "test_judgment_gone_tolerance.star")
+}
+
 func TestJudgmentPromiseOrdering(t *testing.T) {
 	runScript(t, "test_judgment_promise_ordering.star")
 }

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -132,7 +132,7 @@ satisfied them. Unreached scopes never judge their claims.
 | Entry state | `Exists()` | Result |
 |---|---|---|
 | `Pending` | true | `Pending` → `Active` |
-| `Pending` | false | **the transition fails**: `Pending` → `Gone`, with a warning always produced. Under `MissingResourcePolicyStop` (the default) the consuming scope fails — a pending resource that fails its scheme's existence predicate (for **file resources**: the rel does not exist relative to the run's fsroot) is unmet intent (§5.5). Under `Ignore`/`Skip` the scope proceeds and the consumer applies its policy at dispatch. |
+| `Pending` | false | **the transition fails**: `Pending` → `Gone`, with a warning always produced. Under `MissingResourcePolicyStop` (the default) the consuming scope fails — a pending resource that fails its scheme's existence predicate (for **file resources**: the rel does not exist relative to the run's fsroot) is unmet intent (§5.5). Under `Ignore` the scope proceeds and the consumer applies its policy at dispatch. |
 | `Active` | false (a later re-check) | `Active` → `Gone` |
 
 **The claims taxonomy (ruled 2026-08-22; policy model ruled the same day).** Every literal claim is
@@ -145,16 +145,20 @@ values (never iota) and a fail-safe zero:
 - `MissingResourcePolicyIgnore`: the call is **made anyway** — the provider sees the absence and handles it
   (a remove no-ops; the receipt records "target was already absent" so compensation of the no-op is a
   no-op).
-- `MissingResourcePolicySkip`: the call is **skipped** — the unit does not dispatch, recorded as skipped.
+
+A **Skip** variant ("do not dispatch") was considered and **DROPPED (ruled 2026-08-22)**: its undo story is
+trivially clean — nothing ran, nothing to undo — but its forward side (nil-valued promises to downstream
+consumers; a trace that cannot tell "skipped" from "ran and produced nothing") buys machinery Ignore never
+needs, and the structural way to author optional steps already exists (a choose case, whose claims are
+judged only when hit). Re-adding it later is purely additive.
 
 **A warning is produced whenever a missing resource is detected, under every policy.** The parameter's TYPE
 is the declaration — no directive: at announcement, a method with a `MissingResourcePolicy`-typed parameter
 and exactly one consumed (resource-typed) parameter links the two; more than one consumed parameter beside
 one policy is ambiguous and refuses at announcement. The claim still enters the catalog under every policy
 (identity, compensation, and drift all want the entry). Aggregation across consumers of one entry: **Stop
-wins** — any Stop consumer in the verifying scope fails it; otherwise each non-Stop consumer applies its
-own policy at dispatch. Open consequence, owned by the implementing PR: the promise of a *skipped* unit is
-unresolved for downstream consumers — the skip semantics must say what they see.
+wins** — any Stop consumer in the verifying scope fails it; otherwise each Ignore consumer applies its
+policy at dispatch.
 
 **Conditionality is structural, never declared**: a claim consumed only inside a conditional subgraph is
 verified by that subgraph's executor when the branch is hit. The one deliberately strict case: an
@@ -175,7 +179,7 @@ promise and no pending entry exists to check at all.
 | Consumed entry state | Result |
 |---|---|
 | `Active` | dispatch proceeds; a mutating consumer that destroys the resource transitions the entry `Active` → `Gone`, and its receipt carries the undo |
-| `Gone` | **a `Stop` consumer fails on the catalog's verdict** — it sees the state; it does not rediscover the loss through its own I/O. An `Ignore` consumer makes the call (its provider handles the absence; the receipt records it); a `Skip` consumer does not dispatch, recorded as skipped. A warning is produced in every case. |
+| `Gone` | **a `Stop` consumer fails on the catalog's NARRATED verdict** — "consumes X, destroyed by unit N before it could run" (the destroyer stamp) — it sees the state; it does not rediscover the loss through its own I/O. An `Ignore` consumer makes the call: its provider handles the absence. A warning is produced in every case. |
 | `Pending` | unreachable — pre-flight has already activated the entry or failed the run |
 
 Where the guard lives (ruled 2026-08-20): **the action dispatch seam** — `Method.Invoke` converts slot values
@@ -191,10 +195,9 @@ The catalog-resolve verdict remains the in-flight backstop, and provider I/O err
 catalog cannot know (out-of-band deletion mid-run). The `Gone` transition stamps the destroying unit —
 symmetric with `producerID` — so the verdict names both units: *consumed by unit 1 before unit 2 could run*.
 
-Staged rollout: today `file.remove` is path-typed (no consumer link, no transition — scenario 1's receipt shows
-the entry still `pending` after the failed run) and the copy rediscovers the loss as a dispatch-time filesystem
-error. #585 closes both halves: the remove becomes a consumer that transitions the entry, and the second
-consumer's failure becomes the catalog's verdict.
+Delivered (#585 PRs C and D, 2026-08-22): the remove consumes its resource-typed target and transitions the
+entry with the destroyer stamp; the guard at the dispatch seam gives the second consumer the narrated
+verdict. Judgment scenario 1 pins the full ruled shape end to end.
 
 **Why the asymmetry:** a content-addressable URI encodes its identity, so re-producing it is provably the same
 resource (the CAS types: mem, function, json, yaml — [4.2](4.2-mem-resource.md),

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -372,6 +372,23 @@ catalog exposed.**
   consumer's policy; the destroyer stamp). `Move`'s source and `RemoveAll` stay path-typed — chartered as
   the C2 follow-up rather than folded, per the sizing rule.
 - Gate: make check 103 ok / 0 fail, GOOS=windows vet clean.
+
+**PR D record (2026-08-22) — the guard, the stamp, and the Skip drop; phase 3 completes its docket.**
+
+- **Skip is DROPPED (USER ruling)**: its undo story is trivially clean — nothing ran, nothing to undo —
+  but its forward side (nil promises downstream; a trace that cannot tell "skipped" from "ran and produced
+  nothing") buys machinery Ignore never needs; choose cases already express optional steps structurally.
+  The enum is `{Stop 0, Ignore 1}`; "skip" now refuses at parse (pinned).
+- **The destroyer stamp**: `MarkGone(r, destroyerID)` records the mutator's authorship (symmetric with
+  producerID); the trace row gains `destroyed_by`; reactive Gone transitions stamp nothing.
+- **The guard** lands at the ruled seam (`Method.Invoke`, post-conversion pre-forward-call): a consumed
+  Gone entry warns and routes by policy — Stop fails on the **narrated verdict** ("consumes X, destroyed
+  by unit N before it could run"), Ignore proceeds to the provider.
+- **Scenario 1 sharpens to the narrated verdict** (`expect_error("file.copy.*destroyed by")`) — the full
+  ruled semantics proven end to end. The new gone-tolerance scenario pins Ignore: two removes of one file,
+  the second `on_missing="ignore"`, one deletion + one recorded no-op, run succeeds.
+- Gate: make check 103 ok / 0 fail, GOOS=windows vet clean. Phase-3 remainder: C2 (Move's source,
+  RemoveAll) chartered.
 4. Consequence for phase 1's stored section: every stored entry is Pending by construction. **RULED
    2026-08-21: the stored row drops `state` entirely** — the intent row becomes its own `{id, uri}` type
    (presence IS the pending claim), splitting from the trace's `LedgerEntrySnapshot`, whose

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1075,7 +1075,7 @@ func (e *GraphExecutor) bindVariables(graph *Graph, callerVariables map[string]V
 // [Gone] transition through [ResourceCatalog.VerifyExistence]; a warning is produced on every detection of
 // a missing resource, under every policy. The consequence follows the unit's [MissingResourcePolicy]
 // (fail-safe default [MissingResourcePolicyStop]): Stop fails the scope with [ReasonPreflightFailed];
-// Ignore and Skip let the scope proceed — their behavior applies at the consumer's dispatch.
+// Ignore lets the scope proceed — its behavior applies at the consumer's dispatch.
 //
 // Parameters:
 //   - `scopeID`: the verifying scope's unit id, for the warning and the failure.

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -4,6 +4,7 @@
 package op
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -406,6 +407,14 @@ func (m *Method) Invoke(activation *ActivationRecord, receiver any) (Result, Com
 		goArgs = append(goArgs, val)
 	}
 
+	// The consumed-Gone guard (§3's consumption table, ruled 2026-08-20/22), at the ruled seam: after
+	// conversion — the earliest point the complete consumed set exists, promises resolved and strings
+	// interned — and before the forward call. A consumer of an entry the catalog knows is gone SEES the
+	// state; it does not rediscover the loss through its own I/O.
+	if guardErr := guardConsumedGone(activation, goArgs); guardErr != nil {
+		return nil, nil, guardErr
+	}
+
 	result, compensator, dispatchErr := m.Do(receiver, goArgs)
 
 	// Unwrap the reflected return once. m.Do hands back a reflect.Value; the receipt's stored result — and every
@@ -622,6 +631,82 @@ const (
 // endregion
 
 // region HELPER FUNCTIONS
+
+// guardConsumedGone applies the consumed-Gone guard to the converted arguments (§3's consumption table).
+//
+// Each catalog-resident resource among the arguments is checked against the run catalog's state; a [Gone]
+// entry routes through the caller's [MissingResourcePolicy], found among the same arguments by type (the
+// parameter's type is the declaration) with the fail-safe [MissingResourcePolicyStop] default: Stop fails
+// the dispatch on the narrated verdict — "destroyed by <unit> before <consumer> could run" when the
+// destroyer stamp is present — and Ignore proceeds, the provider seeing and handling the absence. A
+// warning is produced on every detection, under both policies.
+//
+// Parameters:
+//   - `activation`: the dispatch activation; carries the run catalog, the caller's id, and the narrator.
+//   - `goArgs`: the converted Go arguments.
+//
+// Returns:
+//   - `error`: the narrated verdict under [MissingResourcePolicyStop]; nil otherwise.
+func guardConsumedGone(activation *ActivationRecord, goArgs []any) error {
+
+	environment := activation.RuntimeEnvironment
+	if environment == nil || environment.ResourceCatalog == nil {
+		return nil
+	}
+
+	policy := MissingResourcePolicyStop
+	for _, arg := range goArgs {
+		if declared, ok := arg.(MissingResourcePolicy); ok {
+			policy = declared
+			break
+		}
+	}
+
+	for _, arg := range goArgs {
+
+		resource, ok := arg.(Resource)
+		if !ok || resource.resourceBase().id == "" {
+			continue
+		}
+
+		if environment.ResourceCatalog.State(resource.ID()) != Gone {
+			continue
+		}
+
+		verdict := verdictForGone(environment.ResourceCatalog, activation.CallerID, resource)
+
+		if environment.Status != nil {
+			environment.Status.Warn(fmt.Sprintf("%s (policy %s)", verdict, policy))
+		}
+
+		if policy == MissingResourcePolicyStop {
+			return errors.New(verdict)
+		}
+		// Ignore: the call proceeds; the provider handles the absence.
+	}
+
+	return nil
+}
+
+// verdictForGone renders the catalog's verdict for a consumed-Gone entry, naming both units when the
+// destroyer stamp is present.
+//
+// Parameters:
+//   - `catalog`: the run catalog holding the destroyer stamp.
+//   - `consumerID`: the consuming unit's id.
+//   - `resource`: the gone resource.
+//
+// Returns:
+//   - `string`: the verdict text.
+func verdictForGone(catalog *ResourceCatalog, consumerID string, resource Resource) string {
+
+	if destroyer := catalog.DestroyerOf(resource.ID()); destroyer != "" {
+		return fmt.Sprintf("%s consumes %s, destroyed by %s before it could run",
+			consumerID, resource.URI(), destroyer)
+	}
+
+	return fmt.Sprintf("%s consumes %s, which is gone", consumerID, resource.URI())
+}
 
 // errorFromValue extracts an error from a reflect.Value, returning nil when the value holds a nil interface.
 //

--- a/pkg/op/missing_resource_policy.go
+++ b/pkg/op/missing_resource_policy.go
@@ -18,7 +18,10 @@ import (
 // The parameter's TYPE is the declaration — no directive: a method with a MissingResourcePolicy-typed
 // parameter and exactly one consumed (resource-typed) parameter links the two at announcement. A warning
 // is produced whenever a missing resource is detected, under every policy. Aggregation across the
-// consumers of one entry: Stop wins.
+// consumers of one entry: Stop wins. A Skip variant ("do not dispatch") was considered and DROPPED (ruled
+// 2026-08-22): its undo story is trivially clean — nothing ran, nothing to undo — but its forward side
+// (nil-valued promises to downstream consumers; a trace that cannot tell "skipped" from "ran and produced
+// nothing") buys machinery that Ignore never needs. Re-adding it later is purely additive.
 type MissingResourcePolicy int
 
 const (
@@ -29,15 +32,12 @@ const (
 	// MissingResourcePolicyIgnore makes the call anyway: the provider sees the absence and handles it
 	// (a remove no-ops), and the receipt records that the target was already absent.
 	MissingResourcePolicyIgnore MissingResourcePolicy = 1
-
-	// MissingResourcePolicySkip skips the call: the unit does not dispatch, recorded as skipped.
-	MissingResourcePolicySkip MissingResourcePolicy = 2
 )
 
 // String returns the canonical lowercase rendering of the policy.
 //
 // Returns:
-//   - `string`: "stop", "ignore", or "skip".
+//   - `string`: "stop" or "ignore".
 func (p MissingResourcePolicy) String() string {
 
 	switch p {
@@ -45,8 +45,6 @@ func (p MissingResourcePolicy) String() string {
 		return "stop"
 	case MissingResourcePolicyIgnore:
 		return "ignore"
-	case MissingResourcePolicySkip:
-		return "skip"
 	}
 
 	assert.Unreachable(fmt.Sprintf("op.MissingResourcePolicy.String: invalid policy value %d", int(p)))
@@ -127,8 +125,6 @@ func (p *MissingResourcePolicy) parse(name string) error {
 		*p = MissingResourcePolicyStop
 	case "ignore":
 		*p = MissingResourcePolicyIgnore
-	case "skip":
-		*p = MissingResourcePolicySkip
 	default:
 		return fmt.Errorf("op.MissingResourcePolicy: unknown policy %q", name)
 	}

--- a/pkg/op/missing_resource_policy_test.go
+++ b/pkg/op/missing_resource_policy_test.go
@@ -24,7 +24,6 @@ func TestMissingResourcePolicy_RoundTripAndZeroValue(t *testing.T) {
 	}{
 		{MissingResourcePolicyStop, "stop"},
 		{MissingResourcePolicyIgnore, "ignore"},
-		{MissingResourcePolicySkip, "skip"},
 	} {
 		if tc.policy.String() != tc.name {
 			t.Errorf("String(%d) = %q, want %q", int(tc.policy), tc.policy.String(), tc.name)
@@ -50,5 +49,10 @@ func TestMissingResourcePolicy_RoundTripAndZeroValue(t *testing.T) {
 	var invalid MissingResourcePolicy
 	if err := invalid.UnmarshalText([]byte("shrug")); err == nil {
 		t.Error("unknown policy name accepted — must refuse")
+	}
+
+	// Skip was considered and dropped (ruled 2026-08-22); the name refuses like any other stranger.
+	if err := invalid.UnmarshalText([]byte("skip")); err == nil {
+		t.Error(`"skip" accepted — the variant was dropped and must refuse`)
 	}
 }

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -657,7 +657,7 @@ func (p *Provider) compensateRemoveDir(receipt *Receipt) error {
 // (4-resource-management.md §3, the claims taxonomy). At dispatch the delete invariants discharge here: the
 // observed entry is moved to the recovery site and its catalog entry marked [op.Gone] on success. A missing
 // target follows the policy — Stop errors (mid-run loss rediscovered at dispatch; scope verification covers
-// the starting line), Ignore and Skip no-op (Skip's do-not-dispatch half is the executor guard's). A
+// the starting line), Ignore no-ops. A
 // directory is an error — use [Provider.RemoveAll] for recursive deletion. When `prune` is set, now-empty
 // parents up to `boundary` are removed.
 //
@@ -710,7 +710,7 @@ func (p *Provider) Remove(
 	}
 
 	receipt = NewReceipt(NewReceiptSpec(entry, MutationDeleteFile).WithRecovery(recoveryID, digest))
-	p.markEntryGone(entry)
+	p.markEntryGone(activationRecord, entry)
 
 	return nil, receipt, nil
 }
@@ -755,7 +755,7 @@ func (p *Provider) RemoveAll(
 	}
 
 	receipt = NewReceipt(NewReceiptSpec(entry, MutationDeleteFile).WithRecovery(recoveryID, digest))
-	p.markEntryGone(entry)
+	p.markEntryGone(activationRecord, entry)
 
 	return nil, receipt, nil
 }
@@ -766,7 +766,7 @@ func (p *Provider) RemoveAll(
 // the kind is fixed by Unlink's own semantics): its literal claim enters the graph's catalog as required
 // intent, gated per call by `onMissing` (§3, the claims taxonomy). At dispatch the delete invariants
 // discharge here: the link is moved to the recovery site and its catalog entry marked [op.Gone] on
-// success. A missing target follows the policy — Stop errors, Ignore and Skip no-op. A target that exists
+// success. A missing target follows the policy — Stop errors, Ignore no-ops. A target that exists
 // but is not a symlink is an error. When `prune` is set, now-empty parents up to `boundary` are removed.
 //
 // Parameters:
@@ -820,7 +820,7 @@ func (p *Provider) Unlink(
 	}
 
 	receipt = NewReceipt(NewReceiptSpec(entry, MutationDeleteFile).WithRecovery(recoveryID, digest))
-	p.markEntryGone(entry)
+	p.markEntryGone(activationRecord, entry)
 
 	return nil, receipt, nil
 }
@@ -1702,10 +1702,10 @@ func (p *Provider) findClosestExistingDir(path string) (ancestor Entry, info os.
 //
 // Parameters:
 //   - `entry`: the deleted [Entry].
-func (p *Provider) markEntryGone(entry Entry) {
+func (p *Provider) markEntryGone(activationRecord *op.ActivationRecord, entry Entry) {
 
 	if catalog := p.RuntimeEnvironment().ResourceCatalog; catalog != nil && entry.ID() != "" {
-		catalog.MarkGone(entry)
+		catalog.MarkGone(entry, activationRecord.CallerID)
 	}
 }
 

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -41,6 +41,11 @@ type ResourceCatalog struct {
 	ns      map[string]string        // namespace key → current id; see [namespaceKey] for the per-addressing keying regime
 	states  map[string]ResourceState // id → per-run lifecycle state; independent of Resource identity
 	nextID  int                      // monotonic counter for id generation
+
+	// destroyers maps an entry id to the unit that destroyed the resource — the mutator-side [Gone]
+	// transition's authorship (the destroyer stamp, ruled 2026-08-20), symmetric with producerID on
+	// production. Reactive Gone transitions (a failed existence check) stamp nothing.
+	destroyers map[string]string
 }
 
 // NewResourceCatalog creates an empty catalog.
@@ -49,9 +54,10 @@ type ResourceCatalog struct {
 //   - `*ResourceCatalog`: the empty catalog.
 func NewResourceCatalog() *ResourceCatalog {
 	return &ResourceCatalog{
-		byID:   make(map[string]int),
-		ns:     make(map[string]string),
-		states: make(map[string]ResourceState),
+		byID:       make(map[string]int),
+		ns:         make(map[string]string),
+		states:     make(map[string]ResourceState),
+		destroyers: make(map[string]string),
 	}
 }
 
@@ -103,12 +109,18 @@ func (c *ResourceCatalog) Clone() *ResourceCatalog {
 		states[k] = v
 	}
 
+	destroyers := make(map[string]string, len(c.destroyers))
+	for k, v := range c.destroyers {
+		destroyers[k] = v
+	}
+
 	return &ResourceCatalog{
-		entries: entries,
-		byID:    byID,
-		ns:      ns,
-		states:  states,
-		nextID:  c.nextID,
+		entries:    entries,
+		byID:       byID,
+		ns:         ns,
+		states:     states,
+		nextID:     c.nextID,
+		destroyers: destroyers,
 	}
 }
 
@@ -380,12 +392,38 @@ func (c *ResourceCatalog) Lookup(id string) (Resource, bool) {
 //
 // Panics with an [*assert.AssertionError] when `r` is nil or not cataloged — a programming error at the call site,
 // not a runtime condition.
-func (c *ResourceCatalog) MarkGone(r Resource) {
+func (c *ResourceCatalog) MarkGone(r Resource, destroyerID string) {
 
 	assert.True("resource required", r != nil)
 	assert.True("resource is cataloged", r.resourceBase().id != "")
 
-	c.markGone(r)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.states[r.resourceBase().id] = Gone
+
+	// The destroyer stamp (ruled 2026-08-20): the mutator is the authority for its own destruction, so
+	// the verdict a later consumer sees can name both units. Empty means unattributed (immediate-mode
+	// dispatch without a caller).
+	if destroyerID != "" {
+		c.destroyers[r.resourceBase().id] = destroyerID
+	}
+}
+
+// DestroyerOf returns the unit that destroyed the entry `id`, or "" when the Gone transition was reactive
+// (a failed existence check) or unattributed.
+//
+// Parameters:
+//   - `id`: the catalog id to look up.
+//
+// Returns:
+//   - `string`: the destroying unit's id, or "".
+func (c *ResourceCatalog) DestroyerOf(id string) string {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.destroyers[id]
 }
 
 // Resolve returns the canonical resource for the given resource's URI, along with its catalog ID.
@@ -513,10 +551,11 @@ func (c *ResourceCatalog) Snapshot() *ResourceLedgerSnapshot {
 		pending = append(pending, captured{
 			resource: resource,
 			entry: LedgerEntrySnapshot{
-				ID:         base.id,
-				URI:        resource.URI(),
-				ProducerID: base.producerID,
-				State:      c.states[base.id],
+				ID:          base.id,
+				URI:         resource.URI(),
+				ProducerID:  base.producerID,
+				State:       c.states[base.id],
+				DestroyedBy: c.destroyers[base.id],
 			},
 		})
 	}
@@ -888,6 +927,11 @@ type LedgerEntrySnapshot struct {
 	// deferred to step 23's Merkle deliverable — leaves it empty); reporting metadata —
 	// [ResourceLedgerSnapshot.Rehydrate] ignores it.
 	Digest string `json:"digest,omitempty" yaml:"digest,omitempty"`
+
+	// DestroyedBy is the unit that destroyed this resource — the destroyer stamp on a mutator-side [Gone]
+	// transition (ruled 2026-08-20), symmetric with ProducerID. Empty for reactive Gone transitions and
+	// every non-Gone state; reporting metadata — [ResourceLedgerSnapshot.Rehydrate] ignores it.
+	DestroyedBy string `json:"destroyed_by,omitempty" yaml:"destroyed_by,omitempty"`
 }
 
 // Rehydrate rebuilds a live [*ResourceCatalog] from the snapshot, preserving every generation's id.

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -636,7 +636,7 @@ func TestMarkGone_RecordsDeletionFromAnyState(t *testing.T) {
 	if got := c.State(pendingID); got != Pending {
 		t.Fatalf("precondition: State = %v, want Pending", got)
 	}
-	c.MarkGone(pending)
+	c.MarkGone(pending, "unit-9")
 	if got := c.State(pendingID); got != Gone {
 		t.Errorf("State after MarkGone from Pending = %v, want Gone", got)
 	}
@@ -644,12 +644,12 @@ func TestMarkGone_RecordsDeletionFromAnyState(t *testing.T) {
 	active := newLifecycle("file:///active", AddressingLocation)
 	_, activeID := c.Resolve(active)
 	c.markActive(active)
-	c.MarkGone(active)
+	c.MarkGone(active, "unit-9")
 	if got := c.State(activeID); got != Gone {
 		t.Errorf("State after MarkGone from Active = %v, want Gone", got)
 	}
 
-	c.MarkGone(active) // idempotent re-mark
+	c.MarkGone(active, "unit-9") // idempotent re-mark
 	if got := c.State(activeID); got != Gone {
 		t.Errorf("State after re-MarkGone = %v, want Gone", got)
 	}
@@ -662,7 +662,7 @@ func TestMarkGone_GoneIsTerminalForDiscovery(t *testing.T) {
 	c := NewResourceCatalog()
 	r := newLifecycle("file:///deleted", AddressingLocation)
 	c.Resolve(r)
-	c.MarkGone(r)
+	c.MarkGone(r, "unit-9")
 
 	_, err := c.Discover(r.URI(), func() (Resource, error) {
 		return newLifecycle("file:///deleted", AddressingLocation), nil
@@ -679,7 +679,7 @@ func TestMarkGone_RevivalIsAProductionAct(t *testing.T) {
 	c := NewResourceCatalog()
 	first := newLifecycle("file:///revived", AddressingLocation)
 	_, firstID := c.Resolve(first)
-	c.MarkGone(first)
+	c.MarkGone(first, "unit-9")
 
 	revived, err := c.GetOrCreate("", first.URI(), func() (Resource, error) {
 		return newLifecycle("file:///revived", AddressingLocation), nil
@@ -710,7 +710,7 @@ func TestMarkGone_UncatalogedIsAProgrammingError(t *testing.T) {
 		}
 	}()
 
-	c.MarkGone(newLifecycle("file:///never-interned", AddressingLocation))
+	c.MarkGone(newLifecycle("file:///never-interned", AddressingLocation), "unit-9")
 }
 
 func TestCatalog_VerifyExistence_PresentMarksActive(t *testing.T) {


### PR DESCRIPTION
Phase 3, PR D of [resource-construction](docs/plans/resource-construction.md) (#585) — the docket's final
item.

## Skip is dropped (ruled)

Undo was never the problem — a skipped unit ran nothing, so there is nothing to undo. The forward side
was: nil promises downstream, and a trace that cannot tell "skipped" from "ran and produced nothing"
without marker machinery `Ignore` never needs. Choose cases already express optional steps structurally.
The enum is `{Stop 0, Ignore 1}`; `"skip"` refuses at parse, pinned.

## The destroyer stamp

`MarkGone(r, destroyerID)` — the mutator's authorship, symmetric with `producerID`; the trace row gains
`destroyed_by`. Reactive Gone transitions stamp nothing.

## The guard, at the ruled seam

`Method.Invoke`, post-conversion, pre-forward-call: a consumed Gone entry **warns** and routes by the
caller's policy (found among the converted arguments by type). `Stop` fails on the **narrated verdict** —
*"consumes X, destroyed by unit N before it could run"* — and `Ignore` proceeds to the provider. The
consumer sees the state; it never rediscovers the loss through its own I/O.

## The scenarios

**Scenario 1 now asserts the narrated verdict** (`file.copy.*destroyed by`) — the delete-then-copy
question you posed at the start of this feature, answered end to end exactly as ruled. The new
gone-tolerance scenario pins Ignore: two removes, the second `on_missing="ignore"`, one deletion + one
recorded no-op, green run.

## Verified

- `make check` — 103 ok, 0 failures
- `make vet` GOOS=windows; gofmt clean; expectation: green stays green

Refs #585, #581.
