### PR TITLE
chore(ci): build and test every arm64 target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,12 @@ jobs:
   # this file does not change again. A gate nobody has watched refuse anything is a claim, not a
   # gate, so phase 4 also proves it by making a Windows test fail on purpose.
   test:
+    # The check context is the platform descriptor, not the runner label: `test (windows-arm64)`,
+    # matching ALL_PLATFORMS and the build/<goos>-<goarch> directories. Without an explicit name
+    # GitHub composes the context from every matrix value — `test (windows-11-arm, false)` — which
+    # leaks the image and the race flag into a string the ruleset has to match exactly, and renames
+    # all five contexts the moment another matrix key is added.
+    name: test (${{ matrix.platform }})
     strategy:
       # Every platform reports independently — a failing leg must not cancel the others' evidence.
       fail-fast: false
@@ -134,14 +140,14 @@ jobs:
       #
       # The Windows pair cannot be matched that way: `windows-latest` is Windows Server 2025 while
       # `windows-11-arm` is a client OS. There is no Windows Server arm64 runner, so that asymmetry
-      # is the platform's, not a choice made here.
+      # is the platform's, not a choice made here — and the descriptor hides it, as it should.
       matrix:
         include:
-          - { os: macos-latest, race: true } # darwin/arm64
-          - { os: ubuntu-latest, race: true } # linux/amd64
-          - { os: ubuntu-24.04-arm, race: true } # linux/arm64
-          - { os: windows-latest, race: true } # windows/amd64
-          - { os: windows-11-arm, race: false } # windows/arm64 — race unsupported by Go
+          - { platform: darwin-arm64, os: macos-latest, race: true }
+          - { platform: linux-amd64, os: ubuntu-latest, race: true }
+          - { platform: linux-arm64, os: ubuntu-24.04-arm, race: true }
+          - { platform: windows-amd64, os: windows-latest, race: true }
+          - { platform: windows-arm64, os: windows-11-arm, race: false } # race unsupported by Go
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -185,18 +191,20 @@ jobs:
   # end-to-end in a pristine sandbox, on every platform (#91 phase-4 audit slice).
   #
   # Uniform, unlike the test job above: scenarios never use -race, so every leg runs the same
-  # command and a bare `os` list says everything there is to say.
+  # command. `include` all the same, so the context is the platform descriptor rather than the
+  # runner label — `scenario (windows-arm64)`, matching the test job and build/<goos>-<goarch>.
   scenario:
+    name: scenario (${{ matrix.platform }})
     strategy:
       # Every platform reports independently — a failing leg must not cancel the others' evidence.
       fail-fast: false
       matrix:
-        os:
-          - macos-latest # darwin/arm64
-          - ubuntu-latest # linux/amd64
-          - ubuntu-24.04-arm # linux/arm64
-          - windows-latest # windows/amd64
-          - windows-11-arm # windows/arm64
+        include:
+          - { platform: darwin-arm64, os: macos-latest }
+          - { platform: linux-amd64, os: ubuntu-latest }
+          - { platform: linux-arm64, os: ubuntu-24.04-arm }
+          - { platform: windows-amd64, os: windows-latest }
+          - { platform: windows-arm64, os: windows-11-arm }
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,13 @@ jobs:
           brew install make
           echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
 
-      - name: Build
-        run: make build
+      # Every platform the project ships, on every push. The codebase is pure Go — zero `import "C"`
+      # — so one runner links the whole matrix with GOOS/GOARCH alone (~41s against ~13s host-only).
+      # Before this, the push path built the host alone and swept GOOS at fixed GOARCH, so nothing
+      # here ever compiled for arm64 while goreleaser shipped arm64 binaries at release: an
+      # arm64-only break surfaced at release rather than at review.
+      - name: Build every platform
+        run: make build PLATFORM=all
 
       - name: Check go.mod tidy
         run: |
@@ -57,9 +62,12 @@ jobs:
       # _darwin.go/_windows.go/_linux.go files. Same runner, one invocation per GOOS. Its first
       # local run found three test files that did not compile under GOOS=windows — the reason three
       # packages reported [build failed] on the windows test leg.
-      - name: Cross-compile every GOOS
-        run: make build-all
-
+      #
+      # `make build-all` used to run here as well. It is dropped rather than kept: `build PLATFORM=all`
+      # above covers every package reachable from ./cmd (120 of 122) across all six GOOS/GOARCH pairs
+      # rather than three GOOS at the host's arch, and `vet-all` below still type-checks all 122 —
+      # test files included, which `go build ./...` never did. The two packages outside cmd's reach
+      # (pkg/op/provider/elevator, pkg/op/server) therefore keep their per-GOOS coverage.
       - name: Vet
         run: make vet-all
 
@@ -116,8 +124,24 @@ jobs:
     strategy:
       # Every platform reports independently — a failing leg must not cancel the others' evidence.
       fail-fast: false
