### PR TITLE
docs(design): the file provider's record catches up with its reshaped surface

### DIFF
--- a/docs/architecture/3.5.4-file-provider.md
+++ b/docs/architecture/3.5.4-file-provider.md
@@ -17,7 +17,7 @@ See also:
 ## Thesis
 
 The file provider (`pkg/op/provider/file`, announced `op.RoleModule|op.RoleAction`, `+devlore:access=both`) is the
-framework's filesystem authority: 24 registered actions spanning mutation, observation, and path algebra, all
+framework's filesystem authority: 25 registered actions spanning mutation, observation, and path algebra, all
 confined to the runtime environment's `fsroot.Dir`. Three ideas carry the design:
 
 1. **One receipt, one compensating action.** Every mutation — create, update, delete, file or directory, from any
@@ -25,11 +25,14 @@ confined to the runtime environment's `fsroot.Dir`. Three ideas carry the design
    `file.compensate_file_mutation`. `CompensateFileMutation` inverts *any* file mutation by dispatching on the
    receipt's `MutationKind` — so a receipt built by `WriteText`, `Move`, or archive extraction compensates
    identically, regardless of which method or dispatcher created it.
-2. **A sealed, intent-declared taxonomy** (phase-8 step 23). `Entry` is the closed interface over exactly three
-   variants — `*Regular`, `*Directory`, `*SymbolicLink` — sealed by an unexported marker method. Kind is
-   **declared by the plan, never stat-assigned**: a plan that asserts one kind while the disk shows another is a
-   kind-mismatch error (`errKindMismatch`), and the same URI claimed under two kinds is a plan conflict surfaced at
-   the earliest claim.
+2. **A sealed taxonomy of asserted kinds** (phase-8 step 23; extended 2026-08-23). `Resource` is the closed
+   interface over four variants — `*Regular`, `*Directory`, `*SymbolicLink`, and `*Any` — sealed by an unexported
+   marker method over an unexported base. Kind is **declared, never stat-assigned**: a claim that asserts one kind
+   while the disk shows another fails verification at the starting line, and the two claims are reconciled by
+   strictness — a kinded claim and an unasserted one on the same rel are one identity, and the kinded claim keeps
+   the ledger slot because it is the one that can fail. `*Any` is the deliberate abstention: it asserts existence
+   alone, which is what a kind-indifferent operation like `move` or `remove` actually needs, and it resolves to the
+   observed kind at activation — the moment the model first consults the disk.
 3. **The write seam** (phase-8 step 49). Every write-path method routes occupied targets through the run's conflict
    policy — `stop` refuses, `skip` leaves the occupant untouched, `replace` (the floor) archives then overwrites —
    read live from the announced `runtime` config section.
@@ -38,11 +41,16 @@ confined to the runtime environment's `fsroot.Dir`. Three ideas carry the design
 
 | Type | Kind | Notes |
 |---|---|---|
-| `Entry` | the sealed interface | `op.Resource` + `Path() fsroot.Path` + the unexported seal |
+| `Resource` | the sealed interface | `op.Resource` + `Path() fsroot.Path` + the unexported seal. Every provider names its resource type `Resource`; file's is an interface rather than a struct because file alone has a kind axis |
+| `*Any` | **unasserted** | asserts existence and nothing else — what a kind-indifferent operation claims. Resolves to the observed kind at activation; a dangling link satisfies it, a FIFO does not |
 | `*Regular` | regular file | the read/write target type (`ReadBytes`/`ReadText` take it) |
