### PR TITLE
fix(op): slice accessors return copies; drop a gen group member the generator retired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,16 +305,20 @@ dist-clean: ## Remove distribution archives
 # Each grouped target (&:) fires one star invocation that produces all gen files. | $(STAR)
 # Generation runs only when provider.go is newer than the gen outputs.
 #
-# access=both     → receiver_type.gen_test + action.gen_test + node_builder.gen_test + module.gen_test + provider
-# access=planned  → receiver_type.gen_test + action.gen_test + node_builder.gen_test + provider
+# access=both     → receiver_type.gen_test + action.gen_test + module.gen_test + provider
+# access=planned  → receiver_type.gen_test + action.gen_test + provider
 # access=immediate → receiver_type.gen_test + module.gen_test + provider
+#
+# Every member listed must be one the generator actually emits: under GNU Make 4.4.1's grouped-target
+# semantics a member that can never appear leaves the whole group permanently stale, so the recipe reruns
+# on every build and cross-compiles die on the exec-format mismatch. node_builder.gen_test was retired
+# with NodeBuilder (phase 5) and removed from these groups on 2026-08-24 (#572).
 
 # --- access=both providers ---
 
 $(P)/json/action_names.gen.go \
 $(P)/json/gen/receiver_type.gen_test.go \
 $(P)/json/gen/action.gen_test.go \
-$(P)/json/gen/node_builder.gen_test.go \
 $(P)/json/gen/module.gen_test.go \
 $(P)/json/gen/provider.gen.go &: $(P)/json/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/json --gen=true --write=true --output=$(P)/json
@@ -322,7 +326,6 @@ $(P)/json/gen/provider.gen.go &: $(P)/json/provider.go | $(STAR)
 $(P)/platform/action_names.gen.go \
 $(P)/platform/gen/receiver_type.gen_test.go \
 $(P)/platform/gen/action.gen_test.go \
-$(P)/platform/gen/node_builder.gen_test.go \
 $(P)/platform/gen/module.gen_test.go \
 $(P)/platform/gen/provider.gen.go &: $(P)/platform/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/platform --gen=true --write=true --output=$(P)/platform
@@ -330,7 +333,6 @@ $(P)/platform/gen/provider.gen.go &: $(P)/platform/provider.go | $(STAR)
 $(P)/regex/action_names.gen.go \
 $(P)/regex/gen/receiver_type.gen_test.go \
 $(P)/regex/gen/action.gen_test.go \
-$(P)/regex/gen/node_builder.gen_test.go \
 $(P)/regex/gen/module.gen_test.go \
 $(P)/regex/gen/provider.gen.go &: $(P)/regex/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/regex --gen=true --write=true --output=$(P)/regex
@@ -338,7 +340,6 @@ $(P)/regex/gen/provider.gen.go &: $(P)/regex/provider.go | $(STAR)
 $(P)/template/action_names.gen.go \
 $(P)/template/gen/receiver_type.gen_test.go \
 $(P)/template/gen/action.gen_test.go \
-$(P)/template/gen/node_builder.gen_test.go \
 $(P)/template/gen/module.gen_test.go \
 $(P)/template/gen/provider.gen.go &: $(P)/template/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/template --gen=true --write=true --output=$(P)/template
@@ -346,7 +347,6 @@ $(P)/template/gen/provider.gen.go &: $(P)/template/provider.go | $(STAR)
 $(P)/yaml/action_names.gen.go \
 $(P)/yaml/gen/receiver_type.gen_test.go \
 $(P)/yaml/gen/action.gen_test.go \
-$(P)/yaml/gen/node_builder.gen_test.go \
 $(P)/yaml/gen/module.gen_test.go \
 $(P)/yaml/gen/provider.gen.go &: $(P)/yaml/provider.go $(P)/yaml/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/yaml --gen=true --write=true --output=$(P)/yaml
@@ -356,7 +356,6 @@ $(P)/yaml/gen/provider.gen.go &: $(P)/yaml/provider.go $(P)/yaml/resource.go | $
 $(P)/appnet/action_names.gen.go \
 $(P)/appnet/gen/receiver_type.gen_test.go \
 $(P)/appnet/gen/action.gen_test.go \
