### PR TITLE
refactor(file): the unasserted claim is AnyKind, so its concrete type can be anyKind

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_judgment_interface_slot_mints.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_interface_slot_mints.star
@@ -7,7 +7,7 @@
 # Replaces the refusal this scenario used to pin. Before the designation, an authored string bound to an
 # interface-typed resource slot was refused outright: a claim asserts a kind and an interface asserts
 # none. The interface now names the claim that deliberately asserts nothing on its behalf — `file.Resource`
-# designates `*file.Any` — so the same authored path claims, and resolves to whatever the disk holds at
+# designates `*file.AnyKind` — so the same authored path claims, and resolves to whatever the disk holds at
 # activation.
 #
 # The narrowed refusal (an interface that designates NO claim type) is unreachable from Starlark, because
@@ -30,6 +30,6 @@ plan.save_definition(graph, doc)
 document = json.decode(data=file.read_text(resource=doc))
 entries = [e for e in document["resources"] if "observed.txt" in str(e)]
 t.expect_equal(len(entries), 1)
-t.expect_equal("file.Any" in str(entries[0]), True)
+t.expect_equal("file.AnyKind" in str(entries[0]), True)
 
 t.run(graph)

--- a/cmd/devlore-test/devloretest/data/test_judgment_move_any_kind.star
+++ b/cmd/devlore-test/devloretest/data/test_judgment_move_any_kind.star
@@ -6,7 +6,7 @@
 #
 # The capability that regressed when kind-honest activation landed (#611): a `*Regular` claim over a
 # symbolic link failed verification, so a link could not be moved at all. `file.move` now takes the
-# taxonomy interface, so an authored path claims as `file.Any` and resolves to whatever the disk holds.
+# taxonomy interface, so an authored path claims as `file.AnyKind` and resolves to whatever the disk holds.
 #
 # All three kinds move in one graph, and the sharp assertion is the link: **the link moves, its target
 # does not**. A follow would show up unmistakably — the target would vanish from its original path.

