### PR TITLE
docs(build): the Makefile documents itself, and ships a man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,18 +104,11 @@ PLATFORM ?=
 # expands to every supported platform; empty means the caller did not choose, so the default stands.
 #
 # A function rather than a variable because the default differs per target, and because a command-line
-# PLATFORM cannot be reassigned from the makefile — a plain `PLATFORM := $(ALL_PLATFORMS)` inside an
+# PLATFORM cannot be reassigned by a plain assignment — only `override` does that, and a bare
+# `PLATFORM := $(ALL_PLATFORMS)` inside an
 # ifeq is silently ignored and the loop builds a platform literally named "all". Verified by writing
 # it that way first.
 select = $(if $(PLATFORM),$(if $(filter all,$(PLATFORM)),$(ALL_PLATFORMS),$(PLATFORM)),$(1))
-
-### BUILD_TAGS
-
-# Build tags for opt-in test suites.
-# Available tags:
-#   e2e — LLM-dependent end-to-end tests (requires configured AI provider)
-# Usage: make test BUILD_TAGS=e2e
-BUILD_TAGS ?=
 
 ### STAR
 
@@ -149,6 +142,11 @@ build/star: FORCE
 FORCE:
 
 ## VARIABLES (static)
+
+# This Makefile's own directory, with a trailing slash. `make -C` and recursive invocations change the
+# working directory, so anything addressing a file in the repository resolves through this rather than
+# through a relative path.
+PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # Provider source roots.
 P := pkg/op/provider
@@ -213,14 +211,23 @@ HOST_COPIES := lore writ
 
 ## TARGETS
 
-.PHONY: all build install clean test test-race cover vet vet-all lint lint-all build-all shell-lint complexity verify-ldflags check dev docs dist dist-all star star-lkg generate inventory help
+.PHONY: all help help-short help-full build install clean test test-race cover vet vet-all lint lint-all build-all shell-lint complexity verify-ldflags check dev docs dist dist-all star star-lkg generate inventory help
 
 ##@ Help
 
 HELP_COLWIDTH ?= 24
 
-help: ## Show available targets
+help: help-short ## Show brief help (alias: help-short)
+
+help-short: ## Show brief help for annotated targets
 	awk 'BEGIN {FS = ":.*##"; pad = $(HELP_COLWIDTH); print "Usage: make <target> [VAR=VALUE]"; print ""; print "Targets:"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  %-*s %s\n", pad, $$1, $$2} /^##@/ {printf "\n%s\n", substr($$0,5)}' $(MAKEFILE_LIST)
+	printf '\nRun `make help-full` for the manual, including every VAR=VALUE.\n'
+
+help-full: ## Show the manual: every target and every variable (man page)
+	# The path form rather than `man -l`: BSD man (macOS) has no -l, while both BSD and GNU man treat
+	# an argument containing a slash as a file to render. PROJECT_ROOT supplies that slash even when
+	# make was invoked from elsewhere.
+	man -P 'less -R' "$(PROJECT_ROOT)docs/devlore-cli.1"
 
 ##@ Build
 

