### PR TITLE
feat(op): an unasserted claim resolves to its observed kind at activation

### DIFF
--- a/docs/plans/any-entry-claims.md
+++ b/docs/plans/any-entry-claims.md
@@ -251,7 +251,7 @@ and the rename, landed together; one finding made it not behavior-neutral after 
 - Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean. CI green on
   all three platforms.
 
-### Phase 2 — kind resolution at the transition — status: pending
+### Phase 2 — kind resolution at the transition — status: complete 2026-08-23 (#618), in tree
 
 1. A seam shaped like `op.RootBinder`: a resource that can resolve its own kind implements it
    (`file.Any` does; nothing else needs to).
@@ -262,6 +262,31 @@ and the rename, landed together; one finding made it not behavior-neutral after 
    happens exactly once, at the consuming scope's starting line.
 4. Pins: the resolution both directions (Active resolves to the observed kind; Gone stays `Any`),
    and the ledger holding one entry throughout.
+
+**Phase 2 record (2026-08-23) — the seam lands; the audit found the part that would have failed
+silently.**
+
+- `op.KindResolver` joins `op.RootBinder` on the transition: `ResolveKind() (Resource, error)` returns
+  the typed resource the observation names, freshly built and uninterned. `file.Any` implements it by
+  delegating to the same `observed()` helper its content-identity tiers use; no other scheme has a kind
+  axis, so no other scheme implements it and no other transition changes.
+- **The audit's catch: `candidateOfMode` builds an UNLINKED candidate** — a fresh URI whose type
+  fragment names the observed kind, and **no catalog id, no producer stamp**. Swapping that in naively
+  would have stranded `byID` on a row whose occupant answers `""` to `ID()`, and `markActive` would have
+  recorded the state under the empty id. Identity therefore crosses the swap and is stamped by the
+  **catalog** (`resolveKind`), not by the implementation — identity is the catalog's business, and an
+  implementation that stamped its own would be claiming an authority it does not have.
+- The namespace needs nothing: location addressing keys on the fragment-stripped URI, so `Any` and
+  `Regular` spellings name one identity. That is also what lets the type fragment move with the
+  resolution — which is how the trace comes to say `Regular` where the graph's intent says `Any`.
+- **A resolution failure is not an existence failure.** The entry has already been observed to exist, so
+  a resolver that errors leaves it Active and unasserted rather than converting a kind problem into a
+  missing-resource verdict.
+- Pins: five at the catalog level with fixtures (resolution with identity carried forward; the Gone
+  branch resolving nothing; exactly-once; the failure tolerance; a non-resolver untouched) and two at
+  the file level against a real filesystem (an `Any` claim becomes `*Regular` with one id and one ledger
+  row; an unmet claim stays `Any` and goes Gone).
+- Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean.
 
 ### Phase 3 — the designated mint type — status: pending
 

