### PR TITLE
feat(op): dispatch resolves resource slots by identity through the run catalog

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_dispatch_miss.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_dispatch_miss.star
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_dispatch_miss.star — judgment scenario: the second wall (docs/plans/resource-construction.md,
+# explicit-conversion suite item 2b).
+#
+# A run-delivered string that misses the run catalog fails at the dispatch seam with the §5.6 verdict —
+# a string is a key, never a constructor. The miss arises in-model: a gather item record carries a raw
+# path string into the copy's resource-typed source (the item frame is exempt from the plan-time variable
+# refusal precisely because its records MAY carry claimed resources — this scenario pins the backstop for
+# the records that do not). Nothing is constructed, and the destination is never created.
+
+dst = t.tmp("never.txt")
+
+copied = plan.file.copy(
+    source=plan.item("source"), destination_path=plan.item("dest"), mode=0o600)
+gathered = plan.gather(items=[{"source": "ghost.txt", "dest": dst}], limit=1, body=[copied])
+
+graph = plan.assemble_definition([gathered])
+
+t.expect_error("not in the run catalog")
+t.expect_no_file(dst)
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_judgment_doctored_checksum.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_doctored_checksum.star
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_doctored_checksum.star — judgment scenario: the first wall (docs/plans/resource-construction.md,
+# explicit-conversion suite item 2a).
+#
+# A hand-doctored document never reaches the dispatch seam: slots live inside the canonical bytes, so the
+# integrity gate refuses the altered document at load — before any catalog, any pre-flight, any dispatch.
+# The dispatch seam's own refusal (the second wall) is pinned by suite item 2b, where the miss arises
+# in-model through an item record.
+
+src = t.tmp("claimed.txt")
+dst = t.tmp("never.txt")
+doc = t.tmp("graph.json")
+bad = t.tmp("doctored.json")
+
+t.write(src, "present and claimed")
+
+copied = plan.file.copy(source=src, destination_path=dst, mode=0o600)
+graph = plan.assemble_definition([copied])
+plan.save_definition(graph, doc)
+
+# Doctor the document's text: every occurrence of the claimed name flips to a ghost. Any alteration of
+# the canonical bytes — slot or claim row alike — breaks the recorded checksum.
+t.write(bad, file.read_text(resource=doc).replace("claimed.txt", "ghost.txt"))
+
+t.expect_error("checksum mismatch")
+t.expect_no_file(dst)
+
+plan.load_definition(bad)

--- a/cmd/devlore-test/devloretest/data/test_judgment_reload_dispatch.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_reload_dispatch.star
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_reload_dispatch.star — judgment scenario: save, reload, run (docs/plans/resource-construction.md,
+# explicit-conversion suite item 1).
+#
+# The prediction, authored from the §5.6 ruling: a reloaded graph's resource-typed slot carries the URI
+# string the save left behind; at graph dispatch that string is a KEY — it resolves through the
+# section-rehydrated run catalog to the claimed entry, and the copy flows. No construction happens at
+# dispatch; the object-identity half of the pin lives in Go (resolveDispatchResource's canonical-pointer
+# assertions and the pristine-location pin).
+
+src = t.tmp("original.txt")
+dst = t.tmp("copied.txt")
+doc = t.tmp("graph.json")
+
+t.write(src, "identity flows")
+
+copied = plan.file.copy(source=src, destination_path=dst, mode=0o600)
+graph = plan.assemble_definition([copied])
+plan.save_definition(graph, doc)
+
+loaded = plan.load_definition(doc)
+
+t.expect_file(dst, content="identity flows")
+
+t.run(loaded)

--- a/cmd/devlore-test/devloretest/data/test_judgment_string_promise_refusal.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_string_promise_refusal.star
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_judgment_string_promise_refusal.star — judgment scenario: the plan-time mirror (docs/plans/
+# resource-construction.md, explicit-conversion suite item 3).
+#
+# A producer whose DECLARED result is a string cannot fill a resource-typed slot: at graph dispatch a
+# string is a key, never a constructor, and a run-computed string is never a recorded identity — so the
+# binding refuses at plan time (checkPromiseTypes' graph-context narrowing), not deep into a run.
+# Undeclared producers meet the dispatch refusal instead (suite item 2b).
+
+src = t.tmp("input.txt")
+dst = t.tmp("never.txt")
+
+t.write(src, "some content")
+
+t.expect_error("returns a string, but the slot is resource-typed")
+
+read = plan.file.read_text(resource=src)
+bad = plan.file.copy(source=read, destination_path=dst, mode=0o600)
+
+plan.assemble_definition([read, bad])

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt.star
@@ -25,7 +25,11 @@ t.set_flags({
 })
 
 mkdir = plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755)
-move  = plan.file.move(source=plan.variable("source_path"), destination_path=plan.variable("dest_path"))
+# The consumed source is an authored plan-space path — a plan-time claim (§5.1). A variable cannot bind a
+# resource-typed slot (interim ruling 2026-08-22): its value arrives at run start, and a string is a key,
+# never a constructor at dispatch; run-start claiming — variables resolved the way promises are — is
+# chartered to lift this. String-typed parameters keep the variable model this fixture exists to pin.
+move  = plan.file.move(source=src_path, destination_path=plan.variable("dest_path"))
 link  = plan.file.link(source_path=plan.variable("dest_path"), target_path=plan.variable("source_path"))
 
 graph = plan.assemble_definition([mkdir, move, link])

--- a/cmd/devlore-test/devloretest/data/test_writ_adopt_subgraph.star
+++ b/cmd/devlore-test/devloretest/data/test_writ_adopt_subgraph.star
@@ -28,7 +28,9 @@ t.set_flags({
 # Phase 1 plan-doc captures the intent here so the bubble-up contract is exercised at the .star level.
 sg = plan.subgraph(body=[
     plan.file.mkdir(path=plan.variable("dest_dir"), mode=0o755),
-    plan.file.move(source=plan.variable("source_path"), destination_path=plan.variable("dest_path")),
+    # The consumed source is an authored plan-space path — a plan-time claim (§5.1); a variable cannot
+    # bind a resource-typed slot (interim ruling 2026-08-22, run-start claiming chartered to lift it).
+    plan.file.move(source=src_path, destination_path=plan.variable("dest_path")),
     plan.file.link(source_path=plan.variable("dest_path"), target_path=plan.variable("source_path")),
 ])
 

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -466,3 +466,19 @@ func TestJudgmentDiscoverAfterExec(t *testing.T) {
 		"implementing PR completes the ordering edge and un-skips")
 	runScript(t, "test_judgment_discover_after_exec.star")
 }
+
+func TestJudgmentReloadDispatch(t *testing.T) {
+	runScript(t, "test_judgment_reload_dispatch.star")
+}
+
+func TestJudgmentDoctoredChecksum(t *testing.T) {
+	runScript(t, "test_judgment_doctored_checksum.star")
+}
+
+func TestJudgmentDispatchMiss(t *testing.T) {
+	runScript(t, "test_judgment_dispatch_miss.star")
+}
+
+func TestJudgmentStringPromiseRefusal(t *testing.T) {
+	runScript(t, "test_judgment_string_promise_refusal.star")
+}

--- a/cmd/writ/writ/adopt/plan.go
+++ b/cmd/writ/writ/adopt/plan.go
@@ -80,11 +80,19 @@ func BuildGraph(env *op.RuntimeEnvironment, items []Item) (*op.Graph, error) {
 		invocations = append(invocations, mkdir)
 	}
 
-	// The gather items: one record per adoption.
+	// The gather items: one record per adoption. The consumed source is CLAIMED at plan time
+	// (4-resource-management.md §5.1 — the item paths are plan-known intent): [file.DiscoverRegular]
+	// mints the identity with no disk contact and interns it pending, and the record carries the claimed
+	// resource, whose identity the dispatch seam resolves through the run catalog (§5.6). A raw path
+	// string here would refuse at dispatch — a string is a key, never a constructor.
 	records := make([]any, 0, len(items))
 	for _, item := range items {
+		source, err := file.DiscoverRegular(env, item.Source)
+		if err != nil {
+			return nil, fmt.Errorf("adopt.BuildGraph: claim source %s: %w", item.Source, err)
+		}
 		records = append(records, map[string]any{
-			"source":    item.Source,
+			"source":    source,
 			"dest_path": item.DestPath,
 		})
 	}

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -471,6 +471,16 @@ Steps:
    IS the run clone's entry: re-based, state-carrying, the same row pre-flight verified. First discovery
    of the implementing PR: where the seam lives (slot-fill vs a step-6 refinement) and how the environment
    names run-vs-session mode (an existing distinction on `RuntimeEnvironment`, or a new bit).
+   **Discovery resolved (2026-08-22, USER-corrected): the seam is slot-fill at `Method.Invoke`, keyed off
+   the activation.** `ActivationRecord` already carries dispatch kind as documented contract — `Graph` is
+   non-nil exactly during graph dispatch (`Stack` and `CallerID` agree) — so the discrimination lives on
+   the per-dispatch frame, NOT on the environment (a first cut added a `GraphDispatch` bit to
+   `RuntimeEnvironment` and was reverted: the environment stays orthogonal ambient capability — the
+   session/dispatch distinction is the activation's to carry) and NOT inside `Convert`'s cascade (which
+   stays context-blind, serving planning and immediate mode unchanged). `WithCatalog` renamed
+   `WithResourceCatalog` in passing (builder names its field). Known boundary, accepted: a resource-typed
+   field nested inside a struct-hydrated parameter would convert inside `Convert`'s recursion, below the
+   seam — no such parameter exists today; recorded like §5.4's lenient-decoding boundary.
 2. **The miss becomes a refusal.** With the catalog complete by construction (every resource-typed input
    claimed at plan time), a graph-dispatch catalog miss is a typed error naming the URI — the catalog's
    verdict, before any disk contact. The fall-through to fresh construction gates on immediate mode only.
@@ -563,6 +573,51 @@ and resolution — the seven rules), and §9 items 15–18.
    Companion fact of life, owned in the same breath (item 7's fourth door): nothing stops an out-of-band
    actor deleting a file under a running graph, short of a lockdown on the targeted fsroot directory —
    the observation layer and reconciliation are the designed response, not prevention.
+9. **Run-start claiming for variable-fed resource slots (RULED 2026-08-22 — sequenced after phase 4).**
+   A variable is resolvable the way a promise is: binding occurs only after execution has begun, so its
+   claim belongs to the run's pre-flight — the chartered pass normalizes variable-fed resource slots
+   through the grammar, mints pending entries into the run clone at the consuming subgraph's pre-flight,
+   and verifies them with the scope's claims. Until it lands, the interim posture (PR 1/#609):
+   `ValidateGraph` refuses a PLAIN variable into a resource-typed slot — flag/config/environment sources
+   are string-valued by construction, so it can never succeed — while the reserved gather frame (`item`)
+   is exempt: its records are plan-authored data that may carry claimed resources (the writ-adopt shape),
+   and the dispatch seam backstops the string case.
+
+**PR 1 record (2026-08-22, complete in tree — uncommitted) — the dispatch seam lands on the activation;
+the refusal's first catches; steps 1–4 delivered.**
+
+- **The seam**: `Method.Invoke`'s slot conversion routes resource-typed parameters through
+  `resolveDispatchResource`, gated by `activation.Graph` — the per-dispatch frame carries dispatch kind
+  (step 1's resolved discovery; the environment stays orthogonal). A Resource value resolves by its URI;
+  a string resolves as the key it is; any other type refuses; a run-catalog miss refuses with the §5.6
+  verdict. Step 6's reload probe retired with it (its job moved to the seam), `Convert` stays
+  context-blind, and `buildCandidateAs`'s prefix strip is documented as serving exactly rehydration and
+  session construction.
+- **Step 4 ruled copy-on-bind**: `bindPendingResources` binds a kind-preserving shallow copy and swaps it
+  into the run clone (`ResourceCatalog.rebindEntry`); scoped verification resolves the canonical before
+  probing (`VerifyExistence` probes the object it is handed — the slot's pristine capture would read the
+  construction root); the planning session's objects stay pristine. The `lifecycleResource` pin's counter
+  became a shared cell so probes through the copy stay observable.
+- **The plan-time mirror landed as leaned**: `checkPromiseTypes` refuses a declared-string producer into
+  a resource-typed slot; `checkVariableResourceSlots` is its variable twin (interim, item-exempt — docket
+  item 9).
+- **The refusal's first catches — writ adopt, both authoring surfaces.** The Go builder fed `file.move`
+  run-computed machine-absolute strings through its gather records — migrated to plan-time claims
+  (`file.DiscoverRegular`: identity minted with no disk contact, interned pending; the records carry the
+  claimed resources, and the item projection delivers them to the seam). The two star fixtures bound the
+  source via `plan.variable` — re-authored to authored claims, and the variable question produced the
+  run-start-claiming ruling (docket item 9).
+- **Executor hygiene as discovered**: the stale `resolvePendingResources` doc block removed (the function
+  retired with scoped verification); the executor takes a value copy of the host's spec before stamping
+  the run catalog, so run-only state never lands on the caller's object; `WithCatalog` renamed
+  `WithResourceCatalog` (USER precision ruling; `WithWorkflowDispatcher` dissolved with the reverted
+  environment bit).
+- **Acceptance delivered — suite items 1–3 flip green** (statuses and evidence in the suite section; item
+  2 refined into two walls during authoring: the integrity gate catches hand-alteration before the seam
+  can, so the in-model miss is authored through the item-frame backstop). Four new judgment stars wired;
+  Go pins in `pkg/op/method_test.go` and the pristine-location pin beside the root-binding pair.
+- Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean. PR 1's
+  docket is complete.
 
 **PR slicing (task issues filed 2026-08-22, indexed by #586):** PR 1
 ([#609](https://github.com/NobleFactor/devlore-cli/issues/609)) — steps 1–4, the dispatch seam (opening
@@ -576,8 +631,7 @@ the plan's standing gate: `make check` (103/0), `make vet-all`, `gofmt -l`.
 
 **Flagged, not decided:** the phase-3 note chartered the Docker and Go Toolchain e2e lore scenarios to run
 alongside the campaign — they have not started, and phase 4 is the natural host if they are to move now;
-step 1's run-vs-session distinction may already exist on `RuntimeEnvironment` or may need a bit — the
-implementing PR's first discovery either way; the plan-time mirror of the step-2 refusal
+the plan-time mirror of the step-2 refusal
 (`checkPromiseTypes` / `typesAreInterconvertible` are documented as agreeing with dispatch,
 pkg/op/validate.go:238, and step 2 changes dispatch's side) — leaning: graph-context narrowing so a
 declared-string producer into a resource-typed slot refuses at `ValidateGraph`, step 2 the backstop for
@@ -737,14 +791,22 @@ progresses. Items 1–3 ride phase 4's PRs 1–2; items 4–13 are PR 3's accept
 
 1. **Save, reload, run — identity all the way through.** Plan with a claimed source, save, reload, run:
    the dispatched source IS the section-rehydrated catalog entry (object identity), re-based to the run
-   root — never a reconstructed twin. Status: predicted (PR 1; the step-7 acceptance restated).
-2. **The doctored miss refuses.** Hand-edit one slot URI to a name the catalog never held: the run fails
-   with the typed verdict naming the URI, the destination is never created, and no disk contact results
-   from the miss. Status: predicted (PR 1).
+   root — never a reconstructed twin. Status: **green** (2026-08-22, PR 1) —
+   `test_judgment_reload_dispatch.star` (the reloaded slot string resolves and the copy flows) plus the
+   Go pins: `resolveDispatchResource`'s canonical-pointer assertions (`pkg/op/method_test.go`) and
+   `TestRun_PlanningCatalogStaysPristineInLocation` (the planning object still binds the plan root after
+   a run under another root — copy-on-bind severed the aliasing).
+2. **The miss refuses — two walls (refined during authoring).** Wall 1: a hand-doctored document never
+   reaches the seam — slots live inside the canonical bytes, so the integrity gate refuses at load
+   (`test_judgment_doctored_checksum.star`, "checksum mismatch"). Wall 2: an in-model miss — a gather
+   item record carrying a raw string into a resource-typed slot (the item-frame backstop) — fails at
+   dispatch with the §5.6 verdict, destination never created (`test_judgment_dispatch_miss.star`,
+   "not in the run catalog"; the seam's own mechanics pinned in `pkg/op/method_test.go`). Status:
+   **green** (2026-08-22, PR 1), both walls.
 3. **The string-promise refusal.** A declared-string producer's promise feeds a `*Regular` slot: refused
-   at `ValidateGraph` if the plan-time narrowing is ruled in, at dispatch otherwise — pinned wherever the
-   implementing PR decides, and pinned that it is never silently minted. Status: predicted (PR 1 rules
-   the mirror).
+   at `ValidateGraph` — the plan-time narrowing landed as leaned
+   (`test_judgment_string_promise_refusal.star`, "returns a string, but the slot is resource-typed");
+   undeclared producers meet the dispatch refusal (wall 2). Status: **green** (2026-08-22, PR 1).
 
 **B. Discover and resolve**
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -616,6 +616,16 @@ the refusal's first catches; steps 1–4 delivered.**
   2 refined into two walls during authoring: the integrity gate catches hand-alteration before the seam
   can, so the in-model miss is authored through the item-frame backstop). Four new judgment stars wired;
   Go pins in `pkg/op/method_test.go` and the pristine-location pin beside the root-binding pair.
+- **First CI re-diagnosis (2026-08-22): two catches, neither assumed.** The quality gate flagged the new
+  code itself — an unchecked type assertion in `shallowCopyResource` (now the house `assert.Type`) and
+  `verifyScopeClaims` over the cognitive-complexity limit (the per-binding body extracted to
+  `verifyClaimBinding`). The Windows test leg exposed the retired step-6 probe's THIRD client: the
+  resume rearm retypes reloaded producer results through `Convert`, and without the probe the tag-URI
+  string fell through to fresh construction — darwin silently swallowed the garbage stat, Windows'
+  fsroot refused the colon-bearing rel ("path escapes from parent"). Fixed at the right layer: the
+  rearm resolves recorded resource results by identity against the rehydrated catalog
+  (`resolveRecordedResource` — rehydration's decode, §5.6), miss-tolerance intact, the dispatch seam
+  the backstop.
 - Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean. PR 1's
   docket is complete.
 

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -31,7 +31,10 @@ var (
 //
 // Convert is the single source of truth for Go↔Go projection in the framework. Every starlark-bridge entry point
 // (wrapper extraction, plan-mode slot fill, immediate-mode dispatch) and method-dispatch site ([Method.Invoke]) routes
-// through here so type-matching semantics stay in one place.
+// through here so type-matching semantics stay in one place. Convert itself is context-blind: graph
+// dispatch precedes it with identity resolution at [Method.Invoke]'s seam ([resolveDispatchResource],
+// 4-resource-management.md §5.6) — a resource-typed slot value there resolves through the run catalog and
+// never reaches the construction steps below.
 //
 // The cascade:
 //
@@ -266,10 +269,11 @@ func tryConvertMap(
 
 // tryConstructResource handles [Convert]'s step 6: registered Resource construction.
 //
-// A value that is the URI of a resource already held by [RuntimeEnvironment.ResourceCatalog] resolves to that restored
-// generation first — this is how a reloaded producer result (a resource's tag-URI string) retypes to the live Resource
-// after resume, since the registered constructor would reject the tag URI (it expects a bare file:// scheme). A path
-// string or unknown URI misses the catalog and constructs fresh.
+// This step serves plan-time claiming (an authored string minting its pending entry — "plan time converts
+// and claims", §9 item 6) and immediate mode (a session constructing from a path). Graph dispatch never
+// reaches it: resource-typed slot values resolve by identity at [Method.Invoke]'s seam
+// ([resolveDispatchResource], 4-resource-management.md §5.6), where a run-catalog miss refuses instead of
+// falling through to construction here.
 //
 // Tried before [TargetConverter] (step 7) so Resources with both a registered constructor and a [TargetConverter]
 // opt-in use the env-aware canonical path at dispatch: the registered constructor receives the full
@@ -300,20 +304,6 @@ func tryConstructResource(
 
 	if !target.Implements(resourceInterfaceType) || runtimeEnvironment == nil {
 		return nil, false, nil
-	}
-
-	// A reloaded producer result is the resource's tag-URI string: a promise resolved after resume hands the consumer
-	// that string, not the live Resource. If the rehydrated catalog already holds that resource, return the full
-	// restored generation rather than reconstructing a fresh, state-less one — and the file constructor would anyway
-	// reject the tag URI, expecting a bare file:// scheme. Path strings and unknown URIs miss the catalog and fall
-	// through to construction below.
-	if uri, isString := value.(string); isString && runtimeEnvironment.ResourceCatalog != nil {
-		if id := runtimeEnvironment.ResourceCatalog.Current(uri); id != "" {
-			resource, ok := runtimeEnvironment.ResourceCatalog.Lookup(id)
-			if ok && reflect.TypeOf(resource).AssignableTo(target) {
-				return resource, true, nil
-			}
-		}
 	}
 
 	// Resources are typically announced under the value type (file.Resource), but the parameter type is the pointer

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1088,45 +1088,71 @@ func (e *GraphExecutor) verifyScopeClaims(scopeID string, units []ExecutableUnit
 		policy := unitMissingResourcePolicy(unit)
 
 		for _, binding := range unit.Slots() {
-
-			immediate, ok := binding.(ImmediateBinding)
-			if !ok {
-				continue
-			}
-
-			resource, ok := immediate.Resolve(nil, nil).(Resource)
-			if !ok {
-				continue
-			}
-
-			// The slot holds the planning session's object; the run's world lives in the clone's ledger,
-			// where the activation binding installed the run-bound COPY (the step-4 ruling). Verification
-			// probes the canonical entry, never the slot's pristine capture.
-			if id := catalog.Current(resource.URI()); id != "" {
-				if canonical, found := catalog.Lookup(id); found {
-					resource = canonical
-				}
-			}
-
-			if !participatesInExistenceVerification(resource) {
-				continue
-			}
-
-			verifyErr := catalog.VerifyExistence(resource)
-			if verifyErr == nil {
-				continue
-			}
-
-			if e.environment.Status != nil {
-				e.environment.Status.Warn(fmt.Sprintf(
-					"%s: %s: missing resource (policy %s): %v", scopeID, unit.ID(), policy, verifyErr))
-			}
-
-			if policy == MissingResourcePolicyStop {
-				return &dispatchFailure{reason: ReasonPreflightFailed,
-					cause: fmt.Errorf("%s: unmet intent: %w", unit.ID(), verifyErr)}
+			if err := e.verifyClaimBinding(scopeID, unit, policy, binding); err != nil {
+				return err
 			}
 		}
+	}
+
+	return nil
+}
+
+// verifyClaimBinding verifies one slot binding's claim, when it carries one.
+//
+// An immediate resource-valued slot resolves to the run clone's canonical entry first — the slot holds
+// the planning session's object, and the activation binding installed the run-bound COPY in the ledger
+// (the step-4 ruling), so verification probes the canonical, never the slot's pristine capture. The
+// canonical is probed through [ResourceCatalog.VerifyExistence]; a warning is produced on every
+// detection; the consequence follows `policy` — Stop fails the scope with [ReasonPreflightFailed],
+// Ignore lets the scope proceed.
+//
+// Parameters:
+//   - `scopeID`: the verifying scope's unit id, for the warning.
+//   - `unit`: the consuming unit.
+//   - `policy`: the unit's declared [MissingResourcePolicy].
+//   - `binding`: the slot binding under consideration.
+//
+// Returns:
+//   - `error`: the reason-carrying dispatch failure for an unmet required claim; nil otherwise.
+func (e *GraphExecutor) verifyClaimBinding(
+	scopeID string, unit ExecutableUnit, policy MissingResourcePolicy, binding Binding,
+) error {
+
+	catalog := e.environment.ResourceCatalog
+
+	immediate, ok := binding.(ImmediateBinding)
+	if !ok {
+		return nil
+	}
+
+	resource, ok := immediate.Resolve(nil, nil).(Resource)
+	if !ok {
+		return nil
+	}
+
+	if id := catalog.Current(resource.URI()); id != "" {
+		if canonical, found := catalog.Lookup(id); found {
+			resource = canonical
+		}
+	}
+
+	if !participatesInExistenceVerification(resource) {
+		return nil
+	}
+
+	verifyErr := catalog.VerifyExistence(resource)
+	if verifyErr == nil {
+		return nil
+	}
+
+	if e.environment.Status != nil {
+		e.environment.Status.Warn(fmt.Sprintf(
+			"%s: %s: missing resource (policy %s): %v", scopeID, unit.ID(), policy, verifyErr))
+	}
+
+	if policy == MissingResourcePolicyStop {
+		return &dispatchFailure{reason: ReasonPreflightFailed,
+			cause: fmt.Errorf("%s: unmet intent: %w", unit.ID(), verifyErr)}
 	}
 
 	return nil
@@ -1520,7 +1546,7 @@ func shallowCopyResource(r Resource) Resource {
 	copied := reflect.New(v.Elem().Type())
 	copied.Elem().Set(v.Elem())
 
-	return copied.Interface().(Resource)
+	return assert.Type[Resource]("resource copy", copied.Interface())
 }
 
 // endregion

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
@@ -304,7 +305,9 @@ func (e *GraphExecutor) ResumeUnwind(ctx context.Context) error {
 		return fmt.Errorf("ResumeUnwind: graph carries no resource catalog — mandatory even when empty")
 	}
 
-	environment, buildErr := NewRuntimeEnvironment(ctx, e.spec.WithCatalog(e.graph.ResourceCatalog().Clone()))
+	// A value copy of the host's spec: run-only state (the cloned catalog) never lands on the caller's object.
+	runSpec := *e.spec
+	environment, buildErr := NewRuntimeEnvironment(ctx, runSpec.WithResourceCatalog(e.graph.ResourceCatalog().Clone()))
 	if buildErr != nil {
 		return fmt.Errorf("ResumeUnwind: build runtime environment: %w", buildErr)
 	}
@@ -498,7 +501,9 @@ func (e *GraphExecutor) Run(ctx context.Context, variables map[string]Variable) 
 		return nil, fmt.Errorf("Run: graph carries no resource catalog — mandatory even when empty")
 	}
 
-	environment, buildErr := NewRuntimeEnvironment(ctx, e.spec.WithCatalog(e.graph.ResourceCatalog().Clone()))
+	// A value copy of the host's spec: run-only state (the cloned catalog) never lands on the caller's object.
+	runSpec := *e.spec
+	environment, buildErr := NewRuntimeEnvironment(ctx, runSpec.WithResourceCatalog(e.graph.ResourceCatalog().Clone()))
 	if buildErr != nil {
 		e.status = RunStatus{Phase: PhaseStopped, Condition: ConditionExecutionFailed,
 			Reason: ReasonPreflightFailed, Message: "runtime environment build failed"}
@@ -1055,18 +1060,6 @@ func (e *GraphExecutor) bindVariables(graph *Graph, callerVariables map[string]V
 	return nil
 }
 
-// resolvePendingResources drives the discovery-side Pending → Active/Gone transition at pre-flight (phase-8 step 22).
-//
-// Plan-time resources are introduced into the graph's catalog as [Pending] — deliberately unresolved — and are
-// expected to resolve here, once the catalog is cloned onto the per-run [RuntimeEnvironment] and the executor owns it.
-// Each [Pending] entry whose type participates in existence verification (see [participatesInExistenceVerification] —
-// the staged rollout's gate) is verified through [ResourceCatalog.VerifyExistence], which reads [Resource.Exists] and
-// applies the catalog-owned transition.
-//
-// The pass marks and never fails the run: a [Gone] resource is a recorded fact, not a stop — planning and running
-// operations against a not-yet-existent path is legitimate (`file.exists` on a missing file answers false; a producer
-// revives a [Gone] URI via shadow), and consumers of a genuinely missing resource fail at their own dispatch (the Q2
-// "dependents fail on their own" precedent). The probes are read-only (stat-class), so the pass also runs in dry-run.
 // verifyScopeClaims verifies the claims a scope's own units consume — the scoped pre-flight (§3, ruled
 // 2026-08-22).
 //
@@ -1102,7 +1095,20 @@ func (e *GraphExecutor) verifyScopeClaims(scopeID string, units []ExecutableUnit
 			}
 
 			resource, ok := immediate.Resolve(nil, nil).(Resource)
-			if !ok || !participatesInExistenceVerification(resource) {
+			if !ok {
+				continue
+			}
+
+			// The slot holds the planning session's object; the run's world lives in the clone's ledger,
+			// where the activation binding installed the run-bound COPY (the step-4 ruling). Verification
+			// probes the canonical entry, never the slot's pristine capture.
+			if id := catalog.Current(resource.URI()); id != "" {
+				if canonical, found := catalog.Lookup(id); found {
+					resource = canonical
+				}
+			}
+
+			if !participatesInExistenceVerification(resource) {
 				continue
 			}
 
@@ -1180,12 +1186,18 @@ func (e *GraphExecutor) bindPendingResources() {
 		// pending entry re-bases onto the run's environment, and a root-relative scheme re-binds its path
 		// rel-first against the run's root through the [RootBinder] seam — so scoped verification, and
 		// every later observation, read the run's world rather than the environment that happened to
-		// construct or rehydrate the object (the run-from-elsewhere defect). Existence is NOT checked
+		// construct or rehydrate the object (the run-from-elsewhere defect). The run binds a COPY (the
+		// step-4 ruling, 2026-08-22): [ResourceCatalog.Clone] shares Resource pointers with the planning
+		// catalog, so binding in place would re-root the planning session's own objects; the bound copy
+		// replaces the clone's ledger entry instead, dispatch reaches it through identity resolution
+		// ([resolveDispatchResource]), and the planning catalog stays pristine. Existence is NOT checked
 		// here: verification is scoped per subgraph executor ([GraphExecutor.verifyScopeClaims]).
-		resource.resourceBase().runtimeEnvironment = e.environment
-		if binder, ok := resource.(RootBinder); ok && e.environment.HasRoot() {
+		bound := shallowCopyResource(resource)
+		bound.resourceBase().runtimeEnvironment = e.environment
+		if binder, ok := bound.(RootBinder); ok && e.environment.HasRoot() {
 			binder.BindRoot(e.environment.Root())
 		}
+		catalog.rebindEntry(resource, bound)
 	}
 }
 
@@ -1483,6 +1495,32 @@ func participatesInExistenceVerification(resource Resource) bool {
 
 	_, ok := existenceVerifiableTypes[resource.resourceBase().ResourceType()]
 	return ok
+}
+
+// shallowCopyResource returns a kind-preserving shallow copy of `r` — a fresh value of r's concrete
+// struct type holding the same field values.
+//
+// The activation binding copies before it re-bases (the step-4 ruling, 2026-08-22): [ResourceCatalog.Clone]
+// shares Resource pointers with the planning catalog, and [RootBinder.BindRoot] assigns a fresh
+// SourcePath rather than mutating shared path state, so a shallow copy of the concrete struct fully
+// severs the bound entry from the planning session's object.
+//
+// Parameters:
+//   - `r`: the resource to copy; expected to be a pointer to its concrete struct (every sealed resource is).
+//
+// Returns:
+//   - `Resource`: the copy, of the same concrete type; `r` itself when it is not a pointer.
+func shallowCopyResource(r Resource) Resource {
+
+	v := reflect.ValueOf(r)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return r
+	}
+
+	copied := reflect.New(v.Elem().Type())
+	copied.Elem().Set(v.Elem())
+
+	return copied.Interface().(Resource)
 }
 
 // endregion

--- a/pkg/op/graph_executor_test.go
+++ b/pkg/op/graph_executor_test.go
@@ -312,8 +312,10 @@ func TestRun_ScopedPreflightVerifiesConsumedClaims(t *testing.T) {
 		t.Fatalf("NewResourceBase(unconsumed): %v", err)
 	}
 
-	present := &lifecycleResource{ResourceBase: presentBase, addressingMode: AddressingLocation, present: true}
-	unconsumed := &lifecycleResource{ResourceBase: unconsumedBase, addressingMode: AddressingLocation, present: true}
+	present := &lifecycleResource{
+		ResourceBase: presentBase, addressingMode: AddressingLocation, present: true, existsCalls: new(int)}
+	unconsumed := &lifecycleResource{
+		ResourceBase: unconsumedBase, addressingMode: AddressingLocation, present: true, existsCalls: new(int)}
 	unenrolled := newLifecycle("test:///unenrolled", AddressingLocation) // bare base: type id "", not enrolled
 
 	// Enroll the fixture type in the staged-rollout gate for the duration of this test.
@@ -347,17 +349,17 @@ func TestRun_ScopedPreflightVerifiesConsumedClaims(t *testing.T) {
 		t.Fatalf("Run: %v — a present consumed claim must verify and the scope proceed", err)
 	}
 
-	if present.existsCalls != 1 {
+	if *present.existsCalls != 1 {
 		t.Errorf("present.existsCalls = %d, want 1 (a consumed claim is probed once, at its scope's start)",
-			present.existsCalls)
+			*present.existsCalls)
 	}
-	if unconsumed.existsCalls != 0 {
+	if *unconsumed.existsCalls != 0 {
 		t.Errorf("unconsumed.existsCalls = %d, want 0 (verification is claim-driven — an entry no unit consumes is never judged)",
-			unconsumed.existsCalls)
+			*unconsumed.existsCalls)
 	}
-	if unenrolled.existsCalls != 0 {
+	if *unenrolled.existsCalls != 0 {
 		t.Errorf("unenrolled.existsCalls = %d, want 0 (the staging gate must skip non-enrolled types)",
-			unenrolled.existsCalls)
+			*unenrolled.existsCalls)
 	}
 
 	// The pass ran on the per-run clone; the graph's planning catalog stays pristine for "plan once, run many."
@@ -375,7 +377,8 @@ func TestRun_ScopedPreflightFailsOnConsumedMissingClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewResourceBase(missing): %v", err)
 	}
-	missing := &lifecycleResource{ResourceBase: missingBase, addressingMode: AddressingLocation, present: false}
+	missing := &lifecycleResource{
+		ResourceBase: missingBase, addressingMode: AddressingLocation, present: false, existsCalls: new(int)}
 
 	typeID := missing.ResourceType()
 	existenceVerifiableTypes[typeID] = struct{}{}

--- a/pkg/op/method.go
+++ b/pkg/op/method.go
@@ -399,7 +399,7 @@ func (m *Method) Invoke(activation *ActivationRecord, receiver any) (Result, Com
 			value = resolved
 		}
 
-		val, err := Convert(activation.RuntimeEnvironment, value, p.Type)
+		val, err := convertSlotValue(activation, value, p.Type)
 		if err != nil {
 			return nil, nil, fmt.Errorf("param %s: %w", p.Name, err)
 		}
@@ -632,6 +632,33 @@ const (
 
 // region HELPER FUNCTIONS
 
+// convertSlotValue converts one resolved slot value toward its parameter type, routing resource-typed
+// parameters through graph dispatch's identity resolution first.
+//
+// At graph dispatch a string is a key, never a constructor (4-resource-management.md §5.6): when the
+// activation is a graph dispatch (`activation.Graph` non-nil — the per-dispatch frame carries dispatch
+// kind) and the parameter is resource-typed, the slot value resolves through the run catalog via
+// [resolveDispatchResource] and a miss is the catalog's refusal, never fresh construction. Every other
+// dispatch — immediate mode's nil-Graph activations — and every non-resource parameter follows
+// [Convert]'s cascade unchanged.
+//
+// Parameters:
+//   - `activation`: the per-dispatch record carrying dispatch kind and the runtime environment.
+//   - `value`: the resolved slot value.
+//   - `target`: the parameter's declared Go type.
+//
+// Returns:
+//   - `any`: the converted (or catalog-resolved) value.
+//   - `error`: non-nil when resolution refuses or no conversion path succeeds.
+func convertSlotValue(activation *ActivationRecord, value any, target reflect.Type) (any, error) {
+
+	if v, applied, err := resolveDispatchResource(activation, value, target); applied {
+		return v, err
+	}
+
+	return Convert(activation.RuntimeEnvironment, value, target)
+}
+
 // guardConsumedGone applies the consumed-Gone guard to the converted arguments (§3's consumption table).
 //
 // Each catalog-resident resource among the arguments is checked against the run catalog's state; a [Gone]
@@ -686,6 +713,73 @@ func guardConsumedGone(activation *ActivationRecord, goArgs []any) error {
 	}
 
 	return nil
+}
+
+// resolveDispatchResource is graph dispatch's identity resolution — the §5.6 seam.
+//
+// Applies only when `activation` is a graph dispatch with a run catalog and `target` implements
+// [Resource]. A [Resource] value resolves by its URI — the dispatched object must BE the run clone's
+// entry (re-based, state-carrying, the row pre-flight verified), never the captured planning object. A
+// string is the rehydrated identity a reload leaves in the slot and resolves as the key it is. Any other
+// value cannot name a resource at dispatch. A miss is the catalog's verdict: the catalog is complete by
+// construction (§5.1), so nothing constructs here — construction from strings survives only in load-time
+// rehydration and immediate mode.
+//
+// Parameters:
+//   - `activation`: the per-dispatch record; its Graph and the environment's catalog gate the step.
+//   - `value`: the resolved slot value.
+//   - `target`: the parameter's declared Go type.
+//
+// Returns:
+//   - `any`: the run clone's canonical entry on a hit.
+//   - `bool`: true when this step applied (regardless of error).
+//   - `error`: the refusal on a miss, a non-identity value, or an entry that cannot fill `target`.
+func resolveDispatchResource(activation *ActivationRecord, value any, target reflect.Type) (resolved any, applied bool, err error) {
+
+	if activation == nil || activation.Graph == nil {
+		return nil, false, nil
+	}
+	environment := activation.RuntimeEnvironment
+	if environment == nil || environment.ResourceCatalog == nil {
+		return nil, false, nil
+	}
+	if !target.Implements(resourceInterfaceType) {
+		return nil, false, nil
+	}
+
+	var key string
+	switch v := value.(type) {
+	case Resource:
+		key = v.URI()
+	case string:
+		key = v
+	case nil:
+		return nil, false, nil
+	default:
+		return nil, true, fmt.Errorf(
+			"graph dispatch: a %T cannot name a resource — a string is a key, never a constructor (4-resource-management.md §5.6)",
+			value)
+	}
+
+	catalog := environment.ResourceCatalog
+
+	id := catalog.Current(key)
+	if id == "" {
+		return nil, true, fmt.Errorf(
+			"graph dispatch: %q is not in the run catalog — a string is a key, never a constructor; nothing constructs at dispatch (4-resource-management.md §5.6)",
+			key)
+	}
+
+	canonical, ok := catalog.Lookup(id)
+	if !ok {
+		return nil, true, fmt.Errorf("graph dispatch: run catalog names %q as %s but holds no entry", key, id)
+	}
+	if !reflect.TypeOf(canonical).AssignableTo(target) {
+		return nil, true, fmt.Errorf(
+			"graph dispatch: run catalog entry %q is %T, which cannot fill a %s slot", key, canonical, target)
+	}
+
+	return canonical, true, nil
 }
 
 // verdictForGone renders the catalog's verdict for a consumed-Gone entry, naming both units when the

--- a/pkg/op/method_test.go
+++ b/pkg/op/method_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// region TEST FUNCTIONS
+
+// TestResolveDispatchResource_StringKeyHitReturnsTheCanonical pins the key half of the §5.6 seam: a
+// string slot value at graph dispatch is an identity, and resolution hands back the run catalog's
+// canonical entry — the very object the ledger holds.
+func TestResolveDispatchResource_StringKeyHitReturnsTheCanonical(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+	entry := newLifecycle("test:///claimed", AddressingLocation)
+	catalog.Resolve(entry)
+
+	activation := &ActivationRecord{Graph: &Graph{}, RuntimeEnvironment: &RuntimeEnvironment{ResourceCatalog: catalog}}
+
+	resolved, applied, err := resolveDispatchResource(activation, "test:///claimed", reflect.TypeFor[*lifecycleResource]())
+	if !applied || err != nil {
+		t.Fatalf("resolveDispatchResource(key) = applied %t, err %v; want applied, nil", applied, err)
+	}
+	if resolved != Resource(entry) {
+		t.Errorf("resolved %p is not the canonical entry %p — dispatch must hand out the ledger's object", resolved, entry)
+	}
+}
+
+// TestResolveDispatchResource_ResourceValueResolvesByURI pins the captured-object half: a Resource slot
+// value resolves by its URI to the canonical, never dispatching the captured object itself — the aliasing
+// between planning catalog and run clone is severed, not load-bearing.
+func TestResolveDispatchResource_ResourceValueResolvesByURI(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+	canonical := newLifecycle("test:///claimed", AddressingLocation)
+	catalog.Resolve(canonical)
+
+	captured := newLifecycle("test:///claimed", AddressingLocation) // the same identity, a different object
+
+	activation := &ActivationRecord{Graph: &Graph{}, RuntimeEnvironment: &RuntimeEnvironment{ResourceCatalog: catalog}}
+
+	resolved, applied, err := resolveDispatchResource(activation, captured, reflect.TypeFor[*lifecycleResource]())
+	if !applied || err != nil {
+		t.Fatalf("resolveDispatchResource(resource) = applied %t, err %v; want applied, nil", applied, err)
+	}
+	if resolved != Resource(canonical) {
+		t.Errorf("resolved %p is not the canonical %p — the captured object must not dispatch", resolved, canonical)
+	}
+}
+
+// TestResolveDispatchResource_MissRefuses pins the refusal: a graph-dispatch catalog miss is the
+// catalog's verdict naming the key — never fresh construction.
+func TestResolveDispatchResource_MissRefuses(t *testing.T) {
+
+	activation := &ActivationRecord{
+		Graph:              &Graph{},
+		RuntimeEnvironment: &RuntimeEnvironment{ResourceCatalog: NewResourceCatalog()},
+	}
+
+	_, applied, err := resolveDispatchResource(activation, "test:///ghost", reflect.TypeFor[*lifecycleResource]())
+	if !applied {
+		t.Fatal("resolveDispatchResource(miss) did not apply — the seam must own resource-typed slots at graph dispatch")
+	}
+	if err == nil || !strings.Contains(err.Error(), "not in the run catalog") {
+		t.Errorf("miss error = %v, want the catalog's verdict naming the key", err)
+	}
+}
+
+// TestResolveDispatchResource_NonIdentityValueRefuses pins the sealing: a value that is neither a
+// Resource nor a string cannot name a resource at graph dispatch.
+func TestResolveDispatchResource_NonIdentityValueRefuses(t *testing.T) {
+
+	activation := &ActivationRecord{
+		Graph:              &Graph{},
+		RuntimeEnvironment: &RuntimeEnvironment{ResourceCatalog: NewResourceCatalog()},
+	}
+
+	_, applied, err := resolveDispatchResource(activation, 42, reflect.TypeFor[*lifecycleResource]())
+	if !applied {
+		t.Fatal("resolveDispatchResource(non-identity) did not apply")
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot name a resource") {
+		t.Errorf("non-identity error = %v, want the cannot-name refusal", err)
+	}
+}
+
+// TestResolveDispatchResource_SessionDispatchFallsThrough pins the gate: a nil-Graph activation —
+// immediate mode's shape — leaves the cascade untouched, so session construction survives (§5.6's
+// second carve-out).
+func TestResolveDispatchResource_SessionDispatchFallsThrough(t *testing.T) {
+
+	activation := &ActivationRecord{RuntimeEnvironment: &RuntimeEnvironment{ResourceCatalog: NewResourceCatalog()}}
+
+	_, applied, _ := resolveDispatchResource(activation, "a/path", reflect.TypeFor[*lifecycleResource]())
+	if applied {
+		t.Error("resolveDispatchResource applied on a session (nil-Graph) activation — immediate mode must construct")
+	}
+}
+
+// endregion

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -103,6 +103,9 @@ func buildCandidateAs(
 	// The input is a filesystem path. One internal round-trip also lands here: catalog rehydration hands
 	// back this provider's own emitted identity specific ("file:" + rel) — strip our own prefix and it is
 	// a path again. No URI parsing: the provider decodes only what it mints (readback does the same).
+	// Graph dispatch never reaches this seam (4-resource-management.md §5.6): resource-typed slot values
+	// resolve by identity at the dispatch seam and a run-catalog miss refuses there, so the strip serves
+	// exactly two callers — load-time rehydration (the identity decode) and session-side construction.
 	path = strings.TrimPrefix(path, "file:")
 	sourcePath := runtimeEnvironment.Root().NewPath(path)
 	var base op.ResourceBase

--- a/pkg/op/provider/plan/root_binding_test.go
+++ b/pkg/op/provider/plan/root_binding_test.go
@@ -139,3 +139,51 @@ func assertTraceBinding(t *testing.T, executor *op.GraphExecutor, runRoot string
 
 	t.Fatalf("trace carries no entry for the claimed rel; entries: %+v", trace.Catalog.Entries)
 }
+
+// TestRun_PlanningCatalogStaysPristineInLocation pins the copy-on-bind ruling (phase 4 step 4,
+// 2026-08-22): the run binds a COPY of each pending entry onto its clone, so after a run under another
+// root the planning session's own object still binds the root it was constructed against, and its state
+// is still the pending intent it was planned as — nothing about a run leaks backward into the plan.
+func TestRun_PlanningCatalogStaysPristineInLocation(t *testing.T) {
+
+	planRoot := t.TempDir()
+	runRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(runRoot, "data.txt"), []byte("bound under the run root"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := planReadText(t, planRoot)
+
+	if _, err := op.NewGraphExecutor(graph, runSpec(runRoot)).Run(context.Background(), nil); err != nil {
+		t.Fatalf("Run under the run root: %v", err)
+	}
+
+	catalog := graph.ResourceCatalog()
+	snapshot := catalog.Snapshot()
+	if snapshot == nil || len(snapshot.Entries) != 1 {
+		t.Fatalf("planning catalog snapshot = %+v, want exactly one entry", snapshot)
+	}
+
+	row := snapshot.Entries[0]
+	if catalog.State(row.ID) != op.Pending {
+		t.Errorf("planning entry state = %v after the run, want Pending (the clone ran, not the plan)", catalog.State(row.ID))
+	}
+
+	entry, ok := catalog.Lookup(row.ID)
+	if !ok {
+		t.Fatalf("planning catalog does not hold its own entry %s", row.ID)
+	}
+	regular, ok := entry.(*file.Regular)
+	if !ok {
+		t.Fatalf("planning entry is %T, want *file.Regular", entry)
+	}
+
+	abs := regular.SourcePath.Abs()
+	if !strings.HasPrefix(abs, planRoot) {
+		t.Errorf("planning object binds %q, want the PLAN root %q — the run re-rooted a shared object", abs, planRoot)
+	}
+	if strings.HasPrefix(abs, runRoot) {
+		t.Errorf("planning object binds the RUN root %q — copy-on-bind failed to sever the aliasing", runRoot)
+	}
+}

--- a/pkg/op/recovery_stack.go
+++ b/pkg/op/recovery_stack.go
@@ -649,9 +649,59 @@ func (s *RecoveryStack) retypeStampedResult(runtimeEnvironment *RuntimeEnvironme
 		return
 	}
 
+	if canonical, resolved := resolveRecordedResource(runtimeEnvironment, s.result, productType); resolved {
+		s.result = canonical
+		return
+	}
+
 	if retyped, err := Convert(runtimeEnvironment, s.result, productType); err == nil {
 		s.result = retyped
 	}
+}
+
+// resolveRecordedResource resolves a reloaded resource-producing result by identity — the rearm's half
+// of load-time rehydration (4-resource-management.md §5.6): a recorded producer result reloads as the
+// resource's tag-URI string, and resume rehydrates the paused run's ledger into the live catalog, so the
+// string resolves as the key it is to the restored generation. An identity decode, never a conversion —
+// the [Convert] cascade would construct a fresh, state-less object from the URI text. A miss leaves the
+// value untouched (the rearm's documented tolerance): a consumer of an unresolvable result meets the
+// dispatch seam's refusal at its own dispatch.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the resumed run's environment, holding the rehydrated catalog.
+//   - `result`: the reloaded result value.
+//   - `productType`: the recorded produced type.
+//
+// Returns:
+//   - `any`: the catalog's canonical entry on a hit.
+//   - `bool`: true when the result resolved (string identity, resource product type, catalog hit).
+func resolveRecordedResource(runtimeEnvironment *RuntimeEnvironment, result any, productType reflect.Type) (any, bool) {
+
+	if runtimeEnvironment == nil || runtimeEnvironment.ResourceCatalog == nil {
+		return nil, false
+	}
+	if !productType.Implements(resourceInterfaceType) {
+		return nil, false
+	}
+
+	uri, isString := result.(string)
+	if !isString {
+		return nil, false
+	}
+
+	catalog := runtimeEnvironment.ResourceCatalog
+
+	id := catalog.Current(uri)
+	if id == "" {
+		return nil, false
+	}
+
+	canonical, ok := catalog.Lookup(id)
+	if !ok || !reflect.TypeOf(canonical).AssignableTo(productType) {
+		return nil, false
+	}
+
+	return canonical, true
 }
 
 // supersede removes the top-most entry for `unitID` from this stack.
@@ -935,6 +985,13 @@ func retypeResult(runtimeEnvironment *RuntimeEnvironment, receipt Receipt) error
 
 	productType, ok := ReceiverRegistry().ProductTypeByID(receipt.ResultType())
 	if !ok {
+		return nil
+	}
+
+	// A resource-producing result resolves by identity against the rehydrated catalog first — the
+	// decode, not a conversion; see [resolveRecordedResource].
+	if canonical, resolved := resolveRecordedResource(runtimeEnvironment, result, productType); resolved {
+		receipt.receiptBase().result = canonical
 		return nil
 	}
 

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -635,6 +635,27 @@ func (c *ResourceCatalog) VerifyExistence(resource Resource) error {
 	return fmt.Errorf("verify existence: resource %q does not exist", resource.URI())
 }
 
+// rebindEntry replaces `old`'s ledger slot with `bound` — the activation binding's copy-on-bind swap
+// (the step-4 ruling, 2026-08-22).
+//
+// Identity, id, state, and the namespace are untouched: the copy carries the same URI and recorded id,
+// so only the object the ledger hands out changes. [GraphExecutor.bindPendingResources] is the sole
+// caller — the run's clone swaps in the run-bound copy so the planning session's shared object stays
+// pristine.
+//
+// Parameters:
+//   - `old`: the entry being replaced; located by its stamped catalog id.
+//   - `bound`: the run-bound copy that takes its ledger slot.
+func (c *ResourceCatalog) rebindEntry(old, bound Resource) {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if i, ok := c.byID[old.resourceBase().id]; ok {
+		c.entries[i] = bound
+	}
+}
+
 // lookupOrCatalog performs the namespace lookup under the catalog mutex.
 //
 // On hit returns the canonical entry; on miss interns r as a discovery entry and returns it. Caller must run any

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -539,7 +539,12 @@ type lifecycleResource struct {
 	resolveErr     error
 	resolveCalls   int
 	present        bool
-	existsCalls    int
+
+	// existsCalls counts Exists probes through a shared cell: the activation binding probes a
+	// kind-preserving COPY of the entry (the step-4 copy-on-bind ruling), so a plain int field would
+	// count on the copy while the test's original read zero. Allocated at construction; a fixture built
+	// without a cell fails loudly on first probe.
+	existsCalls *int
 }
 
 // Addressing returns the caller-supplied [AddressingMode] for this fixture.
@@ -564,7 +569,7 @@ func (r *lifecycleResource) Resolve() error {
 //   - `bool`: the configured presence.
 func (r *lifecycleResource) Exists() bool {
 
-	r.existsCalls++
+	*r.existsCalls++
 	return r.present
 }
 
@@ -581,6 +586,7 @@ func newLifecycle(uri string, mode AddressingMode) *lifecycleResource {
 	return &lifecycleResource{
 		ResourceBase:   ResourceBase{uri: uri},
 		addressingMode: mode,
+		existsCalls:    new(int),
 	}
 }
 
@@ -756,8 +762,8 @@ func TestCatalog_VerifyExistence_ActiveShortCircuits(t *testing.T) {
 	if err := c.VerifyExistence(r); err != nil {
 		t.Fatalf("second VerifyExistence() error = %v", err)
 	}
-	if r.existsCalls != 1 {
-		t.Errorf("existsCalls = %d, want 1 (an Active entry is not re-checked)", r.existsCalls)
+	if *r.existsCalls != 1 {
+		t.Errorf("existsCalls = %d, want 1 (an Active entry is not re-checked)", *r.existsCalls)
 	}
 }
 

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -856,7 +856,7 @@ type RuntimeEnvironmentSpec struct {
 	//
 	// When nil, [NewRuntimeEnvironment] creates a fresh empty [ResourceCatalog]. Callers that need to seed the
 	// environment with a pre-built catalog — typically [GraphExecutor.Run] cloning the graph's planning catalog
-	// onto the per-run environment — set this via [WithCatalog].
+	// onto the per-run environment — set this via [WithResourceCatalog].
 	ResourceCatalog *ResourceCatalog
 
 	// Platform classifies the host (OS, arch, distro, version) and gives access to the managers available to providers.
@@ -922,7 +922,8 @@ func (c *RuntimeEnvironmentSpec) WithApplication(app *application.Application) *
 	return c
 }
 
-// WithCatalog seeds the constructed runtime environment with the supplied [*ResourceCatalog] instead of a fresh one.
+// WithResourceCatalog seeds the constructed runtime environment with the supplied [*ResourceCatalog]
+// instead of a fresh one.
 //
 // Used by [GraphExecutor.Run] to clone the planning graph's catalog onto the per-run environment, so the
 // per-run env is born with the right catalog instead of having one created and immediately replaced.
@@ -933,7 +934,7 @@ func (c *RuntimeEnvironmentSpec) WithApplication(app *application.Application) *
 //
 // Returns:
 //   - *RuntimeEnvironmentSpec: the config for method chaining.
-func (c *RuntimeEnvironmentSpec) WithCatalog(catalog *ResourceCatalog) *RuntimeEnvironmentSpec {
+func (c *RuntimeEnvironmentSpec) WithResourceCatalog(catalog *ResourceCatalog) *RuntimeEnvironmentSpec {
 
 	c.ResourceCatalog = catalog
 	return c

--- a/pkg/op/validate.go
+++ b/pkg/op/validate.go
@@ -6,6 +6,7 @@ package op
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 // ValidateGraph asserts the assembled graph satisfies the plan-time invariants every executable unit
@@ -56,10 +57,68 @@ func ValidateGraph(g *Graph) error {
 	violations = checkRequiredParams(violations, g)
 	violations = checkBubbleUpConsistency(violations, g)
 	violations = checkPromiseTypes(violations, g)
+	violations = checkVariableResourceSlots(violations, g)
 	violations = checkEdges(violations, g)
 	violations = checkItemProjectionScope(violations, g)
 
 	return errors.Join(violations...)
+}
+
+// checkVariableResourceSlots refuses a plain [VariableBinding] into a resource-typed slot — the interim
+// posture while run-start claiming is chartered (ruled 2026-08-22: a variable binds the way a promise
+// does, only after execution begins, so its claim belongs to the run's pre-flight; until that pass
+// exists, a variable-fed resource slot would reach dispatch as a string and refuse there — this check
+// moves the refusal to plan time, the variable mirror of [checkPromiseSlot]'s declared-string narrowing).
+//
+// Plain variables only: flag / config / override / environment sources are string-valued by
+// construction, so a plain variable can never deliver a resource. The reserved gather frame (`item`) is
+// exempt — its records are plan-authored data that may carry CLAIMED resources (the writ-adopt shape),
+// which the dispatch seam resolves by identity; an item field that turns out to be a string meets the
+// dispatch refusal instead.
+//
+// Parameters:
+//   - `violations`: the accumulating violation slice.
+//   - `g`: the graph to walk.
+//
+// Returns:
+//   - []error: the (possibly-extended) violation slice.
+func checkVariableResourceSlots(violations []error, g *Graph) []error {
+
+	for id, unit := range indexUnitsByID(g) {
+
+		action := unit.Action()
+		if action == nil {
+			continue
+		}
+		method := action.Method()
+		if method == nil {
+			continue
+		}
+
+		for slotName, slotValue := range unit.Slots() {
+
+			binding, ok := slotValue.(VariableBinding)
+			if !ok || binding.Name() == "item" {
+				continue
+			}
+
+			param, present := method.ParameterByName(slotName)
+			if !present || param.Type == nil {
+				continue
+			}
+
+			if param.Type.Implements(resourceInterfaceType) {
+				violations = append(violations, fmt.Errorf(
+					"op.ValidateGraph: unit %q slot %q: a variable binds a resource-typed slot (%s) — a variable's "+
+						"value arrives at run start, and a string is a key, never a constructor at dispatch; author "+
+						"the path (a plan-time claim) or feed a producer's promise (run-start claiming is chartered: "+
+						"4-resource-management.md §5.6)",
+					id, slotName, param.Type))
+			}
+		}
+	}
+
+	return violations
 }
 
 // checkItemProjectionScope flags item-field projections outside a gather body (phase-8 step 45).
@@ -326,6 +385,20 @@ func checkPromiseSlot(
 	targetType := param.Type
 	if targetType == nil {
 		return nil
+	}
+
+	// Graph dispatch resolves resource-typed slots by identity and never constructs (§5.6), so a producer
+	// whose DECLARED result is a string can only miss the run catalog — a run-computed string is not a
+	// recorded identity. The binding refuses here, at plan time, rather than at dispatch; undeclared
+	// producers (nil ResultType) pass above and meet the dispatch refusal instead. The general
+	// [typesAreInterconvertible] relation still admits string→Resource for its other uses (bubble-up
+	// dedup, immediate mode), so this narrowing is the graph-context mirror of the dispatch seam.
+	if targetType.Implements(resourceInterfaceType) && sourceType.Kind() == reflect.String {
+		return fmt.Errorf(
+			"op.ValidateGraph: unit %q slot %q: producer %q returns a string, but the slot is resource-typed (%s) — "+
+				"a string is a key, never a constructor at dispatch; produce a resource, or route the run-computed "+
+				"path through an explicit discovery (4-resource-management.md §5.6–5.7)",
+			id, slotName, edge.From, targetType)
 	}
 
 	if typesAreInterconvertible(sourceType, targetType) {


### PR DESCRIPTION
Phase 4, PR 1 of the resource-construction campaign (docs/plans/resource-construction.md). Closes #609.

**The seam** (4-resource-management.md §5.6): `Method.Invoke`'s slot conversion routes resource-typed
parameters through `resolveDispatchResource`, gated by `activation.Graph` — the per-dispatch frame
carries dispatch kind; the environment stays orthogonal (a first-cut environment bit was reverted in
design review). A Resource value resolves by its URI, a string resolves as the key it is, any other
value refuses, and a run-catalog miss refuses with the §5.6 verdict — nothing constructs at dispatch.
Step 6's reload probe retired with it; `Convert` stays context-blind for planning and immediate mode.

**Copy-on-bind** (step 4 ruled): `bindPendingResources` binds a kind-preserving copy and swaps it into
the run clone (`ResourceCatalog.rebindEntry`); scoped verification resolves the canonical before
probing; the planning catalog stays pristine in state AND location (pinned).

**The plan-time mirror**: `checkPromiseTypes` refuses a declared-string producer into a resource-typed
slot; `checkVariableResourceSlots` refuses plain variables (the reserved `item` frame is exempt — its
records may carry claimed resources; the dispatch seam backstops). Run-start claiming for variable-fed
resource slots is ruled and chartered (docket item 9, sequenced after phase 4).

**First catches**: writ adopt migrated — its gather records carry plan-time claims
(`file.DiscoverRegular`: identity minted with no disk contact, interned pending) instead of
machine-absolute strings; the two variable-model star fixtures re-authored to authored claims.

**Acceptance — explicit-conversion suite items 1–3 green**: `test_judgment_reload_dispatch`,
`test_judgment_doctored_checksum` (wall 1: the integrity gate), `test_judgment_dispatch_miss` (wall 2:
the seam), `test_judgment_string_promise_refusal`, plus the `resolveDispatchResource` unit pins and the
pristine-location pin beside the root-binding pair.

Also: `WithCatalog` renamed `WithResourceCatalog`; the executor value-copies the host's spec before
stamping run state; the stale `resolvePendingResources` doc block removed.

Refs #581, #586.

Gate: `make test` 103 ok / 0 fail; `make vet` clean under darwin, windows, and linux; `gofmt -l` clean.
