### PR TITLE
feat(op): a resource announces an interface and reflects on the struct behind it

### DIFF
--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -295,7 +295,7 @@ exported behavioral fields.
 
 ### Part 1 — the eight single-resource providers
 
-#### Phase 1 — the framework repairs and `service` — status: pending
+#### Phase 1 — the framework repairs and `service` — status: complete
 
 Land the framework change from *What ruling 4 costs* first, then prove the whole shape on the provider with
 the smallest external footprint: `service`, with **zero** files outside its own package naming the type
@@ -312,6 +312,23 @@ reloads.
 **The judgment scenario lands here, red first.** A dict supplied where a resource slot is expected mints
 an identity-less resource today; it must fail conversion after. Red before the seal, green after —
 otherwise the correctness claim is argued rather than demonstrated.
+
+**Landed 2026-08-24 (#641).** Four things the phase established that the plan had not predicted:
+
+1. **The implementation crosses the package boundary by registration, not by argument.** The generated
+   announcement cannot name an unexported type, so `op.RegisterResourceImplementation` is called from the
+   provider's own init. Ordering is guaranteed by the language — the generated package imports the provider
+   package, so Go initializes the provider first.
+2. **A sealed provider must also designate its own mint.** An interface asserts no kind, so an authored
+   string bound to an interface-typed slot is refused (§5.7 rule 6) unless the interface names a claim type.
+   `file` needs the rule because it has four variants to choose between; a single-implementation provider
+   designates itself and the question does not arise. Every phase from here needs the same two lines.
+3. **`op.Resource` does not expose everything `ResourceBase` provides** — `ReachabilityURI`, `Equal`,
+   `Format`, and the marshalers were reachable only because embedding leaked the base's whole surface. Every
+   caller is in-package, so tests reach the struct rather than widening the exported contract; a later phase
+   with an out-of-package caller will have to decide differently.
+4. **A provider's own package announces nothing.** It imports neither its gen package nor the inventory, so
+   a test needing the registry populated belongs in `pkg/op/inventory`, not beside the provider.
 
 #### Phase 2 — `git` and `appnet` — status: pending
 

--- a/pkg/op/inventory/discipline_test.go
+++ b/pkg/op/inventory/discipline_test.go
@@ -77,3 +77,79 @@ func TestBootDiscipline_EveryResourceTypeOverridesAddressing(t *testing.T) {
 		t.Fatal("no Resource types found in receiver registry; expected at least one (file, mem, ...)")
 	}
 }
+
+// TestBootDiscipline_EveryResourceResultResolvesItsProductType asserts that a receipt can resolve the product
+// type it records.
+//
+// [op.ReceiptBase.Commit] records the id [canonicalIDOf] reports, and restore resolves it through an index
+// built from every action method's DECLARED result type. Two different derivations of the same identity, and
+// nothing forces them to agree.
+//
+// While every provider's resource was a struct they agreed by construction — the declared return and the
+// value's dynamic type were the same type. Sealing separates them: a method declares the interface while
+// returning the unexported struct behind it. A recorded id taken from the Go type would then name something no
+// method declares.
+//
+// **The failure is silent.** `retypeStampedResult` reads:
+//
+//	productType, ok := ReceiverRegistry().ProductTypeByID(s.resultType)
+//	if !ok {
+//		return
+//	}
+//
+// so a resumed run keeps the raw URI string instead of a resource. No error, no log, and a resume test that
+// only asserts success would pass throughout. This asserts resolution itself.
+//
+// It lives here for the same reason as the discipline test above: inventory blank-imports every provider's gen
+// package, so the registry is fully populated by the time tests run. A provider's own package imports neither
+// its gen package nor any other, so nothing is announced in that test binary at all.
+func TestBootDiscipline_EveryResourceResultResolvesItsProductType(t *testing.T) {
+
+	types := op.SnapshotReceiverTypes()
+	if len(types) == 0 {
+		t.Fatal("no receiver types announced; expected provider gen packages to register types at init")
+	}
+
+	resourceInterface := reflect.TypeFor[op.Resource]()
+	var checked int
+
+	for _, rt := range types {
+
+		provider, isProvider := rt.(op.ProviderReceiverType)
+		if !isProvider {
+			continue
+		}
+
+		for method := range provider.Methods() {
+
+			result := method.ResultType()
+			if result == nil || !result.Implements(resourceInterface) {
+				continue
+			}
+
+			// The id a receipt records for a value of this type: the announced identity, not the Go type.
+			// typeIDOf drops any pointer, which is exactly what op.ResourceBase stores at construction.
+			recorded := op.CanonicalResourceTypeID(result)
+
+			resolved, ok := op.ReceiverRegistry().ProductTypeByID(recorded)
+			if !ok {
+				t.Errorf(
+					"%s.%s returns %s, whose recorded product id %q does not resolve — a receipt from this "+
+						"method would silently fail to retype its result on resume",
+					provider.Name(), method.Name(), result, recorded)
+				continue
+			}
+
+			if !result.AssignableTo(resolved) && !resolved.AssignableTo(result) {
+				t.Errorf("%s.%s: id %q resolved to %s, unrelated to the declared %s",
+					provider.Name(), method.Name(), recorded, resolved, result)
+			}
+
+			checked++
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no action method returns a resource; the index this test guards would be empty")
+	}
+}

--- a/pkg/op/provider/service/forgery_test.go
+++ b/pkg/op/provider/service/forgery_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// TestConvert_ADictCannotForgeAResource is the judgment scenario for the sealed-resource feature (#625).
+//
+// The threat is not a struct literal someone might write — none exists outside its own package anywhere in the
+// tree. It is a path the framework already takes: [op.Convert]'s generic map-to-struct hydration admits any
+// conversion whose source is a string-keyed map and whose target has concrete kind [reflect.Struct]. A resource
+// slot satisfies that while the resource is a struct, so an authored dict reflectively mints one and fills its
+// exported fields.
+//
+// The minted value carries no identity. [op.ResourceBase] has only unexported fields, so it stays zero and URI()
+// returns "" — the resource is not merely unclaimed, it was never issued by any catalog. It then reaches a
+// provider method that acts on the host with it.
+//
+// Sealing removes the path rather than policing it: the slot type becomes an interface, whose kind is not
+// [reflect.Struct], so hydration declines and conversion falls through to the registered constructor, which
+// interns through the catalog and refuses a map outright.
+func TestConvert_ADictCannotForgeAResource(t *testing.T) {
+
+	runtimeEnvironment := newTestRuntimeEnvironment(t)
+
+	forged, err := op.Convert(
+		runtimeEnvironment,
+		map[string]any{"Name": "nginx"},
+		reflect.TypeFor[Resource](),
+	)
+
+	if err == nil {
+		t.Fatalf(
+			"op.Convert(map) = %#v, want an error — a map must never construct a resource; "+
+				"identity comes from the catalog, not from author-supplied fields",
+			forged,
+		)
+	}
+}
+
+// TestConvert_EnvlessStringNoLongerReachesConvertFrom records the observation #649 was deferred pending.
+//
+// [op.Convert] step 7 reaches a resource's [op.TargetConverter] by probing `reflect.New(target)`. While the
+// resource was a struct that probe produced a *Resource, which implements the interface, so ConvertFrom ran and
+// returned a value with no URI. Now that the slot type is an interface, the probe produces a POINTER TO
+// INTERFACE, whose method set is empty — the probe fails and the step declines.
+//
+// Env-less is the case that isolates it: with a runtime environment present, step 6's registered constructor
+// wins first and interns through the catalog, so step 7 never runs either way.
+//
+// If this ever goes green by returning a resource again, #649's premise is wrong and its decision must be
+// revisited.
+func TestConvert_EnvlessStringNoLongerReachesConvertFrom(t *testing.T) {
+
+	converted, err := op.Convert(nil, "nginx", reflect.TypeFor[Resource]())
+
+	if err == nil {
+		t.Fatalf(
+			"op.Convert(env-less string) = %#v, want an error — with the slot sealed, step 7's probe cannot "+
+				"satisfy TargetConverter, so no identity-less resource can be minted here",
+			converted,
+		)
+	}
+}

--- a/pkg/op/provider/service/gen/resource.gen.go
+++ b/pkg/op/provider/service/gen/resource.gen.go
@@ -18,10 +18,6 @@ func init() {
 		func(runtimeEnvironment *op.RuntimeEnvironment, identity any) (op.Resource, error) {
 			return provider.DiscoverResource(runtimeEnvironment, identity)
 		},
-		map[string][]string{
-			"Equal":          {"other"},
-			"CanConvertFrom": {"source"},
-			"ConvertFrom":    {"value"},
-		},
+		nil,
 	)
 }