+      # `include` rather than a bare `os` list because the legs are not uniform: Go's race detector
+      # does not support windows/arm64, so that one leg runs `make test` instead. Naming the
+      # difference in data keeps it from looking like an inconsistency somebody should tidy away.
+      #
+      # ubuntu-24.04-arm rather than ubuntu-26.04-arm: `ubuntu-latest` is still Ubuntu 24.04, and
+      # 26.04 is a preview image. Matching versions across the pair means the arm64 leg varies
+      # architecture alone — vary the OS release too and a failure has two candidate causes.
+      #
+      # The Windows pair cannot be matched that way: `windows-latest` is Windows Server 2025 while
+      # `windows-11-arm` is a client OS. There is no Windows Server arm64 runner, so that asymmetry
+      # is the platform's, not a choice made here.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - { os: macos-latest, race: true } # darwin/arm64
+          - { os: ubuntu-latest, race: true } # linux/amd64
+          - { os: ubuntu-24.04-arm, race: true } # linux/arm64
+          - { os: windows-latest, race: true } # windows/amd64
+          - { os: windows-11-arm, race: false } # windows/arm64 — race unsupported by Go
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -142,20 +166,37 @@ jobs:
       # -race requires cgo and a C toolchain. Set explicitly rather than relying on the default,
       # which varies by platform and by whether a compiler is discoverable; the windows runner
       # ships mingw-w64. `make test-race` depends on `generate`, a chain the scenario job below
-      # already exercises on all three platforms.
+      # already exercises on every platform.
       - name: Test with race detector
+        if: matrix.race
         env:
           CGO_ENABLED: "1"
         run: make test-race
 
+      # Go's race detector supports linux/amd64, linux/ppc64le, linux/arm64, linux/s390x,
+      # linux/loong64, freebsd/amd64, netbsd/amd64, darwin/amd64, darwin/arm64, and windows/amd64 —
+      # windows/arm64 is absent, and no CI configuration changes that. This leg runs the suite
+      # without -race so the platform is still tested, and needs no C toolchain as a result.
+      - name: Test without race detector
+        if: ${{ !matrix.race }}
+        run: make test
+
   # The writ-deploy scenario (docs/plans/writ-deploy-scenario.md, #346): the real binaries driven
-  # end-to-end in a pristine sandbox, on all three platforms (#91 phase-4 audit slice).
+  # end-to-end in a pristine sandbox, on every platform (#91 phase-4 audit slice).
+  #
+  # Uniform, unlike the test job above: scenarios never use -race, so every leg runs the same
+  # command and a bare `os` list says everything there is to say.
   scenario:
     strategy:
       # Every platform reports independently — a failing leg must not cancel the others' evidence.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - macos-latest # darwin/arm64
+          - ubuntu-latest # linux/amd64
+          - ubuntu-24.04-arm # linux/arm64
+          - windows-latest # windows/amd64
+          - windows-11-arm # windows/arm64
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/Makefile
+++ b/Makefile
@@ -85,30 +85,44 @@ PREFIX ?= ~/.local
 # selection.
 ALL_PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
 
-# PLATFORM is the caller's selection: `all`, or one or more <goos>/<goarch> names. It stays empty
-# unless named, because build and dist want opposite defaults — you build what you are about to run,
-# and you ship everything.
+# PLATFORM is the caller's selection: the keyword `host`, the keyword `all`, or one or more
+# <goos>/<goarch> names. It stays empty unless named, because build and dist want opposite defaults
+# — you build what you are about to run, and you ship everything.
 #
-#   make build                                  # this machine
+#   make build                                  # host — build's default
+#   make build PLATFORM=host                    # the same, said out loud
 #   make build PLATFORM=linux/amd64
 #   make build PLATFORM=all                     # every supported platform
-#   make dist                                   # every supported platform
+#   make dist                                   # every supported platform — dist's default
 #   make dist  PLATFORM="linux/amd64 darwin/arm64"
+#
+# `host` rather than `current` or `local`: this file already names the machine it runs on six ways
+# (HOST_GOOS, HOST_GOARCH, HOST_GO, HOST_GOEXE, HOST_DIR, HOST_COPIES), every one of them from Go's
+# own GOHOSTOS/GOHOSTARCH, and CROSS is defined as target ≠ host. `PLATFORM=host` therefore reads as
+# precisely what it does — do not cross-compile — and a third synonym would only blur that.
+#
+# PLATFORM must stay empty by default. A non-empty default is never overridden by a target, so
+# dist's default would become unreachable and releases would go host-only without announcing it.
+# The defaults live at the call sites, as keywords, where each target can state its own.
 #
 # The inner loop should not pay to link six platforms it is not about to run: warm, the full matrix
 # takes ~41s against ~13s for the host alone. Cross-compilation stays one word away rather than a tax
 # on every build.
 PLATFORM ?=
 
-# Resolve the selection against a target-supplied default: $(call select,<default list>). `all`
-# expands to every supported platform; empty means the caller did not choose, so the default stands.
+# Expand the two keywords; anything else is already a list of <goos>/<goarch> names.
+expand = $(if $(filter all,$(1)),$(ALL_PLATFORMS),$(if $(filter host,$(1)),$(HOST_GOOS)/$(HOST_GOARCH),$(1)))
+
+# Resolve the selection against a target-supplied default: $(call select,host) or $(call select,all).
+# The caller's PLATFORM wins when named; otherwise the target's own default stands. Both go through
+# expand, so `host` and `all` mean the same thing whether typed or defaulted.
 #
 # A function rather than a variable because the default differs per target, and because a command-line
 # PLATFORM cannot be reassigned by a plain assignment — only `override` does that, and a bare
 # `PLATFORM := $(ALL_PLATFORMS)` inside an
 # ifeq is silently ignored and the loop builds a platform literally named "all". Verified by writing
 # it that way first.
