### PR TITLE
docs(plan): sealed resources split in two parts; the fragment names the interface

### DIFF
--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -1,153 +1,397 @@
 ---
-title: "Sealed provider resources: every <provider>.Resource is an interface"
+title: "Sealed provider resources: every announced resource type is an interface"
 issue: https://github.com/NobleFactor/devlore-cli/issues/625
 status: approved
 created: 2026-08-23
-updated: 2026-08-23
+updated: 2026-08-24
 ---
 
-# Plan: Sealed provider resources — every `<provider>.Resource` is an interface
+# Plan: Sealed provider resources — every announced resource type is an interface
 
 ## Summary
 
-Make the shape the file provider now has the shape every provider has: **`<provider>.Resource` is a
-sealed interface**, implemented by an unexported struct **`<provider>.resource`** that carries the
-identity and serializes. One rule, no exceptions: *every provider exposes `Resource`, and only that
-provider can produce one.*
+**Every announced resource type is a sealed interface, implemented by an unexported struct.** One rule,
+no exceptions: a provider resource can be produced only by the provider that declares it.
 
-**This is a correctness change. Consistency is its dividend, not its motive** — and the dividend is
-worth naming, because it compounds: one rule with no exceptions is easier to teach, easier to learn, and
+`file` announces four such types (its kind axis); the other eight announce one each. That is not an
+exception — it is one rule applied four times in one place and once in eight others.
+
+**This is a correctness change. Consistency is its dividend, not its motive** — and the dividend is worth
+naming, because it compounds: one rule with no exceptions is easier to teach, easier to learn, and
 therefore easier to onboard into and cheaper to maintain for as long as the codebase lives. A rule with
 one exception is two rules, and the exception is what every newcomer trips over.
 
-The correctness half. An exported struct resource is hand-buildable — `&git.Resource{SourcePath: …}`
-compiles in any package — producing an un-interned, unclaimed resource that can be handed straight into
-a dispatch. Every guarantee the resource model makes assumes resources come from the catalog:
+## The correctness case, concretely
 
-- *claims are true when made* — a hand-built resource was never verified;
-- *identity is the catalog key* — a hand-built resource holds a URI the ledger never issued;
-- *a string is a key, never a constructor* — the dispatch seam refuses run-time construction, then
-  accepts a struct literal that did the same thing at compile time;
+The threat is not a struct literal somebody might one day write. **No `&<provider>.Resource{…}` exists
+outside its own package anywhere in the tree** — checked across all eight on 2026-08-24. The live threat
+is a path the framework already takes.
+
+`tryHydrateStruct` ([pkg/op/convert.go:441](../../pkg/op/convert.go)) is generic map→struct hydration
+inside `op.Convert`. Its guard admits any conversion whose source is a string-keyed map and whose target
+has concrete kind `reflect.Struct`. A resource slot declaring `*service.Resource` satisfies that today.
+So an author who supplies a dict where a resource is expected gets `reflect.New(concrete).Elem()` — a
+freshly minted `service.Resource` with its exported fields filled from the map.
+
+The embedded `op.ResourceBase` has only unexported fields, so it stays zero. `URI()` returns `""`. The
+value is not merely unclaimed, it is **identity-less** — and it reaches
+[pkg/op/provider/service/provider.go:50](../../pkg/op/provider/service/provider.go), which reads
+`name.Name` directly (20 such reads, none re-canonicalizing) and calls `sm.Disable(name.Name)` against
+the host. A host mutation performed for a resource the ledger never issued.
+
+Every guarantee the resource model makes is bypassed on that path:
+
+- *claims are true when made* — nothing was verified;
+- *identity is the catalog key* — the URI is empty;
+- *a string is a key, never a constructor* — the dispatch seam refuses run-time construction, then a map
+  does the same thing one layer down;
 - *the graph carries complete intent* — an unclaimed resource is intent the document never recorded.
 
-Eight providers leave that door open beside those guarantees. A sealed interface closes it: the
-unexported marker method means only the declaring package can implement it, and the unexported struct
-means no one outside can build one. The resource model stops depending on everyone's good manners and
-starts depending on the compiler.
+**Sealing removes the path rather than policing it.** The guard requires `reflect.Struct`. Once the slot
+type is an interface, `tryHydrateStruct` declines and `Convert` falls through to the registered
+constructor, which interns through the catalog. Nothing is left to remember to check.
 