-| `*Directory` | directory | `Mkdir`/`RemoveAll` territory |
-| `*SymbolicLink` | symlink | `Link`/`Unlink` territory; `Exists` is lstat — a link's existence is the link, never its target (2026-08-22) |
-| `Resource` | the catch-all base | deliberately **outside** the seal — a hand-built base value cannot enter a taxonomy signature |
+| `*Directory` | directory | `Mkdir` territory |
+| `*SymbolicLink` | symlink | `Link` territory; `Exists` is lstat — a link's existence is the link, never its target (2026-08-22) |
+| `resource` | the shared base | **unexported**: unnameable and un-hand-buildable outside the package, and outside the seal, so a bare base cannot enter a taxonomy signature |
+
+**An authored string claims as `*Any`** (§5.7 rule 6): the interface designates it, once, so a method that
+does not care about kind can take `Resource` and still be authored with a plain path. The kind is then the
+disk's business — resolved when pre-flight first looks.
 
 Candidates are built (`buildCandidateAs`) carrying the variant's canonical type id — the key the framework's
 rehydration constructors and the pre-flight staging gate dispatch on — then interned into the resource catalog.
@@ -93,10 +101,22 @@ stricter occupancy classification above the seam. Known gap: the encryption prov
 
 **Compensable mutators** (each returns its result plus a `*Receipt`; undo = `CompensateFileMutation` unless noted).
 **Mutation targets are consumed, claimed resources** (ruled 2026-08-20; delivered 2026-08-22, #585): `remove`,
-`unlink`, `remove_all`, and `move`'s source are resource-typed, so each mints a pending claim at plan time and is
+`remove_all`, `backup`, and `move`'s source are resource-typed, so each mints a pending claim at plan time and is
 verified by its consuming scope; a missing target follows `on_missing` (`stop`, the default, fails the scope;
 `ignore` makes the call and the receipt records the no-op), and destruction transitions the catalog entry Gone with
-the destroyer stamp ([4-resource-management.md](4-resource-management.md) §3).
+the destroyer stamp ([4-resource-management.md](4-resource-management.md) §3). **Policy parameters go last** —
+`(target, prune, boundary, on_missing)`: coupled parameters stay adjacent, and the failure posture is the one
+parameter that is not about the work.
+
+**Tolerance covers absence, never a kind mismatch** (ruled 2026-08-23): `ignore` means *the goal already holds*,
+true of an empty path and false of a surprise, so a claim whose path holds the wrong kind stops under every
+policy. That is what makes `writ decommission`'s tolerance safe — it claims the kind it deployed, so a link the
+user replaced with a real file is refused rather than deleted.
+
+**The removal family splits by blast radius, never by kind** (ruled 2026-08-23): `remove` takes one entry,
+`remove_all` takes an entry and everything beneath it, and both accept any kind. This is the standard library's
+split — `os.Remove` tries unlink then rmdir rather than asking the kind, which is why Go never needed an `Unlink`,
+and `os.RemoveAll` opens by calling `os.Remove`. `file.unlink` retired into `remove` for the same reason.
 
 **Claims are kind-honest** (ruled 2026-08-22, #586): each taxonomy kind's `Exists` is lstat plus a kind test, so a
 claim activates only when the disk holds the CLAIMED kind — a `*Regular` claim over a directory or a symbolic link
@@ -105,15 +125,13 @@ symlink to a regular file is kind symbolic-link), which is why the follow is its
 
 | Action | Announced kwargs | Notes |
 |---|---|---|
-| `file.backup` | `source_path, backup_suffix` | timestamped backup via `Move` |
+| `file.backup` | `source, backup_suffix` | timestamped backup via `Move`; the source is a consumed claim of any kind |
 | `file.copy` | `source, destination_path, chmod?, chown?` | contents copy with mode + Dockerfile-style ownership |
 | `file.link` | `source_path, target_path, verbatim?=false` | symlink; archives any displaced entry; `verbatim` stores the literal `source_path` instead of absolutizing it |
 | `file.mkdir` | `path, chmod?, chown?` | creates parents; boundary = nearest pre-existing ancestor |
-| `file.move` | `source, destination_path, on_missing?=stop` | the source is a consumed claim (`*Regular`) — success marks it Gone (destroyer stamp); archives any existing destination |
-| `file.move_directory` | `source, destination_path, on_missing?=stop` | `move`'s kind-honest sibling: a `*Directory` claim, so verification judges the claimed kind at the starting line (2026-08-22) |
-| `file.remove` | `target, on_missing?=stop, prune?, boundary?` | file or empty directory; consumed claim; archived |
-| `file.remove_all` | `target, on_missing?=stop, prune?, boundary?` | subtree removal; consumed claim; archived |
-| `file.unlink` | `target, on_missing?=stop, prune?, boundary?` | symlink removal; consumed claim; archived |
+| `file.move` | `source, destination_path` | moves **any kind** — a directory moves whole, a symbolic link moves as the link. The source is a consumed claim; success marks it Gone (destroyer stamp); archives any existing destination. **No `on_missing`**: moving what is gone accomplishes nothing, and a tolerated miss would hand downstream consumers a nil product |
+| `file.remove` | `target, prune?, boundary?, on_missing?=stop` | one entry of any kind — file, empty directory, or the link itself; a non-empty directory is refused, so destroying a tree must be said; consumed claim; archived |
+| `file.remove_all` | `target, prune?, boundary?, on_missing?=stop` | `rm -rf` with undo, any kind; over a symbolic link it removes the LINK, never the tree it designates; consumed claim; archived |
 | `file.walk_tree` | `root, fn, include_gitignored?` | depth-first fold of `fn` over entries; batch receipt = nested stack (`CompensateWalkTree`) |
 | `file.write_bytes` / `file.write_text` | `destination_path, content, chmod?, chown?` | inline content writes |
 | `file.write_file` | `target_path, src, mode` | streams `src` to disk — the deploy path's transport write |

--- a/docs/architecture/3.5.4-file-provider.status.md
+++ b/docs/architecture/3.5.4-file-provider.status.md
@@ -5,15 +5,26 @@
 test matrix below is verified against the tree (141 named Go tests across 8 test files in `pkg/op/provider/file`,
 plus 18 devlore-test fixtures — counts and names greped, not asserted). **Extended 2026-08-22 by the
 resource-construction campaign's phase 4** (#611): `file.discover` / `file.resolve` (the explicit conversion of
-run-computed paths — lstat and stat, `EntryKind` assertion, the runtime path grammar), `file.move_directory` (the
-kind-honest move sibling), and kind-honest `Exists` on all three taxonomy kinds. The counts above predate that
-addition; the new surface's coverage is the last rows of the matrix.
+run-computed paths — lstat and stat, kind assertion, the runtime path grammar) and kind-honest `Exists`.
+**Reshaped 2026-08-23 by #616**: the resource type became the sealed `Resource` interface over four variants,
+`file.move_directory` and `file.unlink` retired into kind-indifferent `move` and `remove`, and `backup` joined the
+claimed mutators. The counts above predate both; the new surface's coverage is the last rows of the matrix.
+
+**Known coverage gaps, measured 2026-08-24 and chartered on
+[#635](https://github.com/NobleFactor/devlore-cli/issues/635):** `Regular.MismatchesKind` and
+`Directory.MismatchesKind` have no test (only the symbolic-link predicate is pinned); `ResourceKind`'s JSON and
+YAML marshaling has none (only `UnmarshalText` is pinned, though the enum is what a saved document carries);
+`file.discover` / `file.resolve` have nine devlore-test scenarios and **zero Go unit tests**; and the unexported
+base retains a kind-blind, link-following `Exists` at zero coverage.
 
 ## Completion
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Sealed taxonomy (`Entry` = `Regular` / `Directory` / `SymbolicLink`) | Landed (step 23) | intent-declared, never stat-assigned; kind-mismatch + cross-kind-claim errors |
+| Sealed taxonomy (`Resource` = `Any` / `Regular` / `Directory` / `SymbolicLink`) | Landed (step 23; extended 2026-08-23, #616) | declared, never stat-assigned; `*Any` abstains and resolves at activation; a kinded claim supersedes an unasserted one on the same rel |
+| The unasserted claim (`*Any`), kind resolution at activation, the interface's designated mint type | Landed 2026-08-23 (#617–#619) | `op.KindResolver` + `op.RegisterResourceMint`; an authored path claims as `*Any` |
+| `file.move` takes any kind; `move_directory` retired | Landed 2026-08-23 (#620) | closes the symlink-move regression from #611 |
+| Removal splits by blast radius; `unlink` retired; `backup` claims; policy parameters last | Landed 2026-08-23 (#621) | tolerance covers absence, never a kind mismatch (`op.ErrClaimKindMismatch`) |
 | Unified mutation receipt (`MutationKind` ×5, boundary, recovery digest) | Landed | one receipt, one compensating action (`file.compensate_file_mutation`) |
 | Write seam + conflict policy `{stop, skip, replace}` | Landed (step 49) | floor `replace` (amended); reads the announced `runtime` config live |
 | `WalkTree` + batch compensation (nested stack) | Landed | `CompensateWalkTree` unwinds per-entry receipts |
@@ -36,7 +47,7 @@ names shown); "Starlark" = devlore-test fixtures.
 | `Link` | 4 + 4 `TestCompensateLink_*` | `test_link.star` | — |
 | `Mkdir` | 3 + 6 `TestCompensateMkdir_*` (boundary walks) | `test_mkdir_and_remove_all.star` | — |
 | `Move` | 5 `TestCompensateMove_*` (+ forward via Backup/seam paths) | `test_move.star` | closed — `TestMove_{IntoSubdirectory, OverwritesExistingDestination, MissingSource_ReturnsError}` (`provider_backfill_test.go`) |
-| `Remove` / `RemoveAll` / `Unlink` | 4 / 1 / 3 | `test_mkdir_and_remove_all.star`, `test_file_unlink.star` | closed — `TestRemoveAll_{NestedTree_RoundTrip, NonExistentPath_IsNoOp}` (`provider_backfill_test.go`) |
+| `Remove` / `RemoveAll` (any kind, 2026-08-23) | 4 / 1, plus `TestClaimedLink_OverARegularFile_IsAMismatchNotAnAbsence` | `test_mkdir_and_remove_all.star`, `test_file_remove_link.star`, `test_judgment_remove_any_kind.star` | `Regular.MismatchesKind` and `Directory.MismatchesKind` untested — see the coverage note above |
 | `WalkTree` | 4 `TestWalkTree_*` + 2 `TestCompensateWalkTree_{Nil, Empty}Stack_IsNoOp` | `test_walk_tree.star`, `test_walk_tree_closure.star`, `test_walk_tree_gitignore.star`, `test_walk_tree_planned.star` | closed — `TestWalkTree_*` + `TestCompensateWalkTree_{Nil, Empty}Stack_IsNoOp` (`provider_backfill_test.go`) |
 | `WriteBytes` / `WriteText` | 2 / 6 + 3 `TestCompensateWriteText_*` | `test_write_bytes.star`, `test_write_text.star`, `test_write_and_read.star` | — |
 | `WriteFile` (the seam proofs) | `TestWriteFile_Create_RemovedOnCompensate`, `TestWriteFile_Update_RestoredOnCompensate`, `TestCompensateFileMutation_{UnknownKind_Errors, DeleteDir_RecreatesDir}` (seam_test.go) | via writ deploy suites | — |
@@ -45,8 +56,9 @@ names shown); "Starlark" = devlore-test fixtures.
 | `Observe` | 1 (observation_test.go) | — | closed — `TestObserve_ReportsFileFields` (`observe_fields_test.go`); `.star` fixture re-dispositioned (`Observe` consumes a resolved `Entry`, not a path) — see [step 52](../plans/extract-starlark-from-op/phase-8/steps/52-test-backfill-round-2.md) Disposition |
 | `ReadBytes` / `ReadText` | 2 / 2 | `test_write_and_read.star` | — |
 | `Join` / `Name` / `Parent` / `Root` | 3 / 1 / 1 / 2 | `test_file_join.star`, `test_file_name.star`, `test_file_parent.star` | closed — `TestName_EdgeCases`, `TestParent_EdgeCases`, `TestRoot_ReturnsScopedRootPath`, `TestRoot_NilRoot_ReturnsEmpty` (`provider_backfill_test.go`) |
-| `Discover` / `Resolve` (2026-08-22, #611) | `TestEntryKind_*` (round-trip, lstat-strict admits), `TestNormalizeRuntimePath_TheRuntimeDialect` (per-OS) | `test_judgment_discover_after_exec.star`, `test_judgment_discover_kind_verdict.star`, `test_judgment_entry_default_consumer_mismatch.star`, `test_judgment_lstat_stat_pair.star`, `test_judgment_resolve_dangling.star`, `test_judgment_resolve_escape.star`, `test_judgment_runtime_escape_refusal.star`, `test_judgment_claimed_and_discovered.star`, `test_judgment_discovered_then_destroyed.star` | — |
-| `MoveDirectory` (2026-08-22, #611) | via the shared move core's suites | writ migrate's register suites | — |
+| `Discover` / `Resolve` (2026-08-22, #611) | `TestResourceKind_*` (round-trip, lstat-strict admits), `TestNormalizeRuntimePath_TheRuntimeDialect` (per-OS) — **no unit test of the methods themselves** | `test_judgment_discover_after_exec.star`, `test_judgment_discover_kind_verdict.star`, `test_judgment_entry_default_consumer_mismatch.star`, `test_judgment_lstat_stat_pair.star`, `test_judgment_resolve_dangling.star`, `test_judgment_resolve_escape.star`, `test_judgment_runtime_escape_refusal.star`, `test_judgment_claimed_and_discovered.star`, `test_judgment_discovered_then_destroyed.star` | — |
+| `Move` (any kind, 2026-08-23) | via the shared move core's suites | `test_judgment_move_any_kind.star` (all three kinds; the link moves, its target does not), `test_judgment_move_missing_source.star` | — |
+| `Any` — the unasserted claim | `TestAny_*` (predicate matrix incl. dangling link; content-identity delegation; resolution at the transition), `TestResourceKind_*` | `test_judgment_interface_slot_mints.star` | `ResourceKind`'s JSON/YAML marshaling untested |
 | kind-honest `Exists` (2026-08-22, #611) | `TestExists_IsKindHonest` (the 8-row matrix; symlink-to-regular is the door-one fix) | `test_judgment_kind_honest_activation.star` | — |
 | taxonomy / helpers | resource_test 12, regular_test 8, directory_test 9, symbolic_link_test 3, helpers_test 6 (incl. `TestChecksumFile_*`) | `test_file_lifecycle.star` | — |
 

--- a/docs/plans/any-entry-claims.md
+++ b/docs/plans/any-entry-claims.md
@@ -1,9 +1,9 @@
 ---
 title: "Any: claims that assert existence, not kind"
 issue: https://github.com/NobleFactor/devlore-cli/issues/616
-status: approved
+status: complete
 created: 2026-08-23
-updated: 2026-08-23
+updated: 2026-08-24
 ---
 
 # Plan: Any — claims that assert existence, not kind
@@ -407,13 +407,31 @@ Group B of the surface audit, each landing with its own pins and authoring sweep
   rule at the executor, and the mismatch-versus-absence distinction at the claim.
 - Gate: make check 103 ok / 0 fail; vet clean under darwin, windows, and linux; gofmt clean.
 
-### Phase 6 — closure — status: pending
+### Phase 6 — closure — status: complete 2026-08-24 (#622), in tree
 
 1. `3.5.4-file-provider.md` records the four-variant taxonomy, `Any`'s predicate, and the unified
    `move`; `4-resource-management.md` records the resolution-at-transition rule beside the kind-honest
    `Exists` block; both status files follow.
 2. The `resource-construction` plan gains a back-reference: phase 4's `move_directory` is superseded here,
    so the record shows why it existed and why it stopped existing.
+
+**Phase 6 record (2026-08-24) — the record catches up; most of it was already current.**
+
+- Each phase amended `4-resource-management.md` as it landed, so closure found §3's tolerance boundary and
+  `KindMismatcher` seam, §5.7's mint designation, and the kind-honest `Exists` block already written. What
+  remained was the file provider's own doc, which still described the pre-feature world.
+- `3.5.4-file-provider.md`: the thesis now says four variants over an unexported base rather than three, and
+  states the reconciliation rule (a kinded claim keeps the slot; `*Any` is the deliberate abstention); the
+  taxonomy table gains `*Any` and the unexported base; the action table drops `unlink` and `move_directory`,
+  reorders the policy parameter, and records the three rulings — blast radius over kind, tolerance covering
+  absence only, and `move` without a policy. The action count moved 24 → 25.
+- Both status files follow, and the file provider's records the **measured coverage gaps** (2026-08-24) rather
+  than implying the matrix is complete: the two untested `MismatchesKind` predicates, the kind enum's untested
+  JSON/YAML paths, `discover`/`resolve` having nine scenarios and zero unit tests, and the base's kind-blind
+  `Exists` at zero coverage. All chartered on #635.
+- The `resource-construction` plan carries the supersession in place rather than a rewrite: `move_directory`
+  existed because a claim had to name a kind, and the kind-honest activation that phase introduced is what made
+  the gap visible.
 
 ## Judgment scenarios
 

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -418,6 +418,13 @@ catalog exposed.**
   kind-honest claims for directory moves ride the 3.6 method-classification work.
 - Every file-scheme mutator is now a resource-typed consumer. Gate: make check 103 ok / 0 fail,
   GOOS=windows vet clean.
+
+**Superseded 2026-08-23 by [#616](https://github.com/NobleFactor/devlore-cli/issues/616) (AnyEntry).** This
+phase's `file.move_directory` existed only because a claim had to name a kind, and the same constraint had
+just cost `file.move` the ability to move a symbolic link. #616 gave the taxonomy a claim that asserts
+existence without asserting kind (`file.Any`), after which `move_directory` and `unlink` both retired into
+kind-indifferent `move` and `remove`. The record is kept rather than rewritten: the kind-honest activation this
+phase introduced is what made the gap visible, and the gap is what produced the better shape.
 4. Consequence for phase 1's stored section: every stored entry is Pending by construction. **RULED
    2026-08-21: the stored row drops `state` entirely** — the intent row becomes its own `{id, uri}` type
    (presence IS the pending claim), splitting from the trace's `LedgerEntrySnapshot`, whose


### PR DESCRIPTION
Phase 6 of [any-entry-claims.md](https://github.com/NobleFactor/devlore-cli/blob/develop/docs/plans/any-entry-claims.md). Closes #622, and with it feature #616.

Most of the record was already current: each phase amended `4-resource-management.md` as it landed, so closure
found §3's tolerance boundary and the `KindMismatcher` seam, §5.7's mint designation, and the kind-honest
`Exists` block already written. What remained was the file provider's own doc, which still described the
pre-feature world.

**`3.5.4-file-provider.md`** — the thesis now says four variants over an unexported base rather than three, and
states the reconciliation rule: a kinded claim keeps the ledger slot because it is the one that can fail, and
`*Any` is the deliberate abstention that resolves at activation. The taxonomy table gains `*Any` and the
unexported base; the action table drops `unlink` and `move_directory`, moves the policy parameter last, and
records the three rulings — blast radius over kind, tolerance covering absence only, and `move` without a
policy. Action count 24 → 25.

**Both status files follow**, and the file provider's records the **measured** coverage gaps (2026-08-24)
rather than implying the matrix is complete: `Regular.MismatchesKind` and `Directory.MismatchesKind` untested
(only the symbolic-link predicate is pinned — and those two are what protect a deployed copy replaced by a
directory); `ResourceKind`'s JSON/YAML marshaling untested, though the enum is what a saved document carries;
`file.discover` / `file.resolve` with nine devlore-test scenarios and zero Go unit tests; and the unexported
base's kind-blind, link-following `Exists` at zero coverage. All chartered on #635.

**The resource-construction plan** carries the supersession in place rather than a rewrite: `move_directory`
existed because a claim had to name a kind, and the kind-honest activation that phase introduced is exactly
what made the gap visible. The record shows why it existed and why it stopped existing.

Docs only; no code changes. Closes #622. Refs #616, #635.

Gate: `make test` 103 ok / 0 fail; `gofmt -l` clean.
