### PR TITLE
feat(op): same-URI production appends generations; GetOrCreate returns the canonical

### DIFF
--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -72,7 +72,7 @@ namespace. Its surface (tree-verified 2026-07-22):
 Discover(uri, factory)             ← observation: read-or-introduce, no production claim
 GetOrCreate(producerID, uri, factory) ← production: claim the URI for a producing unit
 Resolve(r) → (canonical, id)       ← return the canonical entry for a caller-built resource
-Shadow(r, producerID) → (id, err)  ← new version at an occupied URI; namespace repointed
+Shadow(r, producerID) → id         ← new generation at an occupied URI; namespace repointed (§4)
 Current(uri) → id                  ← the namespace's current version
 Lookup(id) / Len / Link            ← ledger access; Link interns an entry
 State(id) / MarkGone(r) / VerifyExistence(r) ← the state machine (below)

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -495,6 +495,10 @@ Steps:
    end on the run clone: a product at a claimed URI reaches the claimed entry (touch → Etag refresh; real
    change → shadow with `producerID`); a product at a fresh URI appends Active with the producer stamp;
    the trace tells the story. Fix what the audit contradicts; pin both directions.
+   **Corrected by the PR 2 audit (2026-08-22): the parenthetical conflated §4.1's Resolve cascade with
+   production.** The ruled matrix is unconditional for location production: a product at an occupied URI
+   — claimed, produced, or Gone — SHADOWS (fresh generation, producer stamp, prior generation as
+   history); the touch/Etag-refresh cascade is `Resolve`'s cache-hit behavior, not production's.
 6. **Immediate mode unchanged, pinned.** The session string path stays: immediate file ops construct and
    `Discover`-intern into the session catalog; the step-2 refusal never fires there.
 7. **Acceptance.** New judgment scenario — *save, reload, run*: every resource-typed slot dispatches the
@@ -583,8 +587,8 @@ and resolution — the seven rules), and §9 items 15–18.
    is exempt: its records are plan-authored data that may carry claimed resources (the writ-adopt shape),
    and the dispatch seam backstops the string case.
 
