### PR TITLE
feat(op): git and appnet resources are sealed; identity governs the registry name

### DIFF
--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -354,7 +354,8 @@ type — only the *inspection target* is the exported interface, incidentally. I
 instead makes the metadata describe the struct dispatch reflects on, so the two cannot disagree. Ruling 3
 makes resolving one name from the other deterministic.
 
-**This lands before the provider sweep** ([#658](https://github.com/NobleFactor/devlore-cli/issues/658)). Otherwise every
+**This lands before the provider sweep** ([#658](https://github.com/NobleFactor/devlore-cli/issues/658)). Otherwise
+every
 remaining phase inherits the same silent risk and needs a manual per-provider review — five chances to miss
 one, with no signal when you do. It also narrows phase 7 to asserting the shape rather than policing dispatch.
 
@@ -367,10 +368,29 @@ with no methods falls back to itself, which is correct either way. `service`'s t
 hand-editing of `*.gen.go`, and no other provider's announcement moved — verified by comparing the metadata
 shape of all twelve resource announcements before and after.
 
-#### Phase 3 — `git` and `appnet` — status: pending
+#### Phase 3 — `git` and `appnet` — status: complete
 
 One external file and two respectively; neither implements `Unpacker`. Mechanical application of the
 phase-1 template.
+
+**Landed 2026-08-24 (#642).** Not the mechanical pass the plan expected. Four findings:
+
+1. **The registry name collided, and it is a framework fix, not a provider one.** `receiverName` special-cases
+   the type named `Resource` into `<pkg>.Resource`, which is what keeps providers distinct. A sealed
+   implementation is named `resource`, falls through to the default arm, and yields the bare `resource` for
+   *every* provider — so the second one announced panics at init with `"resource" already announced`. Identity
+   now governs the registry name as well as the type id; the implementation governs only reflection. Sealing
+   one provider could never have surfaced this; it took a second.
+2. **Open question 2 is answered here, not at `pkg`.** Both resources carry exported fields the provider reads
+   (`git`: `SourcePath`, `Ref`, `HEAD`; `appnet`: `SourceURL`), so the interface gains accessors. No external
+   consumer needed them — every real read is in-package, and the two out-of-package mentions are doc comments.
+3. **A codec cannot set unexported fields.** `git` decoded through a `type alias Resource` embed, which
+   silently leaves `ref` and `head` at zero once the fields are unexported. Both the JSON and YAML paths now
+   decode into an explicit local struct. Same keys, same shape, but the alias trick is not compatible with
+   sealing.
+4. **`git`'s document form is asymmetric, and was already.** It has no `MarshalJSON`, so the promoted base
+   marshaler writes the URI alone — nothing ever writes the `ref`/`head` keys its unmarshaler carefully
+   preserves. Behavior preserved exactly here; the asymmetry predates this feature and wants its own issue.
 
 #### Phase 4 — the `Unpacker` four: `json`, `yaml`, `mem`, `function` — status: pending
 

--- a/pkg/op/provider/appnet/provider.go
+++ b/pkg/op/provider/appnet/provider.go
@@ -38,9 +38,9 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 // Returns:
 //   - `[]byte`: the response body read from the URL.
 //   - `error`: non-nil if the request fails, the response status is not 200 OK, or the body cannot be read.
-func (p *Provider) Download(url *Resource) (_ []byte, err error) {
+func (p *Provider) Download(url Resource) (_ []byte, err error) {
 
-	rawURL := url.SourceURL.String()
+	rawURL := url.SourceURL().String()
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
 	if err != nil {

--- a/pkg/op/provider/appnet/provider_test.go
+++ b/pkg/op/provider/appnet/provider_test.go
@@ -14,14 +14,14 @@ import (
 
 // --- Test helpers ---
 
-// mustResource parses raw into a *Resource or fails the test.
-func mustResource(t *testing.T, raw string) *Resource {
+// mustResource parses raw into a Resource or fails the test.
+func mustResource(t *testing.T, raw string) Resource {
 	t.Helper()
 	u, err := url.Parse(raw)
 	if err != nil {
 		t.Fatalf("url.Parse(%q): %v", raw, err)
 	}
-	return &Resource{SourceURL: u}
+	return &resource{sourceURL: u}
 }
 
 // --- Download ---

--- a/pkg/op/provider/appnet/resource.go
+++ b/pkg/op/provider/appnet/resource.go
@@ -29,12 +29,47 @@ import (
 //
 // SourceURL is a non-persisted *url.URL view of the URI, populated at construction (and reparsed on unmarshal) for
 // callers that want structured URL access. It always equals url.Parse(URI).
-type Resource struct {
+// Resource is this provider's resource type — the sealed interface over an application-network endpoint.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. A
+// value reaching an appnet method therefore came from a constructor and carries catalog-issued identity.
+type Resource interface {
+	op.Resource
+
+	// SourceURL returns the endpoint's URL. Identity-bearing — the canonical URI derives from it.
+	SourceURL() *url.URL
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete appnet resource — what serializes, and the only thing implementing [Resource].
+//
+// Unexported so `&appnet.resource{...}` cannot be written outside this package.
+type resource struct {
 	op.ResourceBase
 
-	// SourceURL is a parsed view of the URI. Derived from URI at construction and on unmarshal; not
-	// persisted (the URI on ResourceBase is authoritative).
-	SourceURL *url.URL `json:"-" yaml:"-"`
+	// sourceURL is the endpoint's URL. Identity-bearing.
+	sourceURL *url.URL
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// SourceURL returns the endpoint's URL.
+//
+// Returns:
+//   - `*url.URL`: the URL, or nil on an unlinked candidate.
+func (r *resource) SourceURL() *url.URL { return r.sourceURL }
+
+// init wires the two things a sealed resource cannot state from its generated announcement, which lives in a
+// sibling package and can name only exported identifiers.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs an appnet.Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -66,7 +101,7 @@ type Resource struct {
 // Returns:
 //   - `*Resource`: the canonical catalog entry (or the unlinked candidate when no catalog is present).
 //   - `error`: if `value` is not a string, does not parse as a URL, or has no scheme.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -86,9 +121,9 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("appnet.NewResource: catalog entry for %q is %T, want *appnet.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("appnet.NewResource: catalog entry for %q is %T, want *appnet.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -112,7 +147,21 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 // Returns:
 //   - `*Resource`: the canonical catalog entry (or the unlinked candidate when no catalog is present).
 //   - `error`: if `value` is not a string, does not parse as a URL, or has no scheme.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type, which rehydration needs because it
+// assigns through the receiver.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: a URL string or canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -130,10 +179,10 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
 		return nil, fmt.Errorf(
-			"appnet.DiscoverResource: catalog entry for %q is %T, want *appnet.Resource", candidate.URI(), got)
+			"appnet.DiscoverResource: catalog entry for %q is %T, want *appnet.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -151,7 +200,7 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 // Returns:
 //   - `*Resource`: the canonicalized candidate, not yet interned in the catalog.
 //   - `error`: if `value` is not a string, does not parse as a URL, or has no transport scheme.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	raw, ok := value.(string)
 	if !ok {
@@ -167,14 +216,14 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 		return nil, fmt.Errorf("appnet.Resource: URL missing transport scheme: %q", raw)
 	}
 
-	base, err := op.NewResourceBase(runtimeEnvironment, canonical.String(), reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, canonical.String(), reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		SourceURL:    canonical,
+		sourceURL:    canonical,
 	}, nil
 }
 
@@ -190,7 +239,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 //
 // Returns:
 //   - `op.AddressingMode`: always [op.AddressingLocation].
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 	return op.AddressingLocation
 }
 
@@ -204,7 +253,7 @@ func (r *Resource) Addressing() op.AddressingMode {
 // Returns:
 //   - `op.Digest`: sha256 algorithm with 32 raw bytes.
 //   - `error`: nil under normal conditions.
-func (r *Resource) Digest() (op.Digest, error) {
+func (r *resource) Digest() (op.Digest, error) {
 	h := sha256.Sum256([]byte(r.URI()))
 	return op.Digest{Algorithm: "sha256", Bytes: h[:]}, nil
 }
@@ -219,13 +268,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true if `other` is a *appnet.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -242,7 +291,7 @@ func (r *Resource) Equal(other any) bool {
 // Returns:
 //   - `string`: the canonical URL (identical to [op.ResourceBase.URI]).
 //   - `error`: nil under normal conditions.
-func (r *Resource) Etag() (string, error) {
+func (r *resource) Etag() (string, error) {
 	return r.URI(), nil
 }
 
@@ -250,7 +299,7 @@ func (r *Resource) Etag() (string, error) {
 //
 // Returns:
 //   - `string`: `appnet.Resource{uri=<URI>}`.
-func (r *Resource) String() string {
+func (r *resource) String() string {
 	return fmt.Sprintf("appnet.Resource{uri=%s}", r.URI())
 }
 
@@ -271,7 +320,7 @@ func (r *Resource) String() string {
 //
 // Returns:
 //   - `bool`: true when `source` is `string`.
-func (*Resource) CanConvertFrom(source reflect.Type) bool {
+func (*resource) CanConvertFrom(source reflect.Type) bool {
 
 	return source != nil && source.Kind() == reflect.String
 }
@@ -290,7 +339,7 @@ func (*Resource) CanConvertFrom(source reflect.Type) bool {
 // Returns:
 //   - `any`: the constructed unlinked [*Resource].
 //   - `error`: non-nil when `value` is not a `string` or does not parse as a URL.
-func (*Resource) ConvertFrom(value any) (any, error) {
+func (*resource) ConvertFrom(value any) (any, error) {
 
 	str, ok := value.(string)
 	if !ok {
@@ -302,7 +351,7 @@ func (*Resource) ConvertFrom(value any) (any, error) {
 		return nil, fmt.Errorf("appnet.Resource.ConvertFrom: parse URL %q: %w", str, err)
 	}
 
-	return &Resource{SourceURL: u}, nil
+	return &resource{sourceURL: u}, nil
 }
 
 // endregion
@@ -319,7 +368,7 @@ func (*Resource) ConvertFrom(value any) (any, error) {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, JSON decode failure, or rehydration failure.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("appnet.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
@@ -330,7 +379,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -346,13 +395,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, or rehydration failure.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("appnet.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -368,7 +417,7 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, decode failure, or rehydration failure.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("appnet.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
@@ -379,7 +428,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}

--- a/pkg/op/provider/appnet/resource_test.go
+++ b/pkg/op/provider/appnet/resource_test.go
@@ -12,9 +12,9 @@ import (
 
 // --- Test helpers ---
 
-// newRes constructs a *Resource for a URL string. Uses DiscoverResource because the test isn't claiming
+// newRes constructs a Resource for a URL string. Uses DiscoverResource because the test isn't claiming
 // production — it's setting up a fixture handle.
-func newRes(t *testing.T, url string) *Resource {
+func newRes(t *testing.T, url string) Resource {
 	t.Helper()
 	r, err := DiscoverResource(&op.RuntimeEnvironment{}, url)
 	if err != nil {

--- a/pkg/op/provider/git/checkout_pull_observe_test.go
+++ b/pkg/op/provider/git/checkout_pull_observe_test.go
@@ -71,7 +71,7 @@ func TestCheckout_BuildsArgv(t *testing.T) {
 		t.Fatalf("Checkout: %v", err)
 	}
 	if got != repo {
-		t.Errorf("Checkout returned %p, want the same *Resource %p (identity unchanged)", got, repo)
+		t.Errorf("Checkout returned %p, want the same Resource %p (identity unchanged)", got, repo)
 	}
 
 	out := buf.String()
@@ -79,7 +79,7 @@ func TestCheckout_BuildsArgv(t *testing.T) {
 	// "/usr/bin/git -C ..." on Unix and "C:\...\git.exe -C ..." on Windows. Asserting a leading "git " only
 	// ever worked because "/usr/bin/git" ends with "git"; ".exe" breaks the same substring. Assert the part
 	// this test is actually about.
-	want := "-C " + repo.SourcePath.Abs() + " checkout release-1.2"
+	want := "-C " + repo.SourcePath().Abs() + " checkout release-1.2"
 	if !strings.Contains(out, want) {
 		t.Errorf("narrated command =\n  %q\nwant it to contain\n  %q", out, want)
 	}
@@ -140,7 +140,7 @@ func TestPull_BuildsArgv(t *testing.T) {
 		t.Fatalf("Pull: %v", err)
 	}
 	if got != repo {
-		t.Errorf("Pull returned %p, want the same *Resource %p (identity unchanged)", got, repo)
+		t.Errorf("Pull returned %p, want the same Resource %p (identity unchanged)", got, repo)
 	}
 
 	out := buf.String()
@@ -148,7 +148,7 @@ func TestPull_BuildsArgv(t *testing.T) {
 	// "/usr/bin/git -C ..." on Unix and "C:\...\git.exe -C ..." on Windows. Asserting a leading "git " only
 	// ever worked because "/usr/bin/git" ends with "git"; ".exe" breaks the same substring. Assert the part
 	// this test is actually about.
-	want := "-C " + repo.SourcePath.Abs() + " pull"
+	want := "-C " + repo.SourcePath().Abs() + " pull"
 	if !strings.Contains(out, want) {
 		t.Errorf("narrated command =\n  %q\nwant it to contain\n  %q", out, want)
 	}

--- a/pkg/op/provider/git/observation.go
+++ b/pkg/op/provider/git/observation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
-// Observation captures the runtime-observed state of a [*Resource]'s on-disk clone at the moment it was observed.
+// Observation captures the runtime-observed state of a [Resource]'s on-disk clone at the moment it was observed.
 //
 // Distinct from [Resource], which carries identity (URI, [fsroot.Path], and the identity-extension intent fields
 // `HEAD` and `Ref` from the plan). An observation is a point-in-time metadata snapshot record — not a [Resource],
@@ -42,7 +42,7 @@ type Observation struct {
 // NewObservation constructs a *Observation anchored to the resource it observes.
 //
 // Parameters:
-//   - `ofResource`: the [*Resource] this observation is of. Must be non-nil (asserted by [op.NewObservationBase]).
+//   - `ofResource`: the [Resource] this observation is of. Must be non-nil (asserted by [op.NewObservationBase]).
 //   - `exists`: true when the path was a git repository at observation time.
 //   - `observedHEAD`: the disk's current HEAD SHA.
 //   - `observedRef`: the disk's current ref name.
@@ -53,7 +53,7 @@ type Observation struct {
 // Returns:
 //   - `*Observation`: the constructed observation.
 func NewObservation(
-	ofResource *Resource,
+	ofResource Resource,
 	exists bool,
 	observedHEAD string,
 	observedRef string,

--- a/pkg/op/provider/git/provider.go
+++ b/pkg/op/provider/git/provider.go
@@ -69,8 +69,8 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 //     additional flag per the kwarg-to-flag rule.
 //
 // Returns:
-//   - `*Resource`: the cloned git.Resource with populated metadata.
-//   - `*Resource`: the compensation handle — the same [*Resource] as the first return, passed to
+//   - `Resource`: the cloned git.Resource with populated metadata.
+//   - `Resource`: the compensation handle — the same [Resource] as the first return, passed to
 //     [Provider.CompensateClone] to reverse the clone. Git's Clone creates a directory rather than
 //     displacing one, so per the Tombstone rule (a tombstone exists for any object moved to a
 //     RecoverySite) there is no git tombstone; the compensation handle is the created Resource itself.
@@ -93,7 +93,7 @@ func (p *Provider) Clone(
 	recurseSubmodules bool,
 	singleBranch bool,
 	kwargs map[string]any,
-) (*Resource, *Receipt, error) {
+) (Resource, *Receipt, error) {
 
 	if directory == "" {
 		guessed, err := guessDirName(repository)
@@ -103,14 +103,14 @@ func (p *Provider) Clone(
 		directory = guessed
 	}
 
-	destination, err := NewResource(p.RuntimeEnvironment(), activationRecord.CallerID, directory)
+	destination, err := newResource(p.RuntimeEnvironment(), activationRecord.CallerID, directory)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	args := buildCloneArgs(
 		repository,
-		destination.SourcePath.Abs(),
+		destination.SourcePath().Abs(),
 		bare,
 		branch,
 		depth,
@@ -127,9 +127,9 @@ func (p *Provider) Clone(
 		return nil, nil, err
 	}
 
-	abs := destination.SourcePath.Abs()
-	destination.HEAD = readHEADSha(abs)
-	destination.Ref = readBranchName(abs)
+	abs := destination.SourcePath().Abs()
+	destination.head = readHEADSha(abs)
+	destination.ref = readBranchName(abs)
 
 	return destination, NewReceipt(destination), nil
 }
@@ -152,20 +152,20 @@ func (p *Provider) CompensateClone(activationRecord *op.ActivationRecord, receip
 		return nil
 	}
 
-	resource, ok := receipt.Resource().(*Resource)
+	resource, ok := receipt.Resource().(Resource)
 	if !ok || resource == nil {
 		return nil
 	}
 
 	// Confinement: the clone tree belongs to the external git subprocess, which Root never binds.
-	return os.RemoveAll(resource.SourcePath.Abs())
+	return os.RemoveAll(resource.SourcePath().Abs())
 }
 
 // Fallible actions
 
 // Checkout checks out a ref in the given repository directory.
 //
-// `repo.Ref` and `repo.HEAD` are plan-time intent and are not mutated here. Callers that need the
+// `repo.Ref()` and `repo.HEAD()` are plan-time intent and are not mutated here. Callers that need the
 // post-checkout disk state call [Provider.Observe] to obtain a [*Observation] carrying the disk's
 // current `ObservedHEAD` / `ObservedRef`.
 //
@@ -174,11 +174,11 @@ func (p *Provider) CompensateClone(activationRecord *op.ActivationRecord, receip
 //   - `ref`: branch, tag, or commit to check out.
 //
 // Returns:
-//   - `*Resource`: the repository resource (identity unchanged).
+//   - `Resource`: the repository resource (identity unchanged).
 //   - `error`: any error from `git checkout`.
-func (p *Provider) Checkout(repo *Resource, ref string) (*Resource, error) {
+func (p *Provider) Checkout(repo Resource, ref string) (Resource, error) {
 
-	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "git", "-C", repo.SourcePath.Abs(), "checkout", ref)
+	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "git", "-C", repo.SourcePath().Abs(), "checkout", ref)
 
 	if err := p.RuntimeEnvironment().Run(cmd); err != nil {
 		return nil, err
@@ -195,20 +195,20 @@ func (p *Provider) Checkout(repo *Resource, ref string) (*Resource, error) {
 // error. Stat / read failures surface as errors.
 //
 // Provider methods that previously called `r.Resolve()` and read fields off the Resource use
-// `obs := p.Observe(r)` and read fields off the observation. `repo.HEAD` and `repo.Ref` on the
+// `obs := p.Observe(r)` and read fields off the observation. `repo.HEAD()` and `repo.Ref()` on the
 // Resource are plan-time intent; the disk's current state lives on the returned observation's
 // `ObservedHEAD` and `ObservedRef`.
 //
 // Parameters:
-//   - `repo`: the [*Resource] whose current git state to observe.
+//   - `repo`: the [Resource] whose current git state to observe.
 //
 // Returns:
 //   - `*Observation`: the constructed observation; never nil.
 //   - `error`: always nil — the `.git` reads are best-effort and non-existence is a valid observation; the error
 //     return keeps the announced fallible-action shape.
-func (p *Provider) Observe(repo *Resource) (*Observation, error) {
+func (p *Provider) Observe(repo Resource) (*Observation, error) {
 
-	abs := repo.SourcePath.Abs()
+	abs := repo.SourcePath().Abs()
 
 	gitRepo, bare := isGitRepo(abs)
 	if !gitRepo {
@@ -229,18 +229,18 @@ func (p *Provider) Observe(repo *Resource) (*Observation, error) {
 
 // Pull pulls the latest changes in the given repository directory.
 //
-// `repo.Ref` and `repo.HEAD` are plan-time intent and are not mutated here. Callers that need the
+// `repo.Ref()` and `repo.HEAD()` are plan-time intent and are not mutated here. Callers that need the
 // post-pull disk state call [Provider.Observe].
 //
 // Parameters:
 //   - `repo`: git resource identifying the local repository.
 //
 // Returns:
-//   - `*Resource`: the repository resource (identity unchanged).
+//   - `Resource`: the repository resource (identity unchanged).
 //   - `error`: any error from `git pull`.
-func (p *Provider) Pull(repo *Resource) (*Resource, error) {
+func (p *Provider) Pull(repo Resource) (Resource, error) {
 
-	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "git", "-C", repo.SourcePath.Abs(), "pull")
+	cmd := exec.CommandContext(p.RuntimeEnvironment().Context, "git", "-C", repo.SourcePath().Abs(), "pull")
 
 	if err := p.RuntimeEnvironment().Run(cmd); err != nil {
 		return nil, err

--- a/pkg/op/provider/git/provider_test.go
+++ b/pkg/op/provider/git/provider_test.go
@@ -106,19 +106,19 @@ func TestClone_HookReceivesArgv(t *testing.T) {
 	if !reflect.DeepEqual(gotArgs, want) {
 		t.Errorf("cloneFn args =\n  got: %q\n want: %q", gotArgs, want)
 	}
-	if result.SourcePath.Abs() != dir {
-		t.Errorf("result.SourcePath.Abs() = %q, want %q", result.SourcePath.Abs(), dir)
+	if result.SourcePath().Abs() != dir {
+		t.Errorf("result.SourcePath().Abs() = %q, want %q", result.SourcePath().Abs(), dir)
 	}
 
 	if state == nil {
 		t.Fatalf("state = nil, want a *Receipt")
 	}
-	stateResource, ok := state.Resource().(*Resource)
+	stateResource, ok := state.Resource().(Resource)
 	if !ok {
-		t.Fatalf("state.Resource() = %T, want *Resource", state.Resource())
+		t.Fatalf("state.Resource() = %T, want Resource", state.Resource())
 	}
-	if stateResource.SourcePath.Abs() != dir {
-		t.Errorf("state resource path = %q, want %q", stateResource.SourcePath.Abs(), dir)
+	if stateResource.SourcePath().Abs() != dir {
+		t.Errorf("state resource path = %q, want %q", stateResource.SourcePath().Abs(), dir)
 	}
 }
 
@@ -172,8 +172,8 @@ func TestClone_DirectoryDerivedFromRepository(t *testing.T) {
 	if gotArgs[len(gotArgs)-1] != wantDir {
 		t.Errorf("directory arg = %q, want %q", gotArgs[len(gotArgs)-1], wantDir)
 	}
-	if result.SourcePath.Abs() != wantDir {
-		t.Errorf("result.SourcePath.Abs() = %q, want %q", result.SourcePath.Abs(), wantDir)
+	if result.SourcePath().Abs() != wantDir {
+		t.Errorf("result.SourcePath().Abs() = %q, want %q", result.SourcePath().Abs(), wantDir)
 	}
 }
 

--- a/pkg/op/provider/git/receipt.go
+++ b/pkg/op/provider/git/receipt.go
@@ -34,7 +34,7 @@ type Receipt struct {
 //
 // Returns:
 //   - `*Receipt`: the constructed receipt with only its resource populated.
-func NewReceipt(resource *Resource) *Receipt {
+func NewReceipt(resource Resource) *Receipt {
 	return &Receipt{ReceiptBase: op.NewReceiptBase(resource)}
 }
 
@@ -73,7 +73,7 @@ func (r *Receipt) RestoreEncoded(
 	catalog := runtimeEnvironment.ResourceCatalog
 	got, ok := catalog.Lookup(catalog.Current(base.ResourceURI))
 	assert.True("git.Receipt: resource "+base.ResourceURI+" in catalog", ok)
-	resource, ok := got.(*Resource)
+	resource, ok := got.(Resource)
 	assert.True("git.Receipt: catalog entry is *git.Resource", ok)
 
 	r.ReceiptBase = op.NewReceiptBase(resource)

--- a/pkg/op/provider/git/resource.go
+++ b/pkg/op/provider/git/resource.go
@@ -23,25 +23,75 @@ import (
 // are additionally persisted through JSON/YAML so a serialized Resource can carry its version snapshot to contexts
 // where Resolve cannot run (e.g., cross-host comparison, offline inspection); Remotes, Bare, and Dirty are operational
 // and not persisted — they're always rebuilt by Resolve.
-type Resource struct {
+// Resource is this provider's resource type — the sealed interface over a git working tree.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. A
+// value reaching a git method therefore came from a constructor and carries catalog-issued identity; nothing
+// hand-built or reflectively hydrated can satisfy it.
+type Resource interface {
+	op.Resource
+
+	// SourcePath returns the working tree's path handle. Identity-bearing.
+	SourcePath() fsroot.Path
+
+	// Ref returns the branch or tag the clone was asked for — plan-time intent, not an observation of the
+	// tree's current state. Use Observe for that.
+	Ref() string
+
+	// HEAD returns the commit sha recorded at clone or checkout — plan-time intent, as with Ref.
+	HEAD() string
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete git resource — what serializes, and the only thing implementing [Resource].
+//
+// Unexported so `&git.resource{...}` cannot be written outside this package. The exported constructors are the
+// public contract; the struct behind them need not be.
+type resource struct {
 	op.ResourceBase
 
-	// SourcePath is the local clone's canonical absolute path; identity derives from this via the file:// URI. Not
-	// persisted — reconstructed from the URI on deserialization.
-	SourcePath fsroot.Path `json:"-" yaml:"-"`
+	// sourcePath is the working tree's path handle. Identity-bearing — the URI derives from it.
+	sourcePath fsroot.Path
 
-	// Ref is the branch, tag, or commit reference the clone is positioned at as plan-time intent.
-	// Set at construction by [Provider.Clone] (from the just-cloned tree's `.git/HEAD`) or by
-	// serialized-form deserialization (from a saved plan). Not mutated by [Resource.Resolve]; the runtime
-	// view of the disk's current ref lives on [Observation.ObservedRef].
-	Ref string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	// ref is the branch or tag asked for at clone or checkout. Plan-time intent.
+	ref string
 
-	// HEAD is the commit SHA (40-char hex) the clone was positioned at as plan-time intent. Set at
-	// construction by [Provider.Clone] (from the just-cloned tree's `.git/HEAD`) or by serialized-form
-	// deserialization. Pins the clone to an exact version across serialization. Empty for resources
-	// constructed via [NewResource] without an associated clone. Not mutated by [Resource.Resolve];
-	// the runtime view of the disk's current HEAD lives on [Observation.ObservedHEAD].
-	HEAD string `json:"head,omitempty" yaml:"head,omitempty"`
+	// head is the commit sha recorded at clone or checkout. Plan-time intent.
+	head string
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// SourcePath returns the working tree's path handle.
+//
+// Returns:
+//   - `fsroot.Path`: the path handle.
+func (r *resource) SourcePath() fsroot.Path { return r.sourcePath }
+
+// Ref returns the branch or tag asked for.
+//
+// Returns:
+//   - `string`: the ref, or "" when none was recorded.
+func (r *resource) Ref() string { return r.ref }
+
+// HEAD returns the recorded commit sha.
+//
+// Returns:
+//   - `string`: the sha, or "" when none was recorded.
+func (r *resource) HEAD() string { return r.head }
+
+// init wires the two things a sealed resource cannot state from its generated announcement, which lives in a
+// sibling package and can name only exported identifiers. Go initializes an imported package before its
+// importer, so this always runs first.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // Remote carries the fetch and push URLs for a named git remote.
@@ -79,7 +129,25 @@ type Remote struct {
 //   - `*Resource`: the canonical catalog entry (or the unlinked candidate when no catalog is present).
 //   - `error`: if `value` is not a string, or the input violates RFC 8089 when in file URI form, or
 //     [op.ResourceCatalog.GetOrCreate]'s strict assertions fail.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
+	return newResource(runtimeEnvironment, producerID, value)
+}
+
+// newResource is [NewResource] returning the concrete type.
+//
+// The exported form returns the sealed interface, which is what callers should hold. Clone and checkout
+// cannot: they record the observed ref and sha onto the resource after the git command runs, and an
+// interface has nothing to assign to.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `producerID`: the producing caller's id, or "" for caller-less dispatch.
+//   - `value`: a path, file URI, or canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func newResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -98,9 +166,9 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("git.NewResource: catalog entry for %q is %T, want *git.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("git.NewResource: catalog entry for %q is %T, want *git.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -126,7 +194,21 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 // Returns:
 //   - `*Resource`: the canonical catalog entry (or the unlinked candidate when no catalog is present).
 //   - `error`: if `value` is not a string, or the input violates RFC 8089 when in file URI form.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type, which rehydration needs because it
+// assigns through the receiver.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: a path, file URI, or canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -144,9 +226,9 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("git.DiscoverResource: catalog entry for %q is %T, want *git.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("git.DiscoverResource: catalog entry for %q is %T, want *git.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -163,7 +245,7 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 // Returns:
 //   - `*Resource`: the candidate, not yet interned in the catalog.
 //   - `error`: if `value` is not a string, or violates RFC 8089 when in file URI form.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	path, ok := value.(string)
 	if !ok {
@@ -175,14 +257,14 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 	path = strings.TrimPrefix(path, "file://")
 	sourcePath := runtimeEnvironment.Root().NewPath(path)
 
-	base, err := op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, "file://"+sourcePath.Abs(), reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		SourcePath:   sourcePath,
+		sourcePath:   sourcePath,
 	}, nil
 }
 
@@ -200,7 +282,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 //
 // Returns:
 //   - `op.AddressingMode`: always [op.AddressingLocation].
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 	return op.AddressingLocation
 }
 
@@ -220,9 +302,9 @@ func (r *Resource) Addressing() op.AddressingMode {
 // Returns:
 //   - `op.Digest`: sha256 of the HEAD SHA (plus stash-create tree SHA when the working tree is dirty).
 //   - `error`: when the path is not a git repository or HEAD cannot be read.
-func (r *Resource) Digest() (op.Digest, error) {
+func (r *resource) Digest() (op.Digest, error) {
 
-	abs := r.SourcePath.Abs()
+	abs := r.sourcePath.Abs()
 
 	repo, bare := isGitRepo(abs)
 	if !repo {
@@ -258,13 +340,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true if `other` is a *git.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -290,9 +372,9 @@ func (r *Resource) Equal(other any) bool {
 // Returns:
 //   - `string`: the etag (HEAD short-id, optionally suffixed with `-<tree-short>` for a dirty working tree).
 //   - `error`: when the path is not a git repository or HEAD cannot be read.
-func (r *Resource) Etag() (string, error) {
+func (r *resource) Etag() (string, error) {
 
-	abs := r.SourcePath.Abs()
+	abs := r.sourcePath.Abs()
 
 	repo, bare := isGitRepo(abs)
 	if !repo {
@@ -333,8 +415,8 @@ func (r *Resource) Etag() (string, error) {
 //
 // Returns:
 //   - `string`: `git.Resource{uri=<URI>, ref=<ref>, head=<head>}`.
-func (r *Resource) String() string {
-	return fmt.Sprintf("git.Resource{uri=%s, ref=%s, head=%s}", r.URI(), r.Ref, r.HEAD)
+func (r *resource) String() string {
+	return fmt.Sprintf("git.Resource{uri=%s, ref=%s, head=%s}", r.URI(), r.ref, r.head)
 }
 
 // endregion
@@ -359,7 +441,7 @@ func (r *Resource) String() string {
 //
 // Returns:
 //   - `bool`: true when `source` is `string`.
-func (*Resource) CanConvertFrom(source reflect.Type) bool {
+func (*resource) CanConvertFrom(source reflect.Type) bool {
 
 	return source != nil && source.Kind() == reflect.String
 }
@@ -378,14 +460,14 @@ func (*Resource) CanConvertFrom(source reflect.Type) bool {
 // Returns:
 //   - `any`: the constructed unlinked [*Resource].
 //   - `error`: non-nil when `value` is not a `string`.
-func (*Resource) ConvertFrom(value any) (any, error) {
+func (*resource) ConvertFrom(value any) (any, error) {
 
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("git.Resource.ConvertFrom: source must be string, got %T", value)
 	}
 
-	return &Resource{SourcePath: fsroot.NewPath("", str)}, nil
+	return &resource{sourcePath: fsroot.NewPath("", str)}, nil
 }
 
 // UnmarshalJSON populates the receiver from its JSON document.
@@ -400,31 +482,34 @@ func (*Resource) ConvertFrom(value any) (any, error) {
 //
 // Returns:
 //   - `error`: non-nil if the RuntimeEnvironment is missing, the JSON does not decode, or resource construction fails.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("git.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
 	}
 
-	type alias Resource
-	aux := &struct {
-		URI string `json:"uri"`
-		*alias
-	}{alias: (*alias)(r)}
+	// Decoded explicitly rather than through a `type alias` embed. The fields are unexported now, and
+	// encoding/json cannot set those — the alias trick would silently leave ref and head at zero. Same keys,
+	// same shape.
+	var aux struct {
+		URI  string `json:"uri"`
+		Ref  string `json:"ref,omitempty"`
+		HEAD string `json:"head,omitempty"`
+	}
 
-	if err := json.Unmarshal(data, aux); err != nil {
+	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
-	ref, head := r.Ref, r.HEAD
+	ref, head := aux.Ref, aux.HEAD
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), aux.URI)
+	built, err := discoverResource(r.RuntimeEnvironment(), aux.URI)
 	if err != nil {
 		return err
 	}
 
-	built.Ref = ref
-	built.HEAD = head
+	built.ref = ref
+	built.head = head
 
 	*r = *built
 	return nil
@@ -440,13 +525,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: non-nil if the RuntimeEnvironment is missing or resource construction fails.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("git.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -467,31 +552,33 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: non-nil if the RuntimeEnvironment is missing, the YAML does not decode, or resource construction fails.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("git.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
 	}
 
-	type alias Resource
-	aux := &struct {
-		URI string `yaml:"uri"`
-		*alias
-	}{alias: (*alias)(r)}
+	// Decoded explicitly, for the same reason as [resource.UnmarshalJSON]: the fields are unexported and a
+	// codec cannot set those, so the alias embed would silently leave ref and head at zero.
+	var aux struct {
+		URI  string `yaml:"uri"`
+		Ref  string `yaml:"ref,omitempty"`
+		HEAD string `yaml:"head,omitempty"`
+	}
 
-	if err := unmarshal(aux); err != nil {
+	if err := unmarshal(&aux); err != nil {
 		return err
 	}
 
-	ref, head := r.Ref, r.HEAD
+	ref, head := aux.Ref, aux.HEAD
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), aux.URI)
+	built, err := discoverResource(r.RuntimeEnvironment(), aux.URI)
 	if err != nil {
 		return err
 	}
 
-	built.Ref = ref
-	built.HEAD = head
+	built.ref = ref
+	built.head = head
 
 	*r = *built
 	return nil

--- a/pkg/op/provider/git/resource_test.go
+++ b/pkg/op/provider/git/resource_test.go
@@ -19,7 +19,7 @@ import (
 // --- Interface guards ---
 
 func TestResource_ImplementsInterface(t *testing.T) {
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -68,12 +68,12 @@ func commitFile(t *testing.T, dir, name, content string) {
 	runGit(t, dir, "commit", "-m", "add "+name)
 }
 
-// newRes constructs a *Resource for path against an unconfined runtime environment. Uses DiscoverResource
+// newRes constructs a Resource for path against an unconfined runtime environment. Uses DiscoverResource
 // because tests are not claiming production — the file/path being constructed pre-exists or is a fixture.
 //
 // The root anchors at the path's own directory, never the Unix literal "/": a whole-filesystem
 // root cannot make absolute Windows paths relative across volumes (#392).
-func newRes(t *testing.T, path string) *Resource {
+func newRes(t *testing.T, path string) Resource {
 	t.Helper()
 	runtimeEnvironment := testEnvironment(t, filepath.Dir(path))
 	r, err := DiscoverResource(runtimeEnvironment, path)

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -319,7 +319,14 @@ func NewResourceReceiverType(
 		return nil, err
 	}
 
+	// Identity governs BOTH the type id and the registry name; the implementation governs only reflection.
+	//
+	// receiverName special-cases the type named `Resource` into `<pkg>.Resource`, which is what keeps
+	// providers distinct in the registry. A sealed implementation is named `resource`, which falls through
+	// to the default arm and yields the bare `resource` for EVERY provider — the second one announced then
+	// collides with the first. Found exactly that way, sealing `git` beside `service`.
 	base.typeID = typeIDOf(resourceType)
+	base.name = receiverName(resourceType)
 
 	return &resourceReceiverType{
 		receiverType: base,


### PR DESCRIPTION
Phase 3 of #625. Closes #642.

The plan expected a mechanical pass. It was not, and the most important finding is one that **sealing a
single provider could never have surfaced**.

## The registry name collided

`receiverName` special-cases the type named `Resource` into `<pkg>.Resource` — that is what keeps providers
distinct in the registry. A sealed implementation is named `resource`, falls through to the default arm, and
yields the bare `resource` for *every* provider. So the second one announced panics at init:

```
panic: op.AnnounceResource: AnnounceResource(service.Resource): "resource" already announced
```

`service` alone was fine. `git` beside it was not.

Fixed at the framework layer, extending the split phase 1 established: **identity governs the type id AND the
registry name; the implementation governs only reflection.** One line, in `NewResourceReceiverType`.

## Open question 2, answered here rather than at `pkg`

Both resources carry exported fields the provider reads — `git`: `SourcePath`, `Ref`, `HEAD`; `appnet`:
`SourceURL` — so the sealed interfaces gain accessors and the struct fields go unexported.

No external consumer needed them: every real read is in-package, and the only two out-of-package mentions of
`git.Resource` / `appnet.Resource` are doc comments. Checked before transforming rather than after.

## A codec cannot set unexported fields

`git` decoded through a `type alias Resource` embed. Once the fields are unexported that silently leaves `ref`
and `head` at zero — `encoding/json` and the YAML codec can only set exported fields. Both paths now decode
into an explicit local struct: same keys, same shape, no alias.

**This is a trap for the remaining phases.** It fails silently rather than at compile time, and the next
provider using the alias trick will hit it.

## Phase 2 proved out

All three sealed providers keep their full method metadata — `git` 3 entries, `appnet` 3, `service` 3. The
generator fix from #658 carried them across without hand-editing, on two providers it had never seen.

## Not fixed here

`git` has no `MarshalJSON`, so the promoted base marshaler writes the URI alone — **nothing ever writes the
`ref`/`head` keys its unmarshaler carefully preserves.** Behavior is preserved exactly; the asymmetry predates
this feature and wants its own issue rather than a change to a document format inside a sealing phase.

## Verification

`make test` 103 ok / 0 fail · `make build` · `make vet` darwin/linux/windows · `test-scenario` · `complexity`
· `shell-lint` · `gofmt -l` — all clean.
