### PR TITLE
A reloaded number is read against the field it fills

### DIFF
--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -84,6 +84,23 @@ Detailed description.
 - [ ] Task 1
 - [ ] Task 2
 
+## Test Plan
+
+What proves this works, at which level, and how each test is shown to be capable of failing.
+
+| # | What it proves | Level | Fails when |
+| --- | --- | --- | --- |
+| 1 | [the behavior under test] | unit / e2e / scenario | [the defect it catches, restated] |
+
+**Write the failing test first.** A test authored after its fix has to be re-proved by breaking the fix, which
+is slower and sometimes impossible once dependent work has landed.
+
+**Every row names how it fails.** A test that has only ever passed has not been shown to be a test. State the
+change that turns it red, and make that change once before trusting it.
+
+**Say what is NOT covered.** An untested property is a decision, not an oversight, and belongs in writing
+where a reviewer can weigh it.
+
 ## Migration Path
 
 How existing repos/users migrate to this new approach.

--- a/docs/plans/number-fidelity.md
+++ b/docs/plans/number-fidelity.md
@@ -1,7 +1,7 @@
 ---
 title: "A Reloaded Number Is Read Against the Field It Fills"
 issue: 711
-status: draft
+status: complete
 created: 2026-08-27
 updated: 2026-08-27
 ---
@@ -71,14 +71,14 @@ But an improvement to identity is still a change to identity.
 
 | # | Step | ✓ |
 | --- | --- | --- |
-| 1 | A failing test first: an integer parameter, saved as JSON and reloaded, asserted to be an integer | ☐ |
-| 2 | The same test for YAML, pinning the asymmetry closed | ☐ |
-| 3 | Decode JSON with `UseNumber` | ☐ |
-| 4 | Convert each argument to its declared parameter type in `assembleGraph` | ☐ |
-| 5 | **Verify checksums do not move** — save, reload, compare to a stored document | ☐ |
-| 6 | A value too large for its field is an error, not a truncation | ☐ |
-| 7 | `make check`, `test-race`, `test-scenario` | ☐ |
-| 8 | Confirm #709's five save/load failures are resolved by this alone | ☐ |
+| 1 | A failing test first: an integer parameter, saved as JSON and reloaded, asserted to be an integer | ✅ |
+| 2 | The same test for YAML, pinning the asymmetry closed | ✅ |
+| 3 | Decode JSON with `UseNumber` | ✅ |
+| 4 | Convert each argument to its declared parameter type in `assembleGraph` | ✅ |
+| 5 | **Verify checksums do not move** — save, reload, compare to a stored document | ✅ |
+| 6 | A value too large for its field is an error, not a truncation | ✅ |
+| 7 | `make check`, `test-race`, `test-scenario` | ✅ |
+| 8 | Confirm #709's five save/load failures are resolved by this alone | ✅ |
 
 ## Test Plan
 
@@ -116,6 +116,53 @@ have caught the `fs.FileMode` dispatch failure.
   is contained. A changed one means graph identity is in scope and needs a ruling before anything merges.
 - **Step 8 is the reason for the ordering.** #711 exists because #709 turned five save/load tests red. If
   those do not go green on this branch, the diagnosis was wrong and #709 is blocked on something else.