-$(P)/appnet/gen/node_builder.gen_test.go \
 $(P)/appnet/gen/provider.gen.go \
 $(P)/appnet/gen/resource.gen.go &: $(P)/appnet/provider.go $(P)/appnet/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/appnet --gen=true --write=true --output=$(P)/appnet
@@ -364,21 +363,18 @@ $(P)/appnet/gen/resource.gen.go &: $(P)/appnet/provider.go $(P)/appnet/resource.
 $(P)/archive/action_names.gen.go \
 $(P)/archive/gen/receiver_type.gen_test.go \
 $(P)/archive/gen/action.gen_test.go \
-$(P)/archive/gen/node_builder.gen_test.go \
 $(P)/archive/gen/provider.gen.go &: $(P)/archive/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/archive --gen=true --write=true --output=$(P)/archive
 
 $(P)/encryption/action_names.gen.go \
 $(P)/encryption/gen/receiver_type.gen_test.go \
 $(P)/encryption/gen/action.gen_test.go \
-$(P)/encryption/gen/node_builder.gen_test.go \
 $(P)/encryption/gen/provider.gen.go &: $(P)/encryption/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/encryption --gen=true --write=true --output=$(P)/encryption
 
 $(P)/file/action_names.gen.go \
 $(P)/file/gen/receiver_type.gen_test.go \
 $(P)/file/gen/action.gen_test.go \
-$(P)/file/gen/node_builder.gen_test.go \
 $(P)/file/gen/module.gen_test.go \
 $(P)/file/gen/provider.gen.go &: $(P)/file/provider.go $(P)/file/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/file --gen=true --write=true --output=$(P)/file
@@ -386,7 +382,6 @@ $(P)/file/gen/provider.gen.go &: $(P)/file/provider.go $(P)/file/resource.go | $
 $(P)/git/action_names.gen.go \
 $(P)/git/gen/receiver_type.gen_test.go \
 $(P)/git/gen/action.gen_test.go \
-$(P)/git/gen/node_builder.gen_test.go \
 $(P)/git/gen/provider.gen.go \
 $(P)/git/gen/resource.gen.go &: $(P)/git/provider.go $(P)/git/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/git --gen=true --write=true --output=$(P)/git