--- a/cmd/writ/writ/migrate/register.go
+++ b/cmd/writ/writ/migrate/register.go
@@ -113,7 +113,7 @@ func buildRegistrationGraph(
 	var registerInvocation *op.Invocation
 	if useMove {
 		// The source is a directory tree, and the claim no longer has to say so: file.move takes the
-		// taxonomy's interface, so the authored path claims as file.Any and resolves to what the disk
+		// taxonomy's interface, so the authored path claims as file.AnyKind and resolves to what the disk
 		// holds at activation (2026-08-23). The consumed source is a claimed resource, authored in plan
 		// space — the rel against the planning environment's root.
 		sourceRel, relErr := deploy.PlanSpacePath(environment, sourceRoot)

--- a/docs/architecture/3.5.4-file-provider.md
+++ b/docs/architecture/3.5.4-file-provider.md
@@ -26,11 +26,11 @@ confined to the runtime environment's `fsroot.Dir`. Three ideas carry the design
    receipt's `MutationKind` — so a receipt built by `WriteText`, `Move`, or archive extraction compensates
    identically, regardless of which method or dispatcher created it.
 2. **A sealed taxonomy of asserted kinds** (phase-8 step 23; extended 2026-08-23). `Resource` is the closed
-   interface over four variants — `*Regular`, `*Directory`, `*SymbolicLink`, and `*Any` — sealed by an unexported
+   interface over four variants — `*Regular`, `*Directory`, `*SymbolicLink`, and `*AnyKind` — sealed by an unexported
    marker method over an unexported base. Kind is **declared, never stat-assigned**: a claim that asserts one kind
    while the disk shows another fails verification at the starting line, and the two claims are reconciled by
    strictness — a kinded claim and an unasserted one on the same rel are one identity, and the kinded claim keeps
-   the ledger slot because it is the one that can fail. `*Any` is the deliberate abstention: it asserts existence
+   the ledger slot because it is the one that can fail. `*AnyKind` is the deliberate abstention: it asserts existence
    alone, which is what a kind-indifferent operation like `move` or `remove` actually needs, and it resolves to the
    observed kind at activation — the moment the model first consults the disk.
 3. **The write seam** (phase-8 step 49). Every write-path method routes occupied targets through the run's conflict
@@ -42,13 +42,13 @@ confined to the runtime environment's `fsroot.Dir`. Three ideas carry the design
 | Type | Kind | Notes |
 |---|---|---|
 | `Resource` | the sealed interface | `op.Resource` + `Path() fsroot.Path` + the unexported seal. Every provider names its resource type `Resource`; file's is an interface rather than a struct because file alone has a kind axis |
-| `*Any` | **unasserted** | asserts existence and nothing else — what a kind-indifferent operation claims. Resolves to the observed kind at activation; a dangling link satisfies it, a FIFO does not |
+| `*AnyKind` | **unasserted** | asserts existence and nothing else — what a kind-indifferent operation claims. Resolves to the observed kind at activation; a dangling link satisfies it, a FIFO does not |
 | `*Regular` | regular file | the read/write target type (`ReadBytes`/`ReadText` take it) |
 | `*Directory` | directory | `Mkdir` territory |
 | `*SymbolicLink` | symlink | `Link` territory; `Exists` is lstat — a link's existence is the link, never its target (2026-08-22) |
 | `resource` | the shared base | **unexported**: unnameable and un-hand-buildable outside the package, and outside the seal, so a bare base cannot enter a taxonomy signature |
 
-**An authored string claims as `*Any`** (§5.7 rule 6): the interface designates it, once, so a method that
+**An authored string claims as `*AnyKind`** (§5.7 rule 6): the interface designates it, once, so a method that
 does not care about kind can take `Resource` and still be authored with a plain path. The kind is then the
 disk's business — resolved when pre-flight first looks.
 

--- a/docs/architecture/3.5.4-file-provider.status.md
+++ b/docs/architecture/3.5.4-file-provider.status.md
@@ -21,8 +21,8 @@ base retains a kind-blind, link-following `Exists` at zero coverage.
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Sealed taxonomy (`Resource` = `Any` / `Regular` / `Directory` / `SymbolicLink`) | Landed (step 23; extended 2026-08-23, #616) | declared, never stat-assigned; `*Any` abstains and resolves at activation; a kinded claim supersedes an unasserted one on the same rel |
-| The unasserted claim (`*Any`), kind resolution at activation, the interface's designated mint type | Landed 2026-08-23 (#617–#619) | `op.KindResolver` + `op.RegisterResourceMint`; an authored path claims as `*Any` |
+| Sealed taxonomy (`Resource` = `Any` / `Regular` / `Directory` / `SymbolicLink`) | Landed (step 23; extended 2026-08-23, #616) | declared, never stat-assigned; `*AnyKind` abstains and resolves at activation; a kinded claim supersedes an unasserted one on the same rel |
+| The unasserted claim (`*AnyKind`), kind resolution at activation, the interface's designated mint type | Landed 2026-08-23 (#617–#619) | `op.KindResolver` + `op.RegisterResourceMint`; an authored path claims as `*AnyKind` |
 | `file.move` takes any kind; `move_directory` retired | Landed 2026-08-23 (#620) | closes the symlink-move regression from #611 |
 | Removal splits by blast radius; `unlink` retired; `backup` claims; policy parameters last | Landed 2026-08-23 (#621) | tolerance covers absence, never a kind mismatch (`op.ErrClaimKindMismatch`) |
 | Unified mutation receipt (`MutationKind` ×5, boundary, recovery digest) | Landed | one receipt, one compensating action (`file.compensate_file_mutation`) |

--- a/docs/architecture/4-resource-management.md
+++ b/docs/architecture/4-resource-management.md
@@ -413,7 +413,7 @@ The rules, each ruled 2026-08-22:
 6. **An interface-typed resource slot mints its designated claim** (amended 2026-08-23; originally a
    flat refusal). A claim asserts a kind — "claims are true when made" needs a kind to be true about —
    and an interface asserts none, so an interface **designates** the concrete claim that deliberately
-   asserts nothing on its behalf: `file.Resource` designates `*file.Any`, whose predicate is existence
+   asserts nothing on its behalf: `file.Resource` designates `*file.AnyKind`, whose predicate is existence
    alone and which resolves to the observed kind at activation (§3). The designation lives on the
    interface, once, never per parameter: two methods taking the same slot type must claim the same way,
    or one authored path would mean different intent depending on which method received it. The

--- a/docs/plans/any-entry-claims.md
+++ b/docs/plans/any-entry-claims.md
@@ -6,6 +6,12 @@ created: 2026-08-23
 updated: 2026-08-24
 ---
 
+> **Rename, 2026-08-24.** The type this plan calls `file.Any` was renamed to **`file.AnyKind`**
+> (concrete `file.anyKind`) under [#625](https://github.com/NobleFactor/devlore-cli/issues/625) —
+> the lowercase form `any` shadows Go's predeclared identifier. The prose below is left as written;
+> read `Any` as `AnyKind` throughout.
+
+
 # Plan: Any — claims that assert existence, not kind
 
 ## Summary

--- a/docs/plans/resource-construction.md
+++ b/docs/plans/resource-construction.md
@@ -6,6 +6,12 @@ created: 2026-08-20
 updated: 2026-08-22
 ---
 
+> **Rename, 2026-08-24.** The type this plan calls `file.Any` was renamed to **`file.AnyKind`**
+> (concrete `file.anyKind`) under [#625](https://github.com/NobleFactor/devlore-cli/issues/625) —
+> the lowercase form `any` shadows Go's predeclared identifier. The prose below is left as written;
+> read `Any` as `AnyKind` throughout.
+
+
 # Plan: Resource construction — the catalog mediates everything
 
 ## Summary

--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -126,7 +126,7 @@ three ways at once. All three surface in phase 1 and are paid once.
    one, so pointer-receiver methods are visible."* On an interface that yields `*Resource` — a pointer to
    interface, whose method set is **empty**. Providers that announce method metadata fail loudly at init
    (`parseParameters` → `MethodByName` → `"method Equal: not found on type service.Resource"`).
-   `file.Any`, which announces `nil`, fails **silently** with zero methods, because `parseParameters`
+   `file.AnyKind`, which announces `nil`, fails **silently** with zero methods, because `parseParameters`
    returns an empty but non-nil map and the announced path then matches nothing.
 
 2. **`NewMethod` cannot consume an interface method at all** —
@@ -335,16 +335,19 @@ it before transforming it.
 
 #### Phase 5 — `file`'s four variants become interfaces — status: pending
 
-`Any`, `Regular`, `Directory`, `SymbolicLink` each become a sealed interface over an unexported struct,
-discriminated by `kind() <Interface>` per ruling 6. The announcements keep naming `provider.Regular` and
-friends, so the four fragments stay byte-identical.
+`AnyKind`, `Regular`, `Directory`, `SymbolicLink` each become a sealed interface over an unexported
+struct — `anyKind`, `regular`, `directory`, `symbolicLink` — discriminated by `kind() <Interface>` per
+ruling 6. The announcements keep naming `provider.Regular` and friends, so the four fragments stay
+byte-identical.
 
-**Open: what the `Any` struct is called.** The lowercase rule gives `regular`, `directory`, and
-`symbolicLink` without incident, but `any` is a predeclared identifier — declaring a type by that name
-shadows it for the whole package, breaking every use of `any` as a type in `file`. Needs a decision in
-this phase; `anyEntry` has precedent from #616's original name.
+**Settled by the `AnyKind` rename (USER, 2026-08-24; landed ahead of this phase).** The lowercase rule
+would have given `any` for the unasserted variant, which is a predeclared identifier: declaring a type by
+that name does not fail to compile — it silently rebinds all 139 bare `any` occurrences in the package,
+including the constructors' own `value any` parameters. Renaming the exported type to `AnyKind` resolves
+it at the source: `anyKind` shadows nothing, and the variant's name now states its assertion (a kind, any
+kind) rather than borrowing Go's word for the empty interface.
 
-`op.RegisterResourceMint` gains the four interface→struct registrations. `*Any`'s resolution at
+`op.RegisterResourceMint` gains the four interface→struct registrations. `*AnyKind`'s resolution at
 activation (`op.KindResolver`) and the supersession rules from #616 must be re-pinned against interface
 types rather than concrete ones — this is where a silent regression would hide.
 

--- a/pkg/op/graph_executor.go
+++ b/pkg/op/graph_executor.go
@@ -1504,7 +1504,7 @@ func isHardFailure(err error) bool {
 // Each per-type step adds its type as it implements the contract; the gate dissolves once all nine resource-bearing
 // providers participate.
 var existenceVerifiableTypes = map[string]struct{}{
-	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file.Any":          {},
+	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file.AnyKind":      {},
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file.Regular":      {},
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file.Directory":    {},
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file.SymbolicLink": {},

--- a/pkg/op/kind_resolution_test.go
+++ b/pkg/op/kind_resolution_test.go
@@ -12,7 +12,7 @@ import (
 // region TEST FIXTURES
 
 // unassertedResource is a [KindResolver] fixture: it exists, and it resolves to `resolvesTo` — the shape
-// `file.Any` has, without the filesystem.
+// `file.AnyKind` has, without the filesystem.
 type unassertedResource struct {
 	ResourceBase
 	addressingMode AddressingMode

--- a/pkg/op/planner.go
+++ b/pkg/op/planner.go
@@ -406,7 +406,7 @@ func bindAuthoredValue(invocator PlanInvocator, spec *NodeSpec, actionName strin
 	// mint type (4-resource-management.md §5.7 rule 6, amended 2026-08-23). A claim asserts a kind —
 	// "claims are true when made" needs a kind to be true about — and an interface asserts none, so the
 	// interface names the claim that deliberately asserts nothing on its behalf (`file.Resource` →
-	// `*file.Any`, which resolves to the observed kind at activation). Substituting the mint type HERE,
+	// `*file.AnyKind`, which resolves to the observed kind at activation). Substituting the mint type HERE,
 	// ahead of the grammar, the source-constructor lookup, and the conversion, means every downstream
 	// step behaves exactly as it does for an explicitly kinded parameter.
 	//

--- a/pkg/op/planner_test.go
+++ b/pkg/op/planner_test.go
@@ -88,7 +88,7 @@ type mintProbeProvider struct{}
 
 func (mintProbeProvider) Take(claim Resource) error { return nil }
 
-// mintedResource is the concrete type a designation points at — the shape `file.Any` has, minus the
+// mintedResource is the concrete type a designation points at — the shape `file.AnyKind` has, minus the
 // filesystem.
 type mintedResource struct {
 	ResourceBase

--- a/pkg/op/provider/file/any_kind.go
+++ b/pkg/op/provider/file/any_kind.go
@@ -10,10 +10,10 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// Any is the taxonomy variant that asserts existence and nothing else — the unasserted claim
+// AnyKind is the taxonomy variant that asserts existence and nothing else — the unasserted claim
 // (docs/plans/any-entry-claims.md, ruled 2026-08-23).
 //
-// The kinded variants declare what must be at a path; Any declines to, which is what a
+// The kinded variants declare what must be at a path; AnyKind declines to, which is what a
 // kind-indifferent operation needs: a move moves whatever is there, and the author should not have to
 // name a kind the operation does not care about. Its assertion is exactly "some taxonomy entry exists at
 // this rel" — a dangling symbolic link satisfies it (the link is there), a FIFO, socket, or device does
@@ -21,17 +21,17 @@ import (
 //
 // An unasserted claim is in effect a promise to observe: the entry resolves to the variant the disk
 // shows inside the [op.Pending] → [op.Active] transition, where the model first consults the disk. A
-// claim that fails to activate stays an Any — nothing was observed, so there is nothing to resolve
+// claim that fails to activate stays an AnyKind — nothing was observed, so there is nothing to resolve
 // to, and the [op.Gone] entry honestly records an unmet unasserted claim.
 //
 // Identity is the embedded [resource] (URI + SourcePath), and the serialized intent row names this type —
 // intent says *something must be here*; the trace says what was found.
-type Any struct {
+type AnyKind struct {
 	resource
 }
 
-// sealedResource marks Any as a member of the closed [Resource] set (step 23, slice 4).
-func (*Any) sealedResource() {}
+// sealedResource marks AnyKind as a member of the closed [Resource] set (step 23, slice 4).
+func (*AnyKind) sealedResource() {}
 
 // region EXPORTED METHODS
 
@@ -40,7 +40,7 @@ func (*Any) sealedResource() {}
 // Digest returns the honest content hash of whatever the disk holds, by delegating to the observed
 // kind's implementation.
 //
-// An unasserted claim still owes content identity: without this, an Any entry would record no
+// An unasserted claim still owes content identity: without this, an AnyKind entry would record no
 // digest and silently lose drift detection for as long as it remains unresolved. The observed kind's
 // own contract applies verbatim — a directory's digest rule, a link's target hash, a regular file's
 // streamed sha256.
@@ -48,7 +48,7 @@ func (*Any) sealedResource() {}
 // Returns:
 //   - `op.Digest`: the observed kind's digest.
 //   - `error`: an lstat failure, an unsupported entry kind, or the kind's own digest error.
-func (r *Any) Digest() (op.Digest, error) {
+func (r *AnyKind) Digest() (op.Digest, error) {
 
 	observed, err := r.observed()
 	if err != nil {
@@ -59,12 +59,12 @@ func (r *Any) Digest() (op.Digest, error) {
 }
 
 // Etag returns the cheap change-detection token of whatever the disk holds, by delegating to the
-// observed kind's implementation — the screen half of the same contract [Any.Digest] serves.
+// observed kind's implementation — the screen half of the same contract [AnyKind.Digest] serves.
 //
 // Returns:
 //   - `string`: the observed kind's etag.
 //   - `error`: an lstat failure, an unsupported entry kind, or the kind's own etag error.
-func (r *Any) Etag() (string, error) {
+func (r *AnyKind) Etag() (string, error) {
 
 	observed, err := r.observed()
 	if err != nil {
@@ -84,7 +84,7 @@ func (r *Any) Etag() (string, error) {
 //
 // Returns:
 //   - `bool`: true when the path holds a regular file, a directory, or a symbolic link.
-func (r *Any) Exists() bool {
+func (r *AnyKind) Exists() bool {
 
 	mode, present := r.observedMode()
 
@@ -99,7 +99,7 @@ func (r *Any) Exists() bool {
 //
 // Returns:
 //   - `bool`: true when an entry is there and no variant admits it.
-func (r *Any) MismatchesKind() bool {
+func (r *AnyKind) MismatchesKind() bool {
 
 	mode, present := r.observedMode()
 
@@ -119,7 +119,7 @@ func (r *Any) MismatchesKind() bool {
 // Returns:
 //   - `op.Resource`: the observed-kind variant at this path.
 //   - `error`: an lstat failure, or an entry kind the taxonomy has no variant for.
-func (r *Any) ResolveKind() (op.Resource, error) {
+func (r *AnyKind) ResolveKind() (op.Resource, error) {
 
 	return r.observed()
 }
@@ -138,14 +138,14 @@ func (r *Any) ResolveKind() (op.Resource, error) {
 // Returns:
 //   - `Resource`: the observed-kind candidate at this path.
 //   - `error`: an lstat failure or an entry kind the taxonomy has no variant for.
-func (r *Any) observed() (Resource, error) {
+func (r *AnyKind) observed() (Resource, error) {
 
 	root := r.RuntimeEnvironment().Root()
 	abs := r.SourcePath.Abs()
 
 	info, err := root.Lstat(root.NewPath(abs))
 	if err != nil {
-		return nil, fmt.Errorf("file.Any: %s: %w", r.SourcePath.Rel(), err)
+		return nil, fmt.Errorf("file.AnyKind: %s: %w", r.SourcePath.Rel(), err)
 	}
 
 	return candidateOfMode(r.RuntimeEnvironment(), abs, info.Mode())
@@ -155,10 +155,10 @@ func (r *Any) observed() (Resource, error) {
 
 // region HELPER FUNCTIONS
 
-// DiscoverAny registers a [file.Any] via [op.ResourceCatalog.Discover] without claiming
+// DiscoverAnyKind registers a [file.AnyKind] via [op.ResourceCatalog.Discover] without claiming
 // production — the constructor plan-time claiming and rehydration both key on.
 //
-// Any has no producing counterpart: a product is minted as its observed kind (the producer is at
+// AnyKind has no producing counterpart: a product is minted as its observed kind (the producer is at
 // execution time with the disk in hand), so nothing ever produces an unasserted entry. Nil-catalog
 // tolerance returns the unlinked candidate.
 //
@@ -166,24 +166,24 @@ func (r *Any) observed() (Resource, error) {
 //   - `runtimeEnvironment`: the session runtime environment.
 //   - `value`: a string file path or file URI.
 //
-// **Returns the taxonomy interface, not `*Any`** — the one constructor that does, and deliberately. An
+// **Returns the taxonomy interface, not `*AnyKind`** — the one constructor that does, and deliberately. An
 // unasserted claim is satisfied by whatever entry already stands for its identity, and a kinded entry
 // asserts more, so it keeps the ledger slot (the collision rule: one rel, one identity, the stricter
-// assertion wins). A constructor that promised `*Any` would have to fail in exactly the case the rule
+// assertion wins). A constructor that promised `*AnyKind` would have to fail in exactly the case the rule
 // says should succeed.
 //
 // Returns:
-//   - `Resource`: the canonical catalog entry — a fresh [*Any] when the identity is unclaimed, the
+//   - `Resource`: the canonical catalog entry — a fresh [*AnyKind] when the identity is unclaimed, the
 //     existing kinded entry when it is not, or the unlinked candidate when no catalog is present.
 //   - `error`: if `value` is not a string, or the catalog's strict assertions fail.
-func DiscoverAny(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+func DiscoverAnyKind(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
 
-	base, err := buildCandidateAs(runtimeEnvironment, value, reflect.TypeFor[*Any]())
+	base, err := buildCandidateAs(runtimeEnvironment, value, reflect.TypeFor[*AnyKind]())
 	if err != nil {
 		return nil, err
 	}
 
-	candidate := &Any{resource: *base}
+	candidate := &AnyKind{resource: *base}
 
 	if runtimeEnvironment.ResourceCatalog == nil {
 		return candidate, nil

--- a/pkg/op/provider/file/any_kind_test.go
+++ b/pkg/op/provider/file/any_kind_test.go
@@ -53,7 +53,7 @@ func TestAny_Exists_IsPermissiveButTaxonomyBounded(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := anyAt(t, environment, tc.path).Exists(); got != tc.want {
+			if got := anyKindAt(t, environment, tc.path).Exists(); got != tc.want {
 				t.Errorf("Exists() = %t, want %t", got, tc.want)
 			}
 		})
@@ -72,7 +72,7 @@ func TestAny_ContentIdentityDelegatesToTheObservedKind(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unasserted := anyAt(t, environment, "regular.txt")
+	unasserted := anyKindAt(t, environment, "regular.txt")
 
 	kindedBase, err := buildCandidateAs(environment, "regular.txt", reflect.TypeFor[*Regular]())
 	if err != nil {
@@ -82,7 +82,7 @@ func TestAny_ContentIdentityDelegatesToTheObservedKind(t *testing.T) {
 
 	unassertedDigest, err := unasserted.Digest()
 	if err != nil {
-		t.Fatalf("Any.Digest: %v", err)
+		t.Fatalf("AnyKind.Digest: %v", err)
 	}
 	kindedDigest, err := kinded.Digest()
 	if err != nil {
@@ -94,7 +94,7 @@ func TestAny_ContentIdentityDelegatesToTheObservedKind(t *testing.T) {
 
 	unassertedEtag, err := unasserted.Etag()
 	if err != nil {
-		t.Fatalf("Any.Etag: %v", err)
+		t.Fatalf("AnyKind.Etag: %v", err)
 	}
 	kindedEtag, err := kinded.Etag()
 	if err != nil {
@@ -111,10 +111,10 @@ func TestAny_ContentIdentityOnAMissingPathErrors(t *testing.T) {
 
 	environment := testEnvironment(t, t.TempDir())
 
-	if _, err := anyAt(t, environment, "absent.txt").Digest(); err == nil {
+	if _, err := anyKindAt(t, environment, "absent.txt").Digest(); err == nil {
 		t.Error("Digest() over a missing path returned no error")
 	}
-	if _, err := anyAt(t, environment, "absent.txt").Etag(); err == nil {
+	if _, err := anyKindAt(t, environment, "absent.txt").Etag(); err == nil {
 		t.Error("Etag() over a missing path returned no error")
 	}
 }
@@ -123,18 +123,18 @@ func TestAny_ContentIdentityOnAMissingPathErrors(t *testing.T) {
 
 // region HELPER FUNCTIONS
 
-// anyAt builds an UNLINKED [*Any] for `rel` — no interning, so a test may probe several kinds
+// anyKindAt builds an UNLINKED [*AnyKind] for `rel` — no interning, so a test may probe several kinds
 // at several paths under one environment without tripping the catalog's cross-kind claim rule.
-func anyAt(t *testing.T, environment *op.RuntimeEnvironment, rel string) *Any {
+func anyKindAt(t *testing.T, environment *op.RuntimeEnvironment, rel string) *AnyKind {
 
 	t.Helper()
 
-	base, err := buildCandidateAs(environment, rel, reflect.TypeFor[*Any]())
+	base, err := buildCandidateAs(environment, rel, reflect.TypeFor[*AnyKind]())
 	if err != nil {
 		t.Fatalf("candidate %s: %v", rel, err)
 	}
 
-	return &Any{resource: *base}
+	return &AnyKind{resource: *base}
 }
 
 // endregion
@@ -143,9 +143,9 @@ func anyAt(t *testing.T, environment *op.RuntimeEnvironment, rel string) *Any {
 // an unasserted claim, verified through the catalog, becomes the variant the disk holds — and the ledger
 // keeps one entry with one identity throughout.
 //
-// The catalog-level mechanics are pinned in pkg/op; this is the half that proves file.Any actually
+// The catalog-level mechanics are pinned in pkg/op; this is the half that proves file.AnyKind actually
 // resolves, and that the URI's type fragment moves with it (which is how the trace comes to say
-// "Regular" where the graph's intent said "Any").
+// "Regular" where the graph's intent said "AnyKind").
 func TestAny_ResolvesToTheObservedKindAtTheTransition(t *testing.T) {
 
 	dir := t.TempDir()
@@ -155,9 +155,9 @@ func TestAny_ResolvesToTheObservedKindAtTheTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	claim, err := DiscoverAny(environment, "claimed.txt")
+	claim, err := DiscoverAnyKind(environment, "claimed.txt")
 	if err != nil {
-		t.Fatalf("DiscoverAny: %v", err)
+		t.Fatalf("DiscoverAnyKind: %v", err)
 	}
 	id := claim.ID()
 
@@ -190,9 +190,9 @@ func TestAny_AnUnmetClaimStaysUnasserted(t *testing.T) {
 
 	environment := testEnvironment(t, t.TempDir())
 
-	claim, err := DiscoverAny(environment, "absent.txt")
+	claim, err := DiscoverAnyKind(environment, "absent.txt")
 	if err != nil {
-		t.Fatalf("DiscoverAny: %v", err)
+		t.Fatalf("DiscoverAnyKind: %v", err)
 	}
 	id := claim.ID()
 
@@ -201,8 +201,8 @@ func TestAny_AnUnmetClaimStaysUnasserted(t *testing.T) {
 	}
 
 	entry, _ := environment.ResourceCatalog.Lookup(id)
-	if _, stillAny := entry.(*Any); !stillAny {
-		t.Errorf("ledger holds %T, want *Any — an unmet claim has nothing to become", entry)
+	if _, stillAny := entry.(*AnyKind); !stillAny {
+		t.Errorf("ledger holds %T, want *AnyKind — an unmet claim has nothing to become", entry)
 	}
 	if got := environment.ResourceCatalog.State(id); got != op.Gone {
 		t.Errorf("state = %v, want Gone", got)

--- a/pkg/op/provider/file/any_kind_unix_test.go
+++ b/pkg/op/provider/file/any_kind_unix_test.go
@@ -26,7 +26,7 @@ func TestAny_Exists_RefusesAKindTheTaxonomyLacks(t *testing.T) {
 		t.Skipf("mkfifo unavailable here: %v", err)
 	}
 
-	if anyAt(t, environment, "a-fifo").Exists() {
+	if anyKindAt(t, environment, "a-fifo").Exists() {
 		t.Error("Exists() = true over a FIFO; the taxonomy has no variant to resolve to")
 	}
 }

--- a/pkg/op/provider/file/gen/any_kind.gen.go
+++ b/pkg/op/provider/file/gen/any_kind.gen.go
@@ -14,9 +14,9 @@ import (
 
 func init() {
 	op.AnnounceResource(
-		reflect.TypeFor[provider.Any](),
+		reflect.TypeFor[provider.AnyKind](),
 		func(runtimeEnvironment *op.RuntimeEnvironment, identity any) (op.Resource, error) {
-			return provider.DiscoverAny(runtimeEnvironment, identity)
+			return provider.DiscoverAnyKind(runtimeEnvironment, identity)
 		},
 		nil,
 	)

--- a/pkg/op/provider/file/helpers.go
+++ b/pkg/op/provider/file/helpers.go
@@ -272,7 +272,7 @@ func internEntry[E Resource](
 		// — the kinded claim asserts more, and it is the one that can fail, so it must be the one
 		// verification judges. Any other mismatch is a genuine cross-kind conflict: two claims asserting
 		// different kinds of the same path is contradictory intent, and the earliest claim reports it.
-		if _, unasserted := got.(*Any); unasserted {
+		if _, unasserted := got.(*AnyKind); unasserted {
 			superseded, isKind := runtimeEnvironment.ResourceCatalog.Supersede(got, candidate).(E)
 			if isKind {
 				return superseded, nil

--- a/pkg/op/provider/file/planspace.go
+++ b/pkg/op/provider/file/planspace.go
@@ -22,7 +22,7 @@ import (
 // [NormalizePlanSpacePath] before construction.
 func init() {
 	for _, t := range []reflect.Type{
-		reflect.TypeFor[*Any](),
+		reflect.TypeFor[*AnyKind](),
 		reflect.TypeFor[*Regular](),
 		reflect.TypeFor[*Directory](),
 		reflect.TypeFor[*SymbolicLink](),
@@ -31,11 +31,11 @@ func init() {
 		op.RegisterPlanPathNormalizer(t, NormalizePlanSpacePath)
 	}
 
-	// An authored string bound to a `Resource`-typed slot claims as [*Any] — the variant that asserts
+	// An authored string bound to a `Resource`-typed slot claims as [*AnyKind] — the variant that asserts
 	// existence without asserting kind, and resolves to what the disk holds at activation
 	// (4-resource-management.md §5.7 rule 6). Kind-indifferent methods can therefore take the interface
 	// and still be authored with a plain path.
-	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*Any]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*AnyKind]())
 }
 
 // NormalizePlanSpacePath renders an authored plan path into its canonical rel, or refuses it.

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -451,8 +451,8 @@ func (p *Provider) compensateMakeDir(receipt *Receipt) (err error) {
 
 // Move moves `source` to `destinationPath`, archiving any existing destination first.
 //
-// **Any kind moves.** The source is claimed as [Resource], the taxonomy's interface, so an authored path
-// claims as [*Any] and resolves to whatever the disk holds at activation: a regular file, a directory
+// **AnyKind kind moves.** The source is claimed as [Resource], the taxonomy's interface, so an authored path
+// claims as [*AnyKind] and resolves to whatever the disk holds at activation: a regular file, a directory
 // and its subtree (a rename carries it whole), or a symbolic link — the link itself, never the entry it
 // designates. The kind is the disk's business, not the author's; a move moves what is there.
 //
@@ -670,7 +670,7 @@ func (p *Provider) compensateRemoveDir(receipt *Receipt) error {
 
 // Remove deletes the single entry at `target`, archiving it for compensation.
 //
-// **Any kind is removable.** The target is claimed as [Resource], so an authored path claims as [*Any]
+// **AnyKind kind is removable.** The target is claimed as [Resource], so an authored path claims as [*AnyKind]
 // and resolves to whatever the disk holds: a regular file, an empty directory, or a symbolic link — the
 // link itself, never the entry it designates, because the entry is discovered with lstat semantics and a
 // removal never follows. The removal family splits by **blast radius, never by kind**, which is the

--- a/pkg/op/provider/file/resource.go
+++ b/pkg/op/provider/file/resource.go
@@ -15,7 +15,7 @@ import (
 // ruling 4): contexts that legitimately traffic in mixed or observed kinds — enumeration returns, per-entry walker
 // callbacks, observation minting, kind-indifferent mutation — accept or return a Resource rather than a concrete
 // variant. Contexts whose semantics fix the kind use the variant ([*Regular], [*Directory], [*SymbolicLink])
-// directly; [*Any] is the variant that asserts existence without asserting kind.
+// directly; [*AnyKind] is the variant that asserts existence without asserting kind.
 type Resource interface {
 	op.Resource
 
@@ -31,7 +31,7 @@ type Resource interface {
 // Interface guards: the four taxonomy variants are the only Resource implementations — the seal excludes the
 // unexported base by construction (it lacks the marker).
 var (
-	_ Resource = (*Any)(nil)
+	_ Resource = (*AnyKind)(nil)
 	_ Resource = (*Regular)(nil)
 	_ Resource = (*Directory)(nil)
 	_ Resource = (*SymbolicLink)(nil)

--- a/pkg/op/resource_catalog.go
+++ b/pkg/op/resource_catalog.go
@@ -652,7 +652,7 @@ func (c *ResourceCatalog) VerifyExistence(resource Resource) error {
 // catalog id and no producer stamp. Carrying both forward keeps `byID`, the state map, and the recovery
 // stack's id references pointing at the same row they always did — only the object standing in that row
 // changes, and with it the URI's type fragment, which is how the trace comes to say `Regular` where the
-// graph's intent said `Any`. The namespace is untouched: location addressing keys on the
+// graph's intent said `AnyKind`. The namespace is untouched: location addressing keys on the
 // fragment-stripped URI, so both spellings name one identity.
 //
 // A resource that does not implement [KindResolver], a resolver that returns nothing, and a resolver

--- a/pkg/op/resource_mint.go
+++ b/pkg/op/resource_mint.go
@@ -25,7 +25,7 @@ var (
 // A claim asserts a kind — "claims are true when made" needs a kind to be true about — and an interface
 // asserts none, which is why an authored string bound to one is refused by default. A scheme with a kind
 // axis resolves that by naming the claim that deliberately asserts nothing: `file` designates
-// `*file.Any`, whose assertion is existence alone and which resolves to the observed kind at activation.
+// `*file.AnyKind`, whose assertion is existence alone and which resolves to the observed kind at activation.
 //
 // **The designation lives on the interface, once.** Not per parameter: two methods taking the same slot
 // type must claim the same way, or the same authored path would mean different intent depending on which


### PR DESCRIPTION
Renames the unasserted file claim from `Any` to `AnyKind`, so its concrete type under #625 can be
`anyKind`.

Closes #650.

## Why rename rather than pick a different struct name

`any` is a predeclared **alias**, not a keyword — made an alias in Go 1.18 precisely so pre-existing
identifiers named `any` kept compiling. So `type any struct{…}` in package `file` **compiles**. It
silently rebinds all **139** bare `any` occurrences in the package, including `DiscoverAny(…, value any)`,
`Equal(other any)`, `ConvertFrom(value any) (any, error)`, and `UnmarshalYAML(unmarshal func(any) error)`.
Not a diagnostic — a change of meaning that surfaces as errors somewhere else.

Renaming the exported type fixes it at the source, and the new name states the variant's assertion — *a
kind, any kind* — instead of borrowing Go's word for the empty interface.

## Scope

`Any` → `AnyKind`, `DiscoverAny` → `DiscoverAnyKind`, `anyAt` → `anyKindAt`; sources renamed to
`any_kind*.go`; `gen/any.gen.go` regenerated as `gen/any_kind.gen.go`; the `existenceVerifiableTypes`
type-id string; the live `.star` assertion in `test_judgment_interface_slot_mints.star` — which is worth
noting on its own, because it proves the Go type name is observable from Starlark.

**Prose was separated from identifiers by hand.** `Any` appears as an English word in eight Go comments
(`**Any kind moves.**`, `Any existing file is archived`, …). All 75 occurrences were enumerated and
classified rather than swept with a pattern.

**Completed plans keep their prose.** `any-entry-claims.md` and `resource-construction.md` carry a rename
note at the top instead of being retconned; the living design docs are renamed in place.

**Unchanged, deliberately:** the authoring token `kind="any"` and the enum constant `ResourceKindAny`.
Those name the kind axis, not the claim variant.

## Serialization

The unasserted claim's URI fragment moves from `…/file.Any` to `…/file.AnyKind`. Greenfield, so there is
no legacy to break, but it is a document change and is recorded as such.

## Gate

`make build` 0 · `make test` 103 ok / 0 fail · `make test-scenario` PASS · `make vet` clean under darwin,
windows, and linux · `gofmt -l` clean.

`make check`'s lint stage fails **locally** on two typecheck errors inside Go 1.27's own standard library
(`crypto/internal/randutil` cannot import `math/rand/v2`) — a golangci-lint/toolchain mismatch unrelated
to this change. CI's `quality-gate` is the authority and passed on #648 against the same toolchain.