-## The rulings this plan implements (USER, 2026-08-23)
+`file` is exposed here too, and more quietly: its variants carry **zero exported fields**, so hydration
+fills nothing yet still forges and returns an identity-less `*Regular`. Part 1 alone would leave the
+most-used provider open on the very path that motivates the feature — which is why part 2 is not polish.
 
-1. **Every `<provider>.Resource` is an interface** — sealed by an unexported marker method, so
-   implementations cannot be added from outside the package.
-2. **The underlying struct is unexported (`<provider>.resource`) and is what serializes** — the identity
-   payload and the type id in the URI fragment name the concrete struct, as they do today; only its
-   visibility changes.
-3. **Naming is uniform**: the interface takes the provider's headline name (`Resource`), the base takes
-   its lowercase form (`resource`) — the rule already applied to `file` (`Resource`/`resource`).
+**What this does not fix.** `ConvertFrom` — e.g.
+[pkg/op/provider/service/resource.go:305](../../pkg/op/provider/service/resource.go) — returns
+`&Resource{Name: str}`, the same identity-less value, and it ships. Its own doc comment hands the problem
+downstream: *"Provider methods consuming the projected Resource are responsible for re-canonicalization
+… when full identity is required."* That is in-package construction, which the seal permits by design.
+It is a separate defect and needs its own issue.
 
-## Prior art in the tree
+## The rulings this plan implements
 