-select = $(if $(PLATFORM),$(if $(filter all,$(PLATFORM)),$(ALL_PLATFORMS),$(PLATFORM)),$(1))
+select = $(call expand,$(if $(PLATFORM),$(PLATFORM),$(1)))
 
 ### STAR
 
@@ -249,7 +263,7 @@ build: generate ## Build every product for PLATFORM (default: this machine; `all
 	#
 	# Widen with `make build PLATFORM=all`, or name a subset. Generators already ran once, host-side,
 	# in `generate`; this loop only links.
-	for platform in $(call select,$(HOST_GOOS)/$(HOST_GOARCH)); do
+	for platform in $(call select,host); do
 		os=$${platform%/*}
 		arch=$${platform#*/}
 		ext=""
@@ -415,7 +429,7 @@ dist-all: ## Build distribution archives for PLATFORM (default: every supported 
 	# host that those flags bind to real symbols — which is the failure that shipped unnoticed until
 	# 2026-08-16. See docs/plans/version-stamping.md.
 	mkdir -p dist
-	for platform in $(call select,$(ALL_PLATFORMS)); do
+	for platform in $(call select,all); do
 		os=$${platform%/*}
 		arch=$${platform#*/}
 		ext=""

--- a/cmd/writ/scenario_integration_test.go
+++ b/cmd/writ/scenario_integration_test.go
@@ -171,19 +171,45 @@ func initializeRepo(t *testing.T, dest string) {
 
 	t.Helper()
 
+	// The real user's global git config must not reach the sandbox repo (branch-protection hooks
+	// would reject the baseline commit on main).
+	env := isolatedGitEnv(t)
+
 	for _, args := range [][]string{
 		{"init", "--quiet", "--initial-branch=main"},
 		{"add", "-A"},
 		{"-c", "user.name=scenario", "-c", "user.email=scenario@invalid", "commit", "--quiet", "-m", "scenario baseline"},
 	} {
 		cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dest}, args...)...)
-		// The real user's global git config must not reach the sandbox repo (branch-protection
-		// hooks would reject the baseline commit on main).
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
+		cmd.Env = env
 		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}
 	}
+}
+
+// isolatedGitEnv points git's global and system config at an empty file, so a sandbox repository
+// sees no configuration beyond what the test supplies.
+//
+// An empty regular file rather than os.DevNull. os.DevNull is "NUL" on Windows, and the git build
+// on the windows-11-arm runner image refuses to open it as a config path:
+//
+//	fatal: unable to access 'NUL': Invalid argument
+//
+// The identical command succeeds on windows-latest, so this is a property of that image's git, not
+// of the architecture — which is why it stayed hidden until windows/arm64 joined the matrix. An
+// empty file is what git actually needs here: a config it can open and find nothing in. It carries
+// none of the device-file semantics that vary by platform and by git build.
+func isolatedGitEnv(t *testing.T) []string {
+
+	t.Helper()
+
+	empty := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatalf("write empty git config: %v", err)
+	}
+
+	return append(os.Environ(), "GIT_CONFIG_GLOBAL="+empty, "GIT_CONFIG_SYSTEM="+empty)
 }
 
 // copyFixture copies the checked-in fixture tree into the sandbox destination.

--- a/cmd/writ/writ/repo_cmd_test.go
+++ b/cmd/writ/writ/repo_cmd_test.go
@@ -30,17 +30,43 @@ func sourceRepository(t *testing.T) string {
 	t.Helper()
 
 	root := t.TempDir()
+	env := isolatedGitEnv(t)
+
 	for _, args := range [][]string{
 		{"init", "--quiet", "--initial-branch=main"},
 		{"-c", "user.name=t", "-c", "user.email=t@invalid", "commit", "--quiet", "--allow-empty", "-m", "seed"},
 	} {
 		command := exec.CommandContext(context.Background(), "git", append([]string{"-C", root}, args...)...)
-		command.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
+		command.Env = env
 		if output, err := command.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}
 	}
 	return root
+}
+
+// isolatedGitEnv points git's global and system config at an empty file, so a test repository sees
+// no configuration beyond what the test supplies.
+//
+// An empty regular file rather than os.DevNull. os.DevNull is "NUL" on Windows, and the git build
+// on the windows-11-arm runner image refuses to open it as a config path:
+//
+//	fatal: unable to access 'NUL': Invalid argument
+//
+// The identical command succeeds on windows-latest, so this is a property of that image's git, not
+// of the architecture — which is why it stayed hidden until windows/arm64 joined the matrix. An
+// empty file is what git actually needs here: a config it can open and find nothing in. It carries
+// none of the device-file semantics that vary by platform and by git build.
+func isolatedGitEnv(t *testing.T) []string {
+
+	t.Helper()
+
+	empty := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatalf("write empty git config: %v", err)
+	}
+
+	return append(os.Environ(), "GIT_CONFIG_GLOBAL="+empty, "GIT_CONFIG_SYSTEM="+empty)
 }
 
 // runRepo executes the repo command family against a sandboxed layers directory and returns its output.

