### PR TITLE
feat(op): mem and function are sealed; function stops borrowing another provider's identity

### DIFF
--- a/docs/plans/generated-starlark-reference.md
+++ b/docs/plans/generated-starlark-reference.md
@@ -1,0 +1,87 @@
+---
+title: "A generated Starlark reference for package authoring"
+issue: https://github.com/NobleFactor/devlore-cli/issues/675
+status: draft
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+# Plan: a generated Starlark reference
+
+## Goal
+
+**Publish the surface an author actually writes, generated from the announcements, and make drift fail.**
+
+AI will be asked to generate devlore packages (USER, 2026-08-25). What it needs is the Starlark reference
+— command names, parameters, defaults, optionality, and which namespace a command is reachable from — not
+the Go provider reference. An author never writes `activationRecord`, never sees a `*Receipt`, and never
+types `destinationPath`.
+
+## Why generated, not authored
+
+Every hand-maintained surface in the tree is currently wrong, and all three report green:
+
+- **`knowledge/package-authoring/`** lists eleven `file.*` operations. **Six do not exist** — `chmod`,
+  `chown`, `configure`, `edit`, `sops`, `write` — and fifteen real commands are absent.
+- **`star docs starlark`** is a 106-line tutorial teaching `fs.write(...)` and `fs.join(...)`. **There is
+  no `fs` provider.**
+- **`reference.yaml`** records provider blurbs and **zero commands**, so it changes only when a provider is
+  added or removed.
+
+A model given any of them emits calls that cannot resolve — the exact failure the knowledge base exists to
+prevent. Three independent artefacts wrong simultaneously is not three mistakes; it is the absence of a
+mechanism.
+
+## The source already exists
+
+Every `gen/provider.gen.go` carries the surface, machine-readable:
+
+```go
+"Copy":     {ParameterNames: []string{"source", "destination_path",
+                                      "mode?={{ umask 0o755 }}", "user?=\"\"", "group?=\"\""}},
+"Join":     {ParameterNames: []string{"*parts"}},
+"Discover": {ParameterNames: []string{"path", "kind?=any", "after?"}},
+```
+
+Snake-case as authored, `?` optional, `=` default, `*` variadic. Alongside it `op.RoleModule|op.RoleAction`
+decides whether a command is reachable immediately, only as `plan.<ns>.<command>`, or both — something a
+generating model gets wrong constantly and cannot infer from a name. Method doc comments supply the prose,
+already reachable through `goast.type_doc`.
+
+This is generation from data the build already emits and the boot-discipline suite already validates. The
+reference inherits that correctness rather than restating it.
+
+## Steps
+
+| # | Step | Done |
+| --- | --- | --- |
+| 1 | Emit a Starlark reference from the announcements: per command, its parameters and roles | ☐ |
+| 2 | Include the method doc comment as each command's description | ☐ |
+| 3 | Record the role so `plan.<ns>.<command>` versus immediate use is unambiguous | ☐ |
+| 4 | Publish it to devlore-registry as the package-authoring context | ☐ |
+| 5 | Retire the hand-maintained `file.*` list it replaces | ☐ |
+| 6 | Regenerate or retire `star docs starlark` — a tutorial is fine, one naming absent providers is not | ☐ |
+| 7 | **Make drift fail**: a check that breaks when the published surface and the announced surface disagree | ☐ |
+| 8 | Pin it — a fixture asserting a known command's parameters, so a silent shape change is caught | ☐ |
+
+## Order matters
+
+**Step 7 is the point.** Steps 1–6 correct today's content; only 7 stops it recurring, and its absence is
+why three artefacts are wrong at once. A reference that is generated but unchecked drifts the moment
+someone edits the published copy by hand.
+
+**Step 5 after 4.** Removing the hand-maintained list before its replacement is published leaves package
+authoring with no vocabulary at all.
+
+## Verification
+
+Each step: `make check`, `gofmt -l`.
+
+Whole-plan exit: the published reference lists every announced command and no absent one; `file.chmod` and
+`fs.write` appear nowhere; and editing the published copy to disagree with the announcements fails a check.
+
+## Related
+
+- [#674](https://github.com/NobleFactor/devlore-cli/issues/674) — the defect this addresses
+- [#670](https://github.com/NobleFactor/devlore-cli/issues/670) — CI as a strict superset; step 7 is the
+  same principle applied to published artefacts rather than to checks

--- a/docs/plans/sealed-provider-resources.md
+++ b/docs/plans/sealed-provider-resources.md
@@ -414,7 +414,7 @@ resource embed in the tree — `json` and `yaml` embed `op.ResourceBase` alone.
 implementing `op.Unpacker`, the derived loop would skip it, and the test would pass while content
 rehydration was broken. The set is now named explicitly, so a fifth unpacker has to be added deliberately.
 
-#### Phase 5 — `mem` and `function` — status: pending
+#### Phase 5 — `mem` and `function` — status: complete
 
 **`mem` moved here from phase 4 (USER, 2026-08-24): the two cannot be sealed separately.**
 `function.Resource` embeds `mem.Resource` cross-package, and Go cannot embed an unexported type from
@@ -438,6 +438,25 @@ sealed interface that no other provider raises.
 It also carries **the first out-of-package consumer any phase has had to change**:
 `pkg/op/provider/plan/lifecycle_api_test.go:774` asserts `.(*function.Resource)` and becomes
 `.(function.Resource)`. The other four external references are doc comments.
+
+**Landed 2026-08-25 (#662).** The embed came out without the `mem` mixin constructor the ruling
+anticipated — because phase 4's groundwork had already moved the content-address path formula into `op`.
+`function` now embeds `op.ResourceBase` like every other provider and reaches its pack through
+`op.ContentAddressedPath` / `op.ContentAddressedReader`. Four findings:
+
+1. **`function` inherited nine methods and genuinely used two.** `SourcePath` and the `Hash` field. `Pack`
+   and `Unpack` never delegated — they build their own transport envelope — and `sourceBytes` already
+   opened its own mmap. The other seven are the per-provider set every sealed provider writes for itself,
+   so supplying them was joining the convention rather than paying a cost.
+2. **The first out-of-package consumer any phase has had.** `pkg/op/provider/plan/lifecycle_api_test.go`
+   calls `ConvertTo` on a transported function, so `function.Resource` declares `CanConvertTo`/`ConvertTo`
+   — the first sealed interface to reach past `op.Resource` plus accessors. Every earlier provider's
+   consumers turned out to be in-package or doc comments.
+3. **`function`'s six exported fields had no external readers at all**, so they went unexported with no
+   interface methods. The transport envelope's fields stay exported — that struct is the wire form.
+4. **Running the lint gate before pushing caught four issues** a `vet` + `test` check could not see: a
+   cyclomatic-complexity ceiling breach in `ConvertTo`, three receiver-naming inconsistencies, and three
+   misspellings. The first phase where that ran before the push rather than after CI.
 
 #### Phase 6 — `pkg` — status: pending
 

--- a/pkg/op/provider/function/gen/resource.gen.go
+++ b/pkg/op/provider/function/gen/resource.gen.go
@@ -20,6 +20,7 @@ func init() {
 			return provider.DiscoverResource(runtimeEnvironment, identity)
 		},
 		map[string][]string{
+			"Equal":        {"other"},
 			"CanConvertTo": {"target"},
 			"ConvertTo":    {"target"},
 			"Init":         {"thread"},

--- a/pkg/op/provider/function/provider.go
+++ b/pkg/op/provider/function/provider.go
@@ -59,12 +59,18 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 //   - `any`: the function's result, converted to a native Go value.
 //   - `error`: non-nil when the resource fails to initialize, an argument or the result cannot be converted, or the
 //     call itself fails.
-func (p *Provider) Call(callable *Resource, args []any, kwargs map[string]any) (any, error) {
+func (p *Provider) Call(callable Resource, args []any, kwargs map[string]any) (any, error) {
 
 	if callable == nil {
 		return nil, fmt.Errorf("function.Call: callable is nil")
 	}
-	if callable.invoker == nil {
+	// The invoker is implementation state, not part of the sealed contract — a caller holds the interface,
+	// and only this package can produce something that satisfies it.
+	concrete, ok := callable.(*resource)
+	if !ok {
+		return nil, fmt.Errorf("function.Call: callable is %T, want *function.resource", callable)
+	}
+	if concrete.invoker == nil {
 		return nil, fmt.Errorf("function.Call: invoker not initialized on the resource")
 	}
 
@@ -73,7 +79,7 @@ func (p *Provider) Call(callable *Resource, args []any, kwargs map[string]any) (
 		return nil, fmt.Errorf("function.Call: %w", err)
 	}
 
-	return callable.invoker.CallStarlark(starlarkCallable, args, kwargs)
+	return concrete.invoker.CallStarlark(starlarkCallable, args, kwargs)
 }
 
 // endregion

--- a/pkg/op/provider/function/resource.go
+++ b/pkg/op/provider/function/resource.go
@@ -14,23 +14,24 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/NobleFactor/devlore-cli/pkg/op/provider/mem"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 	"golang.org/x/exp/mmap"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
+	"github.com/NobleFactor/devlore-cli/pkg/fsroot"
+	"github.com/NobleFactor/devlore-cli/pkg/iox"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/starlarkbridge"
 )
 
 var errorType = reflect.TypeFor[error]()
 
-// Interface Guard: *Resource implements op.Packer (overriding the embedded mem.Resource implementation).
-var _ op.Packer = (*Resource)(nil)
+// Interface Guard: *Resource implements op.Packer (function packs a transport envelope, not raw content).
+var _ op.Packer = (*resource)(nil)
 
-// Interface Guard: *Resource implements op.Unpacker (overriding the embedded mem.Resource implementation).
-var _ op.Unpacker = (*Resource)(nil)
+// Interface Guard: *Resource implements op.Unpacker (function packs a transport envelope, not raw content).
+var _ op.Unpacker = (*resource)(nil)
 
 // Resource holds a starlark function extracted into a self-contained synthetic source file.
 //
@@ -38,7 +39,7 @@ var _ op.Unpacker = (*Resource)(nil)
 // [writeFunctionPack] for the layout).
 //
 // Identity is content-addressed: the URI's <specific> is `sha256:<hex>` over the synthesized source bytes. The
-// on-disk path follows mem's sharded CAS formula via the embedded [mem.Resource], so the pack lives at
+// on-disk path follows the framework's sharded content-addressed layout, so the pack lives at
 // <Root>/.devlore/function/resource/sha256/<hex[0:2]>/<hex>.
 //
 // Compiled and CompilerVersion are in-memory caches populated by [NewResource] and repopulated by [Resource.Init]
@@ -51,8 +52,48 @@ var _ op.Unpacker = (*Resource)(nil)
 //  2. [Resource.Init](thread) returns a live [starlark.Callable]. Fast path uses the in-memory Compiled cache when
 //     the compiler version matches; otherwise reads the pack, and on compiler-version match loads bytecode, on
 //     mismatch recompiles the source and refreshes the caches.
-type Resource struct {
-	mem.Resource
+//
+// Resource is this provider's resource type — the sealed interface over a compiled Starlark callable.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. The
+// bytecode travels in the graph document's content section, so a forged function resource would be a claim
+// about code nobody compiled.
+type Resource interface {
+	op.Resource
+
+	// Init compiles and returns the callable, rehydrating from the archived pack when the in-memory cache
+	// is cold.
+	Init(thread *starlark.Thread) (starlark.Callable, error)
+
+	// Pack returns the transport envelope — source, name, parameters, position — for the content section.
+	Pack() ([]byte, error)
+
+	// Unpack rebuilds a resource from a document's content section, recompiling the source.
+	Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error)
+
+	// CanConvertTo and ConvertTo project the function into a Go func type, or its archived pack into
+	// []byte or string.
+	//
+	// Declared here because they have an OUT-OF-PACKAGE caller — the first any sealing phase has had.
+	// Every earlier provider's field and method consumers turned out to be in-package or doc comments, so
+	// their interfaces stayed at op.Resource plus accessors. This one does not.
+	CanConvertTo(target reflect.Type) bool
+	ConvertTo(target reflect.Type) (any, error)
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+type resource struct {
+	op.ResourceBase
+
+	// hash is the lowercase hex SHA-256 of the source this function was compiled from. Identity-bearing —
+	// also encoded in the URI's <specific> as `sha256:<hash>`. Previously inherited from an embedded
+	// mem.Resource; held directly now, because function's identity was always its own.
+	hash string
 
 	// invoker is this resource's env-free Go↔Starlark call surface, built at construction and used by ConvertTo to
 	// route every reducer invocation through one conversion path. Unexported, so it is never serialized.
@@ -60,25 +101,34 @@ type Resource struct {
 
 	// Compiled is the starlark bytecode cached in-memory. Not persisted — the pack in RecoverySite carries the
 	// canonical bytes, and Init rehydrates this cache from the pack.
-	Compiled []byte `json:"-" yaml:"-"`
+	compiled []byte `json:"-" yaml:"-"`
 
 	// CompilerVersion is [starlark.CompilerVersion] at the time Compiled was produced. Not persisted; paired with
 	// the in-memory cache.
-	CompilerVersion uint32 `json:"-" yaml:"-"`
+	compilerVersion uint32 `json:"-" yaml:"-"`
 
 	// FuncName is the function name in the synthetic file (the original name, or "_lambda" for anonymous defs).
 	// Persisted in the in-memory marshaled shape but not load-bearing for identity.
-	FuncName string
+	funcName string
 
 	// ParamNames is the ordered list of parameter names extracted from the original function.
-	ParamNames []string
+	paramNames []string
 
 	// NumParams is the total parameter count (for validation against bridge target signatures).
-	NumParams int
+	numParams int
 
 	// OriginalPos is the source position the function was extracted from (diagnostics only, e.g.,
 	// "recipe.star:42").
-	OriginalPos string
+	originalPos string
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (f *resource) sealedResource() {}
+
+// init wires the two things a sealed resource cannot state from its generated announcement.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs a *Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -116,14 +166,14 @@ type Resource struct {
 //   - `identity`: a *starlark.Function (archival) or a canonical tag URI string (metadata-only rehydration).
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported identity type, synthesis/compilation failure, filesystem write failure, malformed URI,
 //     or identity construction failure.
 func NewResource[T *starlark.Function | string](
 	runtimeEnvironment *op.RuntimeEnvironment,
 	producerID string,
 	identity T,
-) (*Resource, error) {
+) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, identity)
 	if err != nil {
@@ -141,9 +191,9 @@ func NewResource[T *starlark.Function | string](
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("function.NewResource: catalog entry for %q is %T, want *function.Resource",
+		return nil, fmt.Errorf("function.NewResource: catalog entry for %q is %T, want *function.resource",
 			candidate.URI(), got)
 	}
 
@@ -169,13 +219,13 @@ func NewResource[T *starlark.Function | string](
 //   - `identity`: a *starlark.Function or a canonical tag URI string; same dispatch as [NewResource].
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported identity type, synthesis/compilation failure, filesystem write failure, malformed URI,
 //     or identity construction failure.
 func DiscoverResource(
 	runtimeEnvironment *op.RuntimeEnvironment,
 	identity any,
-) (*Resource, error) {
+) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, identity)
 	if err != nil {
@@ -193,9 +243,9 @@ func DiscoverResource(
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("function.DiscoverResource: catalog entry for %q is %T, want *function.Resource",
+		return nil, fmt.Errorf("function.DiscoverResource: catalog entry for %q is %T, want *function.resource",
 			candidate.URI(), got)
 	}
 
@@ -218,7 +268,7 @@ func DiscoverResource(
 func buildCandidate(
 	runtimeEnvironment *op.RuntimeEnvironment,
 	identity any,
-) (*Resource, error) {
+) (*resource, error) {
 
 	switch v := identity.(type) {
 	case *starlark.Function:
@@ -240,14 +290,14 @@ func buildCandidate(
 //   - `fn`: starlark function to extract.
 //
 // Returns:
-//   - `*Resource`: candidate with embedded [mem.Resource] keyed on the source digest, in-memory caches populated, and
+//   - `*Resource`: candidate keyed on the source digest, in-memory caches populated, and
 //     the pack archived on disk.
 //   - `error`: extraction, synthesis, compilation, serialization, identity construction, parent-directory creation, or
 //     write failure.
 func newFromFunction(
 	runtimeEnvironment *op.RuntimeEnvironment,
 	fn *starlark.Function,
-) (*Resource, error) {
+) (*resource, error) {
 
 	if fn == nil {
 		return nil, fmt.Errorf("function.Resource: nil *starlark.Function")
@@ -297,7 +347,7 @@ func newFromFunction(
 //   - `source`: the self-contained synthetic source text.
 //
 // Returns:
-//   - `*Resource`: candidate with embedded [mem.Resource] keyed on the source digest, in-memory caches populated,
+//   - `*Resource`: candidate keyed on the source digest, in-memory caches populated,
 //     and the pack archived on disk.
 //   - `error`: compilation, serialization, identity construction, parent-directory creation, or write failure.
 func newFromSource(
@@ -306,47 +356,45 @@ func newFromSource(
 	paramNames []string,
 	originalPos string,
 	source []byte,
-) (*Resource, error) {
+) (*resource, error) {
 
 	// Compute identity from source bytes.
 
 	sum := sha256.Sum256(source)
 	hexDigest := hex.EncodeToString(sum[:])
 
-	base, err := op.NewResourceBase(runtimeEnvironment, "sha256:"+hexDigest, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, "sha256:"+hexDigest, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, fmt.Errorf("function.Resource: %w", err)
 	}
 
-	f := &Resource{
-		Resource: mem.Resource{
-			ResourceBase: base,
-			Hash:         hexDigest,
-		},
-		invoker:     starlarkbridge.NewInvoker(),
-		FuncName:    funcName,
-		ParamNames:  paramNames,
-		NumParams:   len(paramNames),
-		OriginalPos: originalPos,
+	f := &resource{
+		ResourceBase: base,
+		hash:         hexDigest,
+		invoker:      starlarkbridge.NewInvoker(),
+		funcName:     funcName,
+		paramNames:   paramNames,
+		numParams:    len(paramNames),
+		originalPos:  originalPos,
 	}
 
 	// Compile to bytecode.
 
 	prog, err := compileSource(source)
 	if err != nil {
-		return nil, fmt.Errorf("function.Resource: compile %s: %w", f.FuncName, err)
+		return nil, fmt.Errorf("function.Resource: compile %s: %w", f.funcName, err)
 	}
 
 	compiled, err := programToBytes(prog)
 	if err != nil {
-		return nil, fmt.Errorf("function.Resource: serialize %s: %w", f.FuncName, err)
+		return nil, fmt.Errorf("function.Resource: serialize %s: %w", f.funcName, err)
 	}
 
 	// Pack source + compiled + compiler version.
 
 	var packBuf bytes.Buffer
 	if err := writeFunctionPack(&packBuf, source, compiled, starlark.CompilerVersion); err != nil {
-		return nil, fmt.Errorf("function.Resource: pack %s: %w", f.FuncName, err)
+		return nil, fmt.Errorf("function.Resource: pack %s: %w", f.funcName, err)
 	}
 
 	// Write pack to the canonical CAS path (inherited sharded SourcePath via embedded mem.Resource).
@@ -359,13 +407,13 @@ func newFromSource(
 	}
 
 	if err := runtimeEnvironment.Root().WriteFile(sp, packBuf.Bytes(), 0o600); err != nil {
-		return nil, fmt.Errorf("function.Resource: write pack %s: %w", f.FuncName, err)
+		return nil, fmt.Errorf("function.Resource: write pack %s: %w", f.funcName, err)
 	}
 
 	// In-memory caches — not persisted.
 
-	f.Compiled = compiled
-	f.CompilerVersion = starlark.CompilerVersion
+	f.compiled = compiled
+	f.compilerVersion = starlark.CompilerVersion
 
 	return f, nil
 }
@@ -384,7 +432,7 @@ func newFromSource(
 //   - `*Resource`: metadata-only Resource with embedded mem.Resource Hash populated.
 //   - `error`: malformed URI, deferred (empty <specific>) URI, missing colon, unsupported algorithm, malformed hex,
 //     or [op.ResourceBase] construction failure.
-func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resource, error) {
+func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*resource, error) {
 
 	specific, _, err := op.ExtractTagSpecific(uri)
 	if err != nil {
@@ -406,19 +454,127 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 		return nil, fmt.Errorf("function.Resource: invalid digest hex %q: %w", hexPart, err)
 	}
 
-	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[*Resource]())
+	base, err := op.NewResourceBase(runtimeEnvironment, specific, reflect.TypeFor[Resource]())
 	if err != nil {
 		return nil, fmt.Errorf("function.Resource: %w", err)
 	}
 
-	return &Resource{
-		Resource: mem.Resource{
-			ResourceBase: base,
-			Hash:         hexPart,
-		},
-		invoker: starlarkbridge.NewInvoker(),
+	return &resource{
+		ResourceBase: base,
+		hash:         hexPart,
+		invoker:      starlarkbridge.NewInvoker(),
 	}, nil
 }
+
+// region SUPPORTING TYPES
+
+var (
+	// byteSliceType and stringType are the two shapes a function's archived pack projects to, cached so the
+	// comparison in ConvertTo stays allocation-free. Previously reached through the embedded mem.Resource.
+	byteSliceType = reflect.TypeFor[[]byte]()
+	stringType    = reflect.TypeFor[string]()
+)
+
+// endregion
+
+// region SUPPORTING METHODS
+
+// Addressing reports that a function resource is content-addressed.
+//
+// Returns:
+//   - `op.AddressingMode`: [op.AddressingContent] — identity is the digest of the compiled source.
+func (f *resource) Addressing() op.AddressingMode { return op.AddressingContent }
+
+// Hash returns the lowercase hex SHA-256 of the source this function was compiled from.
+//
+// Returns:
+//   - `string`: the digest, without an algorithm prefix.
+func (f *resource) Hash() string { return f.hash }
+
+// Digest returns the content digest.
+//
+// Returns:
+//   - `op.Digest`: sha256 over the compiled source.
+//   - `error`: non-nil when the recorded hash is not a valid digest.
+func (f *resource) Digest() (op.Digest, error) { return op.ParseDigest("sha256:" + f.hash) }
+
+// SourcePath returns where this function's pack lives on disk.
+//
+// The sharded content-addressed layout, computed by the framework from this resource's own base — which is
+// why the pack lands under `.devlore/function/resource/`, and why this no longer needs another provider.
+//
+// Returns:
+//   - `fsroot.Path`: the pack's path, or the zero Path when nothing was archived.
+func (f *resource) SourcePath() fsroot.Path { return op.ContentAddressedPath(f) }
+
+// Reader opens the archived pack, memory-mapped.
+//
+// Returns:
+//   - `io.ReadCloser`: a reader over the pack; Close releases the mapping.
+//   - `error`: nothing archived, or the mapping failed.
+func (f *resource) Reader() (io.ReadCloser, error) { return op.ContentAddressedReader(f) }
+
+// Equal reports whether f and other identify the same function resource.
+//
+// Strict: other must be a *Resource, not merely an [op.Resource] sharing a URI.
+//
+// Parameters:
+//   - `other`: candidate to compare against.
+//
+// Returns:
+//   - `bool`: true when other is a *Resource with the same URI.
+func (f *resource) Equal(other any) bool {
+
+	if other == nil {
+		return false
+	}
+
+	if _, ok := other.(*resource); !ok {
+		return false
+	}
+
+	return f.ResourceBase.Equal(other)
+}
+
+// String returns the compact JSON encoding, for debug output.
+//
+// Returns:
+//   - `string`: the compact JSON encoding of f.
+func (f *resource) String() string { return f.Format(f) }
+
+// contentAs projects the archived pack to []byte or string.
+//
+// The projection an embedded mem.Resource used to supply. Reading content-addressed bytes is a framework
+// concern, so this reads through [op.ContentAddressedReader] rather than through another provider.
+//
+// Parameters:
+//   - `target`: []byte or string.
+//
+// Returns:
+//   - `any`: the pack's bytes, as the requested type.
+//   - `error`: nothing archived, or the read failed.
+func (f *resource) contentAs(target reflect.Type) (result any, err error) {
+
+	reader, err := op.ContentAddressedReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	defer iox.Close(&err, reader)
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("function.Resource: read archived pack: %w", err)
+	}
+
+	if target == stringType {
+		return string(data), nil
+	}
+
+	return data, nil
+}
+
+// endregion
 
 // region EXPORTED METHODS
 
@@ -431,14 +587,14 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 //
 // Returns:
 //   - `bool`: true when target is a Go func type, or when the embedded mem.Resource can convert to target.
-func (f *Resource) CanConvertTo(target reflect.Type) bool {
+func (f *resource) CanConvertTo(target reflect.Type) bool {
 	if reflect.TypeOf(f).AssignableTo(target) {
 		return true
 	}
 	if target.Kind() == reflect.Func {
 		return true
 	}
-	return f.Resource.CanConvertTo(target)
+	return target == byteSliceType || target == stringType
 }
 
 // ConvertTo implements [op.SourceConverter].
@@ -453,31 +609,25 @@ func (f *Resource) CanConvertTo(target reflect.Type) bool {
 //
 // Returns:
 //   - `any`: a Go function of the target type, or the projected content for []byte / string targets.
-//   - `error`: non-nil if the target is not supported, the signature doesn't match, or the underlying call fails.
-func (f *Resource) ConvertTo(target reflect.Type) (any, error) {
-
-	if reflect.TypeOf(f).AssignableTo(target) {
-		// Identity: a slot declared as the resource type itself (e.g. function.call's `callable` parameter) takes the
-		// resource unconverted.
-		return f, nil
-	}
-
-	if target.Kind() != reflect.Func {
-		if f.Resource.CanConvertTo(target) {
-			return f.Resource.ConvertTo(target)
-		}
-		return nil, fmt.Errorf("function.Resource: cannot convert to %s (not a func type)", target)
-	}
-
-	// Initialize the callable. Init runs the program once on its own thread; the reducer call below goes through the
-	// Invoker, which mints a fresh thread per invocation.
+//
+// bridgeable initializes the callable and checks that it can back a Go func of `target`'s shape.
+//
+// Lifted out of [resource.ConvertTo], which had grown past the complexity ceiling: signature validation is a
+// separable concern from the projection dispatch above it, and separating them changes no behavior.
+//
+// Parameters:
+//   - `target`: the Go func type the callable must satisfy.
+//
+// Returns:
+//   - `starlark.Callable`: the initialized callable.
+//   - `error`: init failed, the callable is not a *starlark.Function, the parameter counts disagree, or the
+//     function is variadic and so cannot bridge to a fixed Go signature.
+func (f *resource) bridgeable(target reflect.Type) (starlark.Callable, error) {
 
 	callable, err := f.Init(&starlark.Thread{Name: "function.Resource"})
 	if err != nil {
 		return nil, fmt.Errorf("function.Resource: init: %w", err)
 	}
-
-	// Validate signature.
 
 	starFn, ok := callable.(*starlark.Function)
 	if !ok {
@@ -492,6 +642,34 @@ func (f *Resource) ConvertTo(target reflect.Type) (any, error) {
 	if starFn.HasVarargs() || starFn.HasKwargs() {
 		return nil, fmt.Errorf(
 			"function.Resource: starlark function uses *args/**kwargs, cannot bridge to fixed Go signature")
+	}
+
+	return callable, nil
+}
+
+// - `error`: non-nil if the target is not supported, the signature doesn't match, or the underlying call fails.
+func (f *resource) ConvertTo(target reflect.Type) (any, error) {
+
+	if reflect.TypeOf(f).AssignableTo(target) {
+		// Identity: a slot declared as the resource type itself (e.g. function.call's `callable` parameter) takes the
+		// resource unconverted.
+		return f, nil
+	}
+
+	if target.Kind() != reflect.Func {
+		if target == byteSliceType || target == stringType {
+			return f.contentAs(target)
+		}
+		return nil, fmt.Errorf("function.Resource: cannot convert to %s (not a func type)", target)
+	}
+
+	// Initialize and validate the callable against the target's shape. Init runs the program once on its
+	// own thread; the reducer call below goes through the Invoker, which mints a fresh thread per
+	// invocation.
+
+	callable, err := f.bridgeable(target)
+	if err != nil {
+		return nil, err
 	}
 
 	hasError := target.NumOut() > 0 && target.Out(target.NumOut()-1).Implements(errorType)
@@ -550,7 +728,7 @@ func (f *Resource) ConvertTo(target reflect.Type) (any, error) {
 // Returns:
 //   - `starlark.Callable`: the live function.
 //   - `error`: non-nil if loading, compiling, or initialization fails.
-func (f *Resource) Init(thread *starlark.Thread) (starlark.Callable, error) {
+func (f *resource) Init(thread *starlark.Thread) (starlark.Callable, error) {
 
 	prog, err := f.loadProgram()
 	if err != nil {
@@ -562,14 +740,14 @@ func (f *Resource) Init(thread *starlark.Thread) (starlark.Callable, error) {
 		return nil, fmt.Errorf("function.Resource init: %w", err)
 	}
 
-	fn, ok := globals[f.FuncName]
+	fn, ok := globals[f.funcName]
 	if !ok {
-		return nil, fmt.Errorf("function.Resource init: function %q not found", f.FuncName)
+		return nil, fmt.Errorf("function.Resource init: function %q not found", f.funcName)
 	}
 
 	callable, ok := fn.(starlark.Callable)
 	if !ok {
-		return nil, fmt.Errorf("function.Resource init: %q is %s, not callable", f.FuncName, fn.Type())
+		return nil, fmt.Errorf("function.Resource init: %q is %s, not callable", f.funcName, fn.Type())
 	}
 
 	return callable, nil
@@ -586,7 +764,7 @@ func (f *Resource) Init(thread *starlark.Thread) (starlark.Callable, error) {
 // Returns:
 //   - `[]byte`: the JSON-encoded [transportEnvelope].
 //   - `error`: missing pack (a URI-only rehydrated resource with no local archive), or a read failure.
-func (f *Resource) Pack() ([]byte, error) {
+func (f *resource) Pack() ([]byte, error) {
 
 	source, err := f.sourceBytes()
 	if err != nil {
@@ -594,9 +772,9 @@ func (f *Resource) Pack() ([]byte, error) {
 	}
 
 	return json.Marshal(transportEnvelope{
-		FuncName:    f.FuncName,
-		ParamNames:  f.ParamNames,
-		OriginalPos: f.OriginalPos,
+		FuncName:    f.funcName,
+		ParamNames:  f.paramNames,
+		OriginalPos: f.originalPos,
 		Source:      source,
 	})
 }
@@ -617,7 +795,7 @@ func (f *Resource) Pack() ([]byte, error) {
 // Returns:
 //   - `op.Resource`: the reconstructed *function.Resource, not interned in any catalog.
 //   - `error`: envelope decode failure, compilation or store write failure, or a URI mismatch (integrity failure).
-func (f *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
+func (f *resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
 
 	var envelope transportEnvelope
 	if err := json.Unmarshal(content, &envelope); err != nil {
@@ -657,11 +835,11 @@ func (f *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string,
 // Returns:
 //   - `*starlark.Program`: the compiled program.
 //   - `error`: cache load, mmap, header parse, read, or compile failure.
-func (f *Resource) loadProgram() (*starlark.Program, error) {
+func (f *resource) loadProgram() (*starlark.Program, error) {
 
 	// Fast path: cached in-memory bytecode matches current compiler version.
-	if len(f.Compiled) > 0 && f.CompilerVersion == starlark.CompilerVersion {
-		prog, err := starlark.CompiledProgram(bytes.NewReader(f.Compiled))
+	if len(f.compiled) > 0 && f.compilerVersion == starlark.CompilerVersion {
+		prog, err := starlark.CompiledProgram(bytes.NewReader(f.compiled))
 		if err != nil {
 			return nil, fmt.Errorf("load cached bytecode: %w", err)
 		}
@@ -700,8 +878,8 @@ func (f *Resource) loadProgram() (*starlark.Program, error) {
 			return nil, fmt.Errorf("decode compiled: %w", err)
 		}
 
-		f.Compiled = compiledBytes
-		f.CompilerVersion = h.CompilerVersion
+		f.compiled = compiledBytes
+		f.compilerVersion = h.CompilerVersion
 
 		return prog, nil
 	}
@@ -720,8 +898,8 @@ func (f *Resource) loadProgram() (*starlark.Program, error) {
 
 	// Cache the freshly-compiled bytes for subsequent in-process Init calls.
 	if compiled, cerr := programToBytes(prog); cerr == nil {
-		f.Compiled = compiled
-		f.CompilerVersion = starlark.CompilerVersion
+		f.compiled = compiled
+		f.compilerVersion = starlark.CompilerVersion
 	}
 
 	return prog, nil
@@ -735,7 +913,7 @@ func (f *Resource) loadProgram() (*starlark.Program, error) {
 // Returns:
 //   - `[]byte`: the source text.
 //   - `error`: missing SourcePath (the Resource was not archived locally), mmap, header parse, or read failure.
-func (f *Resource) sourceBytes() ([]byte, error) {
+func (f *resource) sourceBytes() ([]byte, error) {
 
 	abs := f.SourcePath().Abs()
 	if abs == "" {

--- a/pkg/op/provider/function/resource_test.go
+++ b/pkg/op/provider/function/resource_test.go
@@ -16,11 +16,22 @@ import (
 	"go.starlark.net/syntax"
 )
 
+// concrete reaches the struct behind a sealed [Resource], for the implementation state the interface does
+// not expose — SourcePath, the compiled cache, and the transport metadata. All in-package.
+func concrete(t *testing.T, r Resource) *resource {
+	t.Helper()
+	c, ok := r.(*resource)
+	if !ok {
+		t.Fatalf("Resource is %T, want *resource", r)
+	}
+	return c
+}
+
 // --- Interface guards ---
 
 func TestResource_ImplementsResourceInterface(t *testing.T) {
 	// function.Resource embeds mem.Resource, which implements op.Resource.
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -128,27 +139,27 @@ def inc(x):
 		t.Fatalf("NewFunction: %v", err)
 	}
 
-	if f.SourcePath().Abs() == "" {
+	if concrete(t, f).SourcePath().Abs() == "" {
 		t.Fatal("SourcePath is empty — pack was not archived")
 	}
-	if f.Hash == "" {
+	if concrete(t, f).Hash() == "" {
 		t.Fatal("Hash is empty — source was not hashed")
 	}
-	if len(f.Compiled) == 0 {
+	if len(concrete(t, f).compiled) == 0 {
 		t.Fatal("Compiled cache is empty — bytecode was not retained")
 	}
-	if f.CompilerVersion != starlark.CompilerVersion {
-		t.Errorf("CompilerVersion = %d, want %d", f.CompilerVersion, starlark.CompilerVersion)
+	if concrete(t, f).compilerVersion != starlark.CompilerVersion {
+		t.Errorf("CompilerVersion = %d, want %d", concrete(t, f).compilerVersion, starlark.CompilerVersion)
 	}
 
-	if f.FuncName != "inc" {
-		t.Errorf("FuncName = %q, want %q", f.FuncName, "inc")
+	if concrete(t, f).funcName != "inc" {
+		t.Errorf("FuncName = %q, want %q", concrete(t, f).funcName, "inc")
 	}
-	if f.NumParams != 1 {
-		t.Errorf("NumParams = %d, want 1", f.NumParams)
+	if concrete(t, f).numParams != 1 {
+		t.Errorf("NumParams = %d, want 1", concrete(t, f).numParams)
 	}
-	if len(f.ParamNames) != 1 || f.ParamNames[0] != "x" {
-		t.Errorf("ParamNames = %v, want [x]", f.ParamNames)
+	if len(concrete(t, f).paramNames) != 1 || concrete(t, f).paramNames[0] != "x" {
+		t.Errorf("ParamNames = %v, want [x]", concrete(t, f).paramNames)
 	}
 }
 
@@ -201,7 +212,7 @@ def greet(name):
 	f, _ := NewResource(runtimeEnvironment, "", starFn)
 
 	// Wipe memory cache to force mmap fallback.
-	f.Compiled = nil
+	concrete(t, f).compiled = nil
 
 	target := reflect.TypeFor[func(string) string]()
 	bridged, err := op.Convert(runtimeEnvironment, f, target)
@@ -227,8 +238,8 @@ def identity(x):
 	f, _ := NewResource(runtimeEnvironment, "", starFn)
 
 	// Force version skew and wipe cache.
-	f.Compiled = nil
-	f.CompilerVersion = 0
+	concrete(t, f).compiled = nil
+	concrete(t, f).compilerVersion = 0
 
 	target := reflect.TypeFor[func(int) int]()
 	bridged, err := op.Convert(runtimeEnvironment, f, target)
@@ -245,7 +256,7 @@ def identity(x):
 func TestResource_Init_NotAPointer(t *testing.T) {
 
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
-	f := &Resource{}
+	f := &resource{}
 	target := reflect.TypeFor[int]() // not a func
 	_, err := op.Convert(runtimeEnvironment, f, target)
 	if err == nil {

--- a/pkg/op/provider/mem/helpers.go
+++ b/pkg/op/provider/mem/helpers.go
@@ -30,9 +30,9 @@ import (
 //   - `value`: []byte, an [io.Reader], or a canonical tag URI string; any other type is an error.
 //
 // Returns:
-//   - `*Resource`: unlinked candidate.
+//   - `*resource`: unlinked candidate.
 //   - `error`: unsupported value type, or an error from the downstream constructor.
-func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	switch v := value.(type) {
 
@@ -61,9 +61,9 @@ func buildCandidate(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Reso
 //   - `data`: payload bytes; may be empty.
 //
 // Returns:
-//   - `*Resource`: candidate with Hash populated and content archived at the canonical CAS path.
+//   - `*resource`: candidate with Hash populated and content archived at the canonical CAS path.
 //   - `error`: identity construction failure, parent directory creation failure, or write failure.
-func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Resource, error) {
+func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*resource, error) {
 
 	sum := sha256.Sum256(data)
 	hexDigest := hex.EncodeToString(sum[:])
@@ -73,7 +73,7 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 		return nil, fmt.Errorf("mem.Resource: %w", err)
 	}
 
-	r := &Resource{ResourceBase: base, Hash: hexDigest}
+	r := &resource{ResourceBase: base, hash: hexDigest}
 
 	root := runtimeEnvironment.Root()
 	canonical := r.SourcePath()
@@ -109,10 +109,10 @@ func newFromBytes(runtimeEnvironment *op.RuntimeEnvironment, data []byte) (*Reso
 //   - `reader`: source of payload bytes; drained completely.
 //
 // Returns:
-//   - `*Resource`: candidate with Hash populated and content archived at the canonical CAS path.
+//   - `*resource`: candidate with Hash populated and content archived at the canonical CAS path.
 //   - `error`: staging name generation, staging directory creation, open/copy failure, identity construction failure,
 //     canonical directory creation failure, or rename failure.
-func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*Resource, error) {
+func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) (*resource, error) {
 
 	root := runtimeEnvironment.Root()
 
@@ -144,7 +144,7 @@ func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) 
 		return nil, fmt.Errorf("mem.Resource: %w", err)
 	}
 
-	r := &Resource{ResourceBase: base, Hash: hexDigest}
+	r := &resource{ResourceBase: base, hash: hexDigest}
 	canonical := r.SourcePath()
 
 	if err := root.MkdirAll(root.NewPath(filepath.Dir(canonical.Rel())), 0o700); err != nil {
@@ -171,10 +171,10 @@ func newFromReader(runtimeEnvironment *op.RuntimeEnvironment, reader io.Reader) 
 //     are rejected).
 //
 // Returns:
-//   - `*Resource`: metadata-only Resource with Hash populated.
+//   - `*resource`: metadata-only Resource with Hash populated.
 //   - `error`: malformed URI, deferred (empty <specific>) URI, missing colon, unsupported algorithm, malformed hex, or
 //     [op.ResourceBase] construction failure.
-func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resource, error) {
+func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*resource, error) {
 
 	specific, _, err := op.ExtractTagSpecific(uri)
 	if err != nil {
@@ -203,9 +203,9 @@ func newFromURI(runtimeEnvironment *op.RuntimeEnvironment, uri string) (*Resourc
 		return nil, fmt.Errorf("mem.Resource: %w", err)
 	}
 
-	return &Resource{
+	return &resource{
 		ResourceBase: base,
-		Hash:         hexPart,
+		hash:         hexPart,
 	}, nil
 }
 

--- a/pkg/op/provider/mem/resource.go
+++ b/pkg/op/provider/mem/resource.go
@@ -29,10 +29,10 @@ var (
 )
 
 // Interface Guard: *Resource implements op.Packer.
-var _ op.Packer = (*Resource)(nil)
+var _ op.Packer = (*resource)(nil)
 
 // Interface Guard: *Resource implements op.Unpacker.
-var _ op.Unpacker = (*Resource)(nil)
+var _ op.Unpacker = (*resource)(nil)
 
 // Resource represents an in-memory-origin data resource archived on disk at a content-addressed path.
 //
@@ -47,13 +47,62 @@ var _ op.Unpacker = (*Resource)(nil)
 //
 // Content bytes are never held in the Go heap after archival. Consumers read through [Resource.Reader] (a mmap-backed
 // [io.ReadCloser]) or via the [op.SourceConverter] projections to []byte or string.
-type Resource struct {
+// Resource is this provider's resource type — the sealed interface over content-addressed bytes.
+//
+// Sealed by an unexported marker, so the closed set of implementations is the one this package declares. That
+// matters more here than anywhere else: identity IS the digest, so a forged mem resource is a claim about
+// content nobody hashed.
+type Resource interface {
+	op.Resource
+
+	// Hash returns the lowercase hex SHA-256 of the archived content. Identity-bearing — also encoded in the
+	// URI's <specific> as `sha256:<hash>`.
+	Hash() string
+
+	// SourcePath returns the sharded on-disk location of the archived content.
+	SourcePath() fsroot.Path
+
+	// Reader opens the archived content, memory-mapped. Close releases the mapping.
+	Reader() (io.ReadCloser, error)
+
+	// Pack returns the archived bytes, for the document's content section.
+	Pack() ([]byte, error)
+
+	// Unpack rebuilds a resource from a document's content section.
+	Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error)
+
+	// sealedResource marks the closed set of Resource implementations.
+	sealedResource()
+}
+
+// Interface guard: the unexported struct is the only Resource implementation.
+var _ Resource = (*resource)(nil)
+
+// resource is the concrete mem resource — what serializes, and the only thing implementing [Resource].
+//
+// Unexported so `&mem.resource{...}` cannot be written outside this package. Until 2026-08-25 `function`
+// embedded the exported struct across a package boundary; it now holds its own base and reaches content
+// through the framework helpers, which is what made sealing possible.
+type resource struct {
 	op.ResourceBase
 
-	// Hash is the lowercase hex SHA-256 of the archived content. Identity-bearing — also encoded in the URI's
-	// <specific> portion as `sha256:<Hash>`. Populated by both construction (post-hash) and rehydration (parsed
-	// from URI). Not persisted in serialized form because the URI carries the same value.
-	Hash string `json:"-" yaml:"-"`
+	// hash is the lowercase hex SHA-256 of the archived content. Identity-bearing.
+	hash string
+}
+
+// sealedResource marks resource as the member of the closed [Resource] set.
+func (r *resource) sealedResource() {}
+
+// Hash returns the lowercase hex SHA-256 of the archived content.
+//
+// Returns:
+//   - `string`: the digest, without an algorithm prefix.
+func (r *resource) Hash() string { return r.hash }
+
+// init wires the two things a sealed resource cannot state from its generated announcement.
+func init() {
+	op.RegisterResourceImplementation(reflect.TypeFor[Resource](), reflect.TypeFor[resource]())
+	op.RegisterResourceMint(reflect.TypeFor[Resource](), reflect.TypeFor[*resource]())
 }
 
 // NewResource constructs a *Resource and claims production via [op.ResourceCatalog.GetOrCreate].
@@ -83,9 +132,9 @@ type Resource struct {
 //     (metadata-only rehydration).
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, filesystem write failure, malformed URI, or identity construction failure.
-func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (*Resource, error) {
+func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, value any) (Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -103,9 +152,9 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("mem.NewResource: catalog entry for %q is %T, want *mem.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("mem.NewResource: catalog entry for %q is %T, want *mem.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -129,9 +178,23 @@ func NewResource(runtimeEnvironment *op.RuntimeEnvironment, producerID string, v
 //   - `value`: []byte, [io.Reader], or a canonical tag URI string; same dispatch as [NewResource].
 //
 // Returns:
-//   - `*Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `Resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
 //   - `error`: unsupported value type, filesystem write failure, malformed URI, or identity construction failure.
-func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Resource, error) {
+func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (Resource, error) {
+	return discoverResource(runtimeEnvironment, value)
+}
+
+// discoverResource is [DiscoverResource] returning the concrete type, which rehydration needs because it
+// assigns through the receiver.
+//
+// Parameters:
+//   - `runtimeEnvironment`: the session runtime environment.
+//   - `value`: bytes, a reader, or a canonical tag URI.
+//
+// Returns:
+//   - `*resource`: canonical catalog entry, or the unlinked candidate when no catalog is present.
+//   - `error`: malformed input, or [op.ResourceBase] construction failure.
+func discoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, value)
 	if err != nil {
@@ -149,9 +212,9 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 		return nil, err
 	}
 
-	canonical, ok := got.(*Resource)
+	canonical, ok := got.(*resource)
 	if !ok {
-		return nil, fmt.Errorf("mem.DiscoverResource: catalog entry for %q is %T, want *mem.Resource", candidate.URI(), got)
+		return nil, fmt.Errorf("mem.DiscoverResource: catalog entry for %q is %T, want *mem.resource", candidate.URI(), got)
 	}
 
 	return canonical, nil
@@ -168,7 +231,7 @@ func DiscoverResource(runtimeEnvironment *op.RuntimeEnvironment, value any) (*Re
 //
 // Returns:
 //   - `op.AddressingMode`: [op.AddressingContent] — identity is the SHA-256 of the archived bytes.
-func (r *Resource) Addressing() op.AddressingMode {
+func (r *resource) Addressing() op.AddressingMode {
 
 	return op.AddressingContent
 }
@@ -184,7 +247,7 @@ func (r *Resource) Addressing() op.AddressingMode {
 //
 // Returns:
 //   - `bool`: true when target is []byte or string; false otherwise.
-func (r *Resource) CanConvertTo(target reflect.Type) bool {
+func (r *resource) CanConvertTo(target reflect.Type) bool {
 
 	return target == byteSliceType || target == stringType
 }
@@ -200,7 +263,7 @@ func (r *Resource) CanConvertTo(target reflect.Type) bool {
 // Returns:
 //   - `any`: projected value ([]byte or string).
 //   - `error`: unrecognized target type, missing source path, or read failure.
-func (r *Resource) ConvertTo(target reflect.Type) (result any, err error) {
+func (r *resource) ConvertTo(target reflect.Type) (result any, err error) {
 
 	if target != byteSliceType && target != stringType {
 		return nil, fmt.Errorf("mem.Resource: cannot convert to %s", target)
@@ -238,8 +301,8 @@ func (r *Resource) ConvertTo(target reflect.Type) (result any, err error) {
 // Returns:
 //   - `op.Digest`: {Algorithm: "sha256", Bytes: decoded Hash}.
 //   - `error`: non-nil if Hash is malformed; should not occur post-construction or post-rehydration.
-func (r *Resource) Digest() (op.Digest, error) {
-	return op.ParseDigest("sha256:" + r.Hash)
+func (r *resource) Digest() (op.Digest, error) {
+	return op.ParseDigest("sha256:" + r.hash)
 }
 
 // Equal reports whether r and other identify the same mem.Resource.
@@ -252,13 +315,13 @@ func (r *Resource) Digest() (op.Digest, error) {
 //
 // Returns:
 //   - `bool`: true when other is a *mem.Resource with the same URI as r.
-func (r *Resource) Equal(other any) bool {
+func (r *resource) Equal(other any) bool {
 
 	if other == nil {
 		return false
 	}
 
-	if _, ok := other.(*Resource); !ok {
+	if _, ok := other.(*resource); !ok {
 		return false
 	}
 
@@ -273,7 +336,7 @@ func (r *Resource) Equal(other any) bool {
 // Returns:
 //   - `[]byte`: the archived content bytes.
 //   - `error`: missing SourcePath (a URI-only rehydrated resource has no local content), or a read failure.
-func (r *Resource) Pack() ([]byte, error) {
+func (r *resource) Pack() ([]byte, error) {
 
 	reader, err := r.Reader()
 	if err != nil {
@@ -296,7 +359,7 @@ func (r *Resource) Pack() ([]byte, error) {
 // Returns:
 //   - `io.ReadCloser`: reader over the full archived content; Close releases the mmap.
 //   - `error`: missing SourcePath, or mmap failure.
-func (r *Resource) Reader() (io.ReadCloser, error) {
+func (r *resource) Reader() (io.ReadCloser, error) {
 	return op.ContentAddressedReader(r)
 }
 
@@ -312,7 +375,7 @@ func (r *Resource) Reader() (io.ReadCloser, error) {
 // Returns:
 //   - `fsroot.Path`: canonical archive path, or the zero fsroot.Path when the Resource has no [op.RuntimeEnvironment],
 //     no Root, or a <specific> that is not in `<algo>:<hex>` form.
-func (r *Resource) SourcePath() fsroot.Path {
+func (r *resource) SourcePath() fsroot.Path {
 	return op.ContentAddressedPath(r)
 }
 
@@ -323,7 +386,7 @@ func (r *Resource) SourcePath() fsroot.Path {
 //
 // Returns:
 //   - `string`: the compact JSON encoding of r.
-func (r *Resource) String() string {
+func (r *resource) String() string {
 
 	return r.Format(r)
 }
@@ -339,7 +402,7 @@ func (r *Resource) String() string {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, malformed JSON, or rehydration failure.
-func (r *Resource) UnmarshalJSON(data []byte) error {
+func (r *resource) UnmarshalJSON(data []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("mem.Resource: UnmarshalJSON requires RuntimeEnvironment on receiver")
@@ -351,7 +414,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -370,13 +433,13 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, or rehydration failure.
-func (r *Resource) UnmarshalText(text []byte) error {
+func (r *resource) UnmarshalText(text []byte) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("mem.Resource: UnmarshalText requires RuntimeEnvironment on receiver")
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), string(text))
+	built, err := discoverResource(r.RuntimeEnvironment(), string(text))
 	if err != nil {
 		return err
 	}
@@ -395,7 +458,7 @@ func (r *Resource) UnmarshalText(text []byte) error {
 //
 // Returns:
 //   - `error`: missing RuntimeEnvironment on receiver, decode failure, or rehydration failure.
-func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
+func (r *resource) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if r.RuntimeEnvironment() == nil {
 		return errors.New("mem.Resource: UnmarshalYAML requires RuntimeEnvironment on receiver")
@@ -407,7 +470,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	built, err := DiscoverResource(r.RuntimeEnvironment(), uri)
+	built, err := discoverResource(r.RuntimeEnvironment(), uri)
 	if err != nil {
 		return err
 	}
@@ -431,7 +494,7 @@ func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 // Returns:
 //   - `op.Resource`: the reconstructed *mem.Resource, not interned in any catalog.
 //   - `error`: store write failure, identity construction failure, or a URI mismatch (integrity failure).
-func (r *Resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
+func (r *resource) Unpack(runtimeEnvironment *op.RuntimeEnvironment, uri string, content []byte) (op.Resource, error) {
 
 	candidate, err := buildCandidate(runtimeEnvironment, content)
 	if err != nil {

--- a/pkg/op/provider/mem/resource_test.go
+++ b/pkg/op/provider/mem/resource_test.go
@@ -20,10 +20,25 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 )
 
+// concrete reaches the struct behind a sealed [Resource].
+//
+// [op.Resource] declares neither Equal, Pack, nor the marshalers, so the sealed interface does not expose
+// them — before sealing they were reachable only because embedding leaked [op.ResourceBase]'s whole surface.
+// Every caller is in this package, so a white-box test asserting to the implementation is the honest way to
+// reach them rather than widening the exported contract.
+func concrete(t *testing.T, r Resource) *resource {
+	t.Helper()
+	c, ok := r.(*resource)
+	if !ok {
+		t.Fatalf("Resource is %T, want *resource", r)
+	}
+	return c
+}
+
 // --- Interface guards ---
 
 func TestResource_ImplementsInterface(t *testing.T) {
-	var _ op.Resource = (*Resource)(nil)
+	var _ op.Resource = (*resource)(nil)
 }
 
 // --- Test helpers ---
@@ -68,8 +83,8 @@ func TestNewResource_BytesHashesContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewResource: %v", err)
 	}
-	if r.Hash != sha256Hex(payload) {
-		t.Errorf("Hash = %q, want %q", r.Hash, sha256Hex(payload))
+	if r.Hash() != sha256Hex(payload) {
+		t.Errorf("Hash = %q, want %q", r.Hash(), sha256Hex(payload))
 	}
 }
 
@@ -82,7 +97,7 @@ func TestNewResource_BytesURIEncodesDigest(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 	want := "sha256:" + sha256Hex(payload)
-	if got := r.ReachabilityURI(); got != want {
+	if got := concrete(t, r).ReachabilityURI(); got != want {
 		t.Errorf("ReachabilityURI = %q, want %q", got, want)
 	}
 }
@@ -118,8 +133,8 @@ func TestNewResource_BytesEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewResource(empty bytes): %v", err)
 	}
-	if r.Hash != sha256Hex([]byte{}) {
-		t.Errorf("Hash for empty content = %q, want %q", r.Hash, sha256Hex([]byte{}))
+	if r.Hash() != sha256Hex([]byte{}) {
+		t.Errorf("Hash for empty content = %q, want %q", r.Hash(), sha256Hex([]byte{}))
 	}
 }
 
@@ -269,7 +284,7 @@ func TestSourcePath_ShardedLayout(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	want := slashpath.Join(".devlore", "mem", "resource", "sha256", r.Hash[0:2], r.Hash)
+	want := slashpath.Join(".devlore", "mem", "resource", "sha256", r.Hash()[0:2], r.Hash())
 	if got := r.SourcePath().Rel(); got != want {
 		t.Errorf("SourcePath = %q, want %q", got, want)
 	}
@@ -293,8 +308,8 @@ func TestDiscoverResource_RoundTripsURI(t *testing.T) {
 	if discovered.URI() != original.URI() {
 		t.Errorf("URI = %q, want %q", discovered.URI(), original.URI())
 	}
-	if discovered.Hash != original.Hash {
-		t.Errorf("Hash = %q, want %q", discovered.Hash, original.Hash)
+	if discovered.Hash() != original.Hash() {
+		t.Errorf("Hash = %q, want %q", discovered.Hash(), original.Hash())
 	}
 }
 
@@ -326,7 +341,7 @@ func TestConvertTo_Bytes(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	got, err := r.ConvertTo(reflect.TypeFor[[]byte]())
+	got, err := concrete(t, r).ConvertTo(reflect.TypeFor[[]byte]())
 	if err != nil {
 		t.Fatalf("ConvertTo []byte: %v", err)
 	}
@@ -347,7 +362,7 @@ func TestConvertTo_String(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	got, err := r.ConvertTo(reflect.TypeFor[string]())
+	got, err := concrete(t, r).ConvertTo(reflect.TypeFor[string]())
 	if err != nil {
 		t.Fatalf("ConvertTo string: %v", err)
 	}
@@ -364,7 +379,7 @@ func TestConvertTo_UnsupportedTarget(t *testing.T) {
 		t.Fatalf("NewResource: %v", err)
 	}
 
-	_, err = r.ConvertTo(reflect.TypeFor[int]())
+	_, err = concrete(t, r).ConvertTo(reflect.TypeFor[int]())
 	if err == nil {
 		t.Fatal("expected error for unsupported target")
 	}
@@ -389,7 +404,7 @@ func TestCanConvertTo_AcceptsBytesAndString(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := r.CanConvertTo(c.target); got != c.want {
+		if got := concrete(t, r).CanConvertTo(c.target); got != c.want {
 			t.Errorf("CanConvertTo(%s) = %v, want %v", c.target, got, c.want)
 		}
 	}
@@ -409,8 +424,8 @@ func TestEqual_SameBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("r2: %v", err)
 	}
-	if !r1.Equal(r2) {
-		t.Error("expected r1.Equal(r2) for byte-identical inputs")
+	if !concrete(t, r1).Equal(r2) {
+		t.Error("expected concrete(t, r1).Equal(r2) for byte-identical inputs")
 	}
 }
 
@@ -420,7 +435,7 @@ func TestEqual_DifferentBytes(t *testing.T) {
 
 	r1, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("a"))
 	r2, _ := NewResource(activation.RuntimeEnvironment, activation.CallerID, []byte("b"))
-	if r1.Equal(r2) {
+	if concrete(t, r1).Equal(r2) {
 		t.Error("expected Equal to be false for distinct content")
 	}
 }
@@ -429,10 +444,10 @@ func TestEqual_RejectsNonResource(t *testing.T) {
 	runtimeEnvironment := newTestRuntimeEnvironment(t)
 	r, _ := NewResource(runtimeEnvironment, "", []byte("x"))
 
-	if r.Equal("not a resource") {
-		t.Error("expected Equal to reject non-*Resource")
+	if concrete(t, r).Equal("not a resource") {
+		t.Error("expected Equal to reject non-Resource")
 	}
-	if r.Equal(nil) {
+	if concrete(t, r).Equal(nil) {
 		t.Error("expected Equal to reject nil")
 	}
 }
@@ -458,20 +473,20 @@ func TestUnmarshalJSON_RehydratesFromURI(t *testing.T) {
 		t.Fatalf("DiscoverResource seed: %v", err)
 	}
 
-	if err := seeded.UnmarshalJSON(data); err != nil {
+	if err := concrete(t, seeded).UnmarshalJSON(data); err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
 	}
 	if seeded.URI() != original.URI() {
 		t.Errorf("URI after unmarshal = %q, want %q", seeded.URI(), original.URI())
 	}
-	if seeded.Hash != original.Hash {
-		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash, original.Hash)
+	if seeded.Hash() != original.Hash() {
+		t.Errorf("Hash after unmarshal = %q, want %q", seeded.Hash(), original.Hash())
 	}
 }
 
 func TestUnmarshalJSON_RequiresRuntimeEnvironment(t *testing.T) {
-	r := &Resource{}
-	if err := r.UnmarshalJSON([]byte(`"tag:..:sha256:abc#"`)); err == nil ||
+	r := &resource{}
+	if err := concrete(t, r).UnmarshalJSON([]byte(`"tag:..:sha256:abc#"`)); err == nil ||
 		!strings.Contains(err.Error(), "RuntimeEnvironment") {
 		t.Errorf("expected RuntimeEnvironment error, got %v", err)
 	}
@@ -491,7 +506,7 @@ func TestUnmarshalText_RehydratesFromURI(t *testing.T) {
 		t.Fatalf("DiscoverResource seed: %v", err)
 	}
 
-	if err := seeded.UnmarshalText([]byte(original.URI())); err != nil {
+	if err := concrete(t, seeded).UnmarshalText([]byte(original.URI())); err != nil {
 		t.Fatalf("UnmarshalText: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -523,7 +538,7 @@ func TestUnmarshalYAML_RehydratesFromURI(t *testing.T) {
 		return nil
 	}
 
-	if err := seeded.UnmarshalYAML(decode); err != nil {
+	if err := concrete(t, seeded).UnmarshalYAML(decode); err != nil {
 		t.Fatalf("UnmarshalYAML: %v", err)
 	}
 	if seeded.URI() != original.URI() {
@@ -561,9 +576,9 @@ func TestDigest_MatchesHash(t *testing.T) {
 		t.Errorf("Algorithm = %q, want \"sha256\"", d.Algorithm)
 	}
 
-	wantBytes, err := hex.DecodeString(r.Hash)
+	wantBytes, err := hex.DecodeString(r.Hash())
 	if err != nil {
-		t.Fatalf("decode Hash: %v", err)
+		t.Fatalf("decode hash: %v", err)
 	}
 	if !bytes.Equal(d.Bytes, wantBytes) {
 		t.Errorf("Bytes = %x, want %x", d.Bytes, wantBytes)
@@ -573,7 +588,7 @@ func TestDigest_MatchesHash(t *testing.T) {
 // --- Reader error path ---
 
 func TestReader_RejectsMissingSourcePath(t *testing.T) {
-	r := &Resource{}
+	r := &resource{}
 	if _, err := r.Reader(); err == nil {
 		t.Fatal("expected error for missing SourcePath")
 	}

--- a/pkg/op/provider/plan/lifecycle_api_test.go
+++ b/pkg/op/provider/plan/lifecycle_api_test.go
@@ -771,9 +771,9 @@ func TestGraphSaveLoad_ContentTransport(t *testing.T) {
 	}
 
 	// The function executes on the target host — compiled fresh from the transported source.
-	arrivedFunction, ok := transported[functionResource.URI()].(*function.Resource)
+	arrivedFunction, ok := transported[functionResource.URI()].(function.Resource)
 	if !ok {
-		t.Fatalf("transported %s is %T, want *function.Resource", functionResource.URI(),
+		t.Fatalf("transported %s is %T, want function.Resource", functionResource.URI(),
 			transported[functionResource.URI()])
 	}
 


### PR DESCRIPTION
Phase 5 of #625. Closes #662.

**The last cross-package resource embed in the tree is gone.**

## The embed came out cheaply, because of groundwork already laid

`function.Resource` embedded `mem.Resource` across a package boundary — the only such embed anywhere — and
it was never composition. `function` built its own base with `reflect.TypeFor[*function.Resource]()` and
handed *that* to the embedded value, so `mem` was contributing behaviour over `function`'s own identity. A
mixin, wearing an is-a relationship.

The ruling anticipated `mem` exporting a constructor taking a caller-built base. It did not need one: #668
had already moved the content-address path formula into `op`, so `function` now embeds `op.ResourceBase`
like every other provider and reaches its pack through `op.ContentAddressedPath` /
`op.ContentAddressedReader`.

**`function` inherited nine methods and genuinely used two** — `SourcePath` and the `Hash` field. `Pack`
and `Unpack` never delegated; they build their own transport envelope. `sourceBytes` already opened its own
mmap. The remaining seven are the per-provider set `service`, `git`, `appnet`, `json`, and `yaml` each
write for themselves, so supplying them was joining the convention rather than paying a cost.

## The first out-of-package consumer

`pkg/op/provider/plan/lifecycle_api_test.go` calls `ConvertTo` on a transported function, so
`function.Resource` declares `CanConvertTo` / `ConvertTo`. **That is the first sealed interface to reach
past `op.Resource` plus accessors** — every earlier provider's apparent external consumers turned out to be
in-package or doc comments. The plan predicted a phase would eventually have to decide differently; this is
it.

`function`'s six exported fields had **no** external readers, so they went unexported with no interface
methods at all. The transport envelope keeps its exported fields — that struct is the wire form, and
`encoding/json` must be able to set them.

## Running lint before pushing caught four things

`make vet` and `make test` cannot see any of them:

- `ConvertTo` at cyclomatic complexity 16, over the ceiling of 15 — signature validation lifted into
  `bridgeable`, which changes no behavior
- three receiver-naming inconsistencies (`r` where the file uses `f`)
- three misspellings

The last two PRs shipped without that check and one of them failed CI on dead code. This is the first phase
where the gate ran before the push rather than after.

## Verification

`make test` 103 ok / 0 fail · `make build` · `make vet` darwin/linux/windows · `test-scenario` ·
`complexity` · `shell-lint` · `verify-ldflags` · **`star lint go ./pkg/...` — 0 issues** · `gofmt -l` clean.

Metadata preserved without hand-editing: `mem` 3 entries, `function` 4 — #658's generator fix holding on
the last two providers of part 1.

**Seven of nine providers sealed.** `pkg` (#644) and `file`'s four variants (#645) remain.