--- a/docs/devlore-cli.1
+++ b/docs/devlore-cli.1
@@ -1,0 +1,346 @@
+.TH DEVLORE-CLI 1 "August 2026" "Noble Factor" "User Commands"
+.SH NAME
+make \- Build, test, and package the devlore command-line tools
+.SH SYNOPSIS
+.B make
+.I target
+.RI [ VAR=VALUE ... ]
+.SH DESCRIPTION
+The devlore-cli Makefile builds the product binaries and the development tools that act on this
+checkout, runs the test and quality gates, drives code generation, and produces distribution archives.
+.PP
+It is the only supported entry point. Recipes carry linker flags that stamp version information,
+resolve the code generator, and pin the host toolchain; invoking
+.BR go (1)
+directly bypasses all of that and produces binaries that report the wrong version.
+.PP
+Variables are supplied as
+.B VAR=VALUE
+assignments on the command line. Every variable listed below has a working default.
+.SH BUILD MODEL
+.SS Products and tools
+.B Products
+ship:
+.BR lore ,
+.BR star ,
+and
+.BR writ .
+They are cross-compiled once per selected platform into
+.IR build/<goos>-<goarch>/ .
+.PP
+.B Tools
+are instruments of this checkout \(em
+.BR devlore-docs ,
+.BR devlore-index ,
+.BR devlore-inventory ,
+and
+.B devlore-test
+\(em and are built once for the host, staying flat at
+.IR build/<name> .
+A cross-compiled tool would be a binary nothing can run and nothing distributes.
+.PP
+.B lore
+and
+.B writ
+additionally keep a flat host copy at
+.IR build/<name> ,
+so the binary that runs on this machine has one path that does not shift with the host triple.
+.B build/star
+is the generator that codegen invokes; it is produced by the
+.B star
+target rather than by the build matrix, because it must exist before generation can begin.
+.SS Cross-compilation
+The codebase is pure Go, so every supported platform builds from any host with
+.B GOOS
+and
+.B GOARCH
+alone \(em no per-platform toolchains and no build VMs. Build tools are always built for the
+.I host
+even while products are built for a target; without that split, cross-compiling the product would
+cross-compile the generator and the host would fail to execute it.
+.SH VARIABLES
+.TP
+.B PLATFORM
+Which platforms to build for: the literal
+.BR all ,
+or one or more
+.IR <goos>/<goarch>
+names separated by spaces.
+.B The default differs by target.
+.B make build
+defaults to this machine, because the inner loop should not pay to link platforms it is not about to
+run. \fBmake dist\fR defaults to every supported platform, because a release is not a selection.
+Supported values are
+.BR darwin/amd64 ,
+.BR darwin/arm64 ,
+.BR linux/amd64 ,
+.BR linux/arm64 ,
+.BR windows/amd64 ,
+and
+.BR windows/arm64 .
+.TP
+.B TAGS
+Which test suites run, on
+.B test
+and
+.BR test-race .
+.B all
+(the default) runs untagged, integration, and e2e tests. An empty value runs untagged tests only.
+.B integration
+and
+.B e2e
+each add their suite to the untagged set. The e2e suite requires a configured AI provider.
+.TP
+.B PREFIX
+Installation root for
+.BR "make install" ,
+defaulting to
+.IR ~/.local .
+Each tool's self install places binaries, man pages, completions, and configuration beneath it.
+.TP
+.B DEVLORE_VERSION
+The version stamped into every binary. Defaults to
+.BR "git describe --tags --match \(dqv*\(dq --always --dirty" .
+Set it to produce draft or pre-release builds, for example
+.BR "make dist DEVLORE_VERSION=v0.1.0-alpha" .
+.TP
+.B VERSION\fR, \fBCOMMIT\fR, \fBBUILD_DATE
+The three values stamped through
+.BR -ldflags .
+They default from
+.B DEVLORE_VERSION
+and from git, are frozen once per
+.B make
+run, and are exported so that sub-makes stamp identically. Override them only to reproduce a specific
+build.
+.TP
+.B STAR_LKG
+Path to the last-known-good
+.B star
+snapshot, defaulting to
+.IR build/star.lkg .
+When the file exists it becomes the generator, bypassing a rebuild. This is the escape hatch for when
+in-tree changes break
+.B star
+compilation or make it panic on startup \(em without it, code generation cannot run and generated files
+cannot be regenerated. Promote a snapshot with
+.B make star-lkg
+only after a known-green build.
+.TP
+.B STAR
+The generator binary itself. Resolves to
+.B STAR_LKG
+when that file exists and to
+.I build/star
+otherwise. Set it directly only to test an alternative generator.
+.TP
+.B HELP_COLWIDTH
+Column width for the
+.B help-short
+listing. Defaults to 24.
+.SH TARGETS
+.SS Help
+.TP
+.B help
+Alias for
+.BR help-short .
+.TP
+.B help-short
+List every annotated target with a one-line description.
+.TP
+.B help-full
+Display this manual.
+.SS Build
+.TP
+.B build
+Build every product for
+.BR PLATFORM ,
+plus the host tools. Runs code generation first. Verifies that the version stamp bound to real symbols
+by executing the host's own
+.B writ
+\(em a check that announces itself as skipped when
+.B PLATFORM
+excludes this machine, since a foreign binary cannot be run here.
+.TP
+.B star
+Build the code generator for the host.
+.TP
+.B star-lkg
+Snapshot
+.I build/star
+as the last-known-good generator. Run only after a green build.
+.TP
+.B install
+Install
+.BR lore ,
+.BR star ,
+and
+.B writ
+beneath
+.B PREFIX
+using each tool's own self install.
+.TP
+.B clean
+Remove
+.IR build/ .
+.SS Test
+.TP
+.B test
+Run the test suites selected by
+.BR TAGS .
+.TP
+.B test-race
+As
+.BR test ,
+under the race detector.
+.TP
+.B test-scenario
+Drive the real binaries end to end in a sandbox \(em the install path's only end-to-end coverage.
+.TP
+.B cover
+Report per-package and total coverage, writing
+.IR coverage.out .
+Not a gate; use
+.B test
+or
+.B check
+for that.
+.SS Quality
+.TP
+.B check
+Run every quality gate:
+.BR vet ,
+.BR lint ,
+.BR shell-lint ,
+.BR complexity ,
+.BR verify-ldflags ,
+and
+.BR test .
+.TP
+.B vet\fR, \fBlint\fR, \fBshell-lint
+Run
+.BR "go vet" ,
+golangci-lint, and the shell linter respectively.
+.TP
+.B vet-all\fR, \fBlint-all\fR, \fBbuild-all
+Run the corresponding check under every supported
+.BR GOOS .
+These compile without executing anything, so they cannot catch a defect that only appears when a binary
+runs.
+.TP
+.B complexity
+Fail if any function exceeds cyclomatic complexity 20.
+.TP
+.B verify-ldflags
+Assert that every build definition in the repository stamps the same package. A
+.B -X
+flag naming a symbol that does not exist is silently ignored by the linker, so agreement between
+definitions is the only available check.
+.SS Distribution
+.TP
+.B dist
+Build distribution archives for
+.B PLATFORM
+and generate checksums.
+.TP
+.B dist-all
+Build the archives without checksums.
+.TP
+.B checksums
+Generate SHA-256 checksums for the archives.
+.TP
+.B dist-clean
+Remove
+.IR dist/ .
+.SS Development
+.TP
+.B dev
+Activate the repository's git hooks.
+.TP
+.B docs
+Regenerate the CLI documentation under
+.IR docs/cli/ .
+.TP
+.B generate\fR, \fBinventory
+Run code generation, and regenerate the provider inventory from
+.B op.Announce*
+call sites.
+.SH EXAMPLES
+.PP
+Build for this machine, then run the gates:
+.PP
+.RS
+.EX
+make build
+make check
+.EE
+.RE
+.PP
+Build every supported platform, then ship:
+.PP
+.RS
+.EX
+make build PLATFORM=all
+make dist
+.EE
+.RE
+.PP
+Build for two named platforms:
+.PP
+.RS
+.EX
+make build PLATFORM="linux/amd64 darwin/arm64"
+.EE
+.RE
+.PP
+Run only the unit tests, then only the integration suite:
+.PP
+.RS
+.EX
+make test TAGS=
+make test TAGS=integration
+.EE
+.RE
+.PP
+Cut a pre-release:
+.PP
+.RS
+.EX
+make dist DEVLORE_VERSION=v0.1.0-alpha
+.EE
+.RE
+.SH FILES
+.TP
+.I build/<goos>-<goarch>/
+Products for one platform.
+.TP
+.I build/<name>
+Host tools, and the flat host copies of
+.B lore
+and
+.BR writ .
+.TP
+.I build/star
+The code generator that codegen invokes.
+.TP
+.I build/star.lkg
+The last-known-good generator, when one has been promoted.
+.TP
+.I dist/
+Distribution archives and checksums.
+.TP
+.I coverage.out
+Coverage profile written by
+.BR "make cover" .
+.SH REQUIREMENTS
+GNU make 3.82 or later, for
+.BR .ONESHELL .
+macOS ships 3.81; install a newer one with
+.BR "brew install make" ,
+which provides it as
+.BR gmake .
+.SH SEE ALSO
+.BR lore (1),
+.BR writ (1),
+.BR star (1),
+.BR go (1)


### PR DESCRIPTION
Closes #655. Follows the convention already in use across the NobleFactor repositories
(`../docker-homebridge`).

## Three tiers of help

```
make help        # alias for help-short
make help-short  # the annotated-target listing
make help-full   # the manual: every target AND every variable
```

`help-short` now ends by pointing at `help-full`, so the variable surface is discoverable from the
listing rather than only from reading the Makefile.

## `docs/devlore-cli.1`

346 lines of troff: `NAME`, `SYNOPSIS`, `DESCRIPTION`, a `BUILD MODEL` section explaining the
product/tool split and why cross-compilation needs it, then `VARIABLES`, `TARGETS`, `EXAMPLES`,
`FILES`, `REQUIREMENTS`.

**Variables are the point.** `##` annotations document *targets*; they structurally cannot reach the
`VAR=VALUE` surface. Every `?=` variable in the Makefile now has a `.TP` entry — verified by
enumerating them from the Makefile and checking each against the page.

`PLATFORM` is the case that most needed it: **its default differs by target** — `build` defaults to this
machine, `dist` to every supported platform — and `all` is a magic value. No target listing can convey
that.

## Two defects found while writing it

1. **`BUILD_TAGS` was dead.** Declared at Makefile:112-118 with the usage `make test BUILD_TAGS=e2e`,
   and referenced by **nothing** — `TAGS` is the live variable. The documented invocation did nothing.
   Removed rather than documented. Writing out the variable surface is what surfaced it.
2. **`man -l` is not portable.** The reference implementation uses `man -P 'less -R' -l <file>`, which
   works under GNU man and fails under the BSD man macOS ships (`illegal option -- l`). `help-full`
   passes the path instead: both implementations treat an argument containing a slash as a file to
   render. `PROJECT_ROOT` supplies that slash, so it also works under `make -C`.

Also folded in, as agreed on #654: **Makefile:107** said "PLATFORM cannot be reassigned from the
makefile," which is false in general — `override` does exactly that. It now says "cannot be reassigned by
a plain assignment — only `override` does that."

## Verification

`make help`, `make help-short`, `make help-full` all work; `help-full` renders correctly under BSD man
and from another working directory via `make -C`. Every `?=` variable and every annotated target appears
in the page.

`make build` · `make test` 103 ok · `make test TAGS=` (proving the `BUILD_TAGS` removal changed nothing)
· `make vet` darwin/linux/windows · `test-scenario` · `complexity` · `shell-lint` · `verify-ldflags` ·
`gofmt -l` — all clean.

## Not done here

`roonserver-image/makefile` — named as a reference — currently contains live merge conflict markers
(`<<<<<<< HEAD` … `>>>>>>> user/david-noble`) around its `image`/`container`/`clean` targets, so make
cannot parse it. Different repository; noted on #655.