--- a/pkg/op/kind_resolution_test.go
+++ b/pkg/op/kind_resolution_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// region TEST FIXTURES
+
+// unassertedResource is a [KindResolver] fixture: it exists, and it resolves to `resolvesTo` — the shape
+// `file.Any` has, without the filesystem.
+type unassertedResource struct {
+	ResourceBase
+	addressingMode AddressingMode
+	present        bool
+	resolvesTo     Resource
+	resolveErr     error
+	resolveCalls   *int
+}
+
+func (r *unassertedResource) Addressing() AddressingMode { return r.addressingMode }
+func (r *unassertedResource) Exists() bool               { return r.present }
+func (r *unassertedResource) Resolve() error             { return nil }
+
+func (r *unassertedResource) ResolveKind() (Resource, error) {
+	*r.resolveCalls++
+	return r.resolvesTo, r.resolveErr
+}
+
+// resolvedResource is what an unasserted claim becomes: a distinct concrete type, freshly built, with no
+// catalog id and no producer stamp of its own.
+type resolvedResource struct {
+	ResourceBase
+	addressingMode AddressingMode
+}
+
+func (r *resolvedResource) Addressing() AddressingMode { return r.addressingMode }
+func (r *resolvedResource) Exists() bool               { return true }
+func (r *resolvedResource) Resolve() error             { return nil }
+
+// endregion
+
+// region TEST FUNCTIONS
+
+// TestVerifyExistence_ActiveBranchResolvesTheKind pins the transition's resolving half
+// (docs/plans/any-entry-claims.md, ruled 2026-08-23): an entry observed to exist becomes the kind the
+// observation names, and identity crosses the swap intact.
+//
+// The identity assertions are the ones that would fail silently if the carry-forward were wrong: the
+// resolved object arrives with no id, so without stamping, `byID` would point at a row whose occupant
+// answers "" to ID(), and the state would be recorded under the empty id instead of the entry's.
+func TestVerifyExistence_ActiveBranchResolvesTheKind(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+
+	resolved := &resolvedResource{
+		ResourceBase:   ResourceBase{uri: "test:///claimed#resolved"},
+		addressingMode: AddressingLocation,
+	}
+	calls := 0
+	unasserted := &unassertedResource{
+		ResourceBase:   ResourceBase{uri: "test:///claimed#unasserted"},
+		addressingMode: AddressingLocation,
+		present:        true,
+		resolvesTo:     resolved,
+		resolveCalls:   &calls,
+	}
+
+	_, id := catalog.Resolve(unasserted)
+	catalog.entries[catalog.byID[id]].resourceBase().producerID = "node-A"
+
+	if err := catalog.VerifyExistence(unasserted); err != nil {
+		t.Fatalf("VerifyExistence: %v", err)
+	}
+
+	entry, ok := catalog.Lookup(id)
+	if !ok {
+		t.Fatal("the entry vanished from the ledger")
+	}
+	if _, isResolved := entry.(*resolvedResource); !isResolved {
+		t.Fatalf("ledger holds %T, want the resolved kind", entry)
+	}
+	if entry.ID() != id {
+		t.Errorf("resolved entry ID = %q, want the entry's own %q — identity must cross the swap", entry.ID(), id)
+	}
+	if entry.ProducerID() != "node-A" {
+		t.Errorf("resolved entry producer = %q, want node-A carried forward", entry.ProducerID())
+	}
+	if got := catalog.State(id); got != Active {
+		t.Errorf("state = %v, want Active recorded under the entry's own id", got)
+	}
+	if catalog.Len() != 1 {
+		t.Errorf("ledger length = %d, want 1 — resolution replaces, never appends", catalog.Len())
+	}
+	if got := catalog.Current("test:///claimed"); got != id {
+		t.Errorf("namespace = %q, want %q — the fragment is not part of the key", got, id)
+	}
+}
+
+// TestVerifyExistence_GoneBranchResolvesNothing pins the other direction: nothing was observed, so an
+// unasserted claim has nothing to become and stays unasserted — the honest record of unmet intent.
+func TestVerifyExistence_GoneBranchResolvesNothing(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+
+	calls := 0
+	unasserted := &unassertedResource{
+		ResourceBase:   ResourceBase{uri: "test:///absent#unasserted"},
+		addressingMode: AddressingLocation,
+		present:        false,
+		resolvesTo:     &resolvedResource{ResourceBase: ResourceBase{uri: "test:///absent#resolved"}},
+		resolveCalls:   &calls,
+	}
+
+	_, id := catalog.Resolve(unasserted)
+
+	err := catalog.VerifyExistence(unasserted)
+	if err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want the catalog's does-not-exist verdict", err)
+	}
+	if calls != 0 {
+		t.Errorf("ResolveKind called %d times on the Gone branch, want 0", calls)
+	}
+
+	entry, _ := catalog.Lookup(id)
+	if _, stillUnasserted := entry.(*unassertedResource); !stillUnasserted {
+		t.Errorf("ledger holds %T after a Gone transition, want the unasserted entry unchanged", entry)
+	}
+	if got := catalog.State(id); got != Gone {
+		t.Errorf("state = %v, want Gone", got)
+	}
+}
+
+// TestVerifyExistence_ResolutionHappensExactlyOnce pins idempotence, which is free from the
+// already-Active early return: a second verification of the same entry neither re-resolves nor re-swaps.
+func TestVerifyExistence_ResolutionHappensExactlyOnce(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+
+	calls := 0
+	unasserted := &unassertedResource{
+		ResourceBase:   ResourceBase{uri: "test:///once#unasserted"},
+		addressingMode: AddressingLocation,
+		present:        true,
+		resolvesTo: &resolvedResource{
+			ResourceBase:   ResourceBase{uri: "test:///once#resolved"},
+			addressingMode: AddressingLocation,
+		},
+		resolveCalls: &calls,
+	}
+
+	catalog.Resolve(unasserted)
+
+	for range 3 {
+		if err := catalog.VerifyExistence(unasserted); err != nil {
+			t.Fatalf("VerifyExistence: %v", err)
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("ResolveKind called %d times, want exactly 1 — the transition happens once", calls)
+	}
+}
+
+// TestVerifyExistence_AResolutionFailureIsNotAnExistenceFailure pins the tolerance: the entry has
+// already been observed to exist, so a resolver that errors leaves it Active and unasserted rather than
+// converting a kind problem into a missing-resource verdict.
+func TestVerifyExistence_AResolutionFailureIsNotAnExistenceFailure(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+
+	calls := 0
+	unasserted := &unassertedResource{
+		ResourceBase:   ResourceBase{uri: "test:///unresolvable#unasserted"},
+		addressingMode: AddressingLocation,
+		present:        true,
+		resolveErr:     errUnresolvableKind,
+		resolveCalls:   &calls,
+	}
+
+	_, id := catalog.Resolve(unasserted)
+
+	if err := catalog.VerifyExistence(unasserted); err != nil {
+		t.Fatalf("VerifyExistence = %v, want nil — existence was observed", err)
+	}
+	if got := catalog.State(id); got != Active {
+		t.Errorf("state = %v, want Active", got)
+	}
+
+	entry, _ := catalog.Lookup(id)
+	if _, stillUnasserted := entry.(*unassertedResource); !stillUnasserted {
+		t.Errorf("ledger holds %T, want the entry left as it was", entry)
+	}
+}
+
+// TestVerifyExistence_ANonResolverIsUntouched pins that every scheme without a kind axis — which is
+// every scheme but file — transitions exactly as it did before the seam existed.
+func TestVerifyExistence_ANonResolverIsUntouched(t *testing.T) {
+
+	catalog := NewResourceCatalog()
+
+	plain := newLifecycle("test:///plain", AddressingLocation)
+	plain.present = true
+
+	_, id := catalog.Resolve(plain)
+
+	if err := catalog.VerifyExistence(plain); err != nil {
+		t.Fatalf("VerifyExistence: %v", err)
+	}
+
+	entry, _ := catalog.Lookup(id)
+	if entry != Resource(plain) {
+		t.Errorf("ledger holds %p, want the original %p — a non-resolver is never swapped", entry, plain)
+	}
+	if got := catalog.State(id); got != Active {
+		t.Errorf("state = %v, want Active", got)
+	}
+	if _, isResolver := Resource(plain).(KindResolver); isResolver {
+		t.Error("the fixture unexpectedly implements KindResolver; the assertion above proves nothing")
+	}
+}
+
+// endregion
+
+// errUnresolvableKind stands in for a kind the taxonomy cannot name — the failure a real resolver
+// reports when the disk holds something no variant covers.
+var errUnresolvableKind = errors.New("unresolvable kind")

--- a/pkg/op/provider/file/any.go
+++ b/pkg/op/provider/file/any.go
@@ -98,6 +98,22 @@ func (r *Any) Exists() bool {
 
 // endregion
 
+// ResolveKind returns the taxonomy variant the disk currently holds — the promise to observe, come due
+// (4-resource-management.md; [op.KindResolver]).
+//
+// An unasserted claim asserts existence and defers the kind; pre-flight's Pending → Active transition is
+// where the model first looks, so it is where the deferral ends. The returned variant is freshly built
+// and uninterned: the catalog stamps identity across the swap, because identity is the catalog's
+// business, not this resource's.
+//
+// Returns:
+//   - `op.Resource`: the observed-kind variant at this path.
+//   - `error`: an lstat failure, or an entry kind the taxonomy has no variant for.
+func (r *Any) ResolveKind() (op.Resource, error) {
+
+	return r.observed()
+}
+
 // endregion
 
 // region UNEXPORTED METHODS

--- a/pkg/op/provider/file/any_test.go
+++ b/pkg/op/provider/file/any_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -137,3 +138,73 @@ func anyAt(t *testing.T, environment *op.RuntimeEnvironment, rel string) *Any {
 }
 
 // endregion
+
+// TestAny_ResolvesToTheObservedKindAtTheTransition pins the seam end to end against a real filesystem:
+// an unasserted claim, verified through the catalog, becomes the variant the disk holds — and the ledger
+// keeps one entry with one identity throughout.
+//
+// The catalog-level mechanics are pinned in pkg/op; this is the half that proves file.Any actually
+// resolves, and that the URI's type fragment moves with it (which is how the trace comes to say
+// "Regular" where the graph's intent said "Any").
+func TestAny_ResolvesToTheObservedKindAtTheTransition(t *testing.T) {
+
+	dir := t.TempDir()
+	environment := testEnvironment(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "claimed.txt"), []byte("observed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	claim, err := DiscoverAny(environment, "claimed.txt")
+	if err != nil {
+		t.Fatalf("DiscoverAny: %v", err)
+	}
+	id := claim.ID()
+
+	if err := environment.ResourceCatalog.VerifyExistence(claim); err != nil {
+		t.Fatalf("VerifyExistence: %v", err)
+	}
+
+	entry, ok := environment.ResourceCatalog.Lookup(id)
+	if !ok {
+		t.Fatal("the entry vanished from the ledger")
+	}
+	if _, isRegular := entry.(*Regular); !isRegular {
+		t.Fatalf("ledger holds %T, want *Regular — the claim must become what the disk holds", entry)
+	}
+	if entry.ID() != id {
+		t.Errorf("resolved entry ID = %q, want %q — one identity throughout", entry.ID(), id)
+	}
+	if environment.ResourceCatalog.Len() != 1 {
+		t.Errorf("ledger length = %d, want 1 — resolution replaces, never appends",
+			environment.ResourceCatalog.Len())
+	}
+	if !strings.Contains(entry.URI(), "file.Regular") {
+		t.Errorf("resolved URI = %q, want the observed kind in its type fragment", entry.URI())
+	}
+}
+
+// TestAny_AnUnmetClaimStaysUnasserted pins the Gone direction with the real predicate: nothing is at the
+// path, so there is nothing to resolve to, and the entry records unmet intent as what it was claimed as.
+func TestAny_AnUnmetClaimStaysUnasserted(t *testing.T) {
+
+	environment := testEnvironment(t, t.TempDir())
+
+	claim, err := DiscoverAny(environment, "absent.txt")
+	if err != nil {
+		t.Fatalf("DiscoverAny: %v", err)
+	}
+	id := claim.ID()
+
+	if err := environment.ResourceCatalog.VerifyExistence(claim); err == nil {
+		t.Fatal("VerifyExistence returned no error for a path holding nothing")
+	}
+
+	entry, _ := environment.ResourceCatalog.Lookup(id)
+	if _, stillAny := entry.(*Any); !stillAny {
+		t.Errorf("ledger holds %T, want *Any — an unmet claim has nothing to become", entry)
+	}
+	if got := environment.ResourceCatalog.State(id); got != op.Gone {
+		t.Errorf("state = %v, want Gone", got)
+	}
+}

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -49,6 +49,29 @@ type RootBinder interface {
 	BindRoot(root fsroot.Dir)
 }
 
+// KindResolver is the kind-resolution seam (docs/plans/any-entry-claims.md, ruled 2026-08-23): a claim
+// that asserts existence without asserting kind becomes the kind the world actually holds, at the moment
+// the model first looks.
+//
+// An unasserted claim is in effect a promise to observe. Pre-flight's [Pending] → [Active] transition is
+// where the model first consults the world, so it is where the promise comes due: the entry is replaced
+// with the typed resource the observation names, once, at the consuming scope's starting line. The
+// [Gone] branch resolves nothing — nothing was observed, so there is nothing to resolve to, and the
+// entry honestly records an unmet unasserted claim.
+//
+// The catalog drives it and carries identity across the swap, because identity is the catalog's business:
+// an implementation returns a freshly typed resource and does NOT stamp the catalog id or producer onto
+// it. Resources whose scheme has no kind axis — every scheme but `file` today — simply do not implement
+// the interface, and their transitions are untouched.
+type KindResolver interface {
+
+	// ResolveKind returns the typed resource the observation names, freshly built and uninterned.
+	//
+	// Called only on the Active branch of a transition, so the entry is known to exist. A nil resource
+	// with a nil error means "nothing to resolve" and leaves the entry as it is.
+	ResolveKind() (Resource, error)
+}
+
 // Resource is the interface for all resource receiverTypes.
 //
 // Every provider-specific resource (e.g., file.Resource) must embed [ResourceBase] to satisfy it. The unexported

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -627,12 +627,56 @@ func (c *ResourceCatalog) VerifyExistence(resource Resource) error {
 	}
 
 	if resource.Exists() {
-		c.markActive(resource)
+		c.markActive(c.resolveKind(resource))
 		return nil
 	}
 
+	// The Gone branch resolves nothing: nothing was observed, so an unasserted claim has nothing to
+	// become and stays unasserted — an honest record of intent the world did not meet.
 	c.markGone(resource)
 	return fmt.Errorf("verify existence: resource %q does not exist", resource.URI())
+}
+
+// resolveKind replaces an unasserted entry with the kind the observation names — the [KindResolver]
+// seam's catalog half (docs/plans/any-entry-claims.md, ruled 2026-08-23).
+//
+// Identity crosses the swap and is stamped HERE rather than by the implementation, because identity is
+// the catalog's business: the resolved resource is freshly built and uninterned, so it arrives with no
+// catalog id and no producer stamp. Carrying both forward keeps `byID`, the state map, and the recovery
+// stack's id references pointing at the same row they always did — only the object standing in that row
+// changes, and with it the URI's type fragment, which is how the trace comes to say `Regular` where the
+// graph's intent said `Any`. The namespace is untouched: location addressing keys on the
+// fragment-stripped URI, so both spellings name one identity.
+//
+// A resource that does not implement [KindResolver], a resolver that returns nothing, and a resolver
+// that fails are all left exactly as they were — a resolution failure is not an existence failure, and
+// the entry has already been observed to exist.
+//
+// Parameters:
+//   - `resource`: the entry whose existence was just confirmed.
+//
+// Returns:
+//   - `Resource`: the resolved entry when one was produced; `resource` itself otherwise.
+func (c *ResourceCatalog) resolveKind(resource Resource) Resource {
+
+	resolver, ok := resource.(KindResolver)
+	if !ok {
+		return resource
+	}
+
+	resolved, err := resolver.ResolveKind()
+	if err != nil || resolved == nil {
+		return resource
+	}
+
+	existing := resource.resourceBase()
+	base := resolved.resourceBase()
+	base.id = existing.id
+	base.producerID = existing.producerID
+
+	c.rebindEntry(resource, resolved)
+
+	return resolved
 }
 
 // rebindEntry replaces `old`'s ledger slot with `bound` — the activation binding's copy-on-bind swap


### PR DESCRIPTION
Phase 2 of [any-entry-claims.md](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/any-entry-claims.md). Closes #618. Feature: #616.

An unasserted claim is a promise to observe. Pre-flight's `Pending → Active` transition is where the
model first consults the world, so it is where the promise comes due: **`op.KindResolver`** joins
`op.RootBinder` on that transition, and `ResourceCatalog.VerifyExistence` drives it. `file.Any` becomes
the variant the disk holds — once, at the consuming scope's starting line, since `VerifyExistence`
early-returns on an already-`Active` entry.

The `Gone` branch resolves nothing: nothing was observed, so an unasserted claim has nothing to become
and stays unasserted — the honest record of intent the world did not meet.

**The audit's catch, and the part that would have failed silently.** `candidateOfMode` builds an
*unlinked* candidate: a fresh URI whose type fragment names the observed kind, and **no catalog id, no
producer stamp**. Swapping that into the ledger naively would have left `byID` pointing at a row whose
occupant answers `""` to `ID()`, and `markActive` would have recorded the state under the empty id — a
corruption that no existing test would have caught, because every assertion downstream reads through the
namespace rather than the id.

Identity therefore crosses the swap and is stamped by the **catalog**, not by the implementation.
Identity is the catalog's business; an implementation that stamped its own id would be claiming an
authority it does not have. The namespace needs nothing — location addressing keys on the
fragment-stripped URI, so `Any` and `Regular` spellings name one identity, which is also what lets the
type fragment move with the resolution. That is how the trace comes to say `Regular` where the graph's
intent says `Any`: graph = intent, trace = observation, with one identity joining them.

**A resolution failure is not an existence failure.** The entry has already been observed to exist, so a
resolver that errors leaves it Active and unasserted rather than converting a kind problem into a
missing-resource verdict.

Schemes without a kind axis — every scheme but `file` — do not implement the interface, and their
transitions are untouched; that is pinned too.

**Pins:** five at the catalog level with fixtures (resolution with identity carried forward; the Gone
branch resolving nothing; exactly-once; the failure tolerance; a non-resolver untouched) and two at the
file level against a real filesystem (an `Any` claim becomes `*Regular` with one id and one ledger row;
an unmet claim stays `Any` and goes Gone).

Gate: `make test` 103 ok / 0 fail; `make vet` clean under darwin, windows, and linux; `gofmt -l` clean.