-The `file` provider arrived here first, for a different reason — it has a kind axis, so its resource had
-to be an interface over `Regular` / `Directory` / `SymbolicLink` / `Any`. Feature
-[#616](https://github.com/NobleFactor/devlore-cli/issues/616) renamed that interface to `Resource` and
-its base to `resource` precisely so file would stop being the exception. This plan finishes the thought:
-the other nine adopt the same shape, and the exception disappears in the other direction too.
+From 2026-08-23 (USER):
 
-Providers in scope (nine): `git`, `pkg`, `service`, `appnet`, `mem`, `json`, `yaml`, `function`, and any
-resource-bearing provider added before this lands. `file` is already done.
+1. **Every `<provider>.Resource` is an interface** — sealed by an unexported method, so implementations
+   cannot be added from outside the package.
+2. **The underlying struct is unexported (`<provider>.resource`) and is what carries the identity
+   payload.**
+3. **Naming is uniform**: the interface takes the provider's headline name (`Resource`), the struct takes
+   its lowercase form (`resource`).
+
+From 2026-08-24 (USER), after phase-1 investigation:
+
+4. **The URI fragment names the interface, not the struct.** This supersedes the fragment clause of
+   ruling 2. Because ruling 3 gives the interface the name the struct gave up, `typeIDOf` yields a
+   byte-identical string — `…/provider/service.Resource` before and after. See *The correction* below for
+   why the alternative was rejected.
+5. **The work splits in two parts.** Part 1: the eight single-resource providers. Part 2: `file`'s four
+   variants. The goal is reached only at the end of part 2 — the intermediate state is `file` announcing
+   structs while the others announce interfaces, and that is accepted as temporary, not as a stopping
+   point.
+6. **`file`'s variant interfaces are discriminated by `kind() <Interface>`** — `kind() Regular` on
+   `Regular`, `kind() Directory` on `Directory`, and so on.
+
+## The correction
+
+The original plan rested on an enabling fact that is **false**, and phase 1 exists to surface exactly
+this kind of thing. It claimed `pkg/op/provider/<p>/gen/*.gen.go` declares the provider's own package, so
+generated announcements could name unexported types. Verified 2026-08-24 with `go list`:
+
+```
+github.com/NobleFactor/devlore-cli/pkg/op/provider/service       name=service
+github.com/NobleFactor/devlore-cli/pkg/op/provider/service/gen   name=service
+```
+
+Two import paths, the same package *name*, **different packages**. The gen file imports the provider as
+`provider` and can name only its exported identifiers. The earlier check evidently read the
+`package service` line and stopped before the import.
+
+That mattered because the fragment is `typeIDOf(goType) = PkgPath() + "." + Name()`
+([pkg/op/resource.go:529](../../pkg/op/resource.go)). Holding to ruling 2's fragment clause would have
+required each provider to export a `ResourceType() reflect.Type` seam for the gen file to announce — and
+`reflect.New` on that seam forges a resource, reopening the door the feature exists to close. It would
+also have moved every URI, contradicting this plan's own no-drift criterion.
+
+Ruling 4 dissolves both problems: the gen files name `provider.Resource` and `provider.DiscoverResource`,
+exactly as they do today, and **need no changes at all**.
+
+A second correction: the original said nine providers were in scope besides `file`. There are **eight** —
+`appnet`, `function`, `git`, `json`, `mem`, `pkg`, `service`, `yaml` — confirmed by enumerating
+`AnnounceResource` call sites.
+
+## What ruling 4 costs
+
+The receiver machinery is written for concrete types, and `reflect` treats an interface differently in
+three ways at once. All three surface in phase 1 and are paid once.
+
+**Where it breaks.**
+
+1. **The two `PointerTo` promotions** — [pkg/op/helpers.go:258](../../pkg/op/helpers.go) and
+   [pkg/op/receiver_type.go:357](../../pkg/op/receiver_type.go). Both read *"if not a pointer, make it
+   one, so pointer-receiver methods are visible."* On an interface that yields `*Resource` — a pointer to
+   interface, whose method set is **empty**. Providers that announce method metadata fail loudly at init
+   (`parseParameters` → `MethodByName` → `"method Equal: not found on type service.Resource"`).
+   `file.Any`, which announces `nil`, fails **silently** with zero methods, because `parseParameters`
+   returns an empty but non-nil map and the announced path then matches nothing.
+
+2. **`NewMethod` cannot consume an interface method at all** —
+   [pkg/op/method.go:178](../../pkg/op/method.go). Per `reflect`, an interface type's `Method` has
+   `Func == nil` and a `Type` carrying **no receiver**. So `do.Type.In(0)` yields the first *parameter*
+   for `Equal(other any)`, producing the action name `"..Equal"`, and **panics** outright for a no-arg
+   method like `Etag()`, where `NumIn()` is 0. Ten lines on, `doFn := do.Func` is the zero `Value` and
+   `doFn.Call` panics.
+
+3. **Unexported methods become visible.** `NumMethod` counts them *only* for interface types, so
+   `sealedResource` and — after part 2 — `kind` would enter the iteration.
+
+**The change: `receiverType` stores the concrete type and the type id, not the interface.**
+
+Point 2 is why *"stop promoting interfaces"* is not the fix. Enumeration is not the problem; the
+machinery cannot build a dispatchable method from an interface however it is reached. Route it back to
+concrete types instead, and split the one field that is doing two jobs:
+
+- **the concrete `*resource`** serves method enumeration, promotion, dispatch, and the `byType` key at
+  [pkg/op/receiver_registry.go:960](../../pkg/op/receiver_registry.go) — which must key on the concrete
+  type, because `marshalReflect` looks up by `reflect.TypeOf(value)`.
+- **a stored `typeID string`**, computed once from the interface at announce time, serves the two
+  `typeIDOf(ProviderType()) == typeID` comparisons at `receiver_registry.go:486` and `:513`, which match
+  against an id lifted from a URI.
+
+Those two consumers sit on adjacent lines and want opposite things: `:513` needs the interface's id,
+`:514` needs a concrete type to `reflect.New`. That is the whole difficulty, and splitting the field
+resolves it — including `UnpackerByTypeID`, which starts working again for `function`, `json`, `mem`, and
+`yaml` because `:513` matches on the stored id while `:514` mints from the concrete type.
+
+With the concrete type restored, points 1 and 3 evaporate on their own: promotion applies to a struct
+again, and `reflect` on a non-interface excludes unexported methods, so no `PkgPath()` filter is needed
+anywhere.
+
+`AnnounceResource` takes the concrete type as an **explicit argument** rather than resolving it through
+`RegisterResourceMint`, so announcement carries no init-order dependency on registration. The gen file
+emits both.
+
+**The dividend.** The type id stops being re-derived from a Go type at every site and becomes a declared
+identity. Today any Go rename silently invalidates every saved document; afterwards the id is a value that
+can be seen and pinned.
+
+Checked and *not* a cost: `plannerForType` ([pkg/op/planner.go:147](../../pkg/op/planner.go)) does the
+same nil-interface probe but is only ever called with `metadata.Planner` — never a resource type. And
+`deriveMethodParams` ([pkg/op/receiver_type.go:702](../../pkg/op/receiver_type.go)) already filters
+`!m.IsExported()`.
+
+One consequence ruling 6 does add: `file`'s variant interfaces each declare `kind()`, so part 2 must
+confirm the concrete-type routing holds for four interfaces rather than one.
+
+## What serialization does — and does not — do
+
+**URIs do not move.** Ruling 4 makes the fragment `typeIDOf(interface)`, and ruling 3 gives the interface
+the name the struct gave up, so the string is identical. The `resources` section of a document is
+byte-identical for the same intent, before and after every phase.
+
+**Resource payloads do not move.** A resource encodes as its URI (`UnmarshalJSON` takes a bare URI
+string), and `encoding/json` marshals the exported fields of an unexported struct exactly as it does an
+exported one.
+
+**Receipt product-type ids move for resource-bearing results, and ruling 4 does not cover them.** This is
+a separate string, derived from a different type by a different function.
+
+`ReceiptBase.Commit` records `canonicalIDOf(result)` — the produced value's **dynamic** type
+([pkg/op/receipt.go:438](../../pkg/op/receipt.go)). `ProductTypeByID` resolves it through an index built
+from **every** action method's **declared** result type
+([pkg/op/receiver_registry.go:542](../../pkg/op/receiver_registry.go)). The two need not agree, and today
+they agree only by coincidence:
+
+- `file.Move`, `Remove`, `RemoveAll`, and `Backup` already return the `Resource` interface, so they record
+  a concrete dynamic id — `*…/file.Regular`, say. That id resolves because `file.Copy` independently
+  *declares* `*Regular` and contributes the key. `*Directory` comes from `Mkdir`, `*SymbolicLink` from
+  `Link`. Every kind those four can produce happens to be some other method's declared return.
+
+**Sealing removes the coincidence.** The dynamic type becomes `*…/file.regular`, an unexported struct no
+method declares, so nothing contributes the key and the lookup misses. And the miss is **silent** —
+`retypeStampedResult` ([pkg/op/recovery_stack.go:647](../../pkg/op/recovery_stack.go)) reads:
+
+```go
+productType, ok := ReceiverRegistry().ProductTypeByID(s.resultType)
+if !ok {
+	return
+}
+```
+
+A resumed run then leaves the result as its raw decoded value — the bare URI string — instead of retyping
+it into a resource. No error, no log; the receipt quietly stops being a resource.
+
+So this is not a bug the change introduces. It is a **latent fragility the change converts into a live
+silent failure across every provider**, and phase 1 fixes it by recording the announced identity on both
+sides. Because the failure mode passes a test suite unnoticed, it needs its own pin: a resume that
+asserts the *retyped* result, not merely that resume succeeds.
+
+Once both sides agree, the id is `…/service.Resource` without the `*` that today's pointer return
+produces. Receipts therefore **do** change, and that is accepted: the alternative is preserving a `*` that
+no longer describes anything.
+
+**The delta is narrow.** `ResultType` is `omitempty` and `canonicalIDOf` returns `""` for nil, so a
+method with no result omits the field entirely. `file.WalkTree` returns `any` — whatever its reducer
+produced — and a reducer returning an int records `int` before and after. **Only receipts whose result is
+a provider resource move at all.**
+
+**And error text diverges from document text.** `%T` prints `*service.resource`; the URI says
+`service.Resource`. Anyone matching one against the other is now wrong.
+
+## How ruling 6 works
+
+Go compares full method signatures, result types included. So:
+
+```go
+type Regular interface {
+	Resource
+	kind() Regular
+}
+
+type Directory interface {
+	Resource
+	kind() Directory
+}
+```
+
+`*regular` has `kind() Regular` and therefore **cannot** satisfy `Directory`. And because a type may
+declare only one method named `kind`, mutual exclusivity is structural rather than conventional — a
+concrete type cannot be two kinds at once. Recursive interfaces are legal Go, and there is no collision:
+no file resource has a `Kind` method today, and `ResourceKind` is a separate enum type.
+
+This is why the discriminator is not four differently-named markers. Four names would keep the kinds
+distinct but would say nothing about exclusivity; one name with four result types says both, and says it
+to the compiler.
+
+**Without a discriminator the kind system collapses silently.** `Regular` and `Directory` have identical
+exported method sets — verified 2026-08-24:
+
+```
+Regular    Digest Equal Etag Exists MismatchesKind String Unmarshal{JSON,Text,YAML}
+Directory  Digest Equal Etag Exists MismatchesKind String Unmarshal{JSON,Text,YAML}
+```
+
+As bare interfaces they would be structurally interchangeable, `r.(Directory)` would succeed for a
+regular file, and every kind-honesty guarantee established by
+[#616](https://github.com/NobleFactor/devlore-cli/issues/616) would evaporate without a single test
+failing. This is the load-bearing detail of part 2.
 
 ## Epic and issue placement
 
 **Epic: #444 — The resource model (`Epic:ResourceModel`).**
-**Feature: [#625](https://github.com/NobleFactor/devlore-cli/issues/625)** — *Sealed provider resources:
-every `<provider>.Resource` is an interface*.
+**Feature: [#625](https://github.com/NobleFactor/devlore-cli/issues/625).**
 
-| Phase | Task |
-| --- | --- |
-| 1 | [#626](https://github.com/NobleFactor/devlore-cli/issues/626) seal `service` — prove the pattern |
-| 2 | [#627](https://github.com/NobleFactor/devlore-cli/issues/627) seal `git`, `json`, `yaml`, `appnet` |
-| 3 | [#628](https://github.com/NobleFactor/devlore-cli/issues/628) seal `mem`, `function`, `pkg` |
-| 4 | [#629](https://github.com/NobleFactor/devlore-cli/issues/629) make the shape structurally enforceable |
-| 5 | [#630](https://github.com/NobleFactor/devlore-cli/issues/630) closure — the design record states the contract |
+| Part | Phase | Task | Scope |
+| --- | --- | --- | --- |
+| 1 | 1 | #641 | framework repairs and `service` — the template |
+| 1 | 2 | #642 | `git`, `appnet` |
+| 1 | 3 | #643 | `json`, `yaml`, `mem`, `function` — the `Unpacker` four |
+| 1 | 4 | #644 | `pkg` — the widest footprint |
+| 2 | 5 | #645 | `file`'s four variants, discriminated by `kind()` |
+| — | 6 | #646 | the rule becomes structurally enforceable |
+| — | 7 | #647 | closure — the design record states the contract |
 
-## The mechanic that has to be solved first
+Supersedes #626–#630, which were filed against the original phase shape and are closed as superseded.
 
-**Announcements are generated into a sibling package.** `pkg/op/provider/<p>/gen/*.gen.go` is
-`package file` / `package git` etc. — checked 2026-08-23: the gen files declare the *provider's* package,
-not a separate one, so they can already name unexported types. **This is the enabling fact that makes the
-whole plan cheap**, and it must be verified per provider before the sweep rather than assumed from one
-sample.
-
-If any provider's gen output turns out to live in a genuinely separate package, that provider needs one
-of: the announcement emitted in-package, or an exported `func ResourceType() reflect.Type` seam. Decided
-per provider at implementation, not pre-emptively.
-
-**The generator's detection rule already accommodates this**: a resource type is identified by an
-exported constructor `func(*op.RuntimeEnvironment, any) (*T, error)`. An exported constructor may return
-an unexported type — `func DiscoverClone(env *op.RuntimeEnvironment, v any) (*resource, error)` is legal
-Go. The constructor is the public contract; the struct behind it need not be.
+Phases are grouped by risk, not by footprint. The `Unpacker` four share one failure mode and are proved
+together; `pkg` is alone because it has the widest consumer surface (7 files) and the open question about
+exported behavioral fields.
 
 ## Phases
 
-### Phase 1 — the pattern, proven on one provider — status: pending
+### Part 1 — the eight single-resource providers
 
-Take the provider with the smallest external footprint (`service`: zero files outside its package name
-`service.Resource`) and land the full shape there: the sealed `Resource` interface, the unexported
-`resource` base, the marker method, the announcement, and the serialization proof (a saved graph still
-round-trips, and the URI fragment still names the concrete struct). The result is the template every
-later provider follows, and the place where every surprise surfaces cheaply.
+#### Phase 1 — the framework repairs and `service` — status: pending
 
-### Phase 2 — the low-footprint providers — status: pending
+Land the framework change from *What ruling 4 costs* first, then prove the whole shape on the provider with
+the smallest external footprint: `service`, with **zero** files outside its own package naming the type
+(confirmed 2026-08-24 — every other hit is a historical plan document).
 
-`git` (1 external file), `json` (1), `yaml` (1), `appnet` (2) — the same transformation, one PR each or
-batched if phase 1 proves the pattern is mechanical.
+The full shape: sealed `Resource` interface, unexported `resource` struct, exported constructors
+unchanged in signature, announcement unchanged. `Resource.Name` is a field read 20 times in
+`pkg/op/provider/service/provider.go`, so the interface gains a `Name() string` method — all in-package.
 
-### Phase 3 — the high-footprint providers — status: pending
+**Acceptance — serialization must not move.** A graph planned before and after produces the same
+`resources` section for the same intent. Round-trip pins stay byte-identical and a saved document still
+reloads.
 
-`mem` (4), `function` (5), `pkg` (7). These have real consumers naming the type, so each carries an
-authoring sweep. `function` also carries the Starlark-callable path and `mem` the content-addressed
-store, so their round-trip proofs are the load-bearing ones.
+**The judgment scenario lands here, red first.** A dict supplied where a resource slot is expected mints
+an identity-less resource today; it must fail conversion after. Red before the seal, green after —
+otherwise the correctness claim is argued rather than demonstrated.
 
-### Phase 4 — the rule becomes enforceable — status: pending
+#### Phase 2 — `git` and `appnet` — status: pending
 
-1. `4.3-resource-registration.md` states the shape as the contract for adding a provider resource.
-2. A test asserts it structurally: every announced resource type's Go struct is unexported, and every
-   provider package exposes a `Resource` interface. A future provider that exports its struct fails the
-   suite rather than a review.
+One external file and two respectively; neither implements `Unpacker`. Mechanical application of the
+phase-1 template.
 
-### Phase 5 — closure — status: pending
+#### Phase 3 — the `Unpacker` four: `json`, `yaml`, `mem`, `function` — status: pending
 
-Design docs and status files record the uniform shape; `3.5.x` per-provider docs drop any language that
-described the resource as a struct.
+These share the failure mode phase 1 repaired, so they are the proof that the repair holds. `mem` is the
+content-addressed store, where identity *is* the digest and the fragment is doubly load-bearing;
+`function` carries the Starlark-callable path, where bytecode travels in the document's content section.
+Each needs its content-section round-trip pinned, not assumed.
+
+#### Phase 4 — `pkg` — status: pending
+
+Seven external files, the widest surface. Answers the plan's standing question: a resource whose exported
+behavioral fields consumers read must expose them as interface methods, or those consumers change. Size
+it before transforming it.
+
+### Part 2 — `file`
+
+#### Phase 5 — `file`'s four variants become interfaces — status: pending
+
+`Any`, `Regular`, `Directory`, `SymbolicLink` each become a sealed interface over an unexported struct,
+discriminated by `kind() <Interface>` per ruling 6. The announcements keep naming `provider.Regular` and
+friends, so the four fragments stay byte-identical.
+
+**Open: what the `Any` struct is called.** The lowercase rule gives `regular`, `directory`, and
+`symbolicLink` without incident, but `any` is a predeclared identifier — declaring a type by that name
+shadows it for the whole package, breaking every use of `any` as a type in `file`. Needs a decision in
+this phase; `anyEntry` has precedent from #616's original name.
+
+`op.RegisterResourceMint` gains the four interface→struct registrations. `*Any`'s resolution at
+activation (`op.KindResolver`) and the supersession rules from #616 must be re-pinned against interface
+types rather than concrete ones — this is where a silent regression would hide.
+
+At the end of this phase the rule holds with no exceptions, and the feature's goal is met.
+
+### Closure
+
+#### Phase 6 — the rule becomes structurally enforceable — status: pending
+
+1. `4.3-resource-registration.md` states the shape as **the contract** for adding a provider resource.
+2. A test asserts it structurally: every announced resource type is an interface, and the struct behind
+   it is unexported. A future provider that exports its struct fails the suite rather than a review.
+
+Without this the rule is a convention, and conventions decay.
+
+#### Phase 7 — closure — status: pending
+
+The `3.5.x` per-provider design docs drop any language describing the resource as a struct.
+`4-resource-management.md` records what the seal buys: the model's guarantees now rest on the compiler
+rather than on convention. Status files follow.
 
 ## Judgment scenarios
 
-1. **A resource cannot be forged.** Outside its package, `&git.resource{…}` does not compile and no type
-   satisfies `git.Resource` — the seal holds against a hand-built value reaching dispatch. (A compile-time
-   property; pinned as a documented negative plus a `go vet`-visible marker rather than a runtime test.)
-2. **Serialization is unchanged.** A graph planned before the change and one planned after produce the
-   same `resources` section for the same intent — the fragment names the concrete struct either way, and
-   only its visibility changed. The round-trip pins stay byte-identical.
-3. **Rehydration still finds the constructor.** A saved document reloads: the type id resolves through
+1. **A dict cannot forge a resource.** Supplying a map where a resource slot is expected fails
+   conversion instead of minting an identity-less value. Red before phase 1, green after — the scenario
+   that makes the correctness claim demonstrable.
+2. **A resource cannot be built from outside.** `&service.resource{…}` does not compile beyond its
+   package and no outside type satisfies `service.Resource`. A compile-time property, pinned as a
+   documented negative.
+3. **The `resources` section does not move.** For a given intent it is byte-identical before and after
+   every phase. Any drift there is a defect in the phase that caused it, never an accepted consequence.
+   Receipt product-type ids are the one deliberate exception — see *What serialization does*.
+4. **A resumed receipt retypes its result.** Written, reloaded, and resumed after the change, the result
+   comes back as a resource rather than a bare URI string. Asserting that resume *succeeds* is not enough
+   — `retypeStampedResult` swallows an unresolved id and returns, so the failure is invisible unless the
+   retyped value itself is asserted.
+5. **Rehydration still finds the constructor.** A saved document reloads: the fragment resolves through
    the registry to the exported constructor, which returns the unexported struct behind the interface.
-4. **The structural rule bites.** A deliberately non-conforming fixture provider — exported resource
-   struct, no interface — fails phase 4's assertion.
+6. **`Unpacker` survives.** Each of `json`, `yaml`, `mem`, `function` rebuilds from a document's content
+   section after phase 3 — the check that `UnpackerByTypeID` was actually repaired and not merely
+   silenced.
+7. **A regular file is not a directory.** After phase 5, a `*regular` fails a `Directory` assertion at
+   compile time. Ruling 6's whole purpose, and the one that must not regress.
+8. **The structural rule bites.** A deliberately non-conforming fixture — exported resource struct, no
+   interface — fails phase 6's assertion.
 
 ## Verification
 
 Every phase: `make check`, `make vet` under GOOS windows and linux, `gofmt -l`. The Windows baseline is
-zero. Serialization is the risk surface: any change to a `resources` section's bytes is a defect in the
-phase that caused it, not an accepted consequence.
-
-## Open questions
-
-1. **Does the seal want a shared marker?** Each package declaring its own unexported `sealedResource()`
-   is the file precedent and needs no framework support. A framework-side marker would centralize the
-   rule but cannot be unexported *and* implementable across packages — so per-package is likely forced,
-   and phase 1 confirms it.
-2. **What happens to providers whose resource has exported behavioral fields consumers read?** The
-   interface must expose them as methods, or those consumers change. Sized per provider in phases 2–3;
-   `pkg` (7 external files) is the likely worst case.
-3. **Does `op.Resource` itself want the same treatment?** It is already an interface sealed by an
-   unexported base accessor — so the framework layer is where this pattern came from, and the provider
-   layer is catching up rather than inventing.
+zero. Serialization is the risk surface.


### PR DESCRIPTION
Rewrites the #625 plan after investigating phase 1. One fact the original asserted is false, and the
investigation turned up a silent failure the change would have converted from latent to live.

## The enabling fact was false

The plan claimed — and #625 repeated as "verified 2026-08-23" — that `pkg/op/provider/<p>/gen/*.gen.go`
declares the provider's own package, so generated announcements could name unexported types. `go list`
says otherwise:

```
github.com/NobleFactor/devlore-cli/pkg/op/provider/service       name=service
github.com/NobleFactor/devlore-cli/pkg/op/provider/service/gen   name=service
```

Two import paths, the same package *name*, **different packages**. The gen file imports the provider as
`provider` and can name only its exported identifiers.

## Ruling 4 — the URI fragment names the interface

Holding to the original ruling that the fragment names the *struct* would have required an exported
`ResourceType() reflect.Type` seam per provider — and `reflect.New` on that seam forges a resource,
reopening the door the feature exists to close. Giving the fragment to the interface dissolves it: ruling
3 already hands the interface the name the struct gives up, so `typeIDOf` is byte-identical and **the
generated files do not change at all**.

## The receipt-retyping failure this surfaced

Ruling 4 covers the URI. It does **not** cover the receipt's product-type id — and that turned out to be
a latent fragility rather than a clean invariant.

`ReceiptBase.Commit` records `canonicalIDOf(result)`, the produced value's **dynamic** type.
`ProductTypeByID` resolves it against an index built from **every** action method's **declared** result
type. The two need not agree, and today they agree only by coincidence: `file.Move`, `Remove`,
`RemoveAll`, and `Backup` already return the `Resource` interface, so they record a concrete id such as
`*…/file.Regular` — which resolves only because `file.Copy` independently *declares* `*Regular` and
contributes the key.

Sealing removes the coincidence. The dynamic type becomes `*…/file.regular`, an unexported struct no
method declares, so the lookup misses — and the miss is **silent**, because `retypeStampedResult`
(`pkg/op/recovery_stack.go:647`) is `if !ok { return }`. A resumed run leaves the result as its raw
decoded value, the bare URI string, instead of a resource. No error, no log.

So the change converts a latent fragility into a live silent failure across every provider. Phase 1 fixes
both sides to record the announced identity, and the plan pins it with a resume that asserts the
**retyped** result — asserting that resume merely succeeds proves nothing against a bare `return`.

The delta is narrow: `ResultType` is `omitempty` and `canonicalIDOf` returns `""` for nil, so a method
with no result omits the field. `file.WalkTree` returns `any`, and a reducer returning an int records
`int` before and after. Only receipts whose result is a provider resource move, and they move by exactly
one character — `result_type` loses the leading `*` that a pointer return produced.

The acceptance criterion is narrowed accordingly: the `resources` section and URIs stay byte-identical;
resource-bearing receipt ids change deliberately and are pinned to their new value.

## What the receiver machinery needs

The original plan said "filter on `PkgPath()`". That was wrong-headed — enumeration is not the problem.
`NewMethod` cannot consume an interface method **at all**: `reflect` gives an interface method a nil
`Func` and a `Type` with no receiver, so `do.Type.In(0)` returns the first *parameter* for
`Equal(other any)` and **panics** for a no-arg method like `Etag()`.

The change is to split the one field doing two jobs: `receiverType` stores the **concrete** type (method
enumeration, dispatch, and the `byType` key, which must match `reflect.TypeOf(value)`) plus a **stored
type-id string** computed once from the interface (the two `typeIDOf(ProviderType()) == typeID`
comparisons that match against an id lifted from a URI). Those consumers sit on adjacent lines and want
opposite things. With the concrete type restored, the promotion and unexported-method problems evaporate
on their own, and `UnpackerByTypeID` starts working again for `function`, `json`, `mem`, and `yaml`.

Dividend: the type id becomes a declared identity instead of one re-derived at each site. Today any Go
rename silently invalidates every saved document.

## Ruling 5 — two parts, so the goal is actually reached

Part 1 seals the eight single-resource providers; part 2 converts `file`'s four variants. The original
would have left `file` a permanent exception in a *new* direction. It is not merely aesthetic: `file`'s
variants carry zero exported fields, so the forging path fills nothing yet still mints an identity-less
`*Regular`.

## Ruling 6 — `kind() <Interface>` discriminates the variants

`Regular` and `Directory` have identical exported method sets, so as bare interfaces they would be
structurally interchangeable — `r.(Directory)` would succeed for a regular file and every kind-honesty
guarantee from #616 would evaporate without a single test failing. `kind() Regular` and `kind() Directory`
are different signatures, and a type may declare only one method named `kind`, so exclusivity is
structural rather than conventional.

Recorded as open for phase 5: the `Any` struct cannot be named `any` — that shadows the predeclared
identifier for the whole package.

## The correctness case is now concrete

The plan previously argued from a struct literal someone might write. No such literal exists outside its
own package anywhere in the tree — checked across all eight. The plan now names the live path:
`tryHydrateStruct` (`pkg/op/convert.go:441`) reflectively mints a resource from a dict, producing a value
with an empty URI that reaches `sm.Disable(name.Name)` against the host. Phase 1 pins it red before the
seal and green after, so the claim is demonstrated rather than argued.

## Housekeeping

- Phases regroup by **risk** rather than footprint: the four `Unpacker` implementers share one silent
  failure mode and are proved together; `pkg` stands alone on consumer surface.
- Scope corrected: **eight** providers besides `file`, not nine.
- Tasks re-filed as #641–#647; #626–#630 closed as superseded.
- Recorded as not fixed by the seal: `ConvertFrom` returns the same identity-less value in-package, and
  needs its own issue.

Refs #625.
