### PR TITLE
refactor(op): the content-addressed path is the framework's, not a provider's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,15 @@ docs: build ## Generate CLI documentation
 
 dist: dist-all checksums ## Build distribution archives with checksums
 
-dist-all: build ## Build distribution archives for PLATFORM (default: every supported platform)
+dist-all: ## Build distribution archives for PLATFORM (default: every supported platform)
+	# The stamp proof is NOT optional and NOT subject to PLATFORM.
+	#
+	# `build` proves on the host that the -X flags bind to real symbols — the failure that shipped
+	# unnoticed until 2026-08-16. A plain `dist-all: build` prerequisite lost that proof the moment
+	# `build` learned to skip the check when PLATFORM excludes the host: `make dist PLATFORM=linux/amd64`
+	# would then ship archives with nothing having verified the stamp. Forcing a host build here restores
+	# the invariant regardless of what the caller selected.
+	$(MAKE) build PLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)
 	# Depends on `build` for its stamp check, not for its binaries. This is the path that ships
 	# (.github/workflows/release.yaml runs `make dist`), it cross-compiles with the same LDFLAGS and
 	# the same VERSION, and it cannot run what it produces for other platforms. `build` proves on the

--- a/docs/plans/platform-connection-points.md
+++ b/docs/plans/platform-connection-points.md
@@ -1,0 +1,113 @@
+---
+title: "Platform connection points: run the execution matrix on real machines"
+issue: https://github.com/NobleFactor/devlore-cli/issues/671
+status: draft
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+# Plan: platform connection points
+
+## Summary
+
+Declare, per developer, which machines stand in for which **platforms**, so the checks that must *execute*
+can run somewhere real. On a darwin workstation that means naming a linux box and a windows box; the
+matrix then builds locally, ships, runs remotely, and reports back.
+
+**Keyed by platform, not by OS.** `windows/amd64` and `windows/arm64` are different targets — Parallels on
+Apple Silicon makes that concrete — and `PLATFORM`, `build/<goos>-<goarch>/`, and `dist` already share that
+spelling. Reusing it means no translation layer between "what I built" and "where I can run it".
+
+## Why now
+
+[#670](https://github.com/NobleFactor/devlore-cli/issues/670) rules that **CI is a strict superset of the
+local checks**, with a local opt-in to everything. Measuring the gap showed the matrix is not one thing:
+
+| Check | Needs a remote machine | Runs on darwin today |
+| --- | --- | --- |
+| `make build-all` | no | yes — 12s |
+| `make vet-all` | no | yes — 5s |
+| `make lint-all` | no | yes — 59s |
+| `make test`, `make test-race` | **yes** | host only |
+| `make test-scenario` | **yes** | host only |
+
+Cross-*compilation* is pure Go and already works. Only cross-*execution* needs machines. So the static half
+of `make check-all` can land without this plan, and this plan is what grows the execution half.
+
+## The mechanism
+
+### Where it lives
+
+A new announced section, `connections`, in `pkg/devconfig` — the same mechanism the `runtime` section uses.
+No new file format, no new discovery path, and `star config show` describes it without extra work.
+
+It belongs to the **user's** config, never the repository's. Hostnames, accounts, and network topology are
+per-developer facts; committing them would rot immediately and leak detail that does not belong in a repo.
+
+### The shape
+
+```yaml
+connections:
+  linux/amd64:   { host: build-linux }
+  windows/arm64: { host: build-win, shell: pwsh }
+```
+
+**`host` is an `~/.ssh/config` alias, not a hostname.** SSH already solves user, port, identity, jump host,
+agent forwarding, and multiplexing, and the developer already maintains that file. Restating any of it here
+would create a second source of truth that drifts out of step with the first.
+
+The section carries only what SSH config cannot express. Today that is the remote shell: Windows needs
+`pwsh` where the default would be `cmd`.
+
+### The rule that matters most
+
+**An unreachable connection point fails loudly. It never skips.**
+
+A matrix that silently drops a platform because a box is down reproduces exactly the defect this campaign
+has been unwinding — a gate reporting green while not running. The two states are different and must stay
+different:
+
+- **no entry for a platform** — not configured; reported as such, not an error
+- **an entry that will not connect** — a failure, not an omission
+
+### A companion command
+
+`star connections check` (name provisional) proves every configured point is reachable and can run a
+binary, so the matrix never discovers a dead box mid-run. It is also the thing a developer runs once after
+editing their config, rather than learning by way of a failed test sweep.
+
+## Phases
+
+### Phase 1 — the config section — status: pending
+
+`connections` announced in `pkg/devconfig`, platform-keyed, validated: keys must parse as `<goos>/<goarch>`
+and name a supported platform; `host` is required; `shell` is optional and defaults per platform.
+
+### Phase 2 — reachability verification — status: pending
+
+`star connections check`. Connects to each configured point, confirms it can execute a trivial binary
+built for that platform, and reports per-platform. Exit non-zero if any configured point fails.
+
+### Phase 3 — the execution matrix consumes it — status: pending
+
+`make check-all` grows its execution half: for each selected platform that is not the host, ship the
+binaries already in `build/<goos>-<goarch>/`, run the suite there, report back. Builds on
+[#598](https://github.com/NobleFactor/devlore-cli/issues/598)'s build-once/test-many, which is what makes
+the binaries available in the first place.
+
+## Open questions
+
+1. **Does an entry name a platform or a machine?** One box able to emulate might serve `linux/amd64` and
+   `linux/arm64`. Do we allow one entry to claim several platforms, or keep the mapping one-to-one?
+2. **Where do binaries land remotely** — a fixed path, a per-run temp directory, or XDG on the remote?
+3. **Is `shell` the only thing SSH config cannot express?** A remote working directory, an environment
+   prelude, or a sudo policy may follow.
+4. **Does this belong to devlore-cli or to `writ`?** `writ` already knows about machines. The instinct is
+   devlore-cli — this is about testing the product, not deploying dotfiles — but the boundary is a USER
+   call.
+
+## Verification
+
+Every phase: `make check`, `make vet` under GOOS windows and linux, `gofmt -l`. Phase 2 and 3 additionally
+need a configured point to test against, which is the first thing in this campaign that cannot be verified
+from a single machine.

--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -284,8 +284,9 @@ failing. This is the load-bearing detail of part 2.
 | 1 | 5 | #662 | `mem` and `function` — coupled by a cross-package embed |
 | 1 | 6 | #644 | `pkg` — the widest footprint |
 | 2 | 7 | #645 | `file`'s four variants, discriminated by `kind()` |
-| — | 8 | #646 | the rule becomes structurally enforceable |
-| — | 9 | #647 | closure — the design record states the contract |
+| — | 8 | #649 | sweep `ConvertFrom` / `CanConvertFrom` — dead once every provider is sealed |
+| — | 9 | #646 | the rule becomes structurally enforceable |
+| — | 10 | #647 | closure — the design record states the contract |
 
 Supersedes #626–#630, which were filed against the original phase shape and are closed as superseded.
 
@@ -468,7 +469,35 @@ At the end of this phase the rule holds with no exceptions, and the feature's go
 
 ### Closure
 
-#### Phase 8 — the rule becomes structurally enforceable — status: pending
+#### Phase 8 — sweep `ConvertFrom` / `CanConvertFrom` — status: pending
+
+[#649](https://github.com/NobleFactor/devlore-cli/issues/649), scheduled here rather than per-phase (USER,
+2026-08-25). Sealing is what makes a resource's `TargetConverter` pair unreachable: `op.Convert` step 7
+probes `reflect.New(target)`, and on an interface that yields a pointer-to-interface with an empty method
+set. Once every provider is sealed, all sixteen methods are dead **at once**, so the sweep is pure
+dead-code removal rather than a behaviour change threaded through five separate PRs.
+
+**Sixteen methods, eight pairs, five providers** — `appnet`, `git`, `service` (dead since their phases),
+`pkg` (phase 6), and `file`'s four variants plus its base (phase 7). Nothing else goes.
+
+The framework seam **stays**: `op.TargetConverter`, `tryTargetConverter`, `targetSideAdvertises`, and the
+cached type are all live for non-resource targets — `(*OrderingEdge).CanConvertFrom` is a real production
+implementor with nothing to do with resources, and `TestConvert_TargetConverter` keeps exercising step 7.
+
+Two things make this safe rather than merely tidy, and both are evidence rather than argument:
+
+1. **The contract already declares itself optional for resources.** `pkg/op/interfaces.go:65` says
+   implementers *"commonly omit `TargetConverter` when their natural source is content bytes or a parsed
+   structure."* Four resources — `json`, `yaml`, `mem`, `function` — have never implemented it.
+2. **The plan-time worry is answered.** `CanConvertFrom` is `typesAreInterconvertible`'s only bridge for
+   `string ↔ Resource`, and removing it was expected to turn a tolerated slot collision into a hard one.
+   Sealing already removed it for five providers, and the suite, the scenarios, and three platforms stayed
+   green. Nothing depended on it.
+
+Distinct from [#661](https://github.com/NobleFactor/devlore-cli/issues/661), which is the opposite shape: a
+documented override contract that **zero** implementors honour.
+
+#### Phase 9 — the rule becomes structurally enforceable — status: pending
 
 1. `4.3-resource-registration.md` states the shape as **the contract** for adding a provider resource.
 2. A test asserts it structurally: every announced resource type is an interface, and the struct behind
@@ -476,7 +505,7 @@ At the end of this phase the rule holds with no exceptions, and the feature's go
 
 Without this the rule is a convention, and conventions decay.
 
-#### Phase 9 — closure — status: pending
+#### Phase 10 — closure — status: pending
 
 The `3.5.x` per-provider design docs drop any language describing the resource as a struct.
 `4-resource-management.md` records what the seal buys: the model's guarantees now rest on the compiler

--- a/docs/plans/shell-lint-via-star.md
+++ b/docs/plans/shell-lint-via-star.md
@@ -1,0 +1,81 @@
+---
+title: "Shell lint runs on every check-in, through star"
+issue: https://github.com/NobleFactor/devlore-cli/issues/672
+status: draft
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+# Plan: shell lint via star, on every check-in
+
+## Goal
+
+**Shell checks run on every commit, through `star`, with no path that reports green without checking.**
+`.github/scripts/shell-lint.sh` is retired once nothing depends on it.
+
+## Why this is not a one-line swap
+
+Investigating the swap turned up three defects. Two of them make a check report success while doing
+nothing, which is the failure this whole thread has been about.
+
+1. **`star hook pre-commit` is dead.** It fails immediately with
+   `lint.go: unexpected keyword argument "path" (did you mean paths?)` — `hook-pre-commit.star:52` passes
+   `path=` where the parameter is `paths=`, and `:81` passes `path=` to `lint.shell` where the parameter is
+   `files=`. The Go check dies first, so the shell check never runs at all. This is very likely why
+   `.githooks/pre-commit` is hand-written bash and why pre-commit hooks were written off as buggy.
+
+2. **`lint.Shell` reports success on an empty file list.**
+   `if len(files) == 0 { return ShellResult{Passed: true}, nil }`. A discovery gap therefore surfaces as a
+   pass, not as a failure.
+
+3. **`star lint shell` discovers by extension only.** `lint-shell.star`'s `collect_files` globs `*.sh`,
+   `*.bash`, `*.zsh` and hands `lint.shell` an explicit list. Combined with (2), a tree of extensionless
+   scripts lints clean having checked nothing — and this project's convention is extensionless scripts.
+
+The capability itself is not missing: `cmd/star/provider/shellcheck/provider.go`'s `isShellFile` already
+matches the three extensions **or** a `#!/…/{bash,sh,zsh}` / `env {bash,sh,zsh}` shebang **or** a
+`# shellcheck shell=` directive — a strict superset of what `shell-lint.sh` detects, plus `vendor` and
+`node_modules` pruning the script lacks. It belongs to a different entry point than the one the extension
+calls.
+
+## Steps
+
+| # | Step | Done |
+| --- | --- | --- |
+| 1 | `hook-pre-commit.star:52` — `lint.go(path=…)` becomes `paths=` | ☐ |
+| 2 | `hook-pre-commit.star:81` — `lint.shell(path=…)` becomes `files=` | ☐ |
+| 3 | `lint.Shell` stops returning `Passed: true` for an empty file set — an empty set is an error | ☐ |
+| 4 | `lint-shell.star` — `collect_files` stops globbing; discovery uses the shebang/directive rule | ☐ |
+| 5 | Discovery prunes `.devlore`, `build`, `dist` alongside `.git`, `vendor`, `node_modules` | ☐ |
+| 6 | `make shell-lint` invokes `$(STAR) lint shell .` and depends on `$(STAR)` | ☐ |
+| 7 | `.githooks/pre-commit` calls `make shell-lint` rather than `.github/scripts/shell-lint.sh` | ☐ |
+| 8 | Delete `.github/scripts/shell-lint.sh` | ☐ |
+| 9 | Pin it: a fixture with a deliberately bad extensionless script fails the lint | ☐ |
+
+Steps 1–3 are the defect fixes and stand on their own merit. Steps 4–5 restore the discovery the provider
+already implements. Steps 6–8 are the swap you asked for. Step 9 is what keeps 3 and 4 from regressing
+quietly.
+
+## Order matters
+
+**Step 8 last, and only after 4.** Deleting the script before discovery is fixed would silently drop
+`.githooks/pre-commit` — a live, tracked, extensionless script that `shell-lint.sh` lints today and
+`star lint shell` does not — from every check. That is the invisible-removal pattern this campaign exists
+to stop.
+
+**Step 3 before 4.** If discovery is fixed while an empty set still reports green, a later regression in
+discovery goes quiet rather than red.
+
+## Verification
+
+Each step: `make check`, `gofmt -l`. Step 9 is the real proof — a bad extensionless script must fail the
+lint, and after step 7 must fail a commit.
+
+Whole-plan exit: `.github/scripts/shell-lint.sh` no longer exists, `git commit` runs shell checks through
+star, `star lint shell .` finds `.githooks/pre-commit`, and an empty discovery set is an error rather than
+a pass.
+
+## Related
+
+- [#670](https://github.com/NobleFactor/devlore-cli/issues/670) — CI as a strict superset of local; this
+  removes one of its three violations, the two shell-lint implementations

--- a/pkg/op/content_addressed_path.go
+++ b/pkg/op/content_addressed_path.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 )
 
-// ContentPath returns the sharded on-disk location of a content-addressed resource's packed bytes.
+// ContentAddressedPath returns the sharded on-disk location of a content-addressed resource's stored bytes.
 //
 // The layout is `.devlore/<package>/<type>/<algo>/<first-two-hex>/<hex>`, derived entirely from the resource's
 // own base: the run's root, the `<algo>:<hex>` reachability URI, and the type id. It therefore computes the
@@ -31,9 +31,9 @@ import (
 //   - `resource`: any resource whose reachability URI is `<algo>:<hex>`.
 //
 // Returns:
-//   - `fsroot.Path`: the content path, or the zero Path when there is no root or the URI is not in
-//     `<algo>:<hex>` form. A zero Path is the caller's signal that nothing was archived.
-func ContentPath(resource Resource) fsroot.Path {
+//   - `fsroot.Path`: the content-addressed path, or the zero Path when there is no root or the URI is not
+//     in `<algo>:<hex>` form. A zero Path is the caller's signal that this resource is not content-addressed.
+func ContentAddressedPath(resource Resource) fsroot.Path {
 
 	if resource == nil {
 		return fsroot.Path{}
@@ -64,31 +64,31 @@ func ContentPath(resource Resource) fsroot.Path {
 		".devlore", packageName, strings.ToLower(typeName), algo, shard, hexPart)
 }
 
-// ContentReader opens a content-addressed resource's packed bytes, memory-mapped.
+// ContentAddressedReader opens a content-addressed resource's stored bytes, memory-mapped.
 //
 // Each call opens a new mmap; the caller must Close the returned reader, which unmaps the file. The content is
 // never held in the Go heap.
 //
 // Parameters:
-//   - `resource`: any resource whose content lives at [ContentPath].
+//   - `resource`: any resource whose stored bytes live at [ContentAddressedPath].
 //
 // Returns:
 //   - `io.ReadCloser`: a reader over the full archived content.
-//   - `error`: no content path (nothing archived), or the mapping failed.
-func ContentReader(resource Resource) (io.ReadCloser, error) {
+//   - `error`: no content-addressed path (nothing archived), or the mapping failed.
+func ContentAddressedReader(resource Resource) (io.ReadCloser, error) {
 
-	abs := ContentPath(resource).Abs()
+	abs := ContentAddressedPath(resource).Abs()
 
 	if abs == "" {
-		return nil, errors.New("op.ContentReader: no content path — the resource was never archived")
+		return nil, errors.New("op.ContentAddressedReader: no content-addressed path — the resource was never archived")
 	}
 
 	mapped, err := mmap.Open(abs)
 	if err != nil {
-		return nil, fmt.Errorf("op.ContentReader: mmap %s: %w", abs, err)
+		return nil, fmt.Errorf("op.ContentAddressedReader: mmap %s: %w", abs, err)
 	}
 
-	return &contentReader{
+	return &contentAddressedReader{
 		mmap:    mapped,
 		section: io.NewSectionReader(mapped, 0, int64(mapped.Len())),
 	}, nil
@@ -96,8 +96,8 @@ func ContentReader(resource Resource) (io.ReadCloser, error) {
 
 // region SUPPORTING TYPES
 
-// contentReader is the mmap-backed [io.ReadCloser] returned by [ContentReader].
-type contentReader struct {
+// contentAddressedReader is the mmap-backed [io.ReadCloser] returned by [ContentAddressedReader].
+type contentAddressedReader struct {
 
 	// mmap is the underlying memory map; held so Close can unmap it.
 	mmap *mmap.ReaderAt
@@ -114,13 +114,13 @@ type contentReader struct {
 // Returns:
 //   - `int`: bytes read.
 //   - `error`: io.EOF at the end of the content, or a read failure.
-func (r *contentReader) Read(p []byte) (int, error) { return r.section.Read(p) }
+func (r *contentAddressedReader) Read(p []byte) (int, error) { return r.section.Read(p) }
 
 // Close unmaps the underlying file.
 //
 // Returns:
 //   - `error`: non-nil when unmapping fails.
-func (r *contentReader) Close() error { return r.mmap.Close() }
+func (r *contentAddressedReader) Close() error { return r.mmap.Close() }
 
 // endregion
 

--- a/pkg/op/content_path.go
+++ b/pkg/op/content_path.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/exp/mmap"
+
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+)
+
+// ContentPath returns the sharded on-disk location of a content-addressed resource's packed bytes.
+//
+// The layout is `.devlore/<package>/<type>/<algo>/<first-two-hex>/<hex>`, derived entirely from the resource's
+// own base: the run's root, the `<algo>:<hex>` reachability URI, and the type id. It therefore computes the
+// path for WHATEVER resource it is handed — a function pack lands under `.devlore/function/resource/` because
+// function's type id says so, not because any particular provider placed it there.
+//
+// That generality is why this lives here rather than in the provider that happened to need it first. `.devlore`
+// is the framework's directory — [RecoverySite] already owns `.devlore/recovery` — and the parameter is
+// [Resource], so no provider has to depend on another to find its own content.
+//
+// Composition goes through [fsroot], which owns path and root questions; nothing here joins strings by hand.
+//
+// Parameters:
+//   - `resource`: any resource whose reachability URI is `<algo>:<hex>`.
+//
+// Returns:
+//   - `fsroot.Path`: the content path, or the zero Path when there is no root or the URI is not in
+//     `<algo>:<hex>` form. A zero Path is the caller's signal that nothing was archived.
+func ContentPath(resource Resource) fsroot.Path {
+
+	if resource == nil {
+		return fsroot.Path{}
+	}
+
+	runtimeEnvironment := resource.RuntimeEnvironment()
+
+	if runtimeEnvironment == nil || !runtimeEnvironment.HasRoot() {
+		return fsroot.Path{}
+	}
+
+	// Through the sealed base accessor: [Resource] does not declare ReachabilityURI, and widening the public
+	// interface for one framework caller would be the wrong trade. This is what the sealed accessor is for.
+	algo, hexPart, ok := strings.Cut(resource.resourceBase().ReachabilityURI(), ":")
+	if !ok {
+		return fsroot.Path{}
+	}
+
+	shard := hexPart
+
+	if len(shard) >= 2 {
+		shard = hexPart[0:2]
+	}
+
+	packageName, typeName := splitTypeID(resource.ResourceType())
+
+	return runtimeEnvironment.Root().NewPath(
+		".devlore", packageName, strings.ToLower(typeName), algo, shard, hexPart)
+}
+
+// ContentReader opens a content-addressed resource's packed bytes, memory-mapped.
+//
+// Each call opens a new mmap; the caller must Close the returned reader, which unmaps the file. The content is
+// never held in the Go heap.
+//
+// Parameters:
+//   - `resource`: any resource whose content lives at [ContentPath].
+//
+// Returns:
+//   - `io.ReadCloser`: a reader over the full archived content.
+//   - `error`: no content path (nothing archived), or the mapping failed.
+func ContentReader(resource Resource) (io.ReadCloser, error) {
+
+	abs := ContentPath(resource).Abs()
+
+	if abs == "" {
+		return nil, errors.New("op.ContentReader: no content path — the resource was never archived")
+	}
+
+	mapped, err := mmap.Open(abs)
+	if err != nil {
+		return nil, fmt.Errorf("op.ContentReader: mmap %s: %w", abs, err)
+	}
+
+	return &contentReader{
+		mmap:    mapped,
+		section: io.NewSectionReader(mapped, 0, int64(mapped.Len())),
+	}, nil
+}
+
+// region SUPPORTING TYPES
+
+// contentReader is the mmap-backed [io.ReadCloser] returned by [ContentReader].
+type contentReader struct {
+
+	// mmap is the underlying memory map; held so Close can unmap it.
+	mmap *mmap.ReaderAt
+
+	// section is an [io.SectionReader] over the full range of mmap, used for Read.
+	section *io.SectionReader
+}
+
+// Read fills p from the mapped content.
+//
+// Parameters:
+//   - `p`: destination buffer.
+//
+// Returns:
+//   - `int`: bytes read.
+//   - `error`: io.EOF at the end of the content, or a read failure.
+func (r *contentReader) Read(p []byte) (int, error) { return r.section.Read(p) }
+
+// Close unmaps the underlying file.
+//
+// Returns:
+//   - `error`: non-nil when unmapping fails.
+func (r *contentReader) Close() error { return r.mmap.Close() }
+
+// endregion
+
+// region HELPER FUNCTIONS
+
+// splitTypeID splits a canonical type id into its package name and type name.
+//
+// `github.com/NobleFactor/devlore-cli/pkg/op/provider/mem.Resource` yields `mem` and `Resource` — the last
+// path segment rather than the full import path, so the on-disk layout stays short and readable.
+//
+// Parameters:
+//   - `typeID`: a canonical type id, as [Resource.ResourceType] reports it.
+//
+// Returns:
+//   - `pkg`: the package's last path segment, or "" when the id carries no package.
+//   - `typeName`: the type's bare name.
+func splitTypeID(typeID string) (pkg, typeName string) {
+
+	dot := strings.LastIndex(typeID, ".")
+
+	if dot < 0 {
+		return "", typeID
+	}
+
+	typeName = typeID[dot+1:]
+	left := typeID[:dot]
+
+	if slash := strings.LastIndex(left, "/"); slash >= 0 {
+		pkg = left[slash+1:]
+	} else {
+		pkg = left
+	}
+
+	return pkg, typeName
+}
+
+// endregion

--- a/pkg/op/provider/mem/helpers.go
+++ b/pkg/op/provider/mem/helpers.go
@@ -209,40 +209,6 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 	}, nil
 }
 
-// splitTypeID splits a canonical Go type id "<pkgPath>.<TypeName>" into its terminal package segment and type name.
-//
-// Examples:
-//
-//	"github.com/NobleFactor/devlore-cli/pkg/op/provider/mem.Resource" → ("mem", "Resource")
-//	"mem.Resource" → ("mem", "Resource")
-//	"Resource" → ("", "Resource")
-//
-// Parameters:
-//   - `typeID`: canonical Go type id, typically read from a URI fragment.
-//
-// Returns:
-//   - `pkg`: terminal segment of the package path; empty when typeID contains no dot.
-//   - `typeName`: unqualified type name; equals typeID when typeID contains no dot.
-func splitTypeID(typeID string) (pkg, typeName string) {
-
-	dot := strings.LastIndex(typeID, ".")
-
-	if dot < 0 {
-		return "", typeID
-	}
-
-	typeName = typeID[dot+1:]
-	left := typeID[:dot]
-
-	if slash := strings.LastIndex(left, "/"); slash >= 0 {
-		pkg = left[slash+1:]
-	} else {
-		pkg = left
-	}
-
-	return pkg, typeName
-}
-
 // stagingPath returns a fresh staging path under <Root>/.devlore/mem/resource/.staging/.
 //
 // The basename is a 16-byte random hex token from [crypto/rand], chosen to be collision-free against the expected

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -298,7 +298,7 @@ func (r *Resource) Pack() ([]byte, error) {
 //   - `io.ReadCloser`: reader over the full archived content; Close releases the mmap.
 //   - `error`: missing SourcePath, or mmap failure.
 func (r *Resource) Reader() (io.ReadCloser, error) {
-	return op.ContentReader(r)
+	return op.ContentAddressedReader(r)
 }
 
 // SourcePath returns the on-disk archive path for this Resource under the runtime environment's [fsroot.Dir].
@@ -314,7 +314,7 @@ func (r *Resource) Reader() (io.ReadCloser, error) {
 //   - `fsroot.Path`: canonical archive path, or the zero fsroot.Path when the Resource has no [op.RuntimeEnvironment],
 //     no Root, or a <specific> that is not in `<algo>:<hex>` form.
 func (r *Resource) SourcePath() fsroot.Path {
-	return op.ContentPath(r)
+	return op.ContentAddressedPath(r)
 }
 
 // String returns the compact JSON encoding of the Resource for debug output.

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"strings"
 
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
 	"golang.org/x/exp/mmap"
@@ -299,22 +298,7 @@ func (r *Resource) Pack() ([]byte, error) {
 //   - `io.ReadCloser`: reader over the full archived content; Close releases the mmap.
 //   - `error`: missing SourcePath, or mmap failure.
 func (r *Resource) Reader() (io.ReadCloser, error) {
-
-	abs := r.SourcePath().Abs()
-
-	if abs == "" {
-		return nil, errors.New("mem.Resource: no SourcePath")
-	}
-
-	m, err := mmap.Open(abs)
-	if err != nil {
-		return nil, fmt.Errorf("mem.Resource: mmap %s: %w", abs, err)
-	}
-
-	return &resourceReader{
-		mmap:    m,
-		section: io.NewSectionReader(m, 0, int64(m.Len())),
-	}, nil
+	return op.ContentReader(r)
 }
 
 // SourcePath returns the on-disk archive path for this Resource under the runtime environment's [fsroot.Dir].
@@ -330,26 +314,7 @@ func (r *Resource) Reader() (io.ReadCloser, error) {
 //   - `fsroot.Path`: canonical archive path, or the zero fsroot.Path when the Resource has no [op.RuntimeEnvironment],
 //     no Root, or a <specific> that is not in `<algo>:<hex>` form.
 func (r *Resource) SourcePath() fsroot.Path {
-
-	runtimeEnvironment := r.RuntimeEnvironment()
-
-	if runtimeEnvironment == nil || !runtimeEnvironment.HasRoot() {
-		return fsroot.Path{}
-	}
-
-	algo, hexPart, ok := strings.Cut(r.ReachabilityURI(), ":")
-	if !ok {
-		return fsroot.Path{}
-	}
-
-	shard := hexPart
-
-	if len(shard) >= 2 {
-		shard = hexPart[0:2]
-	}
-
-	pkg, typeName := splitTypeID(r.ResourceType())
-	return runtimeEnvironment.Root().NewPath(".devlore", pkg, strings.ToLower(typeName), algo, shard, hexPart)
+	return op.ContentPath(r)
 }
 
 // String returns the compact JSON encoding of the Resource for debug output.

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 
 	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
-	"golang.org/x/exp/mmap"
 
 	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
@@ -448,42 +447,5 @@ func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string,
 }
 
 // endregion
-
-// endregion
-
-// region SUPPORTING TYPES
-
-// resourceReader bundles a [mmap.ReaderAt] handle with an [io.SectionReader] over its full range so that Read drains
-// through the mmap and Close releases it.
-type resourceReader struct {
-
-	// mmap is the underlying memory map; held so Close can unmap it.
-	mmap *mmap.ReaderAt
-
-	// section is an [io.SectionReader] over the full range of mmap, used for Read.
-	section *io.SectionReader
-}
-
-// Close releases the underlying memory map.
-//
-// Returns:
-//   - `error`: any error returned by [mmap.ReaderAt.Close].
-func (r *resourceReader) Close() error {
-
-	return r.mmap.Close()
-}
-
-// Read reads up to len(p) bytes from the underlying [io.SectionReader] into p.
-//
-// Parameters:
-//   - `p`: destination buffer.
-//
-// Returns:
-//   - `int`: number of bytes read.
-//   - `error`: any error returned by [io.SectionReader.Read]; [io.EOF] at end of content.
-func (r *resourceReader) Read(p []byte) (int, error) {
-
-	return r.section.Read(p)
-}
 
 // endregion


### PR DESCRIPTION
Groundwork for #662, landed separately because it stands on its own and the rest of that phase is large.

## What moved

`mem.Resource.SourcePath` owned the formula for where content-addressed bytes live on disk:

```go
pkg, typeName := splitTypeID(r.ResourceType())
return runtimeEnvironment.Root().NewPath(".devlore", pkg, strings.ToLower(typeName), algo, shard, hexPart)
```

**It was never provider-specific.** It derives the subdirectory from *the resource's own type id*, which is
why a `function` pack lands under `.devlore/function/resource/` — not because `mem` put it there, but
because the formula reads whatever resource it is handed. It lived in `mem` because `mem` was the first
content-addressed resource, not because it belonged there.

Now `op.ContentPath(Resource) fsroot.Path` and `op.ContentReader(Resource) (io.ReadCloser, error)`, with
`mem.SourcePath` and `mem.Reader` delegating. The mmap-backed reader and the type-id splitter moved with it.

## Why `op` and not `mem`

- **`.devlore` is already framework territory** — `RecoverySite` owns `.devlore/recovery`. `mem` held the
  only other production line that knew the layout.
- **The parameter type is `op.Resource`**, so no provider has to import another to find its own content.
- **`op` already packs and unpacks the content section** — it calls `Pack()` and writes the result. Knowing
  where that result lives is the same concern.

Path composition still goes through `fsroot` (`Root().NewPath(...)`), exactly as before. Nothing joins
strings by hand and `fsroot` needs no new capability.

## One implementation note

`ContentPath` reads the reachability URI through the **sealed base accessor**, `resource.resourceBase()`,
rather than through the public interface. `op.Resource` does not declare `ReachabilityURI` — a gap noted in
phase 1 — and widening the public contract for one framework caller would be the wrong trade. The sealed
accessor exists for exactly this.

## Why this unblocks #662

`function.Resource` embeds `mem.Resource` cross-package, the only such embed in the tree, and it has already
forced two schedule changes. The embed exists to borrow three behaviours over `function`'s **own** identity —
`function` builds its base with `reflect.TypeFor[*function.Resource]()` and hands it to the embedded value.
That is a mixin, not composition.

With the formula in `op`, `function` can drop the embed and call the helpers directly, which is what #662
does next. Of `mem`'s thirteen methods, `function` genuinely used `SourcePath()` and the `Hash` field —
`Pack` and `Unpack` never delegated, and `sourceBytes()` already opened its own mmap.

## Verification

`make test` 103 ok / 0 fail · `make vet` darwin/linux/windows · `test-scenario` · `complexity` ·
`gofmt -l` — all clean.
