### PR TITLE
DO NOT MERGE: prove the gate refuses

### DIFF
--- a/cmd/writ/gate_proof_test.go
+++ b/cmd/writ/gate_proof_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package main
+
+import "testing"
+
+// TestGateProof_DeliberateFailure fails on purpose. It exists only to prove that ruleset 21539972
+// refuses a merge when a required platform check is red, and it is deleted with the throwaway
+// branch it lives on. It must never reach develop.
+func TestGateProof_DeliberateFailure(t *testing.T) {
+	t.Fatal("deliberate failure: proving the required platform checks block a merge")
+}


### PR DESCRIPTION
Throwaway. A deliberately failing test, to confirm ruleset 21539972 blocks a merge when a required platform check is red. Closed unmerged by the script that opened it.