-**PR 1 record (2026-08-22, complete in tree — uncommitted) — the dispatch seam lands on the activation;
-the refusal's first catches; steps 1–4 delivered.**
+**PR 1 record (2026-08-22, merged as #613 — develop `4fd1cd64`; #609 closed) — the dispatch seam lands on
+the activation; the refusal's first catches; steps 1–4 delivered.**
 
 - **The seam**: `Method.Invoke`'s slot conversion routes resource-typed parameters through
   `resolveDispatchResource`, gated by `activation.Graph` — the per-dispatch frame carries dispatch kind
@@ -628,6 +632,39 @@ the refusal's first catches; steps 1–4 delivered.**
   the backstop.
 - Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean. PR 1's
   docket is complete.
+
+**PR 2 record (2026-08-22, complete in tree — uncommitted) — the production audit; two residues of the
+superseded model fixed; steps 5–6 delivered.**
+
+- **The audit's headline: `Shadow` still carried the superseded model's write-write conflict.** §4
+  (revised 2026-08-20) rules same-URI production as run-time generations — "legal versioning when the
+  plan ordered them, an authoring race when it did not" — but a different producer at an occupied URI
+  ERRORED ("resource conflict: URI targeted by both"). The error is gone: different producers append
+  generations, the namespace repoints, history survives; the dead error return retired with it
+  (`Shadow(r, producerID) → id`; §2's surface listing updated). Shadow's doc header — which still
+  described "the plan-time output registration operation" verbatim — rewritten to the ruled semantics.
+- **The second catch: `GetOrCreate` returned the raw candidate.** It ignored Shadow's returned id,
+  marked the CANDIDATE active (stamping Active under an empty id on the deference path), and handed
+  producers an un-interned object whenever Shadow adopted an existing generation. Now it looks up and
+  returns the canonical for whatever generation Shadow leaves current; and the producerless deference no
+  longer adopts a Gone entry — revival always appends, per the matrix.
+- **Step 5's parenthetical corrected** (noted at the step): production at an occupied location shadows
+  unconditionally; the touch/Etag-refresh cascade is `Resolve`'s cache-hit behavior (§4.1), never
+  production's.
+- **The pins.** Catalog level: different-producers-append-generations (replacing the conflict pin — a
+  pin of the superseded model), same-producer-appends, location-hit-shadows re-pinned with a REAL
+  producer (the old pin passed "" and pinned the raw-candidate bug), producerless-adopts-canonical.
+  Run-clone end to end (`pkg/op/provider/plan/production_matrix_test.go`): fresh-URI production (Active
+  + producer stamp in the trace), claimed-URI production (the claim's activated generation plus the
+  writer's shadow generation, both told by the trace), Gone revival (destroyer stamp on the Gone
+  generation, the writer's Active revival). Immediate mode (step 6): the session product interns, and
+  session-side Convert still constructs and claims — §5.6's second carve-out pinned. The coverage
+  self-audit added three more: producerless-over-Gone appends (the deference's Gone guard), the pristine
+  pin extended to products (a run's products never leak into the planning catalog), and
+  `resolveRecordedResource` unit pins (hit returns the canonical; miss, non-string, and non-resource
+  product types fall through unresolved — the rearm's tolerance, backstopped by the dispatch refusal).
+- Doc hygiene: stale §6.2 references → §3; GetOrCreate's conflict sentence retired.
+- Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean.
 
 **PR slicing (task issues filed 2026-08-22, indexed by #586):** PR 1
 ([#609](https://github.com/NobleFactor/devlore-cli/issues/609)) — steps 1–4, the dispatch seam (opening

--- a/pkg/op/provider/plan/production_matrix_test.go
+++ b/pkg/op/provider/plan/production_matrix_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package plan_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/application"
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/plan"
+)
+
+// region TEST FUNCTIONS
+
+// TestRun_ProductionAtFreshURI_AppendsActiveWithProducer pins the production matrix's first row
+// (4-resource-management.md §3) end to end on the run clone: a product at a fresh URI appends an Active
+// entry carrying the producing unit's stamp, and the trace tells the story.
+func TestRun_ProductionAtFreshURI_AppendsActiveWithProducer(t *testing.T) {
+
+	root := t.TempDir()
+
+	graph := assembleProductionGraph(t, root, func(provider *plan.Provider) []*op.Invocation {
+
+		write, err := provider.Plan(file.WriteText, nil, map[string]any{
+			"destination_path": "out.txt", "content": "produced", "mode": os.FileMode(0o600)})
+		if err != nil {
+			t.Fatalf("Plan(write_text): %v", err)
+		}
+		return []*op.Invocation{write}
+	})
+
+	executor := op.NewGraphExecutor(graph, runSpec(root))
+	if _, err := executor.Run(context.Background(), nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entries := traceEntriesFor(t, executor, "out.txt")
+	if len(entries) != 1 {
+		t.Fatalf("trace entries for the product = %d, want 1", len(entries))
+	}
+	if entries[0].State != op.Active {
+		t.Errorf("product state = %v, want Active", entries[0].State)
+	}
+	if !strings.Contains(entries[0].ProducerID, "write_text") {
+		t.Errorf("product producer = %q, want the writing unit's stamp", entries[0].ProducerID)
+	}
+
+	// Products are runtime facts on the run clone: the planning catalog gains nothing from the run —
+	// the pristine pin, extended from claims to production.
+	if got := graph.ResourceCatalog().Len(); got != 0 {
+		t.Errorf("planning catalog length after the run = %d, want 0 (products never leak backward)", got)
+	}
+}
+
+// TestRun_ProductionAtClaimedURI_ShadowsWithProducer pins the production matrix's occupied-location row:
+// a product at a CLAIMED URI appends a fresh generation with the producer stamp, and the claim's
+// activated generation survives as history — graph = intent, trace = the run's story.
+func TestRun_ProductionAtClaimedURI_ShadowsWithProducer(t *testing.T) {
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "data.txt"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := assembleProductionGraph(t, root, func(provider *plan.Provider) []*op.Invocation {
+
+		read, err := provider.Plan(file.ReadText, nil, map[string]any{"resource": "data.txt"})
+		if err != nil {
+			t.Fatalf("Plan(read_text): %v", err)
+		}
+		write, err := provider.Plan(file.WriteText, nil, map[string]any{
+			"destination_path": "data.txt", "content": read, "mode": os.FileMode(0o600)})
+		if err != nil {
+			t.Fatalf("Plan(write_text): %v", err)
+		}
+		return []*op.Invocation{read, write}
+	})
+
+	executor := op.NewGraphExecutor(graph, runSpec(root))
+	if _, err := executor.Run(context.Background(), nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entries := traceEntriesFor(t, executor, "data.txt")
+	if len(entries) != 2 {
+		t.Fatalf("trace entries for the claimed-and-produced URI = %d, want 2 (claim + shadow)", len(entries))
+	}
+
+	claim, shadow := entries[0], entries[1]
+	if claim.ProducerID != "" || claim.State != op.Active {
+		t.Errorf("claim generation = producer %q, state %v; want producerless Active (verified intent)",
+			claim.ProducerID, claim.State)
+	}
+	if !strings.Contains(shadow.ProducerID, "write_text") || shadow.State != op.Active {
+		t.Errorf("shadow generation = producer %q, state %v; want the writing unit's Active generation",
+			shadow.ProducerID, shadow.State)
+	}
+}
+
+// TestRun_ProductionAtGoneURI_RevivesByShadow pins the revival row: a destroyed entry stays Gone with the
+// destroyer stamp, and a later production at the same URI appends a fresh Active generation.
+func TestRun_ProductionAtGoneURI_RevivesByShadow(t *testing.T) {
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "data.txt"), []byte("doomed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := assembleProductionGraph(t, root, func(provider *plan.Provider) []*op.Invocation {
+
+		remove, err := provider.Plan(file.Remove, nil, map[string]any{
+			"target": "data.txt", "prune": false, "boundary": ""})
+		if err != nil {
+			t.Fatalf("Plan(remove): %v", err)
+		}
+		write, err := provider.Plan(file.WriteText, nil, map[string]any{
+			"destination_path": "data.txt", "content": "revived", "mode": os.FileMode(0o600)})
+		if err != nil {
+			t.Fatalf("Plan(write_text): %v", err)
+		}
+		return []*op.Invocation{remove, write}
+	})
+
+	executor := op.NewGraphExecutor(graph, runSpec(root))
+	if _, err := executor.Run(context.Background(), nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entries := traceEntriesFor(t, executor, "data.txt")
+	if len(entries) != 2 {
+		t.Fatalf("trace entries = %d, want 2 (the Gone generation + the revival)", len(entries))
+	}
+
+	gone, revived := entries[0], entries[1]
+	if gone.State != op.Gone || !strings.Contains(gone.DestroyedBy, "remove") {
+		t.Errorf("first generation = state %v, destroyed_by %q; want Gone with the destroyer stamp",
+			gone.State, gone.DestroyedBy)
+	}
+	if revived.State != op.Active || !strings.Contains(revived.ProducerID, "write_text") {
+		t.Errorf("revival = state %v, producer %q; want the writer's Active generation",
+			revived.State, revived.ProducerID)
+	}
+}
+
+// TestImmediateMode_ConstructionAndInterningSurvive pins §5.6's second carve-out (phase 4 step 6): the
+// session string path stays — an immediate file operation constructs and interns its product into the
+// session catalog, and session-side Convert still constructs a typed resource from a path string (the
+// graph-dispatch refusal never fires outside a graph).
+func TestImmediateMode_ConstructionAndInterningSurvive(t *testing.T) {
+
+	root := t.TempDir()
+
+	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}).
+		WithRoot(root))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = environment.Close() })
+
+	fileProvider := file.NewProvider(environment)
+
+	product, _, err := fileProvider.WriteText(
+		&op.ActivationRecord{RuntimeEnvironment: environment, Context: environment.Context},
+		"session.txt", "immediate", 0o600, "", "")
+	if err != nil {
+		t.Fatalf("immediate WriteText: %v", err)
+	}
+	if id := environment.ResourceCatalog.Current(product.URI()); id == "" {
+		t.Error("the immediate product was not interned into the session catalog")
+	}
+
+	converted, err := op.Convert(environment, "another.txt", reflect.TypeFor[*file.Regular]())
+	if err != nil {
+		t.Fatalf("session Convert(string → *file.Regular): %v — session construction must survive", err)
+	}
+	regular, ok := converted.(*file.Regular)
+	if !ok {
+		t.Fatalf("session Convert returned %T, want *file.Regular", converted)
+	}
+	if id := environment.ResourceCatalog.Current(regular.URI()); id == "" {
+		t.Error("the session-constructed resource was not interned as a claim")
+	}
+}
+
+// endregion
+
+// region HELPER FUNCTIONS
+
+// assembleProductionGraph plans and assembles a graph under a session environment rooted at `root`,
+// with the invocations `build` returns.
+func assembleProductionGraph(
+	t *testing.T, root string, build func(provider *plan.Provider) []*op.Invocation,
+) *op.Graph {
+
+	t.Helper()
+
+	environment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("test").
+		WithApplication(&application.Application{Name: "test"}).
+		WithRoot(root))
+	if err != nil {
+		t.Fatalf("op.NewRuntimeEnvironment: %v", err)
+	}
+	t.Cleanup(func() { _ = environment.Close() })
+
+	provider := plan.NewProvider(environment)
+
+	graph, err := provider.AssembleDefinition(build(provider), nil, nil, nil, nil, nil, provider.Origin("test"))
+	if err != nil {
+		t.Fatalf("AssembleDefinition: %v", err)
+	}
+
+	return graph
+}
+
+// traceEntriesFor returns the trace ledger entries whose URI contains `fragment`, in ledger append order.
+func traceEntriesFor(t *testing.T, executor *op.GraphExecutor, fragment string) []op.LedgerEntrySnapshot {
+
+	t.Helper()
+
+	trace := executor.Trace()
+	if trace == nil || trace.Catalog == nil {
+		t.Fatal("trace carries no ledger snapshot")
+	}
+
+	var matched []op.LedgerEntrySnapshot
+	for _, entry := range trace.Catalog.Entries {
+		if strings.Contains(entry.URI, fragment) {
+			matched = append(matched, entry)
+		}
+	}
+	return matched
+}
+
+// endregion

--- a/pkg/op/recovery_stack_test.go
+++ b/pkg/op/recovery_stack_test.go
@@ -6,10 +6,50 @@ package op
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+// TestResolveRecordedResource_HitReturnsTheCanonical pins the rearm's identity decode
+// (4-resource-management.md §5.6): a reloaded producer result — the resource's URI string — resolves
+// against the rehydrated catalog to the restored generation, never a fresh construction.
+func TestResolveRecordedResource_HitReturnsTheCanonical(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+	entry := newLifecycle("test:///produced", AddressingLocation)
+	catalog.Resolve(entry)
+
+	environment := &RuntimeEnvironment{ResourceCatalog: catalog}
+
+	canonical, resolved := resolveRecordedResource(environment, "test:///produced", reflect.TypeFor[*lifecycleResource]())
+	if !resolved {
+		t.Fatal("resolveRecordedResource(hit) did not resolve")
+	}
+	if canonical != Resource(entry) {
+		t.Errorf("resolved %p is not the catalog's canonical %p", canonical, entry)
+	}
+}
+
+// TestResolveRecordedResource_MissAndNonStringFallThrough pins the rearm's documented tolerance: an
+// unknown URI and a non-string result both fall through unresolved — the value is left as-is, and a
+// consumer that needed the concrete type meets the dispatch seam's refusal at its own dispatch.
+func TestResolveRecordedResource_MissAndNonStringFallThrough(t *testing.T) {
+
+	environment := &RuntimeEnvironment{ResourceCatalog: NewResourceCatalog()}
+	target := reflect.TypeFor[*lifecycleResource]()
+
+	if _, resolved := resolveRecordedResource(environment, "test:///unknown", target); resolved {
+		t.Error("a catalog miss must fall through unresolved (the rearm tolerates, dispatch refuses)")
+	}
+	if _, resolved := resolveRecordedResource(environment, 42, target); resolved {
+		t.Error("a non-string result must fall through unresolved")
+	}
+	if _, resolved := resolveRecordedResource(environment, "test:///x", reflect.TypeFor[string]()); resolved {
+		t.Error("a non-resource product type must fall through unresolved")
+	}
+}
 
 func TestRecoveryStack_Unwind_LIFO(t *testing.T) {
 	s := NewRecoveryStack()

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -274,13 +274,13 @@ func (c *ResourceCatalog) Discover(uri string, factory func() (Resource, error))
 // discovery-vs-production split documented on [ResourceCatalog].
 //
 // Cache-hit behavior branches on the existing entry's [Addressing] × [ResourceState] per
-// docs/architecture/4-resource-management.md §6.2's behavior matrix. The factory is invoked on cache miss, on
+// docs/architecture/4-resource-management.md §3's behavior matrix. The factory is invoked on cache miss, on
 // location-based hits (any state), and on Gone hits (either addressing — Gone is terminal, so revival appends a new
 // ledger entry via [Shadow]). Content-addressable hits on Pending or Active return the existing entry without invoking
-// the factory (singleton). The new or revived entry transitions to Active via [markActive] before returning.
+// the factory (singleton). The current generation transitions to Active via [markActive] before returning.
 //
-// A non-nil factory error short-circuits without touching the catalog. A different producer claiming the same URI
-// surfaces as a Shadow conflict (write-write detection).
+// A non-nil factory error short-circuits without touching the catalog. A different producer at an occupied
+// URI appends a generation (§4, revised 2026-08-20) — run-time versioning, never a conflict.
 //
 // Parameters:
 //   - `producerID`: the producing caller's id (`activation.CallerID` — a unit id or a starlark call-site), or ""
@@ -292,8 +292,7 @@ func (c *ResourceCatalog) Discover(uri string, factory func() (Resource, error))
 //
 // Returns:
 //   - `Resource`: the canonical catalog entry for `uri`, in state Active.
-//   - `error`: any factory error (returned untouched), or a [Shadow] conflict if a different producer already claimed
-//     the same URI.
+//   - `error`: any factory error (returned untouched).
 //
 // Panics with an [*assert.AssertionError] when any precondition is violated — these are programming errors at the call
 // site, not runtime conditions.
@@ -302,9 +301,9 @@ func (c *ResourceCatalog) GetOrCreate(producerID, uri string, factory func() (Re
 	assert.True("uri not empty", uri != "")
 	assert.True("factory required", factory != nil)
 
-	// Cache hit: content-addressable singletons return existing for non-Gone states (Rule 6). Location-based — and Gone on
-	// either addressing — fall through to shadow (Rules 7 and "Gone is terminal, revive via shadow"). See
-	// docs/architecture/4-resource-management.md §6.2.
+	// Cache hit: content-addressable singletons return existing for non-Gone states. Location-based — and Gone on
+	// either addressing — fall through to shadow ("Gone is terminal, revive via shadow"). See
+	// docs/architecture/4-resource-management.md §3's production matrix.
 	if id := c.Current(uri); id != "" {
 		if existing, ok := c.Lookup(id); ok {
 			if existing.Addressing() == AddressingContent && c.State(id) != Gone {
@@ -319,11 +318,17 @@ func (c *ResourceCatalog) GetOrCreate(producerID, uri string, factory func() (Re
 		return nil, err
 	}
 
-	if _, err := c.Shadow(candidate, producerID); err != nil {
-		return nil, err
+	// The canonical is whatever generation Shadow leaves current — the appended candidate, or the adopted
+	// existing generation on the producerless deference — never the raw candidate by fiat: marking and
+	// returning the candidate when Shadow adopted would hand the producer an un-interned, state-less
+	// object and stamp Active under an empty id.
+	id := c.Shadow(candidate, producerID)
+	canonical, ok := c.Lookup(id)
+	if !ok {
+		return nil, fmt.Errorf("get-or-create %q: shadow returned unknown catalog id %q", uri, id)
 	}
-	c.markActive(candidate)
-	return candidate, nil
+	c.markActive(canonical)
+	return canonical, nil
 }
 
 // Len returns the number of entries in the ledger.
@@ -471,55 +476,50 @@ func (c *ResourceCatalog) Resolve(r Resource) (canonical Resource, id string) {
 	return canonical, id
 }
 
-// Shadow catalogs a new resource version under the given producer and updates the namespace to point to it.
+// Shadow appends a new generation for r's URI and repoints the namespace at it — run-time versioning
+// (4-resource-management.md §4, revised 2026-08-20).
 //
-// Shadow is the plan-time output registration operation: a node's Planned companion constructs the identity of the
-// resource the node will produce, and the planner hands that identity to Shadow so subsequent [ResourceCatalog.Resolve]
-// calls for the same URI return the shadowed version — wiring downstream readers to the producer via the stamped
-// `producerID`.
+// The prior generation survives in the ledger as history; the trace tells the story "this URI was
+// version N, and the run made it version N+1." Two producers writing one URI are generations, not a
+// conflict — legal versioning when the plan ordered them, an authoring race when it did not (the former
+// write-write conflict error was the superseded plan-time output model's residue). Shadowing is how
+// production lands at an occupied URI (§3's production matrix, via [ResourceCatalog.GetOrCreate]) and how
+// a [Gone] URI revives.
 //
-// `producerID` may be empty. An empty `producerID` denotes a non-claiming dispatch — typically a bridge-side or test
-// [ActivationRecord] whose Unit is nil. Non-claiming dispatches defer to any existing claim on the same URI and never
-// produce a write-write conflict.
-//
-// Conflict, supersede, and defer semantics:
-//   - both empty, no existing entry → append a discovery entry, point namespace at it
-//   - both empty, existing also empty → idempotent re-discovery (append new ledger entry, repoint namespace)
-//   - incoming non-empty over existing empty → silently supersede (discovery yields to the producer claim)
-//   - incoming non-empty matches existing non-empty → idempotent re-claim (append new ledger entry)
-//   - incoming non-empty differs from existing non-empty → conflict error
-//   - incoming empty over existing non-empty → defer to the existing claim (no new entry, no namespace change)
+// One deference: an empty `producerID` — a non-graph caller — over a produced, non-Gone entry adopts the
+// existing generation rather than minting an anonymous one; a Gone entry is never adopted, so revival
+// always appends.
 //
 // Parameters:
-//   - `r`: the resource whose identity should be shadowed. URI must be set.
-//   - `producerID`: the node ID claiming ownership of the URI, or empty for a non-claiming dispatch.
+//   - `r`: the resource to catalog as the URI's new current generation. URI must be set.
+//   - `producerID`: the producing caller's stamp, or empty for a non-graph caller.
 //
 // Returns:
-//   - `string`: the catalog ID of either the newly-shadowed entry or the existing claim deferred to.
-//   - `error`: non-nil only on a non-empty/non-empty mismatch.
-func (c *ResourceCatalog) Shadow(r Resource, producerID string) (string, error) {
+//   - `string`: the catalog id of the URI's current generation — the appended one, or the adopted
+//     existing one on the producerless deference.
+func (c *ResourceCatalog) Shadow(r Resource, producerID string) string {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	uri := r.URI()
-
 	if existingID, ok := c.ns[namespaceKey(r)]; ok {
 		if idx, ok := c.byID[existingID]; ok {
+			// The one deference: a producerless act over a produced, non-Gone entry adopts the existing
+			// generation rather than minting an anonymous one (the documented [ResourceCatalog.GetOrCreate]
+			// contract for non-graph callers). A Gone entry is never adopted — revival appends (§3's
+			// production matrix).
 			existingProducer := c.entries[idx].resourceBase().producerID
-			switch {
-			case existingProducer != "" && producerID == "":
-				return existingID, nil
-			case existingProducer != "" && producerID != "" && existingProducer != producerID:
-				return "", fmt.Errorf(
-					"resource conflict: URI %q is targeted by both %q and %q",
-					uri, existingProducer, producerID,
-				)
+			if existingProducer != "" && producerID == "" && c.states[existingID] != Gone {
+				return existingID
 			}
 		}
 	}
 
-	return c.catalogLocked(r, producerID), nil
+	// Same-URI production appends a generation and repoints the namespace — run-time versioning
+	// (4-resource-management.md §4, revised 2026-08-20): two producers writing one URI are generations in
+	// the ledger, legal versioning when the plan ordered them and an authoring race when it did not. The
+	// former write-write conflict error was the superseded plan-time model's residue.
+	return c.catalogLocked(r, producerID)
 }
 
 // Snapshot projects the catalog into a serializable [*ResourceLedgerSnapshot] — every generation, keyed by id.
@@ -607,7 +607,7 @@ func (c *ResourceCatalog) State(id string) ResourceState {
 //
 // An entry already resolved to [Active] is left as-is (no re-check); otherwise the resource's [Resource.Exists]
 // predicate drives the catalog-owned transition — [markActive] when the resource exists, [markGone] plus an error when
-// it does not — so a [Pending] entry becomes [Active] or [Gone] per §6.2 of
+// it does not — so a [Pending] entry becomes [Active] or [Gone] per §3 of
 // docs/architecture/4-resource-management.md. The caller owns the reaction to a missing resource: the executor's
 // pre-flight resolve pass records the [Gone] mark and decides independently whether the run proceeds (a `Gone`
 // resource is a recorded fact; consumers of it fail on their own).

--- a/pkg/op/resource_catalog_test.go
+++ b/pkg/op/resource_catalog_test.go
@@ -87,9 +87,7 @@ func TestCatalog_Resolve_ReturnsShadowedVersionAfterShadow(t *testing.T) {
 	c := NewResourceCatalog()
 	shadowed := newFake("file:///etc/foo", 0, "")
 
-	if _, err := c.Shadow(shadowed, "node-A"); err != nil {
-		t.Fatalf("Shadow: %v", err)
-	}
+	c.Shadow(shadowed, "node-A")
 
 	lookup := newFake("file:///etc/foo", 0, "")
 	canonical, _ := c.Resolve(lookup)
@@ -134,10 +132,7 @@ func TestCatalog_Shadow_StampsProducerAndID(t *testing.T) {
 	c := NewResourceCatalog()
 	r := newFake("file:///etc/foo", 0, "")
 
-	id, err := c.Shadow(r, "node-A")
-	if err != nil {
-		t.Fatalf("Shadow: %v", err)
-	}
+	id := c.Shadow(r, "node-A")
 
 	if id == "" {
 		t.Fatalf("Shadow: want non-empty id")
@@ -160,10 +155,7 @@ func TestCatalog_Shadow_EmptyProducerAcceptedAsDiscovery(t *testing.T) {
 	c := NewResourceCatalog()
 	r := newFake("file:///etc/foo", 0, "")
 
-	id, err := c.Shadow(r, "")
-	if err != nil {
-		t.Fatalf("Shadow with empty producer: %v", err)
-	}
+	id := c.Shadow(r, "")
 	if id == "" {
 		t.Fatalf("Shadow with empty producer: want non-empty catalog id, got %q", id)
 	}
@@ -179,48 +171,76 @@ func TestCatalog_Shadow_EmptyProducerDefersToExistingClaim(t *testing.T) {
 
 	c := NewResourceCatalog()
 
-	claimedID, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
-	if err != nil {
-		t.Fatalf("claiming Shadow: %v", err)
-	}
+	claimedID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
 
-	deferredID, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "")
-	if err != nil {
-		t.Fatalf("empty-producer Shadow over existing claim: %v", err)
-	}
+	deferredID := c.Shadow(newFake("file:///etc/foo", 0, ""), "")
 	if deferredID != claimedID {
 		t.Fatalf("empty-producer Shadow: want catalog id %q (defer), got %q", claimedID, deferredID)
 	}
 }
 
-func TestCatalog_Shadow_ConflictOnDifferentProducer(t *testing.T) {
+// TestCatalog_Shadow_DifferentProducersAppendGenerations pins run-time versioning (§4, revised
+// 2026-08-20): two producers writing one URI are generations in the ledger — a fresh entry per producer,
+// the namespace repointed to the newest, the prior generation surviving as history. The former
+// write-write conflict error was the superseded plan-time output model's residue.
+func TestCatalog_Shadow_DifferentProducersAppendGenerations(t *testing.T) {
 
 	c := NewResourceCatalog()
 
-	if _, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A"); err != nil {
-		t.Fatalf("first Shadow: %v", err)
-	}
+	firstID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
+	secondID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-B")
 
-	_, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-B")
-	if err == nil {
-		t.Fatalf("second Shadow with different producer: want error, got nil")
+	if secondID == firstID {
+		t.Fatalf("second producer's Shadow: want a fresh generation, got the first id %q", firstID)
 	}
-
-	if !strings.Contains(err.Error(), "conflict") {
-		t.Fatalf("second Shadow: want error mentioning conflict, got %q", err.Error())
+	if got := c.Current("file:///etc/foo"); got != secondID {
+		t.Fatalf("namespace after second Shadow: want %q (the newest generation), got %q", secondID, got)
+	}
+	if first, ok := c.Lookup(firstID); !ok || first.ProducerID() != "node-A" {
+		t.Fatalf("first generation must survive as history with its producer stamp; ok=%v", ok)
+	}
+	if c.Len() != 2 {
+		t.Fatalf("ledger length = %d, want 2 (both generations)", c.Len())
 	}
 }
 
-func TestCatalog_Shadow_SameProducerAllowed(t *testing.T) {
+func TestCatalog_Shadow_SameProducerAppendsGeneration(t *testing.T) {
 
 	c := NewResourceCatalog()
 
-	if _, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A"); err != nil {
-		t.Fatalf("first Shadow: %v", err)
-	}
+	firstID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
+	secondID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
 
-	if _, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A"); err != nil {
-		t.Fatalf("second Shadow with same producer: %v", err)
+	if secondID == firstID {
+		t.Fatalf("same-producer re-production: want a fresh generation, got the first id %q", firstID)
+	}
+	if c.Len() != 2 {
+		t.Fatalf("ledger length = %d, want 2 (idempotent re-claim appends)", c.Len())
+	}
+}
+
+// TestCatalog_Shadow_ProducerlessOverGoneAppends pins the deference's Gone guard: a producerless act
+// never adopts a Gone generation — Gone is terminal, so revival always appends a fresh generation and
+// repoints the namespace (§3's production matrix).
+func TestCatalog_Shadow_ProducerlessOverGoneAppends(t *testing.T) {
+
+	c := NewResourceCatalog()
+
+	first := newFake("file:///etc/foo", 0, "")
+	firstID := c.Shadow(first, "node-A")
+	c.markActive(first)
+	c.markGone(first)
+
+	revivedID := c.Shadow(newFake("file:///etc/foo", 0, ""), "")
+
+	if revivedID == firstID {
+		t.Fatalf("producerless Shadow over a Gone entry adopted it; want a fresh revival generation")
+	}
+	if got := c.Current("file:///etc/foo"); got != revivedID {
+		t.Fatalf("namespace after revival = %q, want %q", got, revivedID)
+	}
+	if c.State(firstID) != Gone {
+		t.Fatalf("the Gone generation's state = %v, want Gone (history is never rewritten)", c.State(firstID))
 	}
 }
 
@@ -229,10 +249,7 @@ func TestCatalog_Shadow_SupersedesDiscovery(t *testing.T) {
 	c := NewResourceCatalog()
 	_, discoveryID := c.Resolve(newFake("file:///etc/foo", 0, ""))
 
-	shadowID, err := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
-	if err != nil {
-		t.Fatalf("Shadow over discovery: %v", err)
-	}
+	shadowID := c.Shadow(newFake("file:///etc/foo", 0, ""), "node-A")
 
 	if shadowID == discoveryID {
 		t.Fatalf("Shadow over discovery: want new id, got same id %q", shadowID)
@@ -303,8 +320,8 @@ func TestCatalog_Clone_NilReceiverReturnsNil(t *testing.T) {
 func TestCatalog_Clone_CopiesLedgerAndNamespace(t *testing.T) {
 
 	src := NewResourceCatalog()
-	_, _ = src.Shadow(newFake("file:///a", 0, ""), "node-A")
-	_, _ = src.Shadow(newFake("file:///b", 0, ""), "node-B")
+	src.Shadow(newFake("file:///a", 0, ""), "node-A")
+	src.Shadow(newFake("file:///b", 0, ""), "node-B")
 
 	clone := src.Clone()
 
@@ -346,16 +363,12 @@ func TestCatalog_Clone_StatesAreIndependent(t *testing.T) {
 func TestCatalog_Clone_IsIndependent(t *testing.T) {
 
 	src := NewResourceCatalog()
-	_, _ = src.Shadow(newFake("file:///shared", 0, ""), "src-producer")
+	src.Shadow(newFake("file:///shared", 0, ""), "src-producer")
 
 	clone := src.Clone()
 
-	if _, err := src.Shadow(newFake("file:///src-only", 0, ""), "src-producer"); err != nil {
-		t.Fatalf("post-Clone Shadow on src: %v", err)
-	}
-	if _, err := clone.Shadow(newFake("file:///clone-only", 0, ""), "clone-producer"); err != nil {
-		t.Fatalf("post-Clone Shadow on clone: %v", err)
-	}
+	src.Shadow(newFake("file:///src-only", 0, ""), "src-producer")
+	clone.Shadow(newFake("file:///clone-only", 0, ""), "clone-producer")
 
 	if clone.Current("file:///src-only") != "" {
 		t.Error("clone should not see entries added to src after Clone")
@@ -837,9 +850,7 @@ func TestCatalog_Shadow_StampsActiveAndProducer(t *testing.T) {
 	c := NewResourceCatalog()
 	r := newLifecycle("file:///out", AddressingLocation)
 
-	if _, err := c.Shadow(r, "node-A"); err != nil {
-		t.Fatalf("Shadow: %v", err)
-	}
+	c.Shadow(r, "node-A")
 	c.markActive(r)
 
 	if c.State(r.ID()) != Active {
@@ -859,9 +870,7 @@ func TestCatalog_GetOrCreate_CASHit_ReturnsExisting(t *testing.T) {
 
 	c := NewResourceCatalog()
 	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
-	if _, err := c.Shadow(first, "node-A"); err != nil {
-		t.Fatalf("Shadow: %v", err)
-	}
+	c.Shadow(first, "node-A")
 	c.markActive(first)
 
 	probe := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
@@ -882,15 +891,14 @@ func TestCatalog_GetOrCreate_LocationHit_Shadows(t *testing.T) {
 
 	c := NewResourceCatalog()
 	first := newLifecycle("file:///out", AddressingLocation)
-	if _, err := c.Shadow(first, "node-A"); err != nil {
-		t.Fatalf("Shadow first: %v", err)
-	}
+	c.Shadow(first, "node-A")
 	c.markActive(first)
 
-	// Same URI, second producer. Should shadow.
+	// Same URI, second producer: production at an occupied location shadows (§3's production matrix) —
+	// a fresh generation is canonical, the first survives as history.
 	second := newLifecycle("file:///out", AddressingLocation)
 
-	got, err := c.GetOrCreate("", second.URI(), func() (Resource, error) { return second, nil })
+	got, err := c.GetOrCreate("node-B", second.URI(), func() (Resource, error) { return second, nil })
 	if err != nil {
 		t.Fatalf("GetOrCreate: %v", err)
 	}
@@ -901,15 +909,41 @@ func TestCatalog_GetOrCreate_LocationHit_Shadows(t *testing.T) {
 	if c.State(got.ID()) != Active {
 		t.Errorf("new entry state = %v, want Active", c.State(got.ID()))
 	}
+	if c.Len() != 2 {
+		t.Errorf("ledger length = %d, want 2 (the first generation survives as history)", c.Len())
+	}
+}
+
+// TestCatalog_GetOrCreate_ProducerlessHitAdoptsCanonical pins the deference's fixed identity: a
+// producerless GetOrCreate over a produced, non-Gone entry returns the EXISTING canonical — never the
+// raw candidate (pre-fix, the un-interned candidate leaked out and Active was stamped under an empty id).
+func TestCatalog_GetOrCreate_ProducerlessHitAdoptsCanonical(t *testing.T) {
+
+	c := NewResourceCatalog()
+	first := newLifecycle("file:///out", AddressingLocation)
+	c.Shadow(first, "node-A")
+	c.markActive(first)
+
+	candidate := newLifecycle("file:///out", AddressingLocation)
+
+	got, err := c.GetOrCreate("", candidate.URI(), func() (Resource, error) { return candidate, nil })
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+
+	if got != Resource(first) {
+		t.Error("producerless hit must adopt the existing canonical, not hand out the raw candidate")
+	}
+	if c.Len() != 1 {
+		t.Errorf("ledger length = %d, want 1 (adoption appends nothing)", c.Len())
+	}
 }
 
 func TestCatalog_GetOrCreate_GoneHit_RevivesByShadow(t *testing.T) {
 
 	c := NewResourceCatalog()
 	first := newLifecycle("tag:..:sha256:abc#mem", AddressingContent)
-	if _, err := c.Shadow(first, "node-A"); err != nil {
-		t.Fatalf("Shadow first: %v", err)
-	}
+	c.Shadow(first, "node-A")
 	c.markActive(first)
 	c.markGone(first)
 


### PR DESCRIPTION
Phase 4, PR 2 of the resource-construction campaign (docs/plans/resource-construction.md). Closes #610.

The step-5 audit verified the §3 production matrix end to end on the run clone and found two live
residues of the superseded plan-time output model:

**`Shadow` still carried the write-write conflict.** §4 (revised 2026-08-20) rules same-URI production as
run-time generations — "legal versioning when the plan ordered them, an authoring race when it did not" —
but a different producer at an occupied URI errored ("resource conflict: URI targeted by both"). The
error is gone: different producers append generations, the namespace repoints, history survives. The
dead error return retired with it (`Shadow(r, producerID) → id`; §2's surface listing updated), and
Shadow's doc header — which still described "the plan-time output registration operation" verbatim — is
rewritten to the ruled semantics.

**`GetOrCreate` returned the raw candidate.** It ignored Shadow's returned id, marked the CANDIDATE
active (stamping Active under an empty id on the deference path), and handed producers an un-interned
object whenever Shadow adopted an existing generation. It now returns the canonical for whatever
generation Shadow leaves current, and the producerless deference no longer adopts a Gone entry —
revival always appends, per the matrix.

Also corrected: the plan's step-5 parenthetical had conflated `Resolve`'s Etag/digest cascade (§4.1)
with production — production at an occupied location shadows unconditionally.

**Pins.** Catalog level: different-producers-append-generations (replacing the conflict pin — a pin of
the superseded model), same-producer-appends, location-hit-shadows re-pinned with a real producer (the
old pin passed "" and pinned the raw-candidate bug), producerless-adopts-canonical,
producerless-over-Gone-appends. Run-clone end to end (`production_matrix_test.go`): fresh-URI
production (Active + producer stamp in the trace, planning catalog untouched), claimed-URI production
(claim generation + shadow generation), Gone revival (destroyer stamp + the writer's Active revival).
Immediate mode (step 6): the session product interns; session Convert still constructs and claims.
Plus `resolveRecordedResource` unit pins (hit returns the canonical; miss/non-string/non-resource fall
through unresolved).

Refs #581, #586.

Gate: `make test` 103 ok / 0 fail; `make vet` clean under darwin, windows, and linux; `gofmt -l` clean.