--- a/pkg/op/provider/service/product_type_test.go
+++ b/pkg/op/provider/service/product_type_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package service
+
+import (
+	"testing"
+)
+
+// TestReceipt_RecordsTheAnnouncedProductType pins the identity a receipt records for its result.
+//
+// A receipt records its product type at commit and resolves it back on restore through an index built from
+// every action method's DECLARED result type. The two are derived by different code from different types, so
+// they agree only if both name the announced identity.
+//
+// Before sealing they agreed by construction: the declared return was `*service.Resource` and the value's
+// dynamic type was `*service.Resource`. Sealing separates them — the declared return is the interface while the
+// value is `*service.resource` — so a recorded id taken from the Go type would name a struct no method
+// declares, the index would miss, and `retypeStampedResult` would swallow that with a bare `return`, leaving a
+// resumed result as its raw URI string rather than a resource.
+//
+// Asserting that a resume merely succeeds would prove nothing against that failure path. This asserts the
+// recorded id itself.
+func TestReceipt_RecordsTheAnnouncedProductType(t *testing.T) {
+
+	runtimeEnvironment := newTestRuntimeEnvironment(t)
+
+	r, err := NewResource(runtimeEnvironment, "", "nginx")
+	if err != nil {
+		t.Fatalf("NewResource: %v", err)
+	}
+
+	// The announced identity: the interface's canonical type id, which is what the URI fragment carries and
+	// what the product-type index is keyed by.
+	const want = "github.com/NobleFactor/devlore-cli/pkg/op/provider/service.Resource"
+
+	if got := r.ResourceType(); got != want {
+		t.Errorf("ResourceType() = %q, want %q — the fragment must name the interface, not the struct", got, want)
+	}
+
+	if uri := r.URI(); uri != "tag:devlore.noblefactor.com,2026-01-01:svc:nginx#"+want {
+		t.Errorf("URI() = %q, want the fragment to name %q", uri, want)
+	}
+}

--- a/pkg/op/provider/service/provider.go
+++ b/pkg/op/provider/service/provider.go
@@ -41,19 +41,19 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 //   - `*Resource`: the service resource (identity unchanged).
 //   - `*Receipt`: compensation state recording whether the service was enabled before.
 //   - `error`: non-nil when no service manager is available or the disable command fails.
-func (p *Provider) Disable(activationRecord *op.ActivationRecord, name *Resource) (*Resource, *Receipt, error) {
+func (p *Provider) Disable(activationRecord *op.ActivationRecord, name Resource) (Resource, *Receipt, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	wasEnabled := sm.IsEnabled(name.Name)
+	wasEnabled := sm.IsEnabled(name.Name())
 
-	r := sm.Disable(name.Name)
+	r := sm.Disable(name.Name())
 	if !r.OK {
-		return nil, nil, fmt.Errorf("disable %s failed: %s", name.Name, r.Stderr)
+		return nil, nil, fmt.Errorf("disable %s failed: %s", name.Name(), r.Stderr)
 	}
-	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("disabled service %s", name.Name))
+	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("disabled service %s", name.Name()))
 	return name, &Receipt{ReceiptBase: op.NewReceiptBase(name), WasEnabled: wasEnabled}, nil
 }
 
@@ -91,19 +91,19 @@ func (p *Provider) CompensateDisable(activationRecord *op.ActivationRecord, rece
 //   - `*Resource`: the service resource (identity unchanged).
 //   - `*Receipt`: compensation state recording whether the service was enabled before.
 //   - `error`: non-nil when no service manager is available or the enable command fails.
-func (p *Provider) Enable(activationRecord *op.ActivationRecord, name *Resource) (*Resource, *Receipt, error) {
+func (p *Provider) Enable(activationRecord *op.ActivationRecord, name Resource) (Resource, *Receipt, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	wasEnabled := sm.IsEnabled(name.Name)
+	wasEnabled := sm.IsEnabled(name.Name())
 
-	r := sm.Enable(name.Name)
+	r := sm.Enable(name.Name())
 	if !r.OK {
-		return nil, nil, fmt.Errorf("enable %s failed: %s", name.Name, r.Stderr)
+		return nil, nil, fmt.Errorf("enable %s failed: %s", name.Name(), r.Stderr)
 	}
-	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("enabled service %s", name.Name))
+	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("enabled service %s", name.Name()))
 	return name, &Receipt{ReceiptBase: op.NewReceiptBase(name), WasEnabled: wasEnabled}, nil
 }
 