+
+## Step 5's answer: the checksum holds, but only because the rule is narrow
+
+**Numbers only.** The first implementation read *every* decoded value against its declared parameter type,
+which is the honest reading of the rule and is wrong. Handing every value to [Convert] reaches its
+**registered Resource construction** step, so the URI string a resource-typed slot carries was built into a
+`Resource` at load time — and §5.6 of
+[resource-construction.md](resource-construction.md) says that string stays a KEY until dispatch resolves it
+through the run catalog:
+
+> a reloaded graph's resource-typed slot carries the URI string the save left behind; at graph dispatch that
+> string is a KEY … No construction happens at dispatch
+
+The canonical form is computed from those values, so constructing early moved the checksum:
+
+```
+op.LoadGraph: checksum mismatch:
+  document   "sha256:8e5bf1a1…"
+  recomputed "sha256:1bcc33d7…"
+```
+
+That mismatch was the design refusing a rule violation, not a fragile checksum.
+
+Narrowed to numbers — `json.Number`, plus the `int` and `float64` yaml produces — every test passes and the
+checksum is unchanged. So the plan's central bet holds: **this is contained in deserialization and does not
+reach graph identity.** It holds for a reason the plan did not anticipate, and the constraint now lives in a
+comment on `readAgainstField` where the next person will meet it.
+
+A useful consequence: json and yaml now reload to *identical* in-memory values, so the codecs no longer
+disagree — which was a live defect before #709 touched anything.
+
+## Step 8: measured, and the diagnosis holds
+
+#711 exists because #709's category rule turned five save/load tests red. Confirming that this branch
+resolves them needed care, because **checking that those five pass here proves nothing** — they pass on
+`develop` too. They only fail once the rule removes the truncation.
+
+So the guard was pasted onto this branch temporarily and the suite run. Result: all five pass, and exactly one
+failure remains —
+
+```
+TestConvert_HydratesStructFromMap
+  field Count: float64 value is neither assignable nor convertible to int
+```
+
+— which is #709's own, a literal `float64` in a map reaching an `int` field with no json involved. The
+temporary guard was then removed; no remnants.
 
 ## Scope: parameters with a declared type
 

