### PR TITLE
feat(op): json and yaml resources are sealed; the Unpacker repair gets a pin

### DIFF
--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -280,8 +280,8 @@ failing. This is the load-bearing detail of part 2.
 | 1 | 1 | #641 | framework repairs and `service` — the template |
 | 1 | 2 | #658 | the generator inspects the implementation, not the interface |
 | 1 | 3 | #642 | `git`, `appnet` |
-| 1 | 4 | #643 | `json`, `yaml`, `mem` — three of the `Unpacker` four |
-| 1 | 5 | #662 | `function` — the Starlark-callable resource |
+| 1 | 4 | #643 | `json`, `yaml` |
+| 1 | 5 | #662 | `mem` and `function` — coupled by a cross-package embed |
 | 1 | 6 | #644 | `pkg` — the widest footprint |
 | 2 | 7 | #645 | `file`'s four variants, discriminated by `kind()` |
 | — | 8 | #646 | the rule becomes structurally enforceable |
@@ -393,14 +393,38 @@ phase-1 template.
    marshaler writes the URI alone — nothing ever writes the `ref`/`head` keys its unmarshaler carefully
    preserves. Behavior preserved exactly here; the asymmetry predates this feature and wants its own issue.
 
-#### Phase 4 — the `Unpacker` three: `json`, `yaml`, `mem` — status: pending
+#### Phase 4 — `json` and `yaml` — status: complete
 
 These share the failure mode phase 1 repaired, so they are the proof that the repair holds. `mem` is the
 content-addressed store, where identity *is* the digest and the fragment is doubly load-bearing;
 `function` carries the Starlark-callable path, where bytecode travels in the document's content section.
 Each needs its content-section round-trip pinned, not assumed.
 
-#### Phase 5 — `function`, the Starlark-callable resource — status: pending
+**Landed 2026-08-24 (#643).** The mechanical pass the plan kept predicting and had not yet got: both
+providers took the template unchanged, with no framework repair and no surprise. Two things worth recording.
+
+**`mem` had to move out before it started.** `function.Resource` embeds `mem.Resource` cross-package, and Go
+cannot embed an unexported type from another package, so sealing `mem` breaks `function` at compile time.
+Found by surveying before transforming rather than by the compiler afterwards. It is the only cross-package
+resource embed in the tree — `json` and `yaml` embed `op.ResourceBase` alone.
+
+**The `Unpacker` pin needed rewriting to be worth having.** The first version derived its expected set from
+`ProviderType()` — the very value a regression corrupts. A reverted repair would make the type stop
+implementing `op.Unpacker`, the derived loop would skip it, and the test would pass while content
+rehydration was broken. The set is now named explicitly, so a fifth unpacker has to be added deliberately.
+
+#### Phase 5 — `mem` and `function` — status: pending
+
+**`mem` moved here from phase 4 (USER, 2026-08-24): the two cannot be sealed separately.**
+`function.Resource` embeds `mem.Resource` cross-package, and Go cannot embed an unexported type from
+another package — so sealing `mem` breaks `function` at compile time. Verified as isolated rather than a
+pattern: it is the **only** cross-package resource embed in the tree.
+
+The agreed shape has `function.resource` embed the `mem.Resource` *interface* rather than the struct. That
+is legal and preserves the method set, but it is a real semantic change: `function` goes from *is-a*
+`mem.Resource` by value to *holds-a* one, so storage, zero-value behaviour, and any reliance on the
+embedded struct being addressable all shift.
+
 
 Split from phase 4 (USER, 2026-08-24) because it does not fit the template the earlier phases established.
 

--- a/pkg/op/inventory/discipline_test.go
+++ b/pkg/op/inventory/discipline_test.go
@@ -153,3 +153,67 @@ func TestBootDiscipline_EveryResourceResultResolvesItsProductType(t *testing.T) 
 		t.Fatal("no action method returns a resource; the index this test guards would be empty")
 	}
 }
+
+// TestBootDiscipline_EveryUnpackerResolvesByTypeID pins phase 1's `UnpackerByTypeID` repair (#641).
+//
+// A resource whose content lives in the document's content section is rebuilt through
+// [op.Unpacker.Unpack], reached by looking the resource up by the type id its URI carries. That lookup
+// mints its probe reflectively:
+//
+//	unpacker, ok := reflect.New(resourceType.ProviderType()).Interface().(Unpacker)
+//
+// Before #641 it reflected on the ANNOUNCED type. Sealing makes that an interface, `reflect.New` yields a
+// pointer-to-interface with an empty method set, and the assertion fails — returning `ok=false`, which every
+// caller reads as "this type has no unpacker" rather than as an error. Content rehydration would simply stop,
+// quietly. #641 routed the reflection to the implementation; this asserts it, because nothing else does.
+//
+// **The expected set is named rather than derived.** Deriving it from `ProviderType()` would consult the very
+// value the regression corrupts: a reverted fix makes the type stop implementing [op.Unpacker], the derived
+// loop skips it, and the test passes while content rehydration is broken. Naming the four means a fifth
+// unpacker must be added here deliberately — which is the point of a discipline test.
+func TestBootDiscipline_EveryUnpackerResolvesByTypeID(t *testing.T) {
+
+	// Every provider whose resource implements op.Unpacker, by registry name.
+	wantUnpackers := map[string]bool{
+		"function.Resource": true,
+		"json.Resource":     true,
+		"mem.Resource":      true,
+		"yaml.Resource":     true,
+	}
+
+	types := op.SnapshotReceiverTypes()
+	if len(types) == 0 {
+		t.Fatal("no receiver types announced; expected provider gen packages to register types at init")
+	}
+
+	seen := map[string]bool{}
+
+	for _, rt := range types {
+
+		resourceType, isResource := rt.(op.ResourceReceiverType)
+		if !isResource || !wantUnpackers[resourceType.Name()] {
+			continue
+		}
+
+		seen[resourceType.Name()] = true
+
+		unpacker, resolved := op.ReceiverRegistry().UnpackerByTypeID(resourceType.TypeID())
+		if !resolved {
+			t.Errorf(
+				"%s implements Unpack, but UnpackerByTypeID(%q) did not resolve — its content section would "+
+					"silently stop rehydrating, with no error and no log",
+				resourceType.Name(), resourceType.TypeID())
+			continue
+		}
+
+		if unpacker == nil {
+			t.Errorf("%s: UnpackerByTypeID reported resolved but returned nil", resourceType.Name())
+		}
+	}
+
+	for name := range wantUnpackers {
+		if !seen[name] {
+			t.Errorf("%s was never announced — either it lost its resource, or this list is stale", name)
+		}
+	}
+}

