### PR TITLE
chore(ci): every platform leg runs the same test command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,16 +123,15 @@ jobs:
   test:
     # The check context is the platform descriptor, not the runner label: `test (windows-arm64)`,
     # matching ALL_PLATFORMS and the build/<goos>-<goarch> directories. Without an explicit name
-    # GitHub composes the context from every matrix value — `test (windows-11-arm, false)` — which
-    # leaks the image and the race flag into a string the ruleset has to match exactly, and renames
-    # all five contexts the moment another matrix key is added.
+    # GitHub composes the context from every matrix value — `test (windows-11-arm)` — which leaks the
+    # runner image into a string the ruleset has to match exactly, and renames all five contexts the
+    # moment another matrix key is added.
     name: test (${{ matrix.platform }})
     strategy:
       # Every platform reports independently — a failing leg must not cancel the others' evidence.
       fail-fast: false
-      # `include` rather than a bare `os` list because the legs are not uniform: Go's race detector
-      # does not support windows/arm64, so that one leg runs `make test` instead. Naming the
-      # difference in data keeps it from looking like an inconsistency somebody should tidy away.
+      # `include` rather than a bare `os` list so each leg carries its platform descriptor alongside
+      # its runner image. Every leg is otherwise identical -- same step, same command.
       #
       # ubuntu-24.04-arm rather than ubuntu-26.04-arm: `ubuntu-latest` is still Ubuntu 24.04, and
       # 26.04 is a preview image. Matching versions across the pair means the arm64 leg varies
@@ -143,11 +142,11 @@ jobs:
       # is the platform's, not a choice made here — and the descriptor hides it, as it should.
       matrix:
         include:
-          - { platform: darwin-arm64, os: macos-latest, race: true }
-          - { platform: linux-amd64, os: ubuntu-latest, race: true }
-          - { platform: linux-arm64, os: ubuntu-24.04-arm, race: true }
-          - { platform: windows-amd64, os: windows-latest, race: true }
-          - { platform: windows-arm64, os: windows-11-arm, race: false } # race unsupported by Go
+          - { platform: darwin-arm64, os: macos-latest }
+          - { platform: linux-amd64, os: ubuntu-latest }
+          - { platform: linux-arm64, os: ubuntu-24.04-arm }
+          - { platform: windows-amd64, os: windows-latest }
+          - { platform: windows-arm64, os: windows-11-arm }
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -169,23 +168,14 @@ jobs:
           brew install make
           echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
 
-      # -race requires cgo and a C toolchain. Set explicitly rather than relying on the default,
-      # which varies by platform and by whether a compiler is discoverable; the windows runner
-      # ships mingw-w64. `make test-race` depends on `generate`, a chain the scenario job below
-      # already exercises on every platform.
-      - name: Test with race detector
-        if: matrix.race
-        env:
-          CGO_ENABLED: "1"
+      # Identical on every leg. Whether -race is actually applied is the Makefile's decision, taken
+      # by probing the toolchain: Go ships no ThreadSanitizer runtime for windows/arm64, and that is
+      # the sort of fact that rots when a workflow encodes it. When the probe comes back negative the
+      # suite still runs, and `make test-race` emits a ::warning:: annotation so an uninstrumented leg
+      # is visible on the run summary rather than buried in a log. If upstream ever ships that
+      # runtime, the leg starts race-testing with no change here.
+      - name: Test
         run: make test-race
-
-      # Go's race detector supports linux/amd64, linux/ppc64le, linux/arm64, linux/s390x,
-      # linux/loong64, freebsd/amd64, netbsd/amd64, darwin/amd64, darwin/arm64, and windows/amd64 —
-      # windows/arm64 is absent, and no CI configuration changes that. This leg runs the suite
-      # without -race so the platform is still tested, and needs no C toolchain as a result.
-      - name: Test without race detector
-        if: ${{ !matrix.race }}
-        run: make test
 
   # The writ-deploy scenario (docs/plans/writ-deploy-scenario.md, #346): the real binaries driven
   # end-to-end in a pristine sandbox, on every platform (#91 phase-4 audit slice).