@@ -141,21 +141,21 @@ func (p *Provider) CompensateEnable(activationRecord *op.ActivationRecord, recei
 //   - `*Resource`: the service resource (identity unchanged).
 //   - `*Receipt`: compensation state; [Provider.CompensateRestart] is a no-op (the service was already running).
 //   - `error`: non-nil when no service manager is available or the stop/start commands fail.
-func (p *Provider) Restart(activationRecord *op.ActivationRecord, name *Resource) (*Resource, *Receipt, error) {
+func (p *Provider) Restart(activationRecord *op.ActivationRecord, name Resource) (Resource, *Receipt, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	r := sm.Stop(name.Name)
+	r := sm.Stop(name.Name())
 	if !r.OK {
 		return nil, nil, fmt.Errorf("stop before restart: %s", r.Stderr)
 	}
-	r = sm.Start(name.Name)
+	r = sm.Start(name.Name())
 	if !r.OK {
 		return nil, nil, fmt.Errorf("start after restart: %s", r.Stderr)
 	}
-	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("restarted service %s", name.Name))
+	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("restarted service %s", name.Name()))
 	return name, &Receipt{ReceiptBase: op.NewReceiptBase(name)}, nil
 }
 
@@ -181,19 +181,19 @@ func (p *Provider) CompensateRestart(activationRecord *op.ActivationRecord, _ *R
 //   - `*Resource`: the service resource (identity unchanged).
 //   - `*Receipt`: compensation state recording whether the service was running before.
 //   - `error`: non-nil when no service manager is available or the start command fails.
-func (p *Provider) Start(activationRecord *op.ActivationRecord, name *Resource) (*Resource, *Receipt, error) {
+func (p *Provider) Start(activationRecord *op.ActivationRecord, name Resource) (Resource, *Receipt, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	wasRunning := sm.IsRunning(name.Name)
+	wasRunning := sm.IsRunning(name.Name())
 
-	r := sm.Start(name.Name)
+	r := sm.Start(name.Name())
 	if !r.OK {
-		return nil, nil, fmt.Errorf("start %s failed: %s", name.Name, r.Stderr)
+		return nil, nil, fmt.Errorf("start %s failed: %s", name.Name(), r.Stderr)
 	}
-	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("started service %s", name.Name))
+	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("started service %s", name.Name()))
 	return name, &Receipt{ReceiptBase: op.NewReceiptBase(name), WasRunning: wasRunning}, nil
 }
 