--- a/pkg/op/provider/json/provider.go
+++ b/pkg/op/provider/json/provider.go
@@ -94,9 +94,9 @@ func (p *Provider) EncodeIndent(value any, indent string) (string, error) {
 //   - `data`: the JSON text to parse.
 //
 // Returns:
-//   - `*Resource`: the canonical catalog entry holding the parsed value.
+//   - `Resource`: the canonical catalog entry holding the parsed value.
 //   - `error`: non-nil when `data` is not valid JSON or catalog interning fails.
-func (p *Provider) Parse(activationRecord *op.ActivationRecord, data string) (*Resource, error) {
+func (p *Provider) Parse(activationRecord *op.ActivationRecord, data string) (Resource, error) {
 
 	return NewResource(p.RuntimeEnvironment(), activationRecord.CallerID, []byte(data))
 }

--- a/pkg/op/provider/json/resource.go
+++ b/pkg/op/provider/json/resource.go
@@ -23,22 +23,22 @@ import (
 const SchemeJSON = "json"
 
 // Interface Guard: *Resource implements op.Resource.
-var _ op.Resource = (*Resource)(nil)
+var _ op.Resource = (*resource)(nil)
 
 // Interface Guard: *Resource implements json.Unmarshaler.
-var _ json.Unmarshaler = (*Resource)(nil)
+var _ json.Unmarshaler = (*resource)(nil)
 
 // Interface Guard: *Resource implements encoding.TextUnmarshaler.
-var _ encoding.TextUnmarshaler = (*Resource)(nil)
+var _ encoding.TextUnmarshaler = (*resource)(nil)
 
 // Interface Guard: *Resource implements fmt.Stringer.
-var _ fmt.Stringer = (*Resource)(nil)
+var _ fmt.Stringer = (*resource)(nil)
 
 // Interface Guard: *Resource implements op.Packer.
-var _ op.Packer = (*Resource)(nil)
+var _ op.Packer = (*resource)(nil)
 
 // Interface Guard: *Resource implements op.Unpacker.
-var _ op.Unpacker = (*Resource)(nil)
+var _ op.Unpacker = (*resource)(nil)
 
 // Resource represents a parsed JSON document held in memory, identified by the SHA-256 of its canonical form.
 //
@@ -55,19 +55,67 @@ var _ op.Unpacker = (*Resource)(nil)
 //   - Numbers larger than 2^53 lose precision via `float64` round trip — two distinct large integers can collide.
 //   - Object key sort is UTF-8 byte order (Go's [encoding/json] default), not the UTF-16 order JCS specifies. Agrees
 //     with JCS for ASCII keys; diverges for the supplementary plane.
-type Resource struct {
+//
+// Resource is this provider's resource type — the sealed interface over a canonicalized JSON document.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. A
+// value reaching a json method therefore came from a constructor and carries catalog-issued identity;
+// nothing hand-built or reflectively hydrated can satisfy it.
+type Resource interface {
+	op.Resource
+
+	// Data returns the canonical JSON bytes. Content-addressed: the digest derives from them.
+	Data() []byte
+
+	// Hash returns the hex-encoded digest of [Resource.Data].
+	Hash() string
+
+	// Parsed returns the decoded Go value — map[string]any, []any, or a scalar.
+	Parsed() any
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete json resource — what serializes, and the only thing implementing [Resource].
+//
+// Unexported so `&json.resource{...}` cannot be written outside this package.
+type resource struct {
 	op.ResourceBase
 
-	// Data is the canonical JSON bytes (sorted-key, whitespace-free re-marshal of the parsed input). Identity
-	// bearing — `SHA-256(Data)` is encoded in the URI <specific> as `json:<Hash>`.
-	Data []byte `json:"data,omitempty"`
+	// data is the canonical JSON encoding. Identity-bearing — the URI's digest derives from it.
+	data []byte
 
-	// Hash is the lowercase hex SHA-256 of Data, identity-bearing. Also encoded in the URI <specific>.
-	Hash string `json:"hash,omitempty"`
+	// hash is the hex-encoded digest of data.
+	hash string
 
-	// parsed is the decoded Go value, cached at construction for [Resource.Parsed] / [Resource.Validate].
-	// Not persisted; rehydration from URI leaves parsed nil.
+	// parsed is the decoded Go value.
 	parsed any
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// Data returns the canonical JSON bytes.
+//
+// Returns:
+//   - `[]byte`: the canonical encoding.
+func (r *resource) Data() []byte { return r.data }
+
+// Hash returns the hex-encoded digest of the canonical bytes.
+//
+// Returns:
+//   - `string`: the digest.
+func (r *resource) Hash() string { return r.hash }
+
+// init wires the two things a sealed resource cannot state from its generated announcement, which lives in
+// a sibling package and can name only exported identifiers.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs a json.Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -89,9 +137,9 @@ type Resource struct {
 //     streams are parsed and canonicalized during construction; an invalid JSON document errors here.
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, JSON parse failure, malformed URI, or identity construction failure.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -109,9 +157,9 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("json.NewResource: catalog entry for %q is %T, want *json.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("json.NewResource: catalog entry for %q is %T, want *json.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -136,9 +184,23 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 //     [NewResource].
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, JSON parse failure, malformed URI, or identity construction failure.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type, which rehydration needs because it
+// assigns through the receiver.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: bytes, a reader, or a canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -156,9 +218,9 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("json.DiscoverResource: catalog entry for %q is %T, want *json.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("json.DiscoverResource: catalog entry for %q is %T, want *json.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -177,10 +239,10 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 //   - `value`: []byte (raw JSON), [io.Reader] (streaming JSON), or string (canonical tag URI).
 //
 // Returns:
-//   - `*Resource`: unlinked candidate.
+//   - `*resource`: unlinked candidate.
 //   - `error`: unsupported value type, JSON parse failure, malformed URI, URI <specific> not in `json:<hex>` form,
 //     or [op.ResourceBase] construction failure.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	switch v := value.(type) {
 
@@ -199,7 +261,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 }
 
 // newFromBytes parses, canonicalizes, hashes, and builds a *Resource from raw JSON bytes.
-func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Resource, error) {
+func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*resource, error) {
 
 	canonical, parsed, err := canonicalize(data)
 	if err != nil {
@@ -209,15 +271,15 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 	sum := sha256.Sum256(canonical)
 	hash := hex.EncodeToString(sum[:])
 
-	base, err := op.NewResourceBase(runtimeEnvironment, SchemeJSON+":"+hash, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, SchemeJSON+":"+hash, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Data:         canonical,
-		Hash:         hash,
+		data:         canonical,
+		hash:         hash,
 		parsed:       parsed,
 	}, nil
 }
@@ -235,7 +297,7 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 // Returns:
 //   - `*Resource`: candidate produced by [newFromBytes] over the drained bytes.
 //   - `error`: any error from [io.ReadAll] or from [newFromBytes].
-func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*Resource, error) {
+func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*resource, error) {
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
@@ -249,7 +311,7 @@ func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) 
 //
 // The URI's <specific> must be `json:<hex>` with hex being a full 64-character lowercase SHA-256. Data and parsed are
 // left empty — callers that need the content must reconstruct via [NewResource]([]byte).
-func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resource, error) {
+func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*resource, error) {
 
 	specific, _, err := op.ExtractTagSpecific(uri)
 	if err != nil {
@@ -268,14 +330,14 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 		return nil, fmt.Errorf("json.Resource: invalid digest hex %q: %w", hashPart, err)
 	}
 
-	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Hash:         hashPart,
+		hash:         hashPart,
 	}, nil
 }
 
@@ -316,7 +378,7 @@ func canonicalize(data []byte) (canonical []byte, parsed any, err error) {
 //
 // Returns:
 //   - `op.AddressingMode`: [op.AddressingContent] — identity is the SHA-256 of the canonical JSON bytes.
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 	return op.AddressingContent
 }
 
@@ -329,8 +391,8 @@ func (r *Resource) Addressing() op.AddressingMode {
 // Returns:
 //   - `op.Digest`: {Algorithm: "sha256", Bytes: decoded Hash}.
 //   - `error`: non-nil if Hash is malformed; should not occur post-construction or post-rehydration.
-func (r *Resource) Digest() (op.Digest, error) {
-	return op.ParseDigest("sha256:" + r.Hash)
+func (r *resource) Digest() (op.Digest, error) {
+	return op.ParseDigest("sha256:" + r.hash)
 }
 
 // Equal reports whether r and other identify the same json.Resource.
@@ -342,13 +404,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true when other is a *json.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -363,13 +425,13 @@ func (r *Resource) Equal(other any) bool {
 // Returns:
 //   - `[]byte`: the canonical JSON bytes (Data).
 //   - `error`: non-nil when the resource holds no content (a URI-only rehydrated resource).
-func (r *Resource) Pack() ([]byte, error) {
+func (r *resource) Pack() ([]byte, error) {
 
-	if len(r.Data) == 0 {
+	if len(r.data) == 0 {
 		return nil, fmt.Errorf("json.Resource: pack %s: no content (URI-only rehydrated resource)", r.URI())
 	}
 
-	return r.Data, nil
+	return r.data, nil
 }
 
 // Parsed returns the decoded Go value cached during construction.
@@ -379,7 +441,7 @@ func (r *Resource) Pack() ([]byte, error) {
 //
 // Returns:
 //   - `any`: the parsed Go value (map[string]any / []any / scalar), or nil for URI-rehydrated Resources.
-func (r *Resource) Parsed() any {
+func (r *resource) Parsed() any {
 	return r.parsed
 }
 
@@ -388,7 +450,7 @@ func (r *Resource) Parsed() any {
 //
 // Returns:
 //   - `string`: the compact JSON encoding of r.
-func (r *Resource) String() string {
+func (r *resource) String() string {
 	return r.Format(r)
 }
 
@@ -407,7 +469,7 @@ func (r *Resource) String() string {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, malformed JSON, or rehydration failure.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("json.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
@@ -418,7 +480,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -436,13 +498,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, or rehydration failure.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("json.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -460,7 +522,7 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, decode failure, or rehydration failure.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("json.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
@@ -471,7 +533,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -496,7 +558,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 //   - `op.Resource`: the reconstructed *json.Resource, not interned in any catalog.
 //   - `error`: parse or canonicalization failure, identity construction failure, or a URI mismatch (integrity
 //     failure).
-func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
+func (r *resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
 
 	candidate, err := newFromBytes(runtimeEnvironment, content)
 	if err != nil {
@@ -522,7 +584,7 @@ func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string,
 // Returns:
 //   - `ValidationResult`: the validation outcome with Valid bool and Errors []string.
 //   - `error`: schema compilation errors (NOT validation errors — those go in ValidationResult.Errors).
-func (r *Resource) Validate(schemaJSON string) (ValidationResult, error) {
+func (r *resource) Validate(schemaJSON string) (ValidationResult, error) {
 
 	compiler := jsonschema.NewCompiler()
 

--- a/pkg/op/provider/json/resource_test.go
+++ b/pkg/op/provider/json/resource_test.go
@@ -18,10 +18,25 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
+// concrete reaches the struct behind a sealed [Resource].
+//
+// [op.Resource] declares neither Equal, Pack, nor the marshalers, so the sealed interface does not expose
+// them — before sealing they were reachable only because embedding leaked [op.ResourceBase]'s whole surface.
+// Every caller of those methods is in this package, so a white-box test asserting to the implementation is
+// the honest way to reach them rather than widening the exported contract.
+func concrete(t *testing.T, r Resource) *resource {
+	t.Helper()
+	c, ok := r.(*resource)
+	if !ok {
+		t.Fatalf("Resource is %T, want *resource", r)
+	}
+	return c
+}
+
 // --- Interface guards ---
 
 func TestResource_ImplementsInterface(t *testing.T) {
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -58,8 +73,8 @@ func TestNewResource_BytesHashesCanonical(t *testing.T) {
 	}
 
 	want := sha256.Sum256([]byte(`{"a":1,"b":2}`))
-	if r.Hash != hex.EncodeToString(want[:]) {
-		t.Errorf("Hash = %q, want sha256 of canonical form", r.Hash)
+	if r.Hash() != hex.EncodeToString(want[:]) {
+		t.Errorf("Hash = %q, want sha256 of canonical form", r.Hash())
 	}
 }
 
@@ -178,8 +193,8 @@ func TestNewResource_DataIsCanonical(t *testing.T) {
 	}
 
 	// Data should be the canonical bytes (sorted keys, no whitespace), NOT the original input.
-	if !bytes.Equal(r.Data, []byte(`{"a":1,"b":2}`)) {
-		t.Errorf("Data = %q, want canonical form %q", r.Data, `{"a":1,"b":2}`)
+	if !bytes.Equal(r.Data(), []byte(`{"a":1,"b":2}`)) {
+		t.Errorf("Data = %q, want canonical form %q", r.Data(), `{"a":1,"b":2}`)
 	}
 }
 
@@ -209,8 +224,8 @@ func TestDiscoverResource_RoundTripsURI(t *testing.T) {
 	if discovered.URI() != original.URI() {
 		t.Errorf("URI = %q, want %q", discovered.URI(), original.URI())
 	}
-	if discovered.Hash != original.Hash {
-		t.Errorf("Hash = %q, want %q", discovered.Hash, original.Hash)
+	if discovered.Hash() != original.Hash() {
+		t.Errorf("Hash = %q, want %q", discovered.Hash(), original.Hash())
 	}
 }
 
@@ -252,7 +267,7 @@ func TestDigest_MatchesHash(t *testing.T) {
 	if d.Algorithm != "sha256" {
 		t.Errorf("Algorithm = %q, want sha256", d.Algorithm)
 	}
-	wantBytes, _ := hex.DecodeString(r.Hash)
+	wantBytes, _ := hex.DecodeString(r.Hash())
 	if !bytes.Equal(d.Bytes, wantBytes) {
 		t.Errorf("Bytes = %x, want %x", d.Bytes, wantBytes)
 	}
@@ -266,8 +281,8 @@ func TestEqual_SameContent(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte(`{"a":1}`))
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte(`{"a":1}`))
-	if !r1.Equal(r2) {
-		t.Error("expected r1.Equal(r2) for identical content")
+	if !concrete(t, r1).Equal(r2) {
+		t.Error("expected concrete(t, r1).Equal(r2) for identical content")
 	}
 }
 
@@ -277,7 +292,7 @@ func TestEqual_DifferentContent(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte(`{"a":1}`))
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte(`{"a":2}`))
-	if r1.Equal(r2) {
+	if concrete(t, r1).Equal(r2) {
 		t.Error("expected Equal to be false for distinct content")
 	}
 }
@@ -286,10 +301,10 @@ func TestEqual_RejectsNonResource(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", []byte(`{}`))
 
-	if r.Equal("not a resource") {
-		t.Error("expected Equal to reject non-*Resource")
+	if concrete(t, r).Equal("not a resource") {
+		t.Error("expected Equal to reject non-Resource")
 	}
-	if r.Equal(nil) {
+	if concrete(t, r).Equal(nil) {
 		t.Error("expected Equal to reject nil")
 	}
 }
@@ -303,20 +318,20 @@ func TestUnmarshalJSON_RehydratesFromURI(t *testing.T) {
 	data, _ := json.Marshal(original.URI())
 
 	seeded, _ := DiscoverResource(runtimeEnvironment, original.URI())
-	if err := seeded.UnmarshalJSON(data); err != nil {
+	if err := concrete(t, seeded).UnmarshalJSON(data); err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
 	}
 	if seeded.URI() != original.URI() {
 		t.Errorf("URI after unmarshal = %q, want %q", seeded.URI(), original.URI())
 	}
-	if seeded.Hash != original.Hash {
-		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash, original.Hash)
+	if seeded.Hash() != original.Hash() {
+		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash(), original.Hash())
 	}
 }
 
 func TestUnmarshalJSON_RequiresRuntimeEnvironment(t *testing.T) {
-	r := &Resource{}
-	if err := r.UnmarshalJSON([]byte(`"tag:..:json:abc#"`)); err == nil ||
+	r := &resource{}
+	if err := concrete(t, r).UnmarshalJSON([]byte(`"tag:..:json:abc#"`)); err == nil ||
 		!strings.Contains(err.Error(), "RuntimeEnvironment") {
 		t.Errorf("expected RuntimeEnvironment error, got %v", err)
 	}
@@ -327,7 +342,7 @@ func TestUnmarshalText_RehydratesFromURI(t *testing.T) {
 	original, _ := NewResource(runtimeEnvironment, "", []byte(`{"t":1}`))
 
 	seeded, _ := DiscoverResource(runtimeEnvironment, original.URI())
-	if err := seeded.UnmarshalText([]byte(original.URI())); err != nil {
+	if err := concrete(t, seeded).UnmarshalText([]byte(original.URI())); err != nil {
 		t.Fatalf("UnmarshalText: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -351,7 +366,7 @@ func TestUnmarshalYAML_RehydratesFromURI(t *testing.T) {
 		return nil
 	}
 
-	if err := seeded.UnmarshalYAML(decode); err != nil {
+	if err := concrete(t, seeded).UnmarshalYAML(decode); err != nil {
 		t.Fatalf("UnmarshalYAML: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -365,7 +380,7 @@ func TestValidate_AcceptsConformingDocument(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", []byte(`{"name":"x"}`))
 
-	result, err := r.Validate(`{"type":"object","required":["name"]}`)
+	result, err := concrete(t, r).Validate(`{"type":"object","required":["name"]}`)
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}

--- a/pkg/op/provider/yaml/provider.go
+++ b/pkg/op/provider/yaml/provider.go
@@ -79,9 +79,9 @@ func (p *Provider) Encode(value any) (result string, err error) {
 //   - `data`: the YAML text to parse.
 //
 // Returns:
-//   - `*Resource`: the canonical catalog entry holding the parsed value.
+//   - `Resource`: the canonical catalog entry holding the parsed value.
 //   - `error`: non-nil when `data` is not valid YAML or catalog interning fails.
-func (p *Provider) Parse(activationRecord *op.ActivationRecord, data string) (*Resource, error) {
+func (p *Provider) Parse(activationRecord *op.ActivationRecord, data string) (Resource, error) {
 	return NewResource(p.RuntimeEnvironment(), activationRecord.CallerID, []byte(data))
 }
 

--- a/pkg/op/provider/yaml/resource.go
+++ b/pkg/op/provider/yaml/resource.go
@@ -24,22 +24,22 @@ import (
 const SchemeYAML = "yaml"
 
 // Interface Guard: *Resource implements op.Resource.
-var _ op.Resource = (*Resource)(nil)
+var _ op.Resource = (*resource)(nil)
 
 // Interface Guard: *Resource implements json.Unmarshaler.
-var _ json.Unmarshaler = (*Resource)(nil)
+var _ json.Unmarshaler = (*resource)(nil)
 
 // Interface Guard: *Resource implements encoding.TextUnmarshaler.
-var _ encoding.TextUnmarshaler = (*Resource)(nil)
+var _ encoding.TextUnmarshaler = (*resource)(nil)
 
 // Interface Guard: *Resource implements fmt.Stringer.
-var _ fmt.Stringer = (*Resource)(nil)
+var _ fmt.Stringer = (*resource)(nil)
 
 // Interface Guard: *Resource implements op.Packer.
-var _ op.Packer = (*Resource)(nil)
+var _ op.Packer = (*resource)(nil)
 
 // Interface Guard: *Resource implements op.Unpacker.
-var _ op.Unpacker = (*Resource)(nil)
+var _ op.Unpacker = (*resource)(nil)
 
 // Resource represents a parsed YAML document held in memory, identified by the SHA-256 of its canonical form.
 //
@@ -54,19 +54,66 @@ var _ op.Unpacker = (*Resource)(nil)
 // anchors/aliases, comments, multi-line scalar styles — are flattened to their plain JSON equivalents during
 // canonicalization. If typed-tag preservation becomes a requirement, swap this canonicalizer for a YAML-native one that
 // routes through `*yaml.Node` and re-emits canonical YAML.
-type Resource struct {
+// Resource is this provider's resource type — the sealed interface over a canonicalized YAML document.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. A
+// value reaching a yaml method therefore came from a constructor and carries catalog-issued identity;
+// nothing hand-built or reflectively hydrated can satisfy it.
+type Resource interface {
+	op.Resource
+
+	// Data returns the canonical YAML bytes. Content-addressed: the digest derives from them.
+	Data() []byte
+
+	// Hash returns the hex-encoded digest of [Resource.Data].
+	Hash() string
+
+	// Parsed returns the decoded Go value — map[string]any, []any, or a scalar.
+	Parsed() any
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete yaml resource — what serializes, and the only thing implementing [Resource].
+//
+// Unexported so `&yaml.resource{...}` cannot be written outside this package.
+type resource struct {
 	op.ResourceBase
 
-	// Data is the canonical JSON bytes of the parsed YAML document (sorted-key, whitespace-free). Identity bearing —
-	// `SHA-256(Data)` is encoded in the URI <specific> as `yaml:<Hash>`.
-	Data []byte `json:"data,omitempty"`
+	// data is the canonical YAML encoding. Identity-bearing — the URI's digest derives from it.
+	data []byte
 
-	// Hash is the lowercase hex SHA-256 of Data, identity-bearing. Also encoded in the URI <specific>.
-	Hash string `json:"hash,omitempty"`
+	// hash is the hex-encoded digest of data.
+	hash string
 
-	// parsed is the decoded Go value, cached at construction for [Resource.Parsed] / [Resource.Validate].
-	// Not persisted; rehydration from URI leaves parsed nil.
+	// parsed is the decoded Go value.
 	parsed any
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// Data returns the canonical YAML bytes.
+//
+// Returns:
+//   - `[]byte`: the canonical encoding.
+func (r *resource) Data() []byte { return r.data }
+
+// Hash returns the hex-encoded digest of the canonical bytes.
+//
+// Returns:
+//   - `string`: the digest.
+func (r *resource) Hash() string { return r.hash }
+
+// init wires the two things a sealed resource cannot state from its generated announcement, which lives in
+// a sibling package and can name only exported identifiers.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs a yaml.Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -87,9 +134,9 @@ type Resource struct {
 //     streams are parsed + canonicalized during construction; an invalid YAML document errors here.
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, YAML parse failure, malformed URI, or identity construction failure.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -107,9 +154,9 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("yaml.NewResource: catalog entry for %q is %T, want *yaml.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("yaml.NewResource: catalog entry for %q is %T, want *yaml.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -134,9 +181,23 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 //     [NewResource].
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, YAML parse failure, malformed URI, or identity construction failure.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type, which rehydration needs because it
+// assigns through the receiver.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: bytes, a reader, or a canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -154,9 +215,9 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("yaml.DiscoverResource: catalog entry for %q is %T, want *yaml.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("yaml.DiscoverResource: catalog entry for %q is %T, want *yaml.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -175,10 +236,10 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 //   - `value`: []byte (raw YAML, will be canonicalized) or string (canonical tag URI).
 //
 // Returns:
-//   - `*Resource`: unlinked candidate.
+//   - `*resource`: unlinked candidate.
 //   - `error`: unsupported value type, YAML parse failure, malformed URI, URI <specific> not in `yaml:<hex>`
 //     form, or [op.ResourceBase] construction failure.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	switch v := value.(type) {
 
@@ -197,7 +258,7 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 }
 
 // newFromBytes parses YAML, canonicalizes through JSON, hashes, and builds a *Resource from raw YAML bytes.
-func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Resource, error) {
+func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*resource, error) {
 
 	canonical, parsed, err := canonicalize(data)
 	if err != nil {
@@ -207,15 +268,15 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 	sum := sha256.Sum256(canonical)
 	hash := hex.EncodeToString(sum[:])
 
-	base, err := op.NewResourceBase(runtimeEnvironment, SchemeYAML+":"+hash, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, SchemeYAML+":"+hash, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Data:         canonical,
-		Hash:         hash,
+		data:         canonical,
+		hash:         hash,
 		parsed:       parsed,
 	}, nil
 }
@@ -233,7 +294,7 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 // Returns:
 //   - `*Resource`: candidate produced by [newFromBytes] over the drained bytes.
 //   - `error`: any error from [io.ReadAll] or from [newFromBytes].
-func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*Resource, error) {
+func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*resource, error) {
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
@@ -247,7 +308,7 @@ func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) 
 //
 // The URI's <specific> must be `yaml:<hex>` with hex being a full 64-character lowercase SHA-256. Data and
 // parsed are left empty — callers that need the content must reconstruct via [NewResource]([]byte).
-func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resource, error) {
+func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*resource, error) {
 
 	specific, _, err := op.ExtractTagSpecific(uri)
 	if err != nil {
@@ -266,14 +327,14 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 		return nil, fmt.Errorf("yaml.Resource: invalid digest hex %q: %w", hashPart, err)
 	}
 
-	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Hash:         hashPart,
+		hash:         hashPart,
 	}, nil
 }
 
@@ -348,7 +409,7 @@ func normalizeForJSON(v any) (any, error) {
 //
 // Returns:
 //   - `op.AddressingMode`: [op.AddressingContent] — identity is the SHA-256 of the canonical JSON form.
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 	return op.AddressingContent
 }
 
@@ -360,8 +421,8 @@ func (r *Resource) Addressing() op.AddressingMode {
 // Returns:
 //   - `op.Digest`: {Algorithm: "sha256", Bytes: decoded Hash}.
 //   - `error`: non-nil if Hash is malformed; should not occur post-construction or post-rehydration.
-func (r *Resource) Digest() (op.Digest, error) {
-	return op.ParseDigest("sha256:" + r.Hash)
+func (r *resource) Digest() (op.Digest, error) {
+	return op.ParseDigest("sha256:" + r.hash)
 }
 
 // Equal reports whether r and other identify the same yaml.Resource.
@@ -373,13 +434,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true when other is a *yaml.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -392,7 +453,7 @@ func (r *Resource) Equal(other any) bool {
 //
 // Returns:
 //   - `any`: the parsed Go value, or nil for URI-rehydrated Resources.
-func (r *Resource) Parsed() any {
+func (r *resource) Parsed() any {
 	return r.parsed
 }
 
@@ -401,7 +462,7 @@ func (r *Resource) Parsed() any {
 //
 // Returns:
 //   - `string`: the compact JSON encoding of r.
-func (r *Resource) String() string {
+func (r *resource) String() string {
 	return r.Format(r)
 }
 
@@ -418,13 +479,13 @@ func (r *Resource) String() string {
 // Returns:
 //   - `[]byte`: the canonical JSON bytes (Data).
 //   - `error`: non-nil when the resource holds no content (a URI-only rehydrated resource).
-func (r *Resource) Pack() ([]byte, error) {
+func (r *resource) Pack() ([]byte, error) {
 
-	if len(r.Data) == 0 {
+	if len(r.data) == 0 {
 		return nil, fmt.Errorf("yaml.Resource: pack %s: no content (URI-only rehydrated resource)", r.URI())
 	}
 
-	return r.Data, nil
+	return r.data, nil
 }
 
 // UnmarshalJSON populates the receiver from its JSON document (a bare URI string).
@@ -437,7 +498,7 @@ func (r *Resource) Pack() ([]byte, error) {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, malformed JSON, or rehydration failure.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("yaml.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
@@ -448,7 +509,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -466,13 +527,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, or rehydration failure.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("yaml.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -490,7 +551,7 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, decode failure, or rehydration failure.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("yaml.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
@@ -501,7 +562,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -527,7 +588,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 //   - `op.Resource`: the reconstructed *yaml.Resource, not interned in any catalog.
 //   - `error`: parse or canonicalization failure, identity construction failure, or a URI mismatch (integrity
 //     failure).
-func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
+func (r *resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
 
 	candidate, err := newFromBytes(runtimeEnvironment, content)
 	if err != nil {
@@ -553,7 +614,7 @@ func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string,
 // Returns:
 //   - `ValidationResult`: the validation outcome with Valid bool and Errors []string.
 //   - `error`: schema compilation errors (NOT validation errors — those go in ValidationResult.Errors).
-func (r *Resource) Validate(schemaJSON string) (ValidationResult, error) {
+func (r *resource) Validate(schemaJSON string) (ValidationResult, error) {
 
 	compiler := jsonschema.NewCompiler()
 

--- a/pkg/op/provider/yaml/resource_test.go
+++ b/pkg/op/provider/yaml/resource_test.go
@@ -17,10 +17,25 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
+// concrete reaches the struct behind a sealed [Resource].
+//
+// [op.Resource] declares neither Equal, Pack, nor the marshalers, so the sealed interface does not expose
+// them — before sealing they were reachable only because embedding leaked [op.ResourceBase]'s whole surface.
+// Every caller of those methods is in this package, so a white-box test asserting to the implementation is
+// the honest way to reach them rather than widening the exported contract.
+func concrete(t *testing.T, r Resource) *resource {
+	t.Helper()
+	c, ok := r.(*resource)
+	if !ok {
+		t.Fatalf("Resource is %T, want *resource", r)
+	}
+	return c
+}
+
 // --- Interface guards ---
 
 func TestResource_ImplementsInterface(t *testing.T) {
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -57,8 +72,8 @@ func TestNewResource_BytesHashesCanonicalJSON(t *testing.T) {
 
 	// Canonical form is JSON with sorted keys, no whitespace.
 	want := sha256.Sum256([]byte(`{"a":1,"b":2}`))
-	if r.Hash != hex.EncodeToString(want[:]) {
-		t.Errorf("Hash = %q, want sha256 of canonical JSON form", r.Hash)
+	if r.Hash() != hex.EncodeToString(want[:]) {
+		t.Errorf("Hash = %q, want sha256 of canonical JSON form", r.Hash())
 	}
 }
 
@@ -172,8 +187,8 @@ func TestNewResource_DataIsCanonicalJSON(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	if !bytes.Equal(r.Data, []byte(`{"a":1,"b":2}`)) {
-		t.Errorf("Data = %q, want canonical JSON %q", r.Data, `{"a":1,"b":2}`)
+	if !bytes.Equal(r.Data(), []byte(`{"a":1,"b":2}`)) {
+		t.Errorf("Data = %q, want canonical JSON %q", r.Data(), `{"a":1,"b":2}`)
 	}
 }
 
@@ -203,8 +218,8 @@ func TestDiscoverResource_RoundTripsURI(t *testing.T) {
 	if discovered.URI() != original.URI() {
 		t.Errorf("URI = %q, want %q", discovered.URI(), original.URI())
 	}
-	if discovered.Hash != original.Hash {
-		t.Errorf("Hash = %q, want %q", discovered.Hash, original.Hash)
+	if discovered.Hash() != original.Hash() {
+		t.Errorf("Hash = %q, want %q", discovered.Hash(), original.Hash())
 	}
 }
 
@@ -246,7 +261,7 @@ func TestDigest_MatchesHash(t *testing.T) {
 	if d.Algorithm != "sha256" {
 		t.Errorf("Algorithm = %q, want sha256", d.Algorithm)
 	}
-	wantBytes, _ := hex.DecodeString(r.Hash)
+	wantBytes, _ := hex.DecodeString(r.Hash())
 	if !bytes.Equal(d.Bytes, wantBytes) {
 		t.Errorf("Bytes = %x, want %x", d.Bytes, wantBytes)
 	}
@@ -260,8 +275,8 @@ func TestEqual_SameContent(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("a: 1\n"))
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("a: 1\n"))
-	if !r1.Equal(r2) {
-		t.Error("expected r1.Equal(r2) for identical content")
+	if !concrete(t, r1).Equal(r2) {
+		t.Error("expected concrete(t, r1).Equal(r2) for identical content")
 	}
 }
 
@@ -271,7 +286,7 @@ func TestEqual_DifferentContent(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("a: 1\n"))
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("a: 2\n"))
-	if r1.Equal(r2) {
+	if concrete(t, r1).Equal(r2) {
 		t.Error("expected Equal to be false for distinct content")
 	}
 }
@@ -280,10 +295,10 @@ func TestEqual_RejectsNonResource(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", []byte("a: 1\n"))
 
-	if r.Equal("not a resource") {
-		t.Error("expected Equal to reject non-*Resource")
+	if concrete(t, r).Equal("not a resource") {
+		t.Error("expected Equal to reject non-Resource")
 	}
-	if r.Equal(nil) {
+	if concrete(t, r).Equal(nil) {
 		t.Error("expected Equal to reject nil")
 	}
 }
@@ -297,20 +312,20 @@ func TestUnmarshalJSON_RehydratesFromURI(t *testing.T) {
 	data, _ := json.Marshal(original.URI())
 
 	seeded, _ := DiscoverResource(runtimeEnvironment, original.URI())
-	if err := seeded.UnmarshalJSON(data); err != nil {
+	if err := concrete(t, seeded).UnmarshalJSON(data); err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
 	}
 	if seeded.URI() != original.URI() {
 		t.Errorf("URI after unmarshal = %q, want %q", seeded.URI(), original.URI())
 	}
-	if seeded.Hash != original.Hash {
-		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash, original.Hash)
+	if seeded.Hash() != original.Hash() {
+		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash(), original.Hash())
 	}
 }
 
 func TestUnmarshalJSON_RequiresRuntimeEnvironment(t *testing.T) {
-	r := &Resource{}
-	if err := r.UnmarshalJSON([]byte(`"tag:..:yaml:abc#"`)); err == nil ||
+	r := &resource{}
+	if err := concrete(t, r).UnmarshalJSON([]byte(`"tag:..:yaml:abc#"`)); err == nil ||
 		!strings.Contains(err.Error(), "RuntimeEnvironment") {
 		t.Errorf("expected RuntimeEnvironment error, got %v", err)
 	}
@@ -321,7 +336,7 @@ func TestUnmarshalText_RehydratesFromURI(t *testing.T) {
 	original, _ := NewResource(runtimeEnvironment, "", []byte("t: 1\n"))
 
 	seeded, _ := DiscoverResource(runtimeEnvironment, original.URI())
-	if err := seeded.UnmarshalText([]byte(original.URI())); err != nil {
+	if err := concrete(t, seeded).UnmarshalText([]byte(original.URI())); err != nil {
 		t.Fatalf("UnmarshalText: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -345,7 +360,7 @@ func TestUnmarshalYAML_RehydratesFromURI(t *testing.T) {
 		return nil
 	}
 
-	if err := seeded.UnmarshalYAML(decode); err != nil {
+	if err := concrete(t, seeded).UnmarshalYAML(decode); err != nil {
 		t.Fatalf("UnmarshalYAML: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -359,7 +374,7 @@ func TestValidate_AcceptsConformingDocument(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", []byte("name: x\n"))
 
-	result, err := r.Validate(`{"type":"object","required":["name"]}`)
+	result, err := concrete(t, r).Validate(`{"type":"object","required":["name"]}`)
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -381,7 +396,7 @@ func TestNewResource_YAMLAndJSONAgreeOnHash(t *testing.T) {
 	wantSum := sha256.Sum256(wantBytes)
 	wantHash := hex.EncodeToString(wantSum[:])
 
-	if fromYAML.Hash != wantHash {
-		t.Errorf("YAML Hash = %q, want %q (sha256 of canonical JSON form)", fromYAML.Hash, wantHash)
+	if fromYAML.Hash() != wantHash {
+		t.Errorf("YAML Hash = %q, want %q (sha256 of canonical JSON form)", fromYAML.Hash(), wantHash)
 	}
 }


### PR DESCRIPTION
Phase 4 of #625. Closes #643.

**The mechanical pass the plan kept predicting and had not yet got.** Both providers took the template
unchanged — sealed interface, unexported struct, accessors for `Data`/`Hash`/`Parsed`, two registrations
from init — with no framework repair and no surprise. `make test` 103 ok on the first run after the
consumers were updated.

## `mem` moved out before this started

`function.Resource` embeds `mem.Resource` **cross-package**:

```go
type Resource struct {
	mem.Resource
	invoker starlarkbridge.Invoker
	...
}
```

Go cannot embed an unexported type from another package, so sealing `mem` breaks `function` at compile
time — the two are coupled and cannot land separately. `mem` moved to #662 to be sealed alongside
`function`, where `function.resource` will embed the `mem.Resource` *interface* instead.

Found by surveying before transforming rather than by the compiler afterwards. Verified isolated rather
than a pattern: it is the **only** cross-package resource embed in the tree.

## The `Unpacker` repair finally has a pin

Phase 1 routed `UnpackerByTypeID`'s reflective probe to the implementation. Nothing asserted it since — it
has been correct by inspection for four phases, and the failure mode is silent: `ok=false` reads as "this
type has no unpacker," so content rehydration would simply stop.

**The first version of the pin was not worth having, and I nearly kept it.** It derived its expected set
from `ProviderType()` — the very value a regression corrupts. Revert the repair and the type stops
implementing `op.Unpacker`, the derived loop skips it, and the test passes green while content rehydration
is broken. The set is now **named explicitly** (`function`, `json`, `mem`, `yaml`), so a fifth unpacker has
to be added here deliberately, and a vanished one fails rather than disappears.

## Verification

`make test` 103 ok / 0 fail · `make build` · `make vet` darwin/linux/windows · `test-scenario` ·
`complexity` · `shell-lint` · `gofmt -l` — all clean.

Metadata preserved without hand-editing: `json` 2 entries, `yaml` 2 — #658's generator fix holding on two
more providers it had never seen.

## Note preserved, not fixed

`Data` and `Hash` carry `json:"..."` tags, but no resource overrides `MarshalJSON`, so the promoted base
marshaler writes the URI alone and those tags are inert — the same latent asymmetry recorded for `git` in
#661. Content survives through `Pack`/`Unpack` and the content section, not through the resource's own
JSON. Left exactly as found.