--- a/Makefile
+++ b/Makefile
@@ -326,8 +326,38 @@ endif
 test: generate ## Run tests (TAGS=all|integration|e2e|"", default: all)
 	go test $(if $(_TAGS),-tags '$(_TAGS)') $$(go list ./... | grep -v '/pkg/op/provider$$') -timeout 60s
 
+# Whether this toolchain can instrument for the race detector. Asked of the toolchain rather than
+# transcribed from Go's own table (internal/platform.RaceDetectorSupported), which gains ports over
+# time and would drift here. Two distinct failures hide behind a rejected -race, and only one is ours
+# to fix:
+#
+#   "-race requires cgo"                      CGO_ENABLED=0, which this probe sets
+#   "-race is not supported on <goos>/<arch>"  no ThreadSanitizer runtime exists for that target
+#
+# The probe therefore runs with cgo ON, so the second cannot masquerade as the first and silently
+# cost race coverage on a platform that has it. `go list` compiles nothing -- the flag is rejected
+# during validation -- so this costs ~15ms.
+RACE_SUPPORTED := $(shell CGO_ENABLED=1 go list -race errors >/dev/null 2>&1 && echo 1)
+
 test-race: generate ## Run tests with race detector (TAGS=all|integration|e2e|"", default: all)
-	go test $(if $(_TAGS),-tags '$(_TAGS)') $$(go list ./... | grep -v '/pkg/op/provider$$') -count=1 -race -timeout 120s
+	if [ -z "$(RACE_SUPPORTED)" ]; then
+		message="race detector unavailable on $$(go env GOOS)/$$(go env GOARCH) -- tests run UNINSTRUMENTED"
+		# GitHub renders ::warning:: as an annotation on the run summary, so an uninstrumented leg is
+		# visible without opening the log. GITHUB_ACTIONS is unset locally and .SHELLFLAGS carries
+		# nounset, hence the :- default.
+		if [ -n "$${GITHUB_ACTIONS:-}" ]; then
+			echo "::warning title=Race detector unavailable::$$message"
+		fi
+		echo
+		echo "WARNING: $$message"
+		echo
+		race_flags=""
+		export CGO_ENABLED=0
+	else
+		race_flags="-race"
+		export CGO_ENABLED=1
+	fi
+	go test $(if $(_TAGS),-tags '$(_TAGS)') $$(go list ./... | grep -v '/pkg/op/provider$$') -count=1 $$race_flags -timeout 120s
 
 test-scenario: build ## Run every scenario: the real binaries driven end to end in a sandbox
 	# The writ-deploy scenario (docs/plans/writ-deploy-scenario.md) — writ's alone.