--- a/docs/plans/arm64-build-and-test-matrix.md
+++ b/docs/plans/arm64-build-and-test-matrix.md
@@ -1,0 +1,275 @@
+---
+title: "arm64 build and test matrix"
+issue: https://github.com/NobleFactor/devlore-cli/issues/681
+status: in-progress
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+# Plan: arm64 build and test matrix
+
+## Summary
+
+Two build/CI chores, related but distinct:
+
+1. **Build the entire set.** `ALL_PLATFORMS` already names all six targets, and
+   `make build PLATFORM=all` already produces them — but CI never asks for them. The
+   `quality-gate` job runs `make build` (host only) and `make build-all`, which sweeps
+   **GOOS and not GOARCH**. arm64 compilation is therefore unverified on every push, while
+   goreleaser ships arm64 binaries at release. An arm64-only break surfaces at release time.
+2. **Run the entire set.** The `test` and `scenario` matrices are
+   `[ubuntu-latest, macos-latest, windows-latest]` — three legs covering three of the five
+   runnable pairs. Linux and Windows arm64 are never executed.
+
+Cross-compiling proves the code *builds* for a target. A native runner proves it *runs*
+there. Neither substitutes for the other, and today CI does neither for arm64 outside
+macOS.
+
+No production code changes. Two workflow jobs grow, one Makefile invocation widens, and one
+test leg loses the race detector because Go does not support it there.
+
+## Goals
+
+1. **Every shipped target compiles on every push** — six platforms, matching what goreleaser
+   releases.
+2. **Every runnable target executes natively** — five runner legs, so arm64 behavior is
+   observed rather than assumed.
+3. **Change nothing else.** A leg that fails is a finding, not a regression introduced here.
+4. **Keep the ruleset story accurate**: more legs means more check contexts, which the
+   platform-test-matrix plan's phase 4 must name correctly.
+
+## Current State
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| `ALL_PLATFORMS` | ✅ Complete | `darwin/{amd64,arm64} linux/{amd64,arm64} windows/{amd64,arm64}` — all six |
+| `make build PLATFORM=all` | ✅ Works | Pure Go, `CGO_ENABLED=0`, no per-platform toolchains; ~41s vs ~13s host-only |
+| goreleaser | ✅ Complete | `goos: [linux, darwin, windows] × goarch: [amd64, arm64]` — ships all six |
+| CI `make build` | ⚠️ Host only | `quality-gate` runs on `ubuntu-latest`, so this builds linux/amd64 alone |
+| CI `make build-all` | ⚠️ GOOS only | `for os in linux darwin windows: GOOS=$os go build ./...` — **no GOARCH sweep**, emits no binaries |
+| **arm64 compilation in CI** | ❌ **Unverified** | Nothing on the push path compiles for arm64; only release does |
+| `test` matrix | ⚠️ Three legs | `[ubuntu-latest, macos-latest, windows-latest]`, `make test-race` |
+| `scenario` matrix | ⚠️ Three legs | Same three, `make test-scenario` |
+| darwin/arm64 execution | ✅ Covered | `macos-latest` is Apple Silicon — never a gap |
+| linux/arm64 execution | ❌ Absent | `ubuntu-24.04-arm` available, free-tier eligible |
+| windows/arm64 execution | ❌ Absent | `windows-11-arm` available, free-tier eligible |
+| arm64 runners, private repos | ✅ GA 2026-01-29 | `windows-11-arm`, `ubuntu-24.04-arm`, `ubuntu-22.04-arm` |
+| Race detector, windows/arm64 | ❌ Unsupported by Go | Upstream constraint — Requirement 3 |
+
+## Requirements
+
+### Requirement 1: CI builds the entire set
+
+The Makefile already says what is true of this codebase:
+
+> The build comes to the machine: one host produces every platform's binaries, and
+> installing anywhere is a copy. The codebase is pure Go — zero `import "C"` — so the whole
+> matrix cross-compiles from here with GOOS/GOARCH alone, no per-platform toolchains and no
+> build VMs.
+
+So the fix is an argument, not an architecture: `quality-gate` asks for all six.
+
+`build-all` is a *compile* sweep across GOOS that emits no binaries; it exists to catch
+`_darwin.go`/`_windows.go`/`_linux.go` files that a single-GOOS pass never sees, and its
+first local run found three such files. It is worth keeping for that purpose. But it sweeps
+one axis, and arm64 lives on the other. Either widen `build-all` to GOARCH as well, or have
+CI run `make build PLATFORM=all` and get real binaries for the trouble. This plan prefers
+the latter: it exercises the same code path releases use, and ~28 additional seconds on one
+runner is not a cost worth optimizing.
+
+**This is the higher-value half of the plan.** It closes a gap that exists today on every
+push, on one runner, for seconds — where the native-runner work below adds runners to
+observe behavior that is, so far, only theoretically at risk.
+
+### Requirement 2: There is no `-latest` label for arm64
+
+The matrix cannot be expressed as "all platforms latest". GitHub publishes arm64 runners as
+**version-pinned labels only**; no `ubuntu-latest-arm` or `windows-latest-arm` exists.
+
+| Target | Label | Architecture |
+| --- | --- | --- |
+| darwin | `macos-latest` | arm64 (M1) |
+| linux/amd64 | `ubuntu-latest` | x64 |
+| linux/arm64 | `ubuntu-24.04-arm` | arm64 — **pinned, no alias** |
+| windows/amd64 | `windows-latest` | x64 |
+| windows/arm64 | `windows-11-arm` | arm64 — **pinned, no alias** |
+
+Also available: `ubuntu-26.04-arm`, `ubuntu-22.04-arm`, `windows-11-vs2026-arm`.
+
+**Ruled: `ubuntu-24.04-arm`.** Not a compromise against "all platforms latest" — it *is* the
+arm64 counterpart of latest. `ubuntu-latest` still resolves to Ubuntu 24.04, with no announced
+migration to 26.04, and `ubuntu-26.04`/`ubuntu-26.04-arm` are marked **preview** ("some software
+can be unstable on the new platform"). Matching versions across the pair also means the arm64 leg
+varies architecture alone; vary the OS release as well and any failure has two candidate causes.
+
+The Windows pair cannot be matched that way. `windows-latest` is Windows Server 2025 while
+`windows-11-arm` is a client OS, and there is no Windows Server arm64 runner. That asymmetry
+belongs to the platform, not to this plan, and is worth remembering when a Windows leg diverges.
+
+A consequence worth stating: pinned labels drift. Unlike `ubuntu-latest`, these two will not
+follow GitHub's image promotions, so they need an owner and a periodic bump. That is the
+price of arm64 coverage today, not a defect in this plan.
+
+**The build set is six; the runner set is five.** `darwin/amd64` compiles but is never
+executed. That asymmetry is deliberate, and Apple's timeline settles it rather than leaving
+it to taste:
+
+- macOS **Tahoe 26** (September 2025) is the last Intel-supporting release.
+- macOS **27** ships September 2026 — Apple Silicon only.
+- Intel Macs receive **security updates through roughly fall 2028**.
+- The last Intel hardware (2019 Mac Pro, 2020 MacBook Pro and iMac) left sale through mid-2023,
+  so a real population persists to 2028–2030 on ordinary service life.
+
+The decisive asymmetry is Rosetta's direction: it translates x86_64 → arm64, **never the
+reverse**. An Intel Mac cannot run an arm64 binary under any emulation, so dropping
+`darwin/amd64` does not degrade those users — it strands them with no fallback. No other
+target in the matrix has that property.
+
+Hence: **keep building it, do not add an Intel runner.** The build costs one more
+GOOS/GOARCH pair in a pure-Go cross-compile, on a runner already paid for. A runner leg costs
+macOS billing at 10× ([platform-test-matrix.md](./platform-test-matrix.md) ruling 3) to
+observe a shrinking population on a known schedule. Revisit dropping the build target around
+**fall 2028**, when security updates end — not before.
+
+Note the Intel runner label set is now closed: `macos-15-intel` and `macos-26-intel` exist,
+and there will never be a `macos-27-intel`. That is the complete menu, permanently.
+
+### Requirement 3: windows/arm64 cannot run the race detector
+
+The Go race detector supports:
+
+> `linux/amd64`, `linux/ppc64le`, `linux/arm64`, `linux/s390x`, `linux/loong64`,
+> `freebsd/amd64`, `netbsd/amd64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`.
+
+`windows/arm64` is absent. The `test` job runs `make test-race`, so that leg runs
+`make test` instead. This is an upstream limitation: attempting `-race` there fails at the
+toolchain, and no CI configuration changes it. `linux/arm64` **is** supported, so
+`ubuntu-24.04-arm` runs `make test-race` unchanged.
+
+The matrix therefore stops being uniform, which means `matrix.include` with an explicit
+per-leg flag rather than a bare `matrix.os` list:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    include:
+      - { os: macos-latest,     race: true  }   # darwin/arm64
+      - { os: ubuntu-latest,    race: true  }   # linux/amd64
+      - { os: ubuntu-24.04-arm, race: true  }   # linux/arm64
+      - { os: windows-latest,   race: true  }   # windows/amd64
+      - { os: windows-11-arm,   race: false }   # windows/arm64 — race unsupported by Go
+```
+
+The step selects on `matrix.race`, with the reason named in the workflow so the next reader
+does not "fix" the inconsistency.
+
+### Requirement 4: The existing per-leg accommodations must survive
+
+Already in the `test` job, and they must extend rather than be re-derived:
+
+- **macOS ships GNU make 3.81** — the last GPLv2 release, so it will never advance. The job
+  installs `make` via brew and prepends `gnubin`. Unaffected here; the new legs are Linux and
+  Windows.
+- **`-race` requires cgo and a C toolchain**, set explicitly as `CGO_ENABLED: "1"` rather
+  than relying on a platform-varying default. `ubuntu-24.04-arm` needs the same. The
+  `windows-11-arm` leg skips `-race`, so it does not need mingw-w64 — fortunate, since that
+  image's toolchain story is the least proven of the five.
+
+### Requirement 5: More legs means more check contexts
+
+Each leg reports its own check, so `test (ubuntu-latest)` becomes five contexts, and the same
+for `scenario`. The `develop` ruleset currently requires exactly one context, `quality-gate`,
+which is why the `test` job is non-blocking today — deliberately, and without
+`continue-on-error`, so red stays visible as triage data.
+
+Phase 4 of [platform-test-matrix.md](./platform-test-matrix.md) is a ruleset change naming
+the `test (…)` contexts. It must name **five**, not three. This plan does not change the
+ruleset; it changes the names that phase will have to use, and says so here so the two do not
+drift.
+
+## Implementation Phases
+
+### Phase 1: Build the entire set (status: complete)
+
+- [x] `quality-gate` builds all six: the `Build` step is now `make build PLATFORM=all`
+- [x] `build-all` dropped from CI. `build PLATFORM=all` covers the 120 of 122 packages reachable
+      from `./cmd` across all six pairs rather than three GOOS at the host's arch, and `vet-all`
+      still type-checks all 122 including test files — which `go build ./...` never did. The two
+      packages outside cmd's reach (`pkg/op/provider/elevator`, `pkg/op/server`) keep their
+      per-GOOS coverage. The Makefile target remains for local use.
+- [x] Added `host` as a PLATFORM keyword beside `all`; both resolve through `expand`
+- [x] `PLATFORM` stays empty by default — a non-empty default is never overridden by a target, so
+      `dist`'s default would become unreachable and releases would go host-only silently. Defaults
+      moved to the call sites as keywords: `$(call select,host)` for build, `$(call select,all)`
+      for dist.
+- [x] Verified by expansion: `build` → `darwin/arm64`; `build PLATFORM=all` → all six;
+      `dist` → all six; `dist PLATFORM=host` → `darwin/arm64`
+
+**Files**: `.github/workflows/ci.yaml` - Modify
+
+### Phase 2: Run the entire set (status: complete)
+
+- [x] `test` job: `matrix.include`, five legs, `race` flag per leg
+- [x] `test` job: two steps gated on `matrix.race` — `make test-race` where supported,
+      `make test` on `windows-11-arm`, with Go's supported-platform list quoted at the conditional
+- [x] `scenario` job: same five legs, bare `os` list since scenarios never use `-race`
+- [x] `fail-fast: false` retained on both
+- [x] `quality-gate` untouched, on `ubuntu-latest`
+
+**Files**: `.github/workflows/ci.yaml` - Modify
+
+### Phase 3: Triage what the new legs reveal (status: pending)
+
+The point is to learn something, so the first run is data, not pass/fail.
+
+- [ ] Record each new leg's result; failures are findings to file, not blockers on this PR
+- [ ] Confirm `actions/setup-go@v5` resolves a toolchain on both new images
+- [ ] Confirm the scenario harness's `writBinary` resolves `build/<goos>-<goarch>/` on the
+      arm64 legs — it composes from `runtime.GOOS`/`runtime.GOARCH`, so it should hold, but
+      has never run on either image
+- [ ] Confirm symlink creation works on `windows-11-arm`. platform-test-matrix flags symlinks
+      as the Windows risk; an arm64 image is a fresh instance of that question, not a settled
+      one
+
+### Phase 4: Record the pin owner (status: pending)
+
+- [ ] Note beside each pinned label that it does not track GitHub's image promotions and must
+      be bumped deliberately
+- [ ] Decide whether `ubuntu-26.04-arm` supersedes `ubuntu-24.04-arm` once it has mileage
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `.github/workflows/ci.yaml` | Modify | Phases 1–2 — full-set build, five-leg test and scenario |
+| `docs/plans/arm64-test-matrix.md` | Create | This plan |
+| `docs/plans/platform-test-matrix.md` | Modify | Phase 4's context list becomes five names |
+| `Makefile` | Modify | Only if `build-all` is widened to GOARCH (Open Questions) |
+
+## Related Documents
+
+- [platform-test-matrix.md](./platform-test-matrix.md) — the three-platform matrix this
+  extends; its phase 4 ruleset change must name the new contexts
+- [writ-deploy-scenario.md](./writ-deploy-scenario.md) — the scenario harness the new legs
+  drive
+- [arm64 standard runners in private repositories](https://github.blog/changelog/2026-01-29-arm64-standard-runners-are-now-available-in-private-repositories/) — GA 2026-01-29, free-tier eligible
+- [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) — the label table; source for Requirement 2
+- [Go race detector](https://go.dev/doc/articles/race_detector) — supported-platform list; source for Requirement 3
+
+## Open Questions
+
+- [x] ~~`build-all`'s fate?~~ **Resolved:** retired from CI in favour of `make build PLATFORM=all`;
+      `vet-all` retains the per-GOOS sweep over all 122 packages, test files included.
+- [x] ~~`ubuntu-24.04-arm` or `ubuntu-26.04-arm`?~~ **Resolved (Requirement 2):** 24.04-arm.
+      `ubuntu-latest` is still 24.04 and 26.04 is a preview image, so 24.04-arm *is* latest's
+      arm64 counterpart and keeps the pair version-matched.
+- [x] ~~`darwin/amd64` builds but never runs — deliberate, or a gap to close with
+      `macos-15-intel`?~~ **Resolved (Requirement 2):** deliberate. Keep the build target
+      because Rosetta cannot run arm64 on Intel, so dropping it strands those users outright;
+      skip the runner because macOS bills at 10×. Revisit the build target around fall 2028,
+      when Intel security updates end.
+- [ ] Does the `windows-11-arm` image carry a C toolchain at all? Not needed here, since that
+      leg skips `-race`, but it bounds what can ever run there.
+- [ ] Should `scenario`'s five legs also start non-blocking, matching the `test` job's
+      posture, or does its green record on three platforms justify gating immediately?

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -12,8 +12,13 @@ updated: 2026-08-12
 
 The unit suite runs on ubuntu-latest only. macOS and Windows execute exactly one test. The
 ruling is unconditional — **all tests must run on every supported platform** — so this plan moves
-`make test-race` onto the three-platform matrix, triages what that reveals, fixes it, and then
-makes the three legs required rather than advisory.
+`make test-race` onto the platform matrix, triages what that reveals, fixes it, and then makes
+the legs required rather than advisory.
+
+The matrix this plan built was three legs — ubuntu, macOS, and Windows, all x64 except macOS.
+[arm64-build-and-test-matrix.md](./arm64-build-and-test-matrix.md) has since taken it to five by
+adding linux/arm64 and windows/arm64. Phase 4 below is the only part affected: it must require
+five contexts per job, not three.
 
 ## Current State
 
@@ -333,16 +338,30 @@ Branch count and grouping are sized after phase 2, since the failure count is un
 
 Nothing in `ci.yaml` changes, per ruling 2's correction.
 
-- [ ] Add the three `test (…)` legs to `required_status_checks` on ruleset `12426847`, which
-      today lists only `quality-gate`.
-- [ ] Consider adding the three `scenario (…)` legs at the same time — they are not required
+**Both matrices are now five legs, not three** — see
+[arm64-build-and-test-matrix.md](./arm64-build-and-test-matrix.md), which added linux/arm64 and
+windows/arm64. This phase must name all five per job, or the two arm64 legs stay advisory while
+the rest are enforced, which is the worst of both arrangements: a gate that looks complete and
+is not.
+
+- [ ] Add the five `test (…)` legs to `required_status_checks` on ruleset `12426847`, which
+      today lists only `quality-gate`:
+      `test (macos-latest)`, `test (ubuntu-latest)`, `test (ubuntu-24.04-arm)`,
+      `test (windows-latest)`, `test (windows-11-arm)`
+- [ ] Consider adding the five `scenario (…)` legs at the same time — they are not required
       either, so a red Windows scenario does not currently block a merge.
+- [ ] Confirm the context strings against a real run before writing them into the ruleset. The
+      `test` job now uses `matrix.include`, and GitHub composes a leg's check name from the
+      matrix values; a name that does not match exactly is a required check that never arrives,
+      which blocks every merge rather than none.
 - [ ] Confirm a deliberately failing test on Windows blocks a merge. The gate is not proven until
       it has refused something.
 
 ## Verification
 
-`make test-race` green on all three legs, with the check-run attached to the pull request's real
+`make test-race` green on every leg that supports it, and `make test` green on windows/arm64,
+which does not — the full suite runs there, only the race detector is absent. Check-runs must be
+attached to the pull request's real
 head SHA — verified via `gh api repos/<repo>/commits/<sha>/check-runs`, not via `gh pr checks`,
 which reports whatever the pull request head happens to be. PR #371 merged without its tests
 precisely because that distinction was not made.
@@ -355,4 +374,6 @@ None outstanding. The rulings below close every question this plan opened.
 
 - Issue #373 — this gap
 - [docs/plans/audit-remediation.md](./audit-remediation.md) — issue #365; every refactor it lands
-  is currently verified on one platform out of three
+  is currently verified on one platform out of five
+- [arm64-build-and-test-matrix.md](./arm64-build-and-test-matrix.md) — took both matrices from
+  three legs to five, and the push-path build from host-only to all six GOOS/GOARCH pairs

--- a/docs/plans/platform-test-matrix.md
+++ b/docs/plans/platform-test-matrix.md
@@ -346,14 +346,18 @@ is not.
 
 - [ ] Add the five `test (…)` legs to `required_status_checks` on ruleset `12426847`, which
       today lists only `quality-gate`:
-      `test (macos-latest)`, `test (ubuntu-latest)`, `test (ubuntu-24.04-arm)`,
-      `test (windows-latest)`, `test (windows-11-arm)`
-- [ ] Consider adding the five `scenario (…)` legs at the same time — they are not required
-      either, so a red Windows scenario does not currently block a merge.
-- [ ] Confirm the context strings against a real run before writing them into the ruleset. The
-      `test` job now uses `matrix.include`, and GitHub composes a leg's check name from the
-      matrix values; a name that does not match exactly is a required check that never arrives,
-      which blocks every merge rather than none.
+      `test (darwin-arm64)`, `test (linux-amd64)`, `test (linux-arm64)`,
+      `test (windows-amd64)`, `test (windows-arm64)`
+- [ ] Consider adding the five `scenario (…)` legs at the same time — same descriptors,
+      `scenario (darwin-arm64)` through `scenario (windows-arm64)`. They are not required either,
+      so a red Windows scenario does not currently block a merge.
+- [ ] These strings are stable by construction: both jobs set an explicit
+      `name: <job> (${{ matrix.platform }})`, so the context is the platform descriptor and
+      nothing else. Without that, GitHub composes the name from **every** matrix value — the first
+      run of this matrix reported `test (windows-11-arm, false)`, leaking the runner image and the
+      race flag into a string the ruleset must match exactly, and renaming all five contexts the
+      moment another matrix key is added. A required context whose name does not match is a check
+      that never arrives, which blocks every merge rather than none.
 - [ ] Confirm a deliberately failing test on Windows blocks a merge. The gate is not proven until
       it has refused something.
 


### PR DESCRIPTION
Closes #681

Two build/CI chores. No production code changes.

## 1. Nothing on the push path compiled for arm64

`quality-gate` ran `make build` (host only) plus `make build-all`, which sweeps **GOOS at a
fixed GOARCH**. goreleaser ships all six pairs, so an arm64-only break surfaced at release
rather than at review.

`ALL_PLATFORMS` already listed all six and `make build PLATFORM=all` already produced them —
CI never asked. Now it does.

**`build-all` is dropped, and I checked what that costs.** `build PLATFORM=all` links the
**120 of 122** packages reachable from `./cmd`; the two outside its reach are
`pkg/op/provider/elevator` and `pkg/op/server`. But `vet-all` stays and type-checks all 122
per GOOS **including test files**, which `go build ./...` never did — so those two keep their
coverage, and `build-all` was largely redundant with the step below it. The Makefile target
remains for local use.

## 2. Linux and Windows arm64 were never executed

| Leg | Target | Command |
|---|---|---|
| `macos-latest` | darwin/arm64 | `make test-race` |
| `ubuntu-latest` | linux/amd64 | `make test-race` |
| `ubuntu-24.04-arm` | linux/arm64 | `make test-race` |
| `windows-latest` | windows/amd64 | `make test-race` |
| `windows-11-arm` | windows/arm64 | `make test` |

darwin/arm64 was covered all along — `macos-latest` is Apple Silicon. The gap was Linux and
Windows arm64, unblocked by arm64 runners reaching GA for private repositories on 2026-01-29.

## `PLATFORM=host`

New keyword beside `all`. Named `host` rather than `current` or `local` because `CROSS` is
already defined in this Makefile as *target ≠ host* — so `PLATFORM=host` names the one
selection that makes `CROSS` empty, and every `HOST_` variable here comes from Go's
`GOHOSTOS`/`GOHOSTARCH`.

**`PLATFORM` stays empty by default.** `PLATFORM ?= host` would have been the obvious way to
write it and would have silently broken `dist`: a non-empty default is never overridden by a
target, so `dist`'s default becomes unreachable and releases go host-only without saying so.
The defaults now live at the call sites as keywords — `$(call select,host)` for build,
`$(call select,all)` for dist.

## Three constraints, recorded where they bind

- **No `-latest` alias exists for arm64.** `ubuntu-24.04-arm` is pinned because `ubuntu-latest`
  still resolves to Ubuntu 24.04 and `ubuntu-26.04-arm` is a **preview** image. Matching
  versions means the arm64 leg varies architecture alone; vary the OS release too and a failure
  has two candidate causes.
- **Go's race detector does not support windows/arm64.** That leg runs `make test` — the full
  suite, only race detection absent. `linux/arm64` *is* supported and runs `-race` unchanged.
- **The Windows pair cannot be version-matched.** `windows-latest` is Windows Server 2025,
  `windows-11-arm` is a client OS, and no Windows Server arm64 runner exists. The platform's
  asymmetry, not a choice made here — worth knowing before a Windows leg diverges.

## `platform-test-matrix.md` updated in step

Its phase 4 (the ruleset change on `12426847`) must now require **five** contexts per job, not
three, and the five names are written out there. Requiring three of five would leave both arm64
legs advisory while the rest gate — a gate that looks complete and is not.

Added a warning that wasn't there: the `test` job now uses `matrix.include`, and GitHub composes
check names from matrix values. A required context whose name does not match exactly never
arrives, which blocks **every** merge rather than none. Verify the strings against a real run
before writing them into the ruleset.

Historical "three" references in that plan are deliberately untouched — the three `[build failed]`
packages, the three uncompilable test files, the three-GOOS analysis sweep. Those are findings and
a still-correct GOOS count, not stale platform arithmetic.

## Test plan

- [x] Makefile expansion verified: `build` → `darwin/arm64`; `build PLATFORM=host` →
      `darwin/arm64`; `build PLATFORM=linux/arm64` → `linux/arm64`; `build PLATFORM=all` → all
      six; `dist` → all six; `dist PLATFORM=host` → `darwin/arm64`
- [x] `ci.yaml` parses; five legs on both jobs; `race` flag drives the two conditional steps
- [x] Coverage of the dropped `build-all` accounted for (120/122 + `vet-all` over 122)
- [ ] **This PR is the first exercise of the legs it adds.** `test (ubuntu-24.04-arm)` and
      `test (windows-11-arm)` have never run. Per the plan's phase 3, their first results are
      triage data — failures there are findings to file, not automatically blockers.
- [ ] `windows-11-arm` symlink behavior unverified. platform-test-matrix flags symlinks as the
      Windows risk; an arm64 image is a fresh instance of that question.