### PR TITLE
fix(ci): pin every workflow to the Go version go.mod declares

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.27"
 
       - name: Get version
         id: version

--- a/.github/workflows/knowledge-extract.yaml
+++ b/.github/workflows/knowledge-extract.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.27"
           cache-dependency-path: devlore-cli/go.sum
 
       - name: Build star tool

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.27'
 
       - name: Determine version and release type
         id: version


### PR DESCRIPTION
`go.mod` requires **go 1.27.0**. Three workflows asked for 1.24.

| Workflow | Before | After |
| --- | --- | --- |
| `ci.yaml` (×3) | 1.27 | 1.27 |
| `docs-publish.yaml` | **1.24** | 1.27 |
| `knowledge-extract.yaml` | **1.24** | 1.27 |
| `release.yaml` | **1.24** | 1.27 |

## Why it was invisible

`GOTOOLCHAIN` is set nowhere, so it defaults to `auto` — Go 1.24 silently downloads and switches to
1.27 on every run. It works, which is why nobody noticed. But the pin was decorative rather than
pinning anything, it costs a toolchain download per run, and the day anyone sets `GOTOOLCHAIN=local`
as hardening, all three break at once.

`release.yaml` is the one that matters: it triggers on `develop` and on `v*` tags, so releases were
built through an unintended toolchain switch.

## Follow-up worth considering

Setting `GOTOOLCHAIN=local` in these workflows would make a future skew fail loudly instead of
silently downloading. Not done here — it is a behaviour change and deserves its own decision.