--- a/docs/plans/uniform-race-detection.md
+++ b/docs/plans/uniform-race-detection.md
@@ -1,0 +1,76 @@
+---
+title: "Uniform race detection across every platform leg"
+issue: https://github.com/NobleFactor/devlore-cli/issues/XX
+status: draft
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Plan: Uniform race detection across every platform leg
+
+## Summary
+
+`ci.yaml` special-cased windows-arm64: a `race:` column in the matrix, two mutually exclusive
+steps, `CGO_ENABLED` set on one path only, and Go's platform-support table transcribed into a
+YAML comment. Only one fact forced any of it — Go ships no ThreadSanitizer runtime for
+windows/arm64 — and encoding that fact in CI means it rots. This moves the decision into the
+Makefile, where it is probed from the toolchain, and makes every leg run the identical command.
+
+## Current State
+
+| Component | Status |
+| --- | --- |
+| `matrix.race` column | ❌ Encodes a toolchain fact in CI |
+| Two conditional test steps | ❌ Different job internals per platform |
+| Go's support table in a comment | ❌ Drifts as ports gain support |
+| Recovery when upstream ships the blob | ❌ Requires someone to remember |
+
+## Requirements
+
+### The probe must run with cgo enabled
+
+Two distinct failures hide behind a rejected `-race`:
+
+```
+-race requires cgo                        CGO_ENABLED=0 — fixable
+-race is not supported on windows/arm64   no TSan runtime — unfixable
+```
+
+Probing without cgo makes every platform report unsupported and silently drops race coverage
+where it exists. `go list` compiles nothing, so the probe costs ~15ms.
+
+### An uninstrumented leg must be loud
+
+`make test-race` emits a `::warning::` annotation under GitHub Actions so the leg is visible on
+the run summary, plus a plain banner locally. `GITHUB_ACTIONS` is dereferenced as
+`${GITHUB_ACTIONS:-}` because `.SHELLFLAGS` carries `nounset`.
+
+## Implementation Phases
+
+### Phase 1: Makefile
+
+- [x] `RACE_SUPPORTED` probe via `CGO_ENABLED=1 go list -race errors`
+- [x] `test-race` branches on it, setting `race_flags` and `CGO_ENABLED`
+- [x] Warning path verified for local, Actions, and supported cases
+
+### Phase 2: ci.yaml
+
+- [x] Drop the `race:` matrix column
+- [x] Collapse the two steps into one `- name: Test / run: make test-race`
+- [x] Remove the transcribed support table and the stale context-name example
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `Makefile` | Modify | Probe + branching in `test-race` |
+| `.github/workflows/ci.yaml` | Modify | Uniform matrix and single step |
+
+## Not in scope
+
+`goleak` for goroutine-leak detection, which works on windows/arm64 where `-race` cannot. Worth
+doing given the control plane and planned async sidecars, but it is a separate change.
+
+## Open Questions
+
+- [ ] Should a lost `-race` on a platform that previously had it fail the build rather than warn?


### PR DESCRIPTION
Removes the windows-arm64 special case. Every leg now runs `make test-race`, identically.

## Before

```yaml
- { platform: windows-arm64, os: windows-11-arm, race: false } # race unsupported by Go
...
- name: Test with race detector
  if: matrix.race
  env: { CGO_ENABLED: "1" }
  run: make test-race
- name: Test without race detector
  if: ${{ !matrix.race }}
  run: make test
```

## After

```yaml
- { platform: windows-arm64, os: windows-11-arm }
...
- name: Test
  run: make test-race
```

The Makefile probes the toolchain instead:

```make
RACE_SUPPORTED := $(shell CGO_ENABLED=1 go list -race errors >/dev/null 2>&1 && echo 1)
```

**`CGO_ENABLED=1` in the probe is load-bearing.** Two distinct failures hide behind a rejected
`-race`:

| Error | Meaning |
| --- | --- |
| `-race requires cgo` | `CGO_ENABLED=0` — fixable |
| `-race is not supported on windows/arm64` | no ThreadSanitizer runtime — unfixable |

Probing without cgo makes *every* platform report unsupported and silently drops race coverage
where it exists. `go list` compiles nothing, so the probe costs ~15ms.

## The warning

An uninstrumented leg is visible on the run summary, not buried in a log:

```
::warning title=Race detector unavailable::race detector unavailable on windows/arm64 -- tests run UNINSTRUMENTED
```

`GITHUB_ACTIONS` is dereferenced as `${GITHUB_ACTIONS:-}` — `.SHELLFLAGS` carries `nounset`, which
would otherwise abort the recipe locally.

## Why it matters now

`flow.gather` runs a bounded worker pool (`sem`, `WaitGroup`, completion channel) and shares frames
across goroutines by shallow copy; `ControlPlane` holds a mutex and three channels. A control plane
and async sidecars are planned. That code runs on windows/arm64 uninstrumented today, and if
upstream ever ships the runtime this now picks it up with no CI edit.

`goleak` — which is pure Go and *does* work on windows/arm64 — is the complementary change, and is
deliberately not in this PR.