--- a/docs/plans/number-fidelity.md
+++ b/docs/plans/number-fidelity.md
@@ -1,0 +1,133 @@
+---
+title: "A Reloaded Number Is Read Against the Field It Fills"
+issue: 711
+status: draft
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Plan: A Reloaded Number Is Read Against the Field It Fills
+
+**Issue:** [#711](https://github.com/NobleFactor/devlore-cli/issues/711) ·
+**Blocks:** [#709](https://github.com/NobleFactor/devlore-cli/issues/709) ·
+**Excludes:** [#712](https://github.com/NobleFactor/devlore-cli/issues/712) — `any`-typed slots ·
+**Epic:** [#443 — Serialization and the single codec](https://github.com/NobleFactor/devlore-cli/issues/443)
+
+## Summary
+
+JSON has one number type. `LoadGraph` decodes with plain `json.Unmarshal`, so every number in a reloaded
+graph arrives as `float64` — an authored `0o644` reaches an `fs.FileMode` parameter as a float. `op.Convert`
+truncates it back, which is why nothing has noticed.
+
+Two things follow that are true today, before #709 touches anything:
+
+- **The codecs disagree.** `yaml.v3` decodes an integer as `int`. The same graph reloads to different
+  in-memory Go values depending on which codec wrote it.
+- **`float64` cannot represent every `int64`.** A large enough integer in a saved graph is *already* corrupted
+  on reload. Truncation makes the corruption look like a clean number.
+
+## The rule
+
+> **Convert from the value we serialize to the type of the field it fills.**
+
+Preserve the literal through decoding; let the target type decide how to read it.
+
+`json.Decoder.UseNumber()` yields `json.Number`, which keeps the text rather than forcing it through a
+float. The precedent is already in the tree, deliberate and commented — `pkg/result/jq_filter.go:119`.
+
+## Where the conversion belongs, and why it is not obvious
+
+**At assembly, not at parameter binding.** The decode path is registry-aware end-to-end: `assembleGraph`
+resolves each unit's action by short name through `env.Registry`, so the [Method] and its declared parameter
+types are already in scope there. That is the first point where the field's type is known.
+
+Doing it later — lazily, at dispatch — leaves `json.Number` in the graph's in-memory form, and the canonical
+form is computed from that. A `json.Number` renders as a quoted string in YAML where a `float64` renders bare,
+which is exactly the checksum mismatch a prototype produced:
+
+```
+op.LoadGraph: checksum mismatch:
+  document   "sha256:8e5bf1a1…"
+  recomputed "sha256:39ca2d67…"
+```
+
+Converting at assembly means the canonical form never sees a `json.Number` at all.
+
+## The checksum is the risk, and the goal is that it does not move
+
+Graph identity is settled design. **This plan's target is an unchanged checksum**, on the reasoning that
+`fs.FileMode(420)` and `float64(420)` render identically in the canonical YAML — so replacing one with the
+other changes nothing the hash sees.
+
+That is a claim to **verify, not assume**. If checksums do move, this stops being a deserialization fix and
+becomes a change to graph identity, which needs its own ruling against the existing format-identity rulings
+rather than a decision made in passing.
+
+There is an argument the change would be an *improvement*: a canonical form built from declared types no
+longer varies with which codec decoded the document, which is the same asymmetry §the codecs disagree names.
+But an improvement to identity is still a change to identity.
+
+## Steps
+
+| # | Step | ✓ |
+| --- | --- | --- |
+| 1 | A failing test first: an integer parameter, saved as JSON and reloaded, asserted to be an integer | ☐ |
+| 2 | The same test for YAML, pinning the asymmetry closed | ☐ |
+| 3 | Decode JSON with `UseNumber` | ☐ |
+| 4 | Convert each argument to its declared parameter type in `assembleGraph` | ☐ |
+| 5 | **Verify checksums do not move** — save, reload, compare to a stored document | ☐ |
+| 6 | A value too large for its field is an error, not a truncation | ☐ |
+| 7 | `make check`, `test-race`, `test-scenario` | ☐ |
+| 8 | Confirm #709's five save/load failures are resolved by this alone | ☐ |
+
+## Test Plan
+
+| # | What it proves | Level | Fails when |
+| --- | --- | --- | --- |
+| 1 | A JSON-saved integer reloads as an integer | unit | reverting to plain `json.Unmarshal` |
+| 2 | JSON and YAML reload a graph identically | unit | either codec decodes numbers differently |
+| 3 | `0o644` reaches `fs.FileMode` without a `float64` | unit | conversion moves out of `assembleGraph` |
+| 4 | Too large for the field is an error, not a truncation | unit | the range check is dropped |
+| 5 | **A saved document reloads to an identical checksum** | unit | the canonical form sees a new value type |
+| 6 | A graph survives save → reload → run | scenario | any of the above regresses under a real runtime |
+
+**Rows 1 and 2 are written before the fix.** Row 2 fails today for a reason unrelated to #709: `yaml.v3`
+decodes an integer as `int` while JSON yields `float64`, so the asymmetry is a live defect and the test should
+be red on arrival.
+
+**Row 5 is the one that decides the plan.** It is not a regression guard — it is the experiment. An unchanged
+checksum means the fix is contained in deserialization. A changed one means graph identity is in scope and
+needs a ruling before anything merges. Run it before writing step 4, not after.
+
+**Row 6 exists because rows 1–5 all stub the runtime.** #709's failures surfaced through
+`TestJudgmentReloadDispatch` — a scenario, not a unit test — and a unit test over `LoadGraph` alone would not
+have caught the `fs.FileMode` dispatch failure.
+
+### Not covered
+
+- **`any`-typed slots.** Out of scope by ruling; see #712. No test here asserts anything about them, and one
+  that did would encode behavior #712 is going to change.
+- **Non-numeric types through the codecs.** Strings, bools, lists, and dicts survive JSON unambiguously. Not
+  tested here, and worth revisiting if #712 introduces a general envelope.
+
+## Verification
+
+- **Step 5 decides whether this plan is finished or has a second half.** An unchanged checksum means the fix
+  is contained. A changed one means graph identity is in scope and needs a ruling before anything merges.
+- **Step 8 is the reason for the ordering.** #711 exists because #709 turned five save/load tests red. If
+  those do not go green on this branch, the diagnosis was wrong and #709 is blocked on something else.
+
+## Scope: parameters with a declared type
+
+This plan covers **only** parameters whose declared type says how to read the number. That is what makes the
+rule work: an `fs.FileMode` wants an integer, a timeout wants a float, and the preserved literal answers
+either.
+
+**A parameter declared `any` is out of scope**, and not because it is hard — because no load-side fix can
+reach it. `json.Marshal(float64(42))` emits `42`, so a float in an `any` slot loses its type at *save*, before
+anything reloads. `UseNumber` preserves the literal faithfully; the literal simply no longer says "float".
+
+Ruled 2026-08-27: for an `any` slot the **document stores the type**, since with no declared type at either
+end the document is the only place the information can live. That is
+[#712](https://github.com/NobleFactor/devlore-cli/issues/712) — it changes the document format, and it does
+not block this plan. `any`-typed slots keep today's behavior until #712 is decided.

--- a/pkg/op/binding_test.go
+++ b/pkg/op/binding_test.go
@@ -54,7 +54,9 @@ func TestBindings_DocumentRoundTrip_PreservesField(t *testing.T) {
 		"whole":     NewVariableBinding("target"),
 	}
 
-	reloaded := assembleBindings(marshalBindings(bindings))
+	// nil action: these are variable bindings, which name a variable rather than carrying a value, so
+	// no declared parameter type is consulted.
+	reloaded := assembleBindings(marshalBindings(bindings), nil)
 
 	projected, ok := reloaded["projected"].(VariableBinding)
 	if !ok {

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -5,8 +5,10 @@ package op
 
 import (
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -67,6 +69,12 @@ func Convert(runtimeEnvironment *RuntimeEnvironment, value any, target reflect.T
 
 	if value == nil {
 		return reflect.Zero(target).Interface(), nil
+	}
+
+	// Step 0.5: a serialized number, read against the type of the field it fills.
+
+	if v, ok, err := tryParseSerializedNumber(value, target); ok {
+		return v, err
 	}
 
 	// Steps 1-2: identity, the `any` target, and (pointer-dereferenced) assignability/convertibility —
@@ -180,6 +188,64 @@ func convertDirect(value any, target reflect.Type) (any, bool) {
 	}
 
 	return nil, false
+}
+
+// tryParseSerializedNumber handles [Convert]'s step 0.5: a [json.Number] reaching a numeric target.
+//
+// A json document has ONE number type, so unmarshalling into an `any` slot cannot say whether 420 was written
+// as an integer or a float. [LoadGraph] decodes with UseNumber so the literal text survives, and the type of
+// the field being filled is what decides how to read it -- an fs.FileMode wants an integer, a timeout wants a
+// float, and the text answers either without a lossy float64 in between.
+//
+// This is a PARSE, not a numeric conversion, which is why it sits ahead of the direct paths: json.Number is a
+// string kind, and Go will not convert a string to a numeric type at all.
+//
+// Range is enforced by parsing against the target's bit size, so a value the field cannot hold is an error
+// rather than a truncation.
+//
+// Parameters:
+//   - `value`: the value under conversion.
+//   - `target`: the destination type.
+//
+// Returns:
+//   - `parsed`: the number read against the field, when this step applied.
+//   - `applied`: true when this step applied.
+//   - `err`: non-nil when the text does not fit the field.
+func tryParseSerializedNumber(value any, target reflect.Type) (parsed any, applied bool, err error) {
+
+	number, isNumber := value.(json.Number)
+	if !isNumber {
+		return nil, false, nil
+	}
+
+	switch target.Kind() {
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		signed, parseErr := strconv.ParseInt(number.String(), 10, target.Bits())
+		if parseErr != nil {
+			return nil, true, fmt.Errorf("serialized number %s does not fit %s: %w", number, target, parseErr)
+		}
+
+		return reflect.ValueOf(signed).Convert(target).Interface(), true, nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		unsigned, parseErr := strconv.ParseUint(number.String(), 10, target.Bits())
+		if parseErr != nil {
+			return nil, true, fmt.Errorf("serialized number %s does not fit %s: %w", number, target, parseErr)
+		}
+
+		return reflect.ValueOf(unsigned).Convert(target).Interface(), true, nil
+
+	case reflect.Float32, reflect.Float64:
+		floating, parseErr := strconv.ParseFloat(number.String(), target.Bits())
+		if parseErr != nil {
+			return nil, true, fmt.Errorf("serialized number %s does not fit %s: %w", number, target, parseErr)
+		}
+
+		return reflect.ValueOf(floating).Convert(target).Interface(), true, nil
+	}
+
+	return nil, false, nil
 }
 
 // tryConvertSlice handles [Convert]'s step 3: slice → slice element-wise recursion.

--- a/pkg/op/graph.go
+++ b/pkg/op/graph.go
@@ -18,6 +18,7 @@
 package op
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -262,7 +263,15 @@ func LoadGraph(env *RuntimeEnvironment, data []byte, format string) (*Graph, err
 	var p graphData
 	switch strings.ToLower(format) {
 	case "json":
-		if err := json.Unmarshal(data, &p); err != nil {
+		// UseNumber, not plain Unmarshal. Json has ONE number type, so unmarshalling into an `any` slot
+		// yields float64 for every number and an authored integer arrives as a float -- 0o644 reaching an
+		// fs.FileMode by way of float64 is a truncation that happened to be harmless. json.Number keeps the
+		// literal text instead, and [assembleBindings] reads it against the type of the parameter it fills.
+		// Yaml needs none of this: yaml.v3 decodes an integer as an int.
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.UseNumber()
+
+		if err := decoder.Decode(&p); err != nil {
 			return nil, fmt.Errorf("op.LoadGraph: json decode: %w", err)
 		}
 	case "yaml", "yml":

--- a/pkg/op/graph_number_fidelity_test.go
+++ b/pkg/op/graph_number_fidelity_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"encoding/json"
+	"io/fs"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// region Fixture
+
+// numberFidelityFixture carries a method whose parameter has a DECLARED numeric type, which is what #711 is
+// about — the field says how to read the number, so the document does not have to.
+//
+// fs.FileMode is the shape that exposed this: file.mkdir(mode=0o644) reaches a uint32, and a json round trip
+// was handing it a float64 that op.Convert silently truncated back. An `any` parameter would prove something
+// else entirely (#712), because there no declared type exists at either end.
+type numberFidelityFixture struct{ ProviderBase }
+
+// Chmod takes a file mode, the declared-uint32 parameter this test is built around.
+func (p *numberFidelityFixture) Chmod(mode fs.FileMode) error { return nil }
+
+func init() {
+
+	AnnounceProvider(reflect.TypeFor[numberFidelityFixture](), RoleAction,
+		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
+			return &numberFidelityFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
+		},
+		map[string]MethodMetadata{
+			"Chmod": {ParameterNames: []string{"mode"}},
+		})
+}
+
+// numberFidelityGraph builds a one-node graph whose single argument is the integer 0o644.
+func numberFidelityGraph(t *testing.T) *Graph {
+
+	t.Helper()
+
+	action, err := ReceiverRegistry().BuildAction("numberFidelityFixture.chmod")
+	if err != nil {
+		t.Fatalf("BuildAction: %v", err)
+	}
+
+	node, err := NewNode(NewNodeSpec().WithID("chmod").WithAction(action).
+		WithSlot("mode", NewImmediateBinding(int64(0o644))))
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+
+	graph, err := NewGraph(NewGraphSpec().
+		WithOrigin(NewOriginBase("test", "home", NewAnnotationMap(nil))).
+		WithUnits(node).
+		WithTimestamp(time.Unix(1_700_000_000, 0).UTC()))
+	if err != nil {
+		t.Fatalf("NewGraph: %v", err)
+	}
+
+	return graph
+}
+
+// reloadedMode returns the value bound to the graph's single node's "mode" slot.
+func reloadedMode(t *testing.T, graph *Graph) any {
+
+	t.Helper()
+
+	nodes := graph.Nodes()
+	if len(nodes) != 1 {
+		t.Fatalf("graph has %d nodes, want 1", len(nodes))
+	}
+
+	slots := nodes[0].ResolveSlots(nil, nil)
+
+	mode, bound := slots["mode"]
+	if !bound {
+		t.Fatalf("node has no \"mode\" slot; slots are %v", slots)
+	}
+
+	return mode
+}
+
+// TestConvert_SerializedNumberTooLargeForItsFieldIsRefused is row 4 of the #711 test plan.
+//
+// Reading a number against its field means the field's RANGE is part of the answer. A value the parameter
+// cannot hold has to be refused: narrowing it silently produces a plausible number nobody wrote, which is the
+// same defect as the float64 this issue removes, wearing different clothes.
+//
+// Tested against [Convert] rather than through a document, deliberately. Reaching this path from a graph
+// requires a document whose mode literal exceeds uint32, and editing a saved document invalidates its
+// checksum -- so [LoadGraph] refuses it for tampering long before any parameter is read. That ordering is
+// correct and worth stating: integrity is a stronger gate than range, and it runs first. It also means a
+// graph-level test of this behavior would pass without ever reaching the code it claims to cover.
+func TestConvert_SerializedNumberTooLargeForItsFieldIsRefused(t *testing.T) {
+
+	// 2^33: comfortably inside int64, comfortably outside the uint32 an fs.FileMode is.
+	const oversized = json.Number("8589934592")
+
+	got, err := Convert(nil, oversized, reflect.TypeFor[fs.FileMode]())
+	if err == nil {
+		t.Errorf("Convert(%s -> fs.FileMode) = %#v, want an error: the field cannot hold it", oversized, got)
+	}
+}
+
+// TestConvert_SerializedNumberReadsAgainstTheField covers the accepting half.
+//
+// A rule that refuses everything is not a rule. Each of these is a number a document legitimately carries,
+// read against a field that can hold it.
+func TestConvert_SerializedNumberReadsAgainstTheField(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		number json.Number
+		target reflect.Type
+		want   any
+	}{
+		{"file mode", json.Number("420"), reflect.TypeFor[fs.FileMode](), fs.FileMode(0o644)},
+		{"count", json.Number("7"), reflect.TypeFor[int](), 7},
+		{"negative", json.Number("-3"), reflect.TypeFor[int64](), int64(-3)},
+		{"ratio", json.Number("1.5"), reflect.TypeFor[float64](), 1.5},
+		{"integral float stays a float", json.Number("2"), reflect.TypeFor[float64](), 2.0},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			got, err := Convert(nil, testCase.number, testCase.target)
+			if err != nil {
+				t.Fatalf("Convert(%s -> %s): %v", testCase.number, testCase.target, err)
+			}
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("Convert(%s -> %s) = %#v, want %#v", testCase.number, testCase.target, got, testCase.want)
+			}
+		})
+	}
+}
+
+// endregion
+
+// region Tests
+
+// TestLoadGraph_JSONIntegerReloadsAsAnInteger is row 1 of the #711 test plan.
+//
+// json has ONE number type. Decoding into an `any` slot with plain json.Unmarshal yields float64 for every
+// number, so an authored 0o644 comes back as a float and reaches an fs.FileMode parameter as one. Nothing has
+// noticed because op.Convert truncated it back — which is the compensation this issue removes.
+func TestLoadGraph_JSONIntegerReloadsAsAnInteger(t *testing.T) {
+
+	document := serializeGraph(t, numberFidelityGraph(t), "json")
+
+	loaded, err := LoadGraph(formatIdentityEnvironment(t), document, "json")
+	if err != nil {
+		t.Fatalf("LoadGraph(json): %v", err)
+	}
+
+	mode := reloadedMode(t, loaded)
+
+	if _, isFloat := mode.(float64); isFloat {
+		t.Errorf("mode reloaded as float64(%v); an authored integer must not become a float", mode)
+	}
+}
+
+// TestLoadGraph_JSONAndYAMLReloadIdentically is row 2 of the #711 test plan.
+//
+// [TestGraphChecksum_IdenticalAcrossJSONAndYAMLDocuments] proves one graph produces two documents carrying
+// the same STORED checksum — which it must, since both are written from the same in-memory graph. The reverse
+// direction is what has never been tested: two documents, reloaded, recomputing the same checksum.
+//
+// That is where the codecs part company. yaml.v3 decodes an integer as an int; json yields float64. The same
+// graph therefore reloads to different in-memory values depending on which codec wrote it, and the canonical
+// form is computed from those values.
+func TestLoadGraph_JSONAndYAMLReloadIdentically(t *testing.T) {
+
+	graph := numberFidelityGraph(t)
+
+	fromJSON, err := LoadGraph(formatIdentityEnvironment(t), serializeGraph(t, graph, "json"), "json")
+	if err != nil {
+		t.Fatalf("LoadGraph(json): %v", err)
+	}
+
+	fromYAML, err := LoadGraph(formatIdentityEnvironment(t), serializeGraph(t, graph, "yaml"), "yaml")
+	if err != nil {
+		t.Fatalf("LoadGraph(yaml): %v", err)
+	}
+
+	if fromJSON.Checksum() != fromYAML.Checksum() {
+		t.Errorf("reloaded checksums differ by codec: json %q, yaml %q",
+			fromJSON.Checksum(), fromYAML.Checksum())
+	}
+
+	jsonMode := reloadedMode(t, fromJSON)
+	yamlMode := reloadedMode(t, fromYAML)
+
+	if reflect.TypeOf(jsonMode) != reflect.TypeOf(yamlMode) {
+		t.Errorf("mode reloaded as %T from json and %T from yaml; the codecs must agree",
+			jsonMode, yamlMode)
+	}
+}
+
+// endregion

--- a/pkg/op/node.go
+++ b/pkg/op/node.go
@@ -294,20 +294,29 @@ func (n *Node) marshalData() nodeData {
 //
 // Parameters:
 //   - `data`: the document-form slot map (may be nil or empty).
+//   - `action`: the node's resolved action, whose parameter types say how to read a serialized number; nil
+//     when the caller has none, in which case values pass through as decoded.
 //
 // Returns:
 //   - `map[string]Binding`: the live slot map, or nil when `data` is empty.
-func assembleBindings(data map[string]bindingData) map[string]Binding {
+func assembleBindings(data map[string]bindingData, action Action) map[string]Binding {
 
 	if len(data) == 0 {
 		return nil
+	}
+
+	// A nil action carries no declared types, so serialized values pass through as decoded. Only an
+	// immediate binding consults them at all; promise and variable bindings name a unit or a variable.
+	var method *Method
+	if action != nil {
+		method = action.Method()
 	}
 
 	bindings := make(map[string]Binding, len(data))
 	for name, d := range data {
 		switch {
 		case d.Immediate != nil:
-			bindings[name] = NewImmediateBinding(d.Immediate.Value)
+			bindings[name] = NewImmediateBinding(readAgainstField(d.Immediate.Value, method, name))
 		case d.Promise != nil:
 			bindings[name] = NewPromiseBinding(d.Promise.UnitID)
 		case d.Variable != nil:
@@ -346,8 +355,78 @@ func assembleNode(p *nodeData) (*Node, error) {
 		return nil, err
 	}
 
-	node.slots = assembleBindings(p.Slots)
+	node.slots = assembleBindings(p.Slots, action)
 	return node, nil
+}
+
+// readAgainstField reads a decoded slot value against the type of the parameter it fills.
+//
+// Every codec loses something about a number. Json has ONE number type, so an authored integer decodes as a
+// float64 unless the literal is preserved -- [LoadGraph] decodes with UseNumber for exactly that reason. Yaml
+// keeps integers as int but has no notion of the fs.FileMode, time.Duration, or uint32 the parameter actually
+// declares. Neither document can answer what the value IS; only the parameter can.
+//
+// So the declared type decides, whichever codec wrote the document. That is what makes a graph reload to the
+// same in-memory values from json and from yaml, and it is why the canonical form -- computed from those
+// values -- does not vary by codec either.
+//
+// NUMBERS ONLY, and deliberately. Handing every value to [Convert] reaches its resource-construction step,
+// which would build a Resource from the URI string a resource-typed slot carries -- and the §5.6 ruling in
+// docs/plans/resource-construction.md says that string stays a KEY until dispatch resolves it through the
+// run catalog. Converting it here constructs at LOAD time, which the ruling forbids, and it moves the graph's
+// checksum because the canonical form is computed from these values.
+//
+// A slot with no declared type passes through as decoded. An `any` parameter has nothing to read against, and
+// the document does not yet carry the type it would need (#712).
+//
+// A value the field cannot hold also passes through unchanged, so the failure surfaces at dispatch naming the
+// parameter and its type rather than here naming a slot the author never wrote.
+//
+// Parameters:
+//   - `value`: the decoded slot value.
+//   - `method`: the resolved method whose parameter this slot fills; nil when the caller has no action.
+//   - `name`: the slot name, which is the parameter name.
+//
+// Returns:
+//   - `any`: the value read against the field, or the value unchanged.
+func readAgainstField(value any, method *Method, name string) any {
+
+	if method == nil || !isDecodedNumber(value) {
+		return value
+	}
+
+	parameter, declared := method.ParameterByName(name)
+	if !declared || parameter.Type == nil {
+		return value
+	}
+
+	converted, err := Convert(nil, value, parameter.Type)
+	if err != nil {
+		return value
+	}
+
+	return converted
+}
+
+// isDecodedNumber reports whether a decoded slot value is a number a codec may have mistyped.
+//
+// json.Number is what [LoadGraph] preserves rather than letting a number collapse to float64. int and float64
+// are what yaml.v3 produces, and both need reading against the parameter too -- yaml keeps an integer an
+// integer, but has no notion of the fs.FileMode or uint32 the field declares.
+//
+// Parameters:
+//   - `value`: the decoded slot value.
+//
+// Returns:
+//   - `bool`: true when the value is a number this path should read against its field.
+func isDecodedNumber(value any) bool {
+
+	switch value.(type) {
+	case json.Number, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
+	}
+
+	return false
 }
 
 // marshalBindings projects a node's live slot map to its kind-discriminated serialized document form.


### PR DESCRIPTION
Closes #711. Unblocks #709.

JSON has one number type, so unmarshalling into an `any` slot cannot say whether `420` was written as an
integer or a float. `LoadGraph` used plain `json.Unmarshal`, so every number in a reloaded graph came back as
`float64` — an authored `0o644` reached an `fs.FileMode` as a float. Nothing noticed because `op.Convert`
truncated it back: **the conversion layer was compensating for a serialization defect.**

Two things were already true before #709 touched anything:

- **The codecs disagreed.** `yaml.v3` decodes an integer as `int`; JSON yielded `float64`. The same graph
  reloaded to different in-memory values depending on which codec wrote it.
- **`float64` cannot represent every `int64`.** A large enough integer in a saved graph was *already*
  corrupted on reload. Truncation made the corruption look like a clean number.

## The rule

> Convert from the value we serialize to the type of the field it fills.

`LoadGraph` decodes with `UseNumber`, so `json.Number` keeps the literal text. `assembleBindings` reads it
against the parameter — `assembleNode` has already resolved the action through the registry, so the declared
types are in scope at exactly the point the value is bound. YAML goes through the same path: it keeps an
integer an integer, but has no notion of the `fs.FileMode` the field declares.

## Numbers only, and the first implementation got this wrong

Reading **every** value against its field is the literal reading of the rule, and it breaks a ruling. `Convert`
has a *registered Resource construction* step, so the URI string a resource-typed slot carries was built into
a live `Resource` at load time. §5.6 of `docs/plans/resource-construction.md`:

> a reloaded graph's resource-typed slot carries the URI **string** the save left behind; at graph dispatch
> that string is a KEY — it resolves through the section-rehydrated run catalog

The canonical form is computed from those values, so constructing early moved the checksum:

```
op.LoadGraph: checksum mismatch:
  document   "sha256:8e5bf1a1…"
  recomputed "sha256:1bcc33d7…"
```

**That mismatch was the integrity check refusing a rule violation, not a fragile hash.** Narrowing to numbers
is a scope statement rather than a workaround: only numbers are ambiguous coming out of a codec. A string is
already a string, and interpreting it is a decision the design assigned to dispatch.

## Step 5 was the experiment, and it answered

The plan named checksum stability as the question that decides whether this reaches graph identity. Verified
rather than assumed: **checksums are unchanged.** This is contained in deserialization.

## Two tests that passed for the wrong reason

Both caught by asking which path ran, not by trusting a green result.

**The range test** edited a saved document, so `LoadGraph` refused it for a *checksum mismatch* and the test's
early return fired without ever reaching range handling. Moved to `Convert`, where the behavior lives. The
ordering it exposed is worth keeping: integrity is a stronger gate than range and runs first, so a
graph-level range test cannot reach the code it claims to cover.

**Step 8** asked whether this resolves the five save/load failures #709 produced. Running those five here
proves nothing — they pass on `develop` too, and only fail once #709's rule removes the truncation. Pasting
that rule on temporarily: all five pass, and the only remaining failure is #709's own
`convert_struct_test.go`, a literal `float64` in a map reaching an `int` field with no JSON involved.

## Out of scope

An `any` parameter, by ruling — **#712**. `json.Marshal(float64(42))` emits `42`, so a float in an `any` slot
loses its type at *save* and no load-side fix can reach it. There the document must carry the type.

## Also included

`docs/plans/TEMPLATE.md` gains a **Test Plan** section. Zero of 118 plans had one, and the template not
providing it is why. It asks for a "fails when" column per row, failing tests written first, and an explicit
"not covered" list.

## Verified

`make check`, `make test-race`, `make test-scenario` — all pass.
