### PR TITLE
fix(ci): let a devlore-registry failure stop the knowledge sync

### DIFF
--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -102,7 +102,7 @@ jobs:
             exit 0
           fi
 
-          BRANCH="knowledge/sync-${GITHUB_SHA::7}"
+          BRANCH="chore/knowledge-sync-${GITHUB_SHA::7}"
           git checkout -b "$BRANCH"
           git add knowledge/
           git commit -m "chore: sync knowledge from devlore-cli@${{ github.sha }}"
@@ -113,18 +113,24 @@ jobs:
             --body "Automated knowledge sync from [devlore-cli@\`${GITHUB_SHA::7}\`](https://github.com/NobleFactor/devlore-cli/commit/${GITHUB_SHA})." \
             --base "${{ github.ref_name }}")
           echo "Created PR: $PR_URL"
-          # devlore-registry develop sits under the same org ruleset as the site repo,
-          # and the plain merge already failed live: registry PR #69 was app-created,
-          # its run failed on this step, and the PR was merged by hand two minutes
-          # later. --admin disarms gh's client-side merge-state veto; the server-side
-          # entitlement is the NobleFactor Automation app's "always" bypass on the org
-          # ruleset, not repository admin rights. Retry bounded: a transient GitHub
-          # 5xx must not strand a green PR (a 502 stranded site PR #212), and a failed
-          # attempt may still have merged server-side, so the PR state is consulted
-          # before retrying.
+          # This merge is expected to FAIL when devlore-registry's CI is red, and that is
+          # the point: a registry failure must stop this workflow rather than be merged past.
+          # devlore-registry carries repository ruleset 21604093, which requires quality-gate
+          # and validate-yaml-schemas. The NobleFactor Automation app is a bypass actor on the
+          # ORG ruleset (12426847) but NOT on 21604093, so a red check refuses this merge
+          # server-side.
+          #
+          # --admin was removed deliberately. It only disarms gh's client-side merge-state veto
+          # and cannot grant entitlement the app does not have, so against 21604093 it bought
+          # nothing while implying a power that does not exist -- and it turned a clean refusal
+          # into five retries over ~100s before failing anyway.
+          #
+          # Retry bounded, and still worth keeping: a transient GitHub 5xx must not strand a
+          # green PR (a 502 stranded site PR #212), and a failed attempt may still have merged
+          # server-side, so the PR state is consulted before retrying.
           merged=false
           for attempt in 1 2 3 4 5; do
-            if gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --admin --squash --delete-branch; then
+            if gh pr merge "$PR_URL" --repo NobleFactor/devlore-registry --squash --delete-branch; then
               merged=true
               break
             fi


### PR DESCRIPTION
## `--admin` removed

`gh pr merge --admin` disarms gh's *client-side* merge-state veto. It cannot grant
entitlement the actor lacks, and devlore-registry now carries repository ruleset
**21604093** requiring `quality-gate` and `validate-yaml-schemas`:

| Ruleset | NobleFactor Automation app |
| --- | --- |
| Org 12426847 | bypass, `pull_request` mode |
| **Repo 21604093** | **not a bypass actor** |

So against the rule that actually gates this merge, `--admin` bought nothing — while
implying a power that does not exist, and converting a clean server-side refusal into five
retries over ~100s before failing anyway.

A red devlore-registry now stops this workflow. That is the intent: a registry CI failure
should not be merged past.

The comment was independently stale — it claimed the app holds an `"always"` bypass. It is
`pull_request` mode.

## Sync branch renamed

`knowledge/sync-<sha>` → **`chore/knowledge-sync-<sha>`**

Every other prefix in the org's allowed set — `chore`, `fix`, `feature`, `refactor` — names a
**change category**. `knowledge` names a **subject**. It was a noun sitting in a category
slot, which is why it read wrong; the fix is not to legitimize it by adding it to the set.
The category is `chore`, the subject moves into the descriptive part, and the allowed set
needs no new entry.

This matters now because org ruleset 12515090 was inert (`operator: starts_with` against a
regex pattern, and an empty `ref_name.include`) and has been corrected to `operator: regex`
in **evaluate** mode. Under it, `knowledge/*` would be refused.

## Not changed

The retry loop stays. A transient GitHub 5xx must not strand a green PR (a 502 stranded site
PR #212), and a failed attempt may still have merged server-side, so PR state is consulted
before retrying.