### PR TITLE
test(function): function.call gets its first end-to-end coverage

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_function_call_walk_tree.star
+++ b/cmd/devlore-test/devloretest/data/test_function_call_walk_tree.star
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_function_call_walk_tree.star — end-to-end coverage for function.Provider.
+#
+# `function.call` is the provider's only method, and nothing exercised it. The function resource appeared
+# solely as a callback OTHER providers accept — walk_tree's reducer, choose's lambdas — never as the thing
+# being dispatched. function is RoleAction only, so it exists in graph scope alone.
+#
+# A graph's result is not directly assertable, so each callable's return value is observed by feeding it
+# into a write and checking the file.
+
+root = t.tmp("fn_walk")
+rendered = t.tmp("rendered.txt")
+walked_out = t.tmp("walked.txt")
+
+file.mkdir(path=root, mode=0o755)
+file.write_text(destination_path=t.tmp("fn_walk/alpha.txt"), content="alpha", mode=0o644)
+file.write_text(destination_path=t.tmp("fn_walk/beta.txt"), content="beta", mode=0o644)
+
+nested = t.tmp("fn_walk/nested")
+file.mkdir(path=nested, mode=0o755)
+file.write_text(destination_path=t.tmp("fn_walk/nested/gamma.txt"), content="gamma", mode=0o644)
+
+# --- function.call, dispatched as a graph unit ----------------------------------------------------
+
+def render(left, right):
+    return left + "-" + right
+
+# The callable is minted as a resource, carried in the document, and invoked at execution. Its return
+# value reaches the write through a promise.
+called = plan.function.call(render, "left", "right")
+wrote_render = plan.file.write_text(destination_path=rendered, content=called, mode=0o600)
+
+# NOT covered, deliberately: feeding a promise INTO function.call. `plan.function.call(summarize, walked)`
+# hands the callable an unresolved Invocation, because promise resolution operates on declared parameters
+# and `*args` is a catch-all with neither name nor type. Filed as #663; extend this fixture when it is
+# fixed rather than pinning the defect here.
+
+# --- the same resource kind, dispatched by another provider ---------------------------------------
+
+# walk_tree takes the callable as a reducer rather than calling it directly. The reducer folds the tree
+# into one string so the promise can flow into a write.
+def collector(initial, resource, path, stack):
+    if initial == None:
+        return path
+    return initial + "," + path
+
+walked = plan.file.walk_tree(root=root, fn=collector, include_gitignored=True)
+wrote_walk = plan.file.write_text(destination_path=walked_out, content=walked, mode=0o600)
+
+# Consumers first: ordering comes from the promises, not from list position.
+graph = plan.assemble_definition([wrote_render, wrote_walk, called, walked])
+
+t.expect_unit_count(4)
+t.expect_file(rendered, content="left-right")
+
+t.run(graph)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -277,6 +277,17 @@ func TestWalkTree_Planned(t *testing.T) {
 	runScript(t, "test_walk_tree_planned.star")
 }
 