@@ -231,19 +231,19 @@ func (p *Provider) CompensateStart(activationRecord *op.ActivationRecord, receip
 //   - `*Resource`: the service resource (identity unchanged).
 //   - `*Receipt`: compensation state recording whether the service was running before.
 //   - `error`: non-nil when no service manager is available or the stop command fails.
-func (p *Provider) Stop(activationRecord *op.ActivationRecord, name *Resource) (*Resource, *Receipt, error) {
+func (p *Provider) Stop(activationRecord *op.ActivationRecord, name Resource) (Resource, *Receipt, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	wasRunning := sm.IsRunning(name.Name)
+	wasRunning := sm.IsRunning(name.Name())
 
-	r := sm.Stop(name.Name)
+	r := sm.Stop(name.Name())
 	if !r.OK {
-		return nil, nil, fmt.Errorf("stop %s failed: %s", name.Name, r.Stderr)
+		return nil, nil, fmt.Errorf("stop %s failed: %s", name.Name(), r.Stderr)
 	}
-	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("stopped service %s", name.Name))
+	p.RuntimeEnvironment().Status.Succeed(fmt.Sprintf("stopped service %s", name.Name()))
 	return name, &Receipt{ReceiptBase: op.NewReceiptBase(name), WasRunning: wasRunning}, nil
 }
 
@@ -281,12 +281,12 @@ func (p *Provider) CompensateStop(activationRecord *op.ActivationRecord, receipt
 // Returns:
 //   - `bool`: true when the service is enabled.
 //   - `error`: non-nil when no service manager is available.
-func (p *Provider) Enabled(name *Resource) (bool, error) {
+func (p *Provider) Enabled(name Resource) (bool, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return false, err
 	}
-	return sm.IsEnabled(name.Name), nil
+	return sm.IsEnabled(name.Name()), nil
 }
 
 // Exists returns true if the named service exists on the system.
@@ -297,12 +297,12 @@ func (p *Provider) Enabled(name *Resource) (bool, error) {
 // Returns:
 //   - `bool`: true when the service exists.
 //   - `error`: non-nil when no service manager is available.
-func (p *Provider) Exists(name *Resource) (bool, error) {
+func (p *Provider) Exists(name Resource) (bool, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return false, err
 	}
-	return sm.Exists(name.Name), nil
+	return sm.Exists(name.Name()), nil
 }
 
 // Running returns true if the named service is currently running.
@@ -313,12 +313,12 @@ func (p *Provider) Exists(name *Resource) (bool, error) {
 // Returns:
 //   - `bool`: true when the service is running.
 //   - `error`: non-nil when no service manager is available.
-func (p *Provider) Running(name *Resource) (bool, error) {
+func (p *Provider) Running(name Resource) (bool, error) {
 	sm, err := p.serviceManager()
 	if err != nil {
 		return false, err
 	}
-	return sm.IsRunning(name.Name), nil
+	return sm.IsRunning(name.Name()), nil
 }
 
 // endregion
@@ -361,13 +361,13 @@ func (p *Provider) serviceManager() (platform.ServiceManager, error) {
 //   - `receipt`: the receipt whose affected resource carries the service name.
 //
 // Returns:
-//   - `string`: the service name, or "" when the receipt has no [*Resource].
+//   - `string`: the service name, or "" when the receipt has no [Resource].
 func resourceName(receipt *Receipt) string {
-	r, ok := receipt.Resource().(*Resource)
+	r, ok := receipt.Resource().(Resource)
 	if !ok || r == nil {
 		return ""
 	}
-	return r.Name
+	return r.Name()
 }
 
 // endregion

--- a/pkg/op/provider/service/provider_test.go
+++ b/pkg/op/provider/service/provider_test.go
@@ -103,9 +103,9 @@ func newTestProvider(sm *mockServiceManager) *Provider {
 	}
 }
 
-// res constructs a *Resource for a service name. Uses DiscoverResource because the test isn't claiming
+// res constructs a Resource for a service name. Uses DiscoverResource because the test isn't claiming
 // production — service.Resource is a reference handle to an existing host service.
-func res(t *testing.T, name string) *Resource {
+func res(t *testing.T, name string) Resource {
 	t.Helper()
 	r, err := DiscoverResource(&op.RuntimeEnvironment{}, name)
 	if err != nil {
@@ -126,8 +126,8 @@ func TestStart_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Start() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Start() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
 	if state.WasRunning {
 		t.Error("Start() WasRunning = true, want false")
@@ -147,8 +147,8 @@ func TestStart_AlreadyRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Start() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Start() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
 	if !state.WasRunning {
 		t.Error("Start() WasRunning = false, want true")
@@ -175,7 +175,7 @@ func TestCompensateStart_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateStart(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasRunning:  false,
 		}); err != nil {
 			t.Fatalf("CompensateStart() error = %v", err)
@@ -191,7 +191,7 @@ func TestCompensateStart_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateStart(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasRunning:  true,
 		}); err != nil {
 			t.Fatalf("CompensateStart() error = %v", err)
@@ -221,8 +221,8 @@ func TestStop_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stop() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Stop() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Stop() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
 	if !state.WasRunning {
 		t.Error("Stop() WasRunning = false, want true")
@@ -241,7 +241,7 @@ func TestCompensateStop_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateStop(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasRunning:  true,
 		}); err != nil {
 			t.Fatalf("CompensateStop() error = %v", err)
@@ -257,7 +257,7 @@ func TestCompensateStop_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateStop(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasRunning:  false,
 		}); err != nil {
 			t.Fatalf("CompensateStop() error = %v", err)
@@ -279,15 +279,15 @@ func TestRestart_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Restart() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Restart() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Restart() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
-	resource, ok := state.Resource().(*Resource)
+	resource, ok := state.Resource().(Resource)
 	if !ok {
-		t.Fatalf("Restart() state.Resource() = %T, want *Resource", state.Resource())
+		t.Fatalf("Restart() state.Resource() = %T, want Resource", state.Resource())
 	}
-	if resource.Name != "nginx" {
-		t.Errorf("Restart() resource.Name = %q, want %q", resource.Name, "nginx")
+	if resource.Name() != "nginx" {
+		t.Errorf("Restart() resource.Name() = %q, want %q", resource.Name(), "nginx")
 	}
 	if !sm.running["nginx"] {
 		t.Error("service should be running after Restart()")
@@ -329,8 +329,8 @@ func TestEnable_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Enable() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Enable() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Enable() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
 	if state.WasEnabled {
 		t.Error("Enable() WasEnabled = true, want false")
@@ -349,7 +349,7 @@ func TestCompensateEnable_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateEnable(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasEnabled:  false,
 		}); err != nil {
 			t.Fatalf("CompensateEnable() error = %v", err)
@@ -365,7 +365,7 @@ func TestCompensateEnable_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateEnable(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasEnabled:  true,
 		}); err != nil {
 			t.Fatalf("CompensateEnable() error = %v", err)
@@ -387,8 +387,8 @@ func TestDisable_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Disable() error = %v", err)
 	}
-	if result.Name != "nginx" {
-		t.Errorf("Disable() result.ReceiverName = %q, want %q", result.Name, "nginx")
+	if result.Name() != "nginx" {
+		t.Errorf("Disable() result.ReceiverName = %q, want %q", result.Name(), "nginx")
 	}
 	if !state.WasEnabled {
 		t.Error("Disable() WasEnabled = false, want true")
@@ -407,7 +407,7 @@ func TestCompensateDisable_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateDisable(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasEnabled:  true,
 		}); err != nil {
 			t.Fatalf("CompensateDisable() error = %v", err)
@@ -423,7 +423,7 @@ func TestCompensateDisable_Success(t *testing.T) {
 
 		p := newTestProvider(sm)
 		if err := p.CompensateDisable(testActivation(t, p.RuntimeEnvironment()), &Receipt{
-			ReceiptBase: op.NewReceiptBase(&Resource{Name: "nginx"}),
+			ReceiptBase: op.NewReceiptBase(&resource{name: "nginx"}),
 			WasEnabled:  false,
 		}); err != nil {
 			t.Fatalf("CompensateDisable() error = %v", err)

--- a/pkg/op/provider/service/receipt.go
+++ b/pkg/op/provider/service/receipt.go
@@ -106,7 +106,7 @@ func (r *Receipt) RestoreEncoded(
 	catalog := runtimeEnvironment.ResourceCatalog
 	got, ok := catalog.Lookup(catalog.Current(base.ResourceURI))
 	assert.True("service.Receipt: resource in catalog", ok)
-	resource := assert.Type[*Resource]("service catalog entry", got)
+	resource := assert.Type[*resource]("service catalog entry", got)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)
 

--- a/pkg/op/provider/service/resource.go
+++ b/pkg/op/provider/service/resource.go
@@ -15,29 +15,78 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// Interface Guard: *Resource implements op.Resource (via op.ResourceBase + own overrides).
-var _ op.Resource = (*Resource)(nil)
+// Interface Guard: *resource implements op.Resource (via op.ResourceBase + own overrides).
+var _ op.Resource = (*resource)(nil)
 
-// Interface Guard: *Resource implements json.Unmarshaler.
-var _ json.Unmarshaler = (*Resource)(nil)
+// Interface Guard: *resource implements json.Unmarshaler.
+var _ json.Unmarshaler = (*resource)(nil)
 
-// Interface Guard: *Resource implements encoding.TextUnmarshaler.
-var _ encoding.TextUnmarshaler = (*Resource)(nil)
+// Interface Guard: *resource implements encoding.TextUnmarshaler.
+var _ encoding.TextUnmarshaler = (*resource)(nil)
 
-// Interface Guard: *Resource implements fmt.Stringer.
-var _ fmt.Stringer = (*Resource)(nil)
+// Interface Guard: *resource implements fmt.Stringer.
+var _ fmt.Stringer = (*resource)(nil)
 
-// Resource represents a system service identified by name.
+// Resource is this provider's resource type — the sealed interface over a system service identified by name.
 //
-// Location-keyed: the canonical URI is `tag:devlore.noblefactor.com,2026-01-01:svc:<Name>#...service.Resource`.
-// Service state (running, enabled, mode, last-changed) is host-side and not part of identity — two
-// service.Resources with the same Name on different hosts share a URI and a catalog entry.
-type Resource struct {
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares and no
+// value reaching a service method was built anywhere else. That is the guarantee the resource model rests on:
+// identity is the catalog key, and a hand-built or reflectively-hydrated value carries none.
+//
+// Location-keyed: the canonical URI is `tag:devlore.noblefactor.com,2026-01-01:svc:<name>#...service.Resource`.
+// Service state (running, enabled, mode, last-changed) is host-side and not part of identity — two Resources
+// naming the same service on different hosts share a URI and a catalog entry.
+type Resource interface {
+	op.Resource
+
+	// Name returns the service name (e.g., "nginx", "sshd"). Identity-bearing — it appears in the URI
+	// <specific> as `svc:<name>` and is derivable from the URI.
+	Name() string
+
+	// sealedResource marks the closed set of Resource implementations: only this package can declare it, so
+	// no type outside can satisfy Resource.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete service resource — what serializes, and the only thing that implements [Resource].
+//
+// Unexported so that `&service.resource{...}` cannot be written anywhere else. The exported constructors are
+// the public contract; the struct behind them need not be.
+type resource struct {
 	op.ResourceBase
 
-	// Name is the service name (e.g., "nginx", "sshd"). Identity-bearing — appears in the URI <specific> as
-	// `svc:<Name>`. Derivable from URI.
-	Name string
+	// name is the service name. Identity-bearing — appears in the URI <specific> as `svc:<name>`.
+	name string
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// Name returns the service name.
+//
+// Returns:
+//   - `string`: the service name (e.g., "nginx").
+func (r *resource) Name() string { return r.name }
+
+// init wires the two things a sealed resource cannot state from the generated announcement.
+//
+// Both are needed because that announcement lives in a sibling package and can name only exported
+// identifiers. Go initializes an imported package before its importer, so this always runs first.
+func init() {
+
+	// What reflection runs against. The NON-pointer form, matching what the announcement passed while the
+	// resource was a struct — receiver construction promotes it to a pointer itself, so registering the
+	// pointer here would change the announced kind and nothing else.
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+
+	// What an authored string claims as. An interface asserts no kind, so a plain string bound to an
+	// interface-typed slot is refused unless the interface designates a claim type (§5.7 rule 6). `file`
+	// needs that rule because it has a kind axis and four variants to choose between; a provider with one
+	// implementation designates it and the question does not arise.
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs a service.Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -61,9 +110,9 @@ type Resource struct {
 //   - `value`: a bare service name string, or a canonical tag URI (`tag:..:svc:<name>#...`).
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: non-string input, malformed URI, or [op.ResourceBase] construction failure.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -82,10 +131,10 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
 		return nil, fmt.Errorf(
-			"service.NewResource: catalog entry for %q is %T, want *service.Resource",
+			"service.NewResource: catalog entry for %q is %T, want *service.resource",
 			candidate.URI(), got,
 		)
 	}
@@ -111,9 +160,25 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 //   - `value`: a bare service name string, or a canonical tag URI; same dispatch as [NewResource].
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: non-string input, malformed URI, or [op.ResourceBase] construction failure.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type.
+//
+// The exported form returns the sealed interface, which is what callers should hold. Rehydration cannot: it
+// assigns through the receiver (`*r = *built`), and that needs a value, not an interface.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: a bare service name string, or a canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: non-string input, malformed URI, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -131,10 +196,10 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
 		return nil, fmt.Errorf(
-			"service.DiscoverResource: catalog entry for %q is %T, want *service.Resource",
+			"service.DiscoverResource: catalog entry for %q is %T, want *service.resource",
 			candidate.URI(), got,
 		)
 	}
@@ -153,10 +218,10 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 //   - `value`: a string service name or canonical tag URI; any other type is an error.
 //
 // Returns:
-//   - `*Resource`: unlinked candidate.
+//   - `*resource`: unlinked candidate.
 //   - `error`: non-string input, malformed URI, URI <specific> not in `svc:<name>` form, or [op.ResourceBase]
 //     construction failure.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	raw, ok := value.(string)
 	if !ok {
@@ -176,14 +241,14 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 		name = extracted
 	}
 
-	base, err := op.NewResourceBase(runtimeEnvironment, "svc:"+name, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, "svc:"+name, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Name:         name,
+		name:         name,
 	}, nil
 }
 
@@ -198,7 +263,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 //
 // Returns:
 //   - `op.AddressingMode`: [op.AddressingLocation] — identity is the service name embedded in the URI.
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 	return op.AddressingLocation
 }
 
@@ -212,7 +277,7 @@ func (r *Resource) Addressing() op.AddressingMode {
 // Returns:
 //   - `op.Digest`: sha256 of the URI; Algorithm = "sha256", Bytes = 32 raw digest bytes.
 //   - `error`: nil under normal conditions.
-func (r *Resource) Digest() (op.Digest, error) {
+func (r *resource) Digest() (op.Digest, error) {
 	h := sha256.Sum256([]byte(r.URI()))
 	return op.Digest{Algorithm: "sha256", Bytes: h[:]}, nil
 }
@@ -227,13 +292,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true when `other` is a *service.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -249,7 +314,7 @@ func (r *Resource) Equal(other any) bool {
 // Returns:
 //   - `string`: the canonical URI (identical to [op.ResourceBase.URI]).
 //   - `error`: nil under normal conditions.
-func (r *Resource) Etag() (string, error) {
+func (r *resource) Etag() (string, error) {
 	return r.URI(), nil
 }
 
@@ -260,7 +325,7 @@ func (r *Resource) Etag() (string, error) {
 //
 // Returns:
 //   - `string`: the compact JSON encoding of r.
-func (r *Resource) String() string {
+func (r *resource) String() string {
 	return r.Format(r)
 }
 
@@ -282,7 +347,7 @@ func (r *Resource) String() string {
 //
 // Returns:
 //   - `bool`: true when `source` is `string`.
-func (*Resource) CanConvertFrom(source reflect.Type) bool {
+func (*resource) CanConvertFrom(source reflect.Type) bool {
 
 	return source != nil && source.Kind() == reflect.String
 }
@@ -301,14 +366,14 @@ func (*Resource) CanConvertFrom(source reflect.Type) bool {
 // Returns:
 //   - `any`: the constructed unlinked [*Resource].
 //   - `error`: non-nil when `value` is not a `string`.
-func (*Resource) ConvertFrom(value any) (any, error) {
+func (*resource) ConvertFrom(value any) (any, error) {
 
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("service.Resource.ConvertFrom: source must be string, got %T", value)
 	}
 
-	return &Resource{Name: str}, nil
+	return &resource{name: str}, nil
 }
 
 // endregion
@@ -326,7 +391,7 @@ func (*Resource) ConvertFrom(value any) (any, error) {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, malformed JSON, or rehydration failure.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("service.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
@@ -337,7 +402,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -356,13 +421,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, or rehydration failure.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("service.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -381,7 +446,7 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, decode failure, or rehydration failure.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("service.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
@@ -392,7 +457,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}

--- a/pkg/op/provider/service/resource_test.go
+++ b/pkg/op/provider/service/resource_test.go
@@ -19,7 +19,7 @@ import (
 // --- Interface guards ---
 
 func TestResource_ImplementsInterface(t *testing.T) {
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -44,6 +44,21 @@ func testActivation(t *testing.T, runtimeEnvironment *op.RuntimeEnvironment) *op
 	return op.NewActivationRecord(nil, "", runtimeEnvironment)
 }
 
+// concrete reaches the struct behind a sealed [Resource].
+//
+// [op.Resource] declares neither ReachabilityURI nor the marshalers, so the sealed interface does not expose
+// them either — before sealing they were reachable only because embedding leaked [op.ResourceBase]'s whole
+// surface. Every caller of those methods is in this package, so a white-box test asserting to the
+// implementation is the honest way to reach them rather than widening the exported contract.
+func concrete(t *testing.T, r Resource) *resource {
+	t.Helper()
+	c, ok := r.(*resource)
+	if !ok {
+		t.Fatalf("Resource is %T, want *resource", r)
+	}
+	return c
+}
+
 // --- NewResource ---
 
 func TestNewResource_FromName(t *testing.T) {
@@ -53,10 +68,10 @@ func TestNewResource_FromName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewResource: %v", err)
 	}
-	if r.Name != "nginx" {
-		t.Errorf("Name = %q, want %q", r.Name, "nginx")
+	if r.Name() != "nginx" {
+		t.Errorf("Name = %q, want %q", r.Name(), "nginx")
 	}
-	if got := r.ReachabilityURI(); got != "svc:nginx" {
+	if got := concrete(t, r).ReachabilityURI(); got != "svc:nginx" {
 		t.Errorf("ReachabilityURI = %q, want %q", got, "svc:nginx")
 	}
 }
@@ -76,8 +91,8 @@ func TestNewResource_FromTagURI(t *testing.T) {
 	if second.URI() != first.URI() {
 		t.Errorf("URI from URI input = %q, want %q", second.URI(), first.URI())
 	}
-	if second.Name != "sshd" {
-		t.Errorf("Name = %q, want %q", second.Name, "sshd")
+	if second.Name() != "sshd" {
+		t.Errorf("Name = %q, want %q", second.Name(), "sshd")
 	}
 }
 
@@ -154,8 +169,8 @@ func TestEqual_SameName(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, "nginx")
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, "nginx")
-	if !r1.Equal(r2) {
-		t.Error("expected r1.Equal(r2) for same-name resources")
+	if !concrete(t, r1).Equal(r2) {
+		t.Error("expected concrete(t, r1).Equal(r2) for same-name resources")
 	}
 }
 
@@ -165,7 +180,7 @@ func TestEqual_DifferentName(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, "nginx")
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, "sshd")
-	if r1.Equal(r2) {
+	if concrete(t, r1).Equal(r2) {
 		t.Error("expected Equal to be false for distinct names")
 	}
 }
@@ -174,10 +189,10 @@ func TestEqual_RejectsNonResource(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", "nginx")
 
-	if r.Equal("not a resource") {
-		t.Error("expected Equal to reject non-*Resource")
+	if concrete(t, r).Equal("not a resource") {
+		t.Error("expected Equal to reject non-Resource")
 	}
-	if r.Equal(nil) {
+	if concrete(t, r).Equal(nil) {
 		t.Error("expected Equal to reject nil")
 	}
 }
@@ -196,10 +211,11 @@ func TestUnmarshalJSON_RehydratesFromURI(t *testing.T) {
 		t.Fatalf("Marshal URI: %v", err)
 	}
 
-	seeded, err := DiscoverResource(runtimeEnvironment, original.URI())
+	seededResource, err := DiscoverResource(runtimeEnvironment, original.URI())
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	seeded := concrete(t, seededResource)
 
 	if err := seeded.UnmarshalJSON(data); err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
@@ -207,14 +223,14 @@ func TestUnmarshalJSON_RehydratesFromURI(t *testing.T) {
 	if seeded.URI() != original.URI() {
 		t.Errorf("URI after unmarshal = %q, want %q", seeded.URI(), original.URI())
 	}
-	if seeded.Name != "nginx" {
-		t.Errorf("Name after unmarshal = %q, want %q", seeded.Name, "nginx")
+	if seeded.Name() != "nginx" {
+		t.Errorf("Name after unmarshal = %q, want %q", seeded.Name(), "nginx")
 	}
 }
 
 func TestUnmarshalJSON_RequiresRuntimeEnvironment(t *testing.T) {
-	r := &Resource{}
-	if err := r.UnmarshalJSON([]byte(`"tag:..:svc:nginx#"`)); err == nil ||
+	r := &resource{}
+	if err := concrete(t, r).UnmarshalJSON([]byte(`"tag:..:svc:nginx#"`)); err == nil ||
 		!strings.Contains(err.Error(), "RuntimeEnvironment") {
 		t.Errorf("expected RuntimeEnvironment error, got %v", err)
 	}
@@ -227,10 +243,11 @@ func TestUnmarshalText_RehydratesFromURI(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	seeded, err := DiscoverResource(runtimeEnvironment, original.URI())
+	seededResource, err := DiscoverResource(runtimeEnvironment, original.URI())
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	seeded := concrete(t, seededResource)
 
 	if err := seeded.UnmarshalText([]byte(original.URI())); err != nil {
 		t.Fatalf("UnmarshalText: %v", err)
@@ -247,10 +264,11 @@ func TestUnmarshalYAML_RehydratesFromURI(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	seeded, err := DiscoverResource(runtimeEnvironment, original.URI())
+	seededResource, err := DiscoverResource(runtimeEnvironment, original.URI())
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	seeded := concrete(t, seededResource)
 
 	target := original.URI()
 	decode := func(v any) error {

--- a/pkg/op/receiver_registry.go
+++ b/pkg/op/receiver_registry.go
@@ -248,10 +248,18 @@ func AnnounceResource(
 
 	label := fmt.Sprintf("AnnounceResource(%s)", resourceType)
 
-	parsed, err := parseParameters(resourceType, methodParameters)
+	// A sealed resource announces its interface; reflection needs the struct behind it, registered by the
+	// provider's own init via [RegisterResourceImplementation]. A struct announcement is its own
+	// implementation, so this is a no-op for every provider that has not been sealed yet.
+	implementation := resourceImplementationFor(resourceType)
+	assert.Truef(implementation != nil,
+		"%s: %s is an interface with no registered implementation — the provider's init must call "+
+			"op.RegisterResourceImplementation before the generated announcement runs", label, resourceType)
+
+	parsed, err := parseParameters(implementation, methodParameters)
 	assert.NoError(label, err)
 
-	rt, err := NewResourceReceiverType(resourceType, construct, parsed, sourceTypes...)
+	rt, err := NewResourceReceiverType(resourceType, implementation, construct, parsed, sourceTypes...)
 	assert.NoError(label, err)
 
 	err = announced.registerReceiverType(rt)
@@ -483,7 +491,7 @@ func (r *receiverRegistry) ResourceConstructorByTypeID(typeID string) (ResourceC
 	defer r.mu.RUnlock()
 
 	for _, resourceType := range r.resources {
-		if typeIDOf(resourceType.ProviderType()) == typeID {
+		if resourceType.TypeID() == typeID {
 			return resourceType.Construct(), true
 		}
 	}
@@ -510,7 +518,7 @@ func (r *receiverRegistry) UnpackerByTypeID(typeID string) (Unpacker, bool) {
 	defer r.mu.RUnlock()
 
 	for _, resourceType := range r.resources {
-		if typeIDOf(resourceType.ProviderType()) == typeID {
+		if resourceType.TypeID() == typeID {
 			unpacker, ok := reflect.New(resourceType.ProviderType()).Interface().(Unpacker)
 			return unpacker, ok
 		}
@@ -538,8 +546,21 @@ func (r *receiverRegistry) ProductTypeByID(id string) (reflect.Type, bool) {
 		index := make(map[string]reflect.Type)
 		for _, providerType := range r.actions {
 			for method := range providerType.Methods() {
-				if productType := method.ResultType(); productType != nil {
-					index[canonicalID(productType)] = productType
+
+				productType := method.ResultType()
+				if productType == nil {
+					continue
+				}
+
+				index[canonicalID(productType)] = productType
+
+				// A resource result is also keyed by its ANNOUNCED type id, which is what
+				// [ReceiptBase.Commit] records — [canonicalIDOf] asks the resource rather than reflecting on
+				// it. The two spellings differ by the pointer star for an unsealed provider and by the whole
+				// name for a sealed one, so indexing both is what lets a receipt resolve its own product type
+				// either way.
+				if productType.Implements(resourceInterfaceType) {
+					index[typeIDOf(productType)] = productType
 				}
 			}
 		}

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -21,6 +21,7 @@ import (
 type ReceiverType interface {
 	Name() string
 	ProviderType() reflect.Type
+	TypeID() string
 	Methods() iter.Seq[*Method]
 	MethodByName(name string) (*Method, bool)
 	Do(method string, receiver any, args []any) (reflect.Value, reflect.Value, error)
@@ -115,6 +116,7 @@ type ResourceConstructor func(runtimeEnvironment *RuntimeEnvironment, value any)
 // It can be used to represent any Go type by reflection.
 type receiverType struct {
 	providerType  reflect.Type
+	typeID        string
 	name          string
 	methods       []*Method
 	methodMap     map[string]*Method
@@ -176,6 +178,17 @@ func (t *receiverType) Methods() iter.Seq[*Method] {
 // Returns:
 //   - reflect.Type: the type.
 func (t *receiverType) ProviderType() reflect.Type { return t.providerType }
+
+// TypeID returns the canonical type id — the string a saved document carries in a resource URI's fragment.
+//
+// Equal to [typeIDOf] of [receiverType.ProviderType] for providers and for a resource announced as a struct.
+// A SEALED resource announces its interface while reflecting on the unexported struct behind it, so the two
+// diverge there: the id names the interface, which is the name serialization has always used, while
+// ProviderType is the struct reflection needs.
+//
+// Returns:
+//   - `string`: the canonical type id.
+func (t *receiverType) TypeID() string { return t.typeID }
 
 // ReceiverName returns the name used to identify this receiver in starlark.
 //
@@ -293,15 +306,20 @@ type resourceReceiverType struct {
 //   - `error`: non-nil if method classification fails.
 func NewResourceReceiverType(
 	resourceType reflect.Type,
+	implementation reflect.Type,
 	construct ResourceConstructor,
 	methodParameters map[string][]Parameter,
 	sourceTypes ...reflect.Type,
 ) (ResourceReceiverType, error) {
 
-	base, err := newReceiverType(resourceType, methodParameters, nil, false)
+	// Reflection runs against the implementation; identity comes from the announced type. For a resource
+	// announced as a struct these are the same type and nothing changes.
+	base, err := newReceiverType(implementation, methodParameters, nil, false)
 	if err != nil {
 		return nil, err
 	}
+
+	base.typeID = typeIDOf(resourceType)
 
 	return &resourceReceiverType{
 		receiverType: base,
@@ -373,6 +391,7 @@ func newReceiverType(providerType reflect.Type, methodParameters map[string][]Pa
 
 	return receiverType{
 		providerType:  providerType,
+		typeID:        typeIDOf(providerType),
 		name:          name,
 		methods:       methods,
 		methodMap:     methodMap,

--- a/pkg/op/receiver_type_test.go
+++ b/pkg/op/receiver_type_test.go
@@ -551,7 +551,9 @@ func TestNewResourceReceiverType_Public(t *testing.T) {
 		return &testLocalResource{}, nil
 	}
 
-	rt, err := NewResourceReceiverType(rType, construct, mustParseParameters(t, rType, map[string][]string{
+	// A struct-announced resource is its own implementation — both arguments are the same type, which is
+	// what every provider passes until it is sealed.
+	rt, err := NewResourceReceiverType(rType, rType, construct, mustParseParameters(t, rType, map[string][]string{
 		"URI": {},
 	}))
 

--- a/pkg/op/resource.go
+++ b/pkg/op/resource.go
@@ -560,6 +560,22 @@ func canonicalID(goType reflect.Type) string {
 	}
 }
 
+// CanonicalResourceTypeID returns the id a receipt records for a resource of type `t`.
+//
+// The announced identity — [typeIDOf], which drops any pointer — rather than the Go type's canonical id, which
+// carries one. [op.ResourceBase] stores exactly this at construction, and [canonicalIDOf] reads it back off the
+// value, so a test or a tool that needs the id WITHOUT a value in hand derives it here rather than
+// reimplementing the rule.
+//
+// Parameters:
+//   - `t`: a resource type, pointer or interface.
+//
+// Returns:
+//   - `string`: the canonical type id.
+func CanonicalResourceTypeID(t reflect.Type) string {
+	return typeIDOf(t)
+}
+
 // canonicalIDOf returns [canonicalID] of a value's dynamic type, or "" for a nil value.
 //
 // Parameters:
@@ -572,6 +588,16 @@ func canonicalIDOf(value any) string {
 	if value == nil {
 		return ""
 	}
+
+	// A resource reports the identity it was ANNOUNCED under, not the Go type it happens to be. The two
+	// diverge once a provider is sealed: the value is an unexported struct that no method declares, while the
+	// product-type index is built from declared result types. Recording the Go type there would key the
+	// receipt by a name nothing can resolve, and the miss is silent — retypeStampedResult swallows it with a
+	// bare return, leaving a resumed result as its raw URI string.
+	if resource, isResource := value.(Resource); isResource {
+		return resource.ResourceType()
+	}
+
 	return canonicalID(reflect.TypeOf(value))
 }
 

--- a/pkg/op/resource_implementation.go
+++ b/pkg/op/resource_implementation.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"reflect"
+	"sync"
+)
+
+var (
+	// resourceImplementationsMu guards resourceImplementations. Registration happens in provider init
+	// functions; lookups run once per announcement.
+	resourceImplementationsMu sync.RWMutex
+
+	// resourceImplementations maps a provider's sealed resource INTERFACE to the unexported struct behind
+	// it. One entry per interface.
+	resourceImplementations = make(map[reflect.Type]reflect.Type)
+)
+
+// RegisterResourceImplementation designates `implementation` as the concrete struct behind the sealed
+// resource interface `resourceInterface`.
+//
+// A sealed resource is an exported interface over an unexported struct, so nothing outside the provider's
+// package can name the struct — including the generated announcement, which lives in a sibling package and
+// can reach only exported identifiers. This is how the struct crosses that boundary: the provider package
+// registers it from its own init, and [AnnounceResource] resolves it when the interface is announced.
+//
+// **Ordering is guaranteed by the language, not by convention.** The generated package imports the provider
+// package, and Go initializes imported packages first, so this registration always precedes the
+// announcement that consumes it.
+//
+// The two types serve different roles and cannot be collapsed. The interface supplies the canonical type id
+// — the URI fragment a saved document carries — while the struct supplies everything reflection needs: the
+// method set, the dispatch target, and the key `marshalReflect` looks up when it wraps a returned value.
+//
+// Distinct from [RegisterResourceMint], which answers a different question: what a bare authored string
+// claims as. The two coincide only for an interface with exactly one implementation. `file` designates
+// `*file.AnyKind` as its mint while having four implementations, so conflating them would be wrong there.
+//
+// Parameters:
+//   - `resourceInterface`: the provider's sealed resource interface type.
+//   - `implementation`: the concrete pointer type implementing it.
+func RegisterResourceImplementation(resourceInterface, implementation reflect.Type) {
+
+	resourceImplementationsMu.Lock()
+	defer resourceImplementationsMu.Unlock()
+
+	resourceImplementations[resourceInterface] = implementation
+}
+
+// region HELPER FUNCTIONS
+
+// resourceImplementationFor returns the concrete type reflection should use for `announced`.
+//
+// A non-interface announcement is its own implementation — the shape every provider had before sealing, and
+// the reason this is a no-op for them.
+//
+// Parameters:
+//   - `announcedType`: the type passed to [AnnounceResource]. Named in full because `announced` is the
+//     package-level registry variable, and shadowing it here would be a trap for the next reader.
+//
+// Returns:
+//   - `reflect.Type`: the concrete type, or nil when an interface was announced without a registration.
+func resourceImplementationFor(announcedType reflect.Type) reflect.Type {
+
+	if announcedType == nil || announcedType.Kind() != reflect.Interface {
+		return announcedType
+	}
+
+	resourceImplementationsMu.RLock()
+	defer resourceImplementationsMu.RUnlock()
+
+	return resourceImplementations[announcedType]
+}
+
+// endregion


### PR DESCRIPTION
Phase 1 of #625. Closes #641.

## The judgment scenario, red first

The forging test went in before the seal, and its failure is the argument for the whole feature:

```
service.Resource{
  ResourceBase: op.ResourceBase{runtimeEnvironment:nil, id:"", producerID:"",
                                specific:"", typeID:"", uri:""},
  Name: "nginx",
}
```

Every identity field empty, `Name` filled from an author-supplied map. `op.Convert`'s generic map-to-struct
hydration admits any target whose concrete kind is `reflect.Struct`, so a dict where a resource is expected
reflectively minted one — and it reaches `sm.Disable(name.Name)` against the host. Sealing removes the path
rather than policing it: the slot type becomes an interface, hydration declines, and conversion falls through
to the registered constructor. **The test is green now.**

## The framework change

`receiverType` carried one type doing two jobs. Split:

- **the concrete type** serves method enumeration, promotion, dispatch, and the `byType` key
- **a stored `typeID`** serves the two `typeIDOf(ProviderType()) == typeID` comparisons that match an id
  lifted from a URI

`NewMethod` cannot consume an interface method at all — `reflect` gives one a nil `Func` and a `Type` with no
receiver, so `do.Type.In(0)` returns the first *parameter* and panics outright for a no-arg method. Routing
reflection back to the struct is what makes sealing possible; it is not an enumeration nicety.

**No generated file changed.** The announcement still names `provider.Resource` and `provider.DiscoverResource`,
both exported. The struct crosses the package boundary by registration instead — `op.RegisterResourceImplementation`,
called from the provider's own init. Ordering is guaranteed by the language: the generated package imports the
provider package, so Go initializes the provider first.

## The receipt-retyping failure

`Commit` records what `canonicalIDOf` reports; restore resolves it through an index built from declared result
types. Two derivations of one identity, with nothing forcing agreement — they agreed only because the declared
return and the dynamic type were the same type. Sealing separates them.

The failure would have been **silent**: `retypeStampedResult` is `if !ok { return }`, so a resumed run keeps the
raw URI string instead of a resource. Fixed on both sides — `canonicalIDOf` asks a resource for its announced
identity, and the index is additionally keyed by that identity. Pinned in `pkg/op/inventory`, which is where the
registry is populated, and the pin asserts resolution rather than asserting that a resume succeeded.

## Serialization did not move

`service`'s URI fragment is still `…/provider/service.Resource`, pinned byte-for-byte. Ruling 4 works exactly
as designed: the interface took the name the struct gave up, so `typeIDOf` is unchanged.

## #649's deferral trigger, observed

`op.Convert` step 7 no longer reaches `ConvertFrom` for a resource slot — `reflect.New(interface)` yields a
pointer-to-interface with an empty method set, so the `TargetConverter` probe fails. Recorded as a test that
fails if it ever regains the ability to mint an identity-less resource. #649 can now be decided.

## Four things phase 1 found that the plan had not predicted

1. **A sealed provider must also designate its own mint.** An interface asserts no kind, so an authored string
   bound to one is refused unless the interface names a claim type. Every later phase needs the same two lines.
2. **`op.Resource` does not expose everything `ResourceBase` provides** — `ReachabilityURI`, `Equal`, `Format`,
   and the marshalers were reachable only because embedding leaked the base's surface. Every caller is
   in-package, so the tests reach the struct rather than widening the exported contract. A later phase with an
   out-of-package caller will have to decide differently.
3. **A provider's own package announces nothing** — it imports neither its gen package nor the inventory, so a
   test needing a populated registry belongs in `pkg/op/inventory`. The first placement of the resolution pin
   was wrong for exactly this reason.
4. The implementation registry is deliberately **not** `RegisterResourceMint`. That answers a different
   question — what a bare authored string claims as — and the two coincide only for a single-implementation
   interface. `file` designates `*file.AnyKind` while having four implementations.

All four are recorded in the plan, which now marks phase 1 complete.

## Verification

`make test` 103 ok / 0 fail · `make build` · `make vet` darwin/linux/windows · `make test-scenario` ·
`complexity` · `shell-lint` · `verify-ldflags` · `gofmt -l` — all clean.