@@ -394,7 +389,6 @@ $(P)/git/gen/resource.gen.go &: $(P)/git/provider.go $(P)/git/resource.go | $(ST
 $(P)/pkg/action_names.gen.go \
 $(P)/pkg/gen/receiver_type.gen_test.go \
 $(P)/pkg/gen/action.gen_test.go \
-$(P)/pkg/gen/node_builder.gen_test.go \
 $(P)/pkg/gen/provider.gen.go \
 $(P)/pkg/gen/resource.gen.go &: $(P)/pkg/provider.go $(P)/pkg/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/pkg --gen=true --write=true --output=$(P)/pkg
@@ -402,7 +396,6 @@ $(P)/pkg/gen/resource.gen.go &: $(P)/pkg/provider.go $(P)/pkg/resource.go | $(ST
 $(P)/service/action_names.gen.go \
 $(P)/service/gen/receiver_type.gen_test.go \
 $(P)/service/gen/action.gen_test.go \
-$(P)/service/gen/node_builder.gen_test.go \
 $(P)/service/gen/provider.gen.go \
 $(P)/service/gen/resource.gen.go &: $(P)/service/provider.go $(P)/service/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/service --gen=true --write=true --output=$(P)/service
@@ -410,21 +403,18 @@ $(P)/service/gen/resource.gen.go &: $(P)/service/provider.go $(P)/service/resour
 $(P)/shell/action_names.gen.go \
 $(P)/shell/gen/receiver_type.gen_test.go \
 $(P)/shell/gen/action.gen_test.go \
-$(P)/shell/gen/node_builder.gen_test.go \
 $(P)/shell/gen/provider.gen.go &: $(P)/shell/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/shell --gen=true --write=true --output=$(P)/shell
 
 $(P)/powershell/action_names.gen.go \
 $(P)/powershell/gen/receiver_type.gen_test.go \
 $(P)/powershell/gen/action.gen_test.go \
-$(P)/powershell/gen/node_builder.gen_test.go \
 $(P)/powershell/gen/provider.gen.go &: $(P)/powershell/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/powershell --gen=true --write=true --output=$(P)/powershell
 
 $(P)/function/action_names.gen.go \
 $(P)/function/gen/receiver_type.gen_test.go \
 $(P)/function/gen/action.gen_test.go \
-$(P)/function/gen/node_builder.gen_test.go \
 $(P)/function/gen/provider.gen.go \
 $(P)/function/gen/resource.gen.go &: $(P)/function/provider.go $(P)/function/resource.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/function --gen=true --write=true --output=$(P)/function
@@ -432,7 +422,6 @@ $(P)/function/gen/resource.gen.go &: $(P)/function/provider.go $(P)/function/res
 $(P)/flow/action_names.gen.go \
 $(P)/flow/gen/receiver_type.gen_test.go \
 $(P)/flow/gen/action.gen_test.go \
-$(P)/flow/gen/node_builder.gen_test.go \
 $(P)/flow/gen/provider.gen.go &: $(P)/flow/provider.go | $(STAR)
 	$(STAR) devlore actions generate --source=$(P)/flow --gen=true --write=true --output=$(P)/flow
 

--- a/pkg/op/accessor_aliasing_test.go
+++ b/pkg/op/accessor_aliasing_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"testing"
+)
+
+// region TEST FUNCTIONS
+
+// TestSliceAccessors_DoNotAliasInternalStorage pins that the graph's slice accessors return copies
+// (#532): a caller outside pkg/op could otherwise rewrite which edges and children the graph records,
+// leaving the construction checksum describing contents that no longer exist.
+//
+// Each accessor is written through with a deliberately wrong value; the graph must be unmoved. The
+// elements themselves stay shared — that is the sharing the rule permits, and only the slice header is
+// defended.
+func TestSliceAccessors_DoNotAliasInternalStorage(t *testing.T) {
+
+	first, err := NewNode(NewNodeSpec().WithID("first").WithAction(&action{name: "file.copy"}))
+	if err != nil {
+		t.Fatalf("NewNode(first): %v", err)
+	}
+	second, err := NewNode(NewNodeSpec().WithID("second").WithAction(&action{name: "file.copy"}))
+	if err != nil {
+		t.Fatalf("NewNode(second): %v", err)
+	}
+	intruder, err := NewNode(NewNodeSpec().WithID("intruder").WithAction(&action{name: "file.copy"}))
+	if err != nil {
+		t.Fatalf("NewNode(intruder): %v", err)
+	}
+
+	graph, err := NewGraph(NewGraphSpec().WithOrigin(OriginBase{}).WithUnits(first, second))
+	if err != nil {
+		t.Fatalf("NewGraph: %v", err)
+	}
+	root := graph.Root()
+	root.edges = []Edge{{From: "first", To: "second"}}
+
+	t.Run("Graph.Edges", func(t *testing.T) {
+		edges := graph.Edges()
+		if len(edges) == 0 {
+			t.Fatal("no edges to write through")
+		}
+		edges[0] = Edge{From: "intruder", To: "intruder"}
+
+		if got := graph.Edges()[0]; got.From != "first" || got.To != "second" {
+			t.Errorf("the graph's edge became %+v; the accessor aliases its storage", got)
+		}
+	})
+
+	t.Run("Subgraph.Edges", func(t *testing.T) {
+		edges := root.Edges()
+		if len(edges) == 0 {
+			t.Fatal("no edges to write through")
+		}
+		edges[0] = Edge{From: "intruder", To: "intruder"}
+
+		if got := root.Edges()[0]; got.From != "first" || got.To != "second" {
+			t.Errorf("the subgraph's edge became %+v; the accessor aliases its storage", got)
+		}
+	})
+
+	t.Run("Subgraph.Children", func(t *testing.T) {
+		children := root.Children()
+		if len(children) < 2 {
+			t.Fatalf("children = %d, want at least 2 to write through", len(children))
+		}
+		children[0] = intruder
+
+		if got := root.Children()[0]; got.ID() == "intruder" {
+			t.Error("the subgraph was re-parented through Children(); the accessor aliases its storage")
+		}
+	})
+
+	t.Run("the elements stay shared", func(t *testing.T) {
+		if got := root.Children()[0]; got != root.Children()[0] {
+			t.Error("successive calls yield different units; only the slice header should be copied")
+		}
+	})
+}
+
+// endregion

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -643,9 +644,13 @@ func (g *Graph) Checksum() string { return g.checksum }
 
 // Edges returns the ordering edges at the root level.
 //
+// A copy: the graph's construction checksum is computed over its contents, so a caller that could
+// rewrite the recorded edges could leave the checksum describing a graph that no longer exists. The Edge
+// values inside are shared, which is exactly the sharing the rule permits.
+//
 // Returns:
-//   - `[]Edge`: the root-level dependency edges in insertion order.
-func (g *Graph) Edges() []Edge { return g.root.edges }
+//   - `[]Edge`: a copy of the root-level dependency edges, in insertion order.
+func (g *Graph) Edges() []Edge { return slices.Clone(g.root.edges) }
 
 // Filename returns the standard filename for this graph.
 //

--- a/pkg/op/subgraph.go
+++ b/pkg/op/subgraph.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
@@ -109,25 +110,27 @@ func (s *Subgraph) ChildByID(id string) ExecutableUnit {
 
 // Children returns this subgraph's direct children in their assembled order.
 //
-// Topological order once [Subgraph.sortChildren] has run; otherwise declaration order. The returned slice aliases the
-// unexported storage; callers must not mutate it.
+// Topological order once [Subgraph.sortChildren] has run; otherwise declaration order. A copy: writing
+// through the returned slice would re-parent a subtree and leave the construction checksum describing
+// contents that no longer exist. The units themselves are shared — that is the sharing the rule permits.
 //
 // Returns:
-//   - `[]ExecutableUnit`: the direct children.
+//   - `[]ExecutableUnit`: a copy of the direct children.
 func (s *Subgraph) Children() []ExecutableUnit {
 
-	return s.executableUnits
+	return slices.Clone(s.executableUnits)
 }
 
 // Edges returns this subgraph's edges.
 //
-// The returned slice aliases the underlying storage; callers must not mutate it directly.
+// A copy, for the reason [Subgraph.Children] gives: external mutation becomes impossible rather than
+// discouraged.
 //
 // Returns:
-//   - `[]Edge`: the edges (it may be nil).
+//   - `[]Edge`: a copy of the edges (nil when there are none).
 func (s *Subgraph) Edges() []Edge {
 
-	return s.edges
+	return slices.Clone(s.edges)
 }
 
 // endregion


### PR DESCRIPTION
Two verified defects from the epic audit. Closes #532 and #572.

## #532 — slice accessors aliased the graph's internal storage

`Graph.Edges`, `Subgraph.Edges`, and `Subgraph.Children` returned the graph's own slices, so a caller
outside `pkg/op` could rewrite which edges and children the graph records — leaving the construction
checksum describing contents that no longer exist. `Subgraph.Edges` documented the defect rather than
fixing it: *"The returned slice aliases the underlying storage; callers must not mutate it directly."*

All three now `slices.Clone`. External mutation becomes impossible rather than discouraged, and the
elements inside stay shared — exactly the sharing the rule permits. The three "must not mutate" comments
are gone because they are no longer true.

Pinned as the issue's exit asks: each accessor is written through with a deliberately wrong value and the
graph is asserted unmoved, plus a check that the units themselves are still shared so only the slice
header is defended.

## #572 — a grouped-target member the generator can never emit

Every provider's grouped generation target listed `gen/node_builder.gen_test.go`, whose emission was
retired with NodeBuilder in phase 5. Under GNU Make 4.4.1's grouped-target (`&:`) semantics a member that
can never appear leaves the whole group **permanently stale**, so codegen re-ran on every single build.
Removed from all 16 groups, and the comment block above them corrected to describe what is actually
emitted — with the reason recorded, so the next member added is checked against the generator.

**Verified rather than assumed:** a second consecutive `make build` now runs **zero** codegen invocations.
Before the fix every group was stale, so it ran them all, every time.

The issue's second half — *"the groups are also missing a member in the other direction"* — is **already
correct** in the tree: all 19 providers that emit `gen/module.gen_test.go` list it. Only the
`node_builder` half was live.

## What this does not fix

`GOOS=linux make build` still fails, and it is a **separate defect**, now filed as #639: `GOOS`/`GOARCH`
are ambient, so cross-compiling the product also cross-compiles the *build tools* — `go run
./cmd/devlore-inventory` produces a Linux binary and then tries to execute it on the host. The standing
cross-platform gate never caught it because `make vet` compiles without running anything.

Gate: `make test` 103 ok / 0 fail; `make vet` clean under darwin, windows, and linux; `gofmt -l` clean.