+// --- function provider ---
+
+// TestFunctionCall_OverWalkTree is function.Provider's only end-to-end coverage.
+//
+// `function.call` is the provider's sole method, and until this fixture nothing exercised it. The function
+// resource appeared only as a callback other providers accept — walk_tree's reducer, choose's lambdas — never
+// as the thing being dispatched.
+func TestFunctionCall_OverWalkTree(t *testing.T) {
+	runScript(t, "test_function_call_walk_tree.star")
+}
+
 // --- Planned action tests — template provider ---
 
 func TestTemplateRender(t *testing.T) {

--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -280,11 +280,12 @@ failing. This is the load-bearing detail of part 2.
 | 1 | 1 | #641 | framework repairs and `service` — the template |
 | 1 | 2 | #658 | the generator inspects the implementation, not the interface |
 | 1 | 3 | #642 | `git`, `appnet` |
-| 1 | 4 | #643 | `json`, `yaml`, `mem`, `function` — the `Unpacker` four |
-| 1 | 5 | #644 | `pkg` — the widest footprint |
-| 2 | 6 | #645 | `file`'s four variants, discriminated by `kind()` |
-| — | 7 | #646 | the rule becomes structurally enforceable |
-| — | 8 | #647 | closure — the design record states the contract |
+| 1 | 4 | #643 | `json`, `yaml`, `mem` — three of the `Unpacker` four |
+| 1 | 5 | #662 | `function` — the Starlark-callable resource |
+| 1 | 6 | #644 | `pkg` — the widest footprint |
+| 2 | 7 | #645 | `file`'s four variants, discriminated by `kind()` |
+| — | 8 | #646 | the rule becomes structurally enforceable |
+| — | 9 | #647 | closure — the design record states the contract |
 
 Supersedes #626–#630, which were filed against the original phase shape and are closed as superseded.
 
@@ -357,7 +358,7 @@ makes resolving one name from the other deterministic.
 **This lands before the provider sweep** ([#658](https://github.com/NobleFactor/devlore-cli/issues/658)). Otherwise
 every
 remaining phase inherits the same silent risk and needs a manual per-provider review — five chances to miss
-one, with no signal when you do. It also narrows phase 7 to asserting the shape rather than policing dispatch.
+one, with no signal when you do. It also narrows phase 8 to asserting the shape rather than policing dispatch.
 
 What it does not settle: whether a method *belongs* on the interface stays a design question per provider. It
 stops being a silent regression and becomes an ordinary question about the public contract.
@@ -392,14 +393,28 @@ phase-1 template.
    marshaler writes the URI alone — nothing ever writes the `ref`/`head` keys its unmarshaler carefully
    preserves. Behavior preserved exactly here; the asymmetry predates this feature and wants its own issue.
 
-#### Phase 4 — the `Unpacker` four: `json`, `yaml`, `mem`, `function` — status: pending
+#### Phase 4 — the `Unpacker` three: `json`, `yaml`, `mem` — status: pending
 
 These share the failure mode phase 1 repaired, so they are the proof that the repair holds. `mem` is the
 content-addressed store, where identity *is* the digest and the fragment is doubly load-bearing;
 `function` carries the Starlark-callable path, where bytecode travels in the document's content section.
 Each needs its content-section round-trip pinned, not assumed.
 
-#### Phase 5 — `pkg` — status: pending
+#### Phase 5 — `function`, the Starlark-callable resource — status: pending
+
+Split from phase 4 (USER, 2026-08-24) because it does not fit the template the earlier phases established.
+
+Six exported fields against `service`'s one, four of them carrying no codec tag. It holds a compiled
+`*starlark.Function` whose bytecode travels in the document's content section, so its `Unpack` is the most
+load-bearing of the four — rehydration reconstitutes an executable, not just an identity. And `Compiled` /
+`CompilerVersion` are runtime state rather than identity, which raises a question about what belongs on a
+sealed interface that no other provider raises.
+
+It also carries **the first out-of-package consumer any phase has had to change**:
+`pkg/op/provider/plan/lifecycle_api_test.go:774` asserts `.(*function.Resource)` and becomes
+`.(function.Resource)`. The other four external references are doc comments.
+
+#### Phase 6 — `pkg` — status: pending
 
 Seven external files, the widest surface. Answers the plan's standing question: a resource whose exported
 behavioral fields consumers read must expose them as interface methods, or those consumers change. Size
@@ -407,7 +422,7 @@ it before transforming it.
 
 ### Part 2 — `file`
 
-#### Phase 6 — `file`'s four variants become interfaces — status: pending
+#### Phase 7 — `file`'s four variants become interfaces — status: pending
 
 `AnyKind`, `Regular`, `Directory`, `SymbolicLink` each become a sealed interface over an unexported
 struct — `anyKind`, `regular`, `directory`, `symbolicLink` — discriminated by `kind() <Interface>` per
@@ -429,7 +444,7 @@ At the end of this phase the rule holds with no exceptions, and the feature's go
 
 ### Closure
 
-#### Phase 7 — the rule becomes structurally enforceable — status: pending
+#### Phase 8 — the rule becomes structurally enforceable — status: pending
 
 1. `4.3-resource-registration.md` states the shape as **the contract** for adding a provider resource.
 2. A test asserts it structurally: every announced resource type is an interface, and the struct behind
@@ -437,7 +452,7 @@ At the end of this phase the rule holds with no exceptions, and the feature's go
 
 Without this the rule is a convention, and conventions decay.
 
-#### Phase 8 — closure — status: pending
+#### Phase 9 — closure — status: pending
 
 The `3.5.x` per-provider design docs drop any language describing the resource as a struct.
 `4-resource-management.md` records what the seal buys: the model's guarantees now rest on the compiler
@@ -463,10 +478,10 @@ rather than on convention. Status files follow.
 6. **`Unpacker` survives.** Each of `json`, `yaml`, `mem`, `function` rebuilds from a document's content
    section after phase 3 — the check that `UnpackerByTypeID` was actually repaired and not merely
    silenced.
-7. **A regular file is not a directory.** After phase 6, a `*regular` fails a `Directory` assertion at
+7. **A regular file is not a directory.** After phase 7, a `*regular` fails a `Directory` assertion at
    compile time. Ruling 6's whole purpose, and the one that must not regress.
 8. **The structural rule bites.** A deliberately non-conforming fixture — exported resource struct, no
-   interface — fails phase 7's assertion.
+   interface — fails phase 8's assertion.
 
 ## Verification
 


### PR DESCRIPTION
`function.Provider` has exactly one method, `function.call`, and **nothing exercised it**. The function
resource appeared only as a callback other providers accept — `walk_tree`'s reducer, `choose`'s lambdas —
never as the thing being dispatched. `function` is `RoleAction` only, so it exists in graph scope alone.

## What the fixture covers

`cmd/devlore-test/devloretest/data/test_function_call_walk_tree.star`:

- **`function.call` dispatched as a graph unit** — a Starlark callable minted as a resource, carried in the
  document, invoked at execution, its return value flowing onward through a promise into a write.
- **The same resource kind dispatched by another provider** — `file.walk_tree` taking the callable as a
  reducer rather than calling it. One provider *calls* the function, the other *folds* with it.

A graph's result is not directly assertable, so each callable's return value is observed by feeding it into
a write and checking the file.

## The defect it found

**#663** — a promise passed to `function.call`'s variadic arguments arrives **unresolved**, as an
`Invocation`:

```
function.call: sorted: for parameter iterable: got Invocation, want iterable
```

The graph assembles, the edge records, ordering is correct — the promise simply is not resolved. Promise
resolution operates on **declared** parameters, and `*args` is a catch-all with neither name nor type.
`plan.file.write_text(content=walked)` resolves the identical promise fine, because `content` is a declared
slot. Whether a promise resolves depends on the shape of the receiving parameter rather than on the value
being a promise — and it bites hardest on the one action whose purpose is to invoke author code on a value.

**The fixture deliberately does not pin the broken case.** An `expect_error` there would enshrine the
defect. The omission is marked at the point where it would go, pointing at #663.

## Two more defects logged while writing it

- **#664** — `devlore-test run` fails on **24 of 104** fixtures the Go harness passes. 12 with an `mmap`
  error on a hashed content-store path (all carrying a function resource), 3 rejecting a callable outright,
  6 star-extension failures flagged as needing separate confirmation. Not a regression: proved by running
  `test_walk_tree_planned.star`, untouched by any current work, and watching it fail identically.
- **#665** — `devlore-test run` writes per-fixture artifacts into the working directory; 73 untracked files
  in one sweep, none covered by `.gitignore`.

Neither is caused by this change; both are recorded on #625 as *found during, not caused by*.

## Also in this commit

The plan's phase split: `function` moved out of #643 into its own phase (#662), and phases renumbered 1..9.
It carries six exported fields against `service`'s one, holds a compiled `*starlark.Function` whose bytecode
travels in the content section, and owns the first out-of-package consumer any phase has had to change.

## Verification

`make test` 103 ok / 0 fail — including the new `TestFunctionCall_OverWalkTree` · `make vet` · `gofmt -l`
clean.
