### PR TITLE
Conversions follow Python's rule: cross-category is an error

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_imm_ui_no_bool.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_ui_no_bool.star
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_imm_ui_no_bool.star — a bool is refused where a string is wanted.
+#
+# Go permits no bool-to-string conversion, so this was already refused before #709 and is pinned
+# here to keep the pair visible: an integer is refused by RULE, a bool by the language. Losing
+# either one silently would be a regression, and only one of them has a guard protecting it.
+
+t.expect_error("string")
+
+print(True)

--- a/cmd/devlore-test/devloretest/data/test_imm_ui_one_string.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_ui_one_string.star
@@ -8,13 +8,11 @@
 # variadic one would receive Go natives after conversion and render True as true, None as <nil>.
 # Requiring str() keeps rendering in starlark, where it is correct by construction.
 #
-# A bool is rejected, which is what this pins.
-#
-# An INT is not, and that is a defect rather than a decision: op.Convert reaches
+# An integer is refused here, which it was not until 2026-08-27. op.Convert reached
 # reflect.Value.Convert, where int64 counts as "convertible" to string and yields the RUNE at that
-# code point -- print(65) emits "A". Tracked separately; it affects every provider method taking a
-# string parameter, not just these. When it is fixed, print(42) belongs in this fixture too.
+# code point -- print(65) emitted "A". #709 made a cross-category conversion an error whatever the
+# value, which is python's rule: str(65) says what an author means, and 65 does not.
 
-t.expect_error("param msg: bool value is neither assignable nor convertible to string")
+t.expect_error(r"write str\(x\) to render it")
 
-print(True)
+print(42)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -366,6 +366,10 @@ func TestImmUI_OneString(t *testing.T) {
 	runScriptImm(t, "test_imm_ui_one_string.star")
 }
 
+func TestImmUI_NoBool(t *testing.T) {
+	runScriptImm(t, "test_imm_ui_no_bool.star")
+}
+
 func TestImmUI_Fail(t *testing.T) {
 	runScriptImm(t, "test_imm_ui_fail.star")
 }

--- a/docs/plans/lossless-conversions.md
+++ b/docs/plans/lossless-conversions.md
@@ -1,7 +1,7 @@
 ---
 title: "Conversions Follow Python's Rule: Cross-Category Is an Error"
 issue: 709
-status: draft
+status: complete
 created: 2026-08-27
 updated: 2026-08-27
 ---
@@ -9,7 +9,7 @@ updated: 2026-08-27
 # Plan: Conversions Follow Python's Rule — Cross-Category Is an Error
 
 **Issue:** [#709](https://github.com/NobleFactor/devlore-cli/issues/709) ·
-**Blocked by:** [#711](https://github.com/NobleFactor/devlore-cli/issues/711) — JSON reload yields float64 ·
+**Unblocked by:** [#711](https://github.com/NobleFactor/devlore-cli/issues/711), merged as #713 ·
 **Epic:** [#444 — The resource model](https://github.com/NobleFactor/devlore-cli/issues/444)
 
 ## Summary
@@ -69,14 +69,55 @@ integer→integer, in range, and stays allowed — which is why the rule cannot 
 
 | # | Step | ✓ |
 | --- | --- | --- |
-| 1 | Failing tests first — all four rows, plus `3.0 → int`, asserting each is rejected | ☐ |
-| 2 | Reject integer→string and float→integer by kind, ahead of the `ConvertibleTo` branch | ☐ |
-| 3 | Range check for integer→integer; out of range is an error | ☐ |
-| 4 | Confirm `0o644 → os.FileMode`, `int64 → float64`, and `string ↔ []byte` still convert | ☐ |
-| 5 | Error messages in Python's voice, naming the fix: `str(x)`, `int(x)` | ☐ |
-| 6 | Sweep for callers that depended on the looseness | ☐ |
-| 7 | `test_imm_ui_one_string.star` gains `print(42)`, which #708 had to leave out | ☐ |
-| 8 | `make check`, `test-race`, `test-scenario` | ☐ |
+| 1 | Failing tests first — all four rows, plus `3.0 → int`, asserting each is rejected | ✅ |
+| 2 | Reject integer→string and float→integer by kind, ahead of the `ConvertibleTo` branch | ✅ |
+| 3 | Range check for integer→integer; out of range is an error | ✅ |
+| 4 | Confirm `0o644 → os.FileMode`, `int64 → float64`, and `string ↔ []byte` still convert | ✅ |
+| 5 | Error messages in Python's voice, naming the fix: `str(x)`, `int(x)` | ✅ |
+| 6 | Sweep for callers that depended on the looseness | ✅ |
+| 7 | `test_imm_ui_one_string.star` gains `print(42)`, which #708 had to leave out | ✅ |
+| 8 | `make check`, `test-race`, `test-scenario` | ✅ |
+
+## Outcome
+
+Complete. `make check`, `make test-race`, and `make test-scenario` all pass.
+
+### #711 was the blocker, and it was the whole blocker
+
+Merging #713 in produced a conflict in `convert.go` — both branches added a step to the same conversion
+ladder. Resolved by keeping **both**, because they are complementary rather than competing:
+
+| Step | |
+| --- | --- |
+| `tryParseSerializedNumber` (#713) | reads a serialized number *against* its field |
+| `losesMeaning` (#709) | refuses conversions that change meaning |
+
+After the merge exactly one test failed — `convert_struct_test.go`, precisely as step 8's measurement
+predicted. Its own doc comment said "an int from a JSON float64", so it was encoding the compensation rather
+than a contract. Now `json.Number("3")`, which is what a json decode actually produces.
+
+### The error messages became real work
+
+"Python's voice" could have been satisfied by rewording a sentence. Done properly it is `explainRefusal`,
+which recognizes the three refusal shapes and names the remedy:
+
+| Refusal | Message |
+| --- | --- |
+| integer → string | `cannot use int64 where string is wanted: write str(x) to render it` |
+| float → integer | `a float64 cannot be interpreted as int: write int(x) to truncate it deliberately` |
+| out of range | `300 is out of range for int8` |
+
+What a script author sees, end to end: `param msg: cannot use int64 where string is wanted: write str(x) to
+render it`. The parameter name comes free from the dispatch layer.
+
+**The test asserts the guidance, not the refusal** — it matches `write str(x)`, not `string`. A test matching
+only `string` passes whether the message helps or not.
+
+### `print(42)` is finally assertable
+
+Row 8 was blocked on #711 and now runs. The bool case moved to its own fixture rather than sharing one: an
+integer is refused **by rule**, a bool **by the language**, and only one of them has a guard protecting it.
+Collapsing them would hide which is which — and which one a regression could silently remove.
 
 ## Test Plan
 

--- a/docs/plans/lossless-conversions.md
+++ b/docs/plans/lossless-conversions.md
@@ -1,0 +1,110 @@
+---
+title: "Conversions Follow Python's Rule: Cross-Category Is an Error"
+issue: 709
+status: draft
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Plan: Conversions Follow Python's Rule — Cross-Category Is an Error
+
+**Issue:** [#709](https://github.com/NobleFactor/devlore-cli/issues/709) ·
+**Blocked by:** [#711](https://github.com/NobleFactor/devlore-cli/issues/711) — JSON reload yields float64 ·
+**Epic:** [#444 — The resource model](https://github.com/NobleFactor/devlore-cli/issues/444)
+
+## Summary
+
+`convertDirect` asks Go whether the source type is `ConvertibleTo` the target and converts if so. Go's answer
+is about *representability*, not meaning, and several conversions it permits silently produce a value the
+author never wrote.
+
+Measured against `op.Convert`:
+
+| Conversion | Result | What happened |
+| --- | --- | --- |
+| `int64(65)` → `string` | `"A"` | the rune at that code point |
+| `int64(300)` → `int8` | `44` | wraparound |
+| `int64(-1)` → `uint8` | `255` | sign reinterpretation |
+| `float64(3.9)` → `int` | `3` | truncation |
+
+All four are silent. No error, no warning, and each result is plausible enough to survive review.
+`float64 → string` and `bool → string` are already rejected, because Go permits neither — and that contrast
+is what makes the integer cases read as deliberate.
+
+## The rule
+
+**Starlark is Python-shaped, so conversions answer to Python's rule rather than Go's.**
+
+> **A cross-category conversion is an error, whatever the value. Within the integer category, the value must
+> be in range.**
+
+Category is decided by kind, not by inspecting the value. Range is the only question a value gets asked, and
+only integer→integer asks it.
+
+| From → To | Verdict | Why |
+| --- | --- | --- |
+| integer → string | **error** | Python never coerces; `str(x)` says it properly |
+| float → integer | **error** | `TypeError: 'float' object cannot be interpreted as an integer` |
+| integer → integer | in range, or **error** | Python's `struct.error: byte format requires -128 <= number <= 127` |
+| integer → float | allow | Python widens implicitly (`1 + 2.0`) |
+| string ↔ `[]byte` | allow, unchanged | see Out of scope |
+
+**`float(3.0) → int` is an error too.** It is integral and survives a round trip, and Python still rejects it:
+`[1,2,3][1.0]` is a `TypeError`. The rule is about category, not about whether this particular value happens
+to be safe. That is the whole reason to prefer it over a round-trip test — a round-trip rule would accept
+`3.0` today and reject `3.9`, which is a distinction no author can predict.
+
+**Integer → string is rejected by kind, not by range.** `65 → "A"` round-trips back to `65`, so a
+value-based check would let it through. Nobody passing `65` to a string parameter means `"A"`.
+
+**The strictness is fair because Starlark has the escape hatches.** `str()`, `int()`, and `float()` all exist.
+An author who means `"65"` writes `str(65)`; one who means `3` writes `int(3.9)`.
+
+## What must keep working
+
+**`file.mkdir(mode=0o644)`.** A Starlark int reaching an `os.FileMode`, which is a `uint32`. This is
+integer→integer, in range, and stays allowed — which is why the rule cannot be "reject int→uint32 by kind".
+
+## Steps
+
+| # | Step | ✓ |
+| --- | --- | --- |
+| 1 | Failing tests first — all four rows, plus `3.0 → int`, asserting each is rejected | ☐ |
+| 2 | Reject integer→string and float→integer by kind, ahead of the `ConvertibleTo` branch | ☐ |
+| 3 | Range check for integer→integer; out of range is an error | ☐ |
+| 4 | Confirm `0o644 → os.FileMode`, `int64 → float64`, and `string ↔ []byte` still convert | ☐ |
+| 5 | Error messages in Python's voice, naming the fix: `str(x)`, `int(x)` | ☐ |
+| 6 | Sweep for callers that depended on the looseness | ☐ |
+| 7 | `test_imm_ui_one_string.star` gains `print(42)`, which #708 had to leave out | ☐ |
+| 8 | `make check`, `test-race`, `test-scenario` | ☐ |
+
+## Verification
+
+- **Step 1 comes first deliberately.** On the previous two branches every test written after its fix had to be
+  re-proved by breaking the fix — twice, and the second time it deadlocked the build. Writing the failing test
+  first makes that proof free.
+- **Step 6 is the risk, and it fired.** The rule turned five save/load tests red with
+  `param mode: float64 ... fs.FileMode`. Not a defect in the rule: `LoadGraph` decodes json with plain
+  `json.Unmarshal`, so every reloaded number is a `float64`, and `Convert` had been truncating it back. That
+  is **[#711](https://github.com/NobleFactor/devlore-cli/issues/711)**, it reaches graph identity because the
+  fix changes recomputed checksums, and it must land before this plan can go green.
+
+- `convert_struct_test.go:41` hydrates a struct from a map with a literal `float64` reaching an `int` field —
+  no json involved. That one encodes the old lenient contract and belongs to this plan, not to #711.
+
+## Placement
+
+The guard belongs in `convertDirect`, which is where the `ConvertibleTo` branch lives. That call is the last
+resort for the whole ladder, so the rule will also govern slice elements, map values, and struct fields.
+**That is intended**, and it is a wider blast radius than the issue title suggests — worth stating here rather
+than discovering in step 6.
+
+## Out of scope, and why
+
+**`string ↔ []byte` stays implicit.** Python requires an explicit `.encode()` / `.decode()`, so a strictly
+Python-shaped surface would make this explicit too. Starlark has a distinct `bytes` type, which makes it a
+real question — and a much wider change than #709, affecting every provider method taking bytes. Separate.
+
+**`bool` where an integer is wanted stays rejected.** Python allows it (`True == 1`); Go says not convertible,
+so we reject today. Python-like would *loosen* this. Not worth loosening: a bool arriving where a number is
+expected is far more likely to be a mistake than an intent.

--- a/docs/plans/lossless-conversions.md
+++ b/docs/plans/lossless-conversions.md
@@ -78,6 +78,47 @@ integer→integer, in range, and stays allowed — which is why the rule cannot 
 | 7 | `test_imm_ui_one_string.star` gains `print(42)`, which #708 had to leave out | ☐ |
 | 8 | `make check`, `test-race`, `test-scenario` | ☐ |
 
+## Test Plan
+
+| # | What it proves | Level | Fails when |
+| --- | --- | --- | --- |
+| 1 | `int64(65) -> string` is refused | unit | the kind check is dropped; it yields `"A"` |
+| 2 | `int64(0) -> string` is refused | unit | the check becomes value-based; `0` round-trips |
+| 3 | `float64(3.9) -> int` is refused | unit | float-to-int is allowed; it yields `3` |
+| 4 | `float64(3.0) -> int` is refused | unit | the rule becomes round-trip instead of category |
+| 5 | `int64(300) -> int8` is refused | unit | the range check is dropped; it wraps to `44` |
+| 6 | `int64(-1) -> uint8` is refused | unit | as above; it yields `255` |
+| 7 | `0o644 -> uint32`, `int64 -> float64`, `string <-> []byte` still convert | unit | the rule overreaches |
+| 8 | `print(42)` is refused at the starlark surface | e2e | the guard does not reach dispatch |
+
+**Rows 1-6 were written before the fix, and each failed for its documented reason.** That output is the bug
+report: `Convert(65 -> string) = "A"`, `Convert(0 -> string) = "\x00"`, `Convert(300 -> int8) = 44`,
+`Convert(-1 -> uint8) = 0xff`.
+
+**Row 4 is the ruling made executable.** A round-trip rule accepts `3.0` and refuses `3.9`; the category rule
+refuses both. Nothing else in the suite distinguishes them, so without this row someone could "simplify" the
+guard back into the unpredictable version and every other test would still pass.
+
+**Row 2 is why the string check is by kind.** `0` round-trips through `"\x00"` and back, so a value-based
+check lets it through and emits a NUL byte.
+
+**Row 7 is the counterweight.** A rule that rejects everything is not a rule. `file.mkdir(mode=0o644)` depends
+on integer-to-integer in range, so this row passed before the fix and must keep passing after.
+
+**Row 8 is blocked on [#711](https://github.com/NobleFactor/devlore-cli/issues/711).**
+`test_imm_ui_one_string.star` currently pins the bool rejection and names the integer gap in a comment;
+`print(42)` joins it once reload stops producing floats.
+
+### Not covered
+
+- **`bool` where an integer is wanted.** Rejected today because Go says not convertible; python would allow it
+  (`True == 1`). Left rejected deliberately, so no test asserts the python behavior — we are not adopting it.
+- **`string <-> []byte` made explicit.** Python requires `.encode()` / `.decode()`. Out of scope, and a test
+  here would encode a decision not yet made.
+- **Conversions reached through slice elements, map values, and struct fields.** The guard sits in
+  `convertDirect`, which those paths funnel through, so they are covered by construction rather than by a
+  test naming each one. `convert_struct_test.go` exercises the struct path incidentally.
+
 ## Verification
 
 - **Step 1 comes first deliberately.** On the previous two branches every test written after its fix had to be

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -163,16 +163,14 @@ func explainRefusal(value any, target reflect.Type) error {
 	sourceKind, targetKind := source.Kind(), target.Kind()
 
 	switch {
-	case targetKind == reflect.String && (isSignedInteger(sourceKind) || isUnsignedInteger(sourceKind)):
+	case targetKind == reflect.String && isInteger(sourceKind):
 		return fmt.Errorf("cannot use %s where %s is wanted: write str(x) to render it", source, target)
 
-	case (isSignedInteger(targetKind) || isUnsignedInteger(targetKind)) &&
-		(sourceKind == reflect.Float32 || sourceKind == reflect.Float64):
+	case isInteger(targetKind) && isFloat(sourceKind):
 		return fmt.Errorf("a %s cannot be interpreted as %s: write int(x) to truncate it deliberately",
 			source, target)
 
-	case (isSignedInteger(sourceKind) || isUnsignedInteger(sourceKind)) &&
-		(isSignedInteger(targetKind) || isUnsignedInteger(targetKind)):
+	case isInteger(sourceKind) && isInteger(targetKind):
 		return fmt.Errorf("%v is out of range for %s", value, target)
 	}
 
@@ -259,37 +257,49 @@ func convertDirect(value any, target reflect.Type) (any, bool) {
 //   - `bool`: true when the conversion must be refused.
 func losesMeaning(elem reflect.Value, target reflect.Type) bool {
 
-	source := elem.Kind()
+	source, destination := elem.Kind(), target.Kind()
+
+	switch {
 
 	// A string target reached from a number. Only integers are ConvertibleTo string in Go -- float and bool
-	// already fail earlier -- and an integer arriving here means a rune conversion nobody asked for.
-	if target.Kind() == reflect.String && (isSignedInteger(source) || isUnsignedInteger(source)) {
+	// fail earlier -- and an integer arriving here means a rune conversion nobody asked for.
+	case destination == reflect.String && isInteger(source):
 		return true
-	}
 
 	// An integer target reached from a float, fractional or not.
-	if (isSignedInteger(target.Kind()) || isUnsignedInteger(target.Kind())) &&
-		(source == reflect.Float32 || source == reflect.Float64) {
+	case isInteger(destination) && isFloat(source):
 		return true
-	}
 
 	// Integer to integer: the one pair whose value decides.
-	if (isSignedInteger(source) || isUnsignedInteger(source)) &&
-		(isSignedInteger(target.Kind()) || isUnsignedInteger(target.Kind())) {
-
+	case isInteger(source) && isInteger(destination):
 		return integerLosesValue(elem, target)
-	}
 
 	// Float to float: narrowing that overflows silently yields ±Inf. Precision loss does not count -- python
-	// packs 0.1 into a single-precision float without complaint and only raises when the value will not fit.
-	if (source == reflect.Float32 || source == reflect.Float64) &&
-		(target.Kind() == reflect.Float32 || target.Kind() == reflect.Float64) {
-
+	// packs 0.1 into a single-precision float without complaint and raises only when the value will not fit.
+	case isFloat(source) && isFloat(destination):
 		return !math.IsInf(elem.Float(), 0) && math.IsInf(elem.Convert(target).Float(), 0)
 	}
 
 	return false
 }
+
+// isInteger reports whether kind is any of Go's integer kinds, signed or unsigned.
+//
+// Parameters:
+//   - `kind`: the reflect kind under test.
+//
+// Returns:
+//   - `bool`: true for int through int64 and uint through uint64.
+func isInteger(kind reflect.Kind) bool { return isSignedInteger(kind) || isUnsignedInteger(kind) }
+
+// isFloat reports whether kind is one of Go's floating-point kinds.
+//
+// Parameters:
+//   - `kind`: the reflect kind under test.
+//
+// Returns:
+//   - `bool`: true for float32 and float64.
+func isFloat(kind reflect.Kind) bool { return kind == reflect.Float32 || kind == reflect.Float64 }
 
 // integerLosesValue reports whether an integer-to-integer conversion changes the value.
 //

--- a/pkg/op/convert.go
+++ b/pkg/op/convert.go
@@ -170,7 +170,7 @@ func convertDirect(value any, target reflect.Type) (any, bool) {
 		if elem.Type().AssignableTo(target) {
 			return elem.Interface(), true
 		}
-		if elem.Type().ConvertibleTo(target) {
+		if elem.Type().ConvertibleTo(target) && !losesMeaning(elem, target) {
 			return elem.Convert(target).Interface(), true
 		}
 	}
@@ -180,6 +180,81 @@ func convertDirect(value any, target reflect.Type) (any, bool) {
 	}
 
 	return nil, false
+}
+
+// losesMeaning reports whether a conversion Go permits would produce a value the author did not write.
+//
+// [reflect.Type.ConvertibleTo] answers a question about REPRESENTABILITY, and Go's answer is yes to several
+// conversions that silently change meaning: an integer becomes the rune at its code point, a wide integer
+// wraps into a narrow one, a negative reinterprets as unsigned, and a float loses its fraction.
+//
+// Starlark is python-shaped, so the rule here is python's rather than Go's: a cross-category conversion is an
+// error whatever the value, and within the integer category the value must be in range. str(), int(), and
+// float() exist for an author who means the conversion, and their rendering is correct by construction.
+//
+//	int -> string     rejected by kind. 65 would become "A". A value check cannot catch this: 65 round-trips
+//	                  back to 65, and 0 round-trips through "\x00". Only the kinds tell the truth.
+//	float -> int      rejected by kind, INCLUDING an integral float. python rejects [1,2,3][1.0] though 1.0 is
+//	                  integral, and a rule that took 3.0 but refused 3.9 is one no author could predict.
+//	int -> int        allowed in range, rejected outside it. file.mkdir(mode=0o644) reaches an os.FileMode --
+//	                  a uint32 -- so this pair cannot be rejected by kind.
+//	int -> float      allowed. python widens implicitly, as in 1 + 2.0.
+//
+// Parameters:
+//   - `elem`: the dereferenced source value.
+//   - `target`: the destination type.
+//
+// Returns:
+//   - `bool`: true when the conversion must be refused.
+func losesMeaning(elem reflect.Value, target reflect.Type) bool {
+
+	source := elem.Kind()
+
+	// A string target reached from a number. Only integers are ConvertibleTo string in Go -- float and bool
+	// already fail earlier -- and an integer arriving here means a rune conversion nobody asked for.
+	if target.Kind() == reflect.String && (isSignedInteger(source) || isUnsignedInteger(source)) {
+		return true
+	}
+
+	// An integer target reached from a float, fractional or not.
+	if (isSignedInteger(target.Kind()) || isUnsignedInteger(target.Kind())) &&
+		(source == reflect.Float32 || source == reflect.Float64) {
+		return true
+	}
+
+	// Integer to integer: the one pair whose value decides. Convert and convert back; a value that does not
+	// return unchanged was truncated, wrapped, or had its sign reinterpreted.
+	if (isSignedInteger(source) || isUnsignedInteger(source)) &&
+		(isSignedInteger(target.Kind()) || isUnsignedInteger(target.Kind())) {
+
+		return !elem.Convert(target).Convert(elem.Type()).Equal(elem)
+	}
+
+	return false
+}
+
+// isSignedInteger reports whether kind is one of Go's signed integer kinds.
+//
+// Parameters:
+//   - `kind`: the reflect kind under test.
+//
+// Returns:
+//   - `bool`: true for int through int64.
+func isSignedInteger(kind reflect.Kind) bool {
+	return kind >= reflect.Int && kind <= reflect.Int64
+}
+
+// isUnsignedInteger reports whether kind is one of Go's unsigned integer kinds.
+//
+// Uintptr is deliberately excluded: it is an address, not a number an author writes.
+//
+// Parameters:
+//   - `kind`: the reflect kind under test.
+//
+// Returns:
+//   - `bool`: true for uint through uint64.
+func isUnsignedInteger(kind reflect.Kind) bool {
+	return kind >= reflect.Uint && kind <= reflect.Uint64
 }
 
 // tryConvertSlice handles [Convert]'s step 3: slice → slice element-wise recursion.

--- a/pkg/op/convert_numeric_semantics_test.go
+++ b/pkg/op/convert_numeric_semantics_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package op
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// region Numeric semantics (#709)
+
+// TestNumericSemantics_MatchPython enumerates every numeric conversion class and the rule that decides it.
+//
+// Starlark is python-shaped, so conversions answer to python's rule rather than Go's: a cross-category
+// conversion is an error whatever the value, and within a category the value must survive. This table is the
+// whole of that contract in one place — the accepting cases and the refusing ones together, because a rule
+// stated only by its refusals cannot be checked for overreach.
+//
+// Each row names the python behavior it mirrors. Where devlore deliberately DIFFERS from python, the row
+// lives in [TestNumericSemantics_DeliberateDeviationsFromPython] instead, so a deviation can never hide here
+// as an untested assumption.
+func TestNumericSemantics_MatchPython(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name    string
+		value   any
+		target  reflect.Type
+		refused bool
+		python  string
+	}{
+		// --- cross-category: refused whatever the value ---
+		{
+			name: "integer to string", value: int64(65), target: reflect.TypeFor[string](),
+			refused: true,
+			python:  `"x" + 65 raises TypeError; str(65) is how an author says it`,
+		},
+		{
+			name: "integer zero to string", value: int64(0), target: reflect.TypeFor[string](),
+			refused: true,
+			python:  "same rule; 0 is here because it round-trips through a string and back, so only a kind check refuses it",
+		},
+		{
+			name: "rune to string", value: 'A', target: reflect.TypeFor[string](),
+			refused: true,
+			python:  "a rune is an int32; chr(65) is explicit in python for the same reason",
+		},
+		{
+			name: "float to integer, fractional", value: 3.9, target: reflect.TypeFor[int](),
+			refused: true,
+			python:  "'float' object cannot be interpreted as an integer",
+		},
+		{
+			name: "float to integer, integral", value: 3.0, target: reflect.TypeFor[int](),
+			refused: true,
+			python:  "[1,2,3][1.0] raises TypeError though 1.0 is integral: the rule is category, not value",
+		},
+		{
+			name: "string to integer", value: "42", target: reflect.TypeFor[int](),
+			refused: true,
+			python:  "int(\"42\") is required; python never coerces a string to a number",
+		},
+		{
+			name: "float to string", value: 1.5, target: reflect.TypeFor[string](),
+			refused: true,
+			python:  "str(1.5) is required; Go refuses this one too, so no guard is involved",
+		},
+
+		// --- within the integer category: the value decides ---
+		{
+			name: "file mode, in range", value: int64(0o644), target: reflect.TypeFor[uint32](),
+			refused: false,
+			python:  "struct.pack('I', 0o644) succeeds; this is what file.mkdir(mode=...) depends on",
+		},
+		{
+			name: "widening", value: int64(300), target: reflect.TypeFor[int64](),
+			refused: false,
+			python:  "an int is an int; python has one integer type and no width to overflow",
+		},
+		{
+			name: "too wide for the target", value: int64(300), target: reflect.TypeFor[int8](),
+			refused: true,
+			python:  "struct.error: byte format requires -128 <= number <= 127",
+		},
+		{
+			name: "negative to unsigned", value: int64(-1), target: reflect.TypeFor[uint8](),
+			refused: true,
+			python:  "struct.error: argument out of range",
+		},
+		{
+			name: "unsigned above the signed range, same width", value: uint64(math.MaxUint64), target: reflect.TypeFor[int64](),
+			refused: true,
+			python: "struct.error: argument out of range. Same width means signed and unsigned share a bit " +
+				"pattern, so a round trip returns the original and hides the sign flip; sign is asked about directly",
+		},
+
+		// --- widening into the float category: python does this implicitly ---
+		{
+			name: "integer to float", value: int64(7), target: reflect.TypeFor[float64](),
+			refused: false,
+			python:  "1 + 2.0 == 3.0; python widens an int to a float without being asked",
+		},
+		{
+			name: "integer beyond float64's exact range", value: int64(9007199254740993), target: reflect.TypeFor[float64](),
+			refused: false,
+			python: "float(9007199254740993) silently returns 9007199254740992.0. Python loses this precision " +
+				"too, so refusing it would be stricter than python rather than truer to it",
+		},
+		{
+			name: "float widening", value: float32(1.5), target: reflect.TypeFor[float64](),
+			refused: false,
+			python:  "a widening loses nothing",
+		},
+
+		// --- within the float category ---
+		{
+			name: "float narrowing that loses precision", value: 0.1, target: reflect.TypeFor[float32](),
+			refused: false,
+			python: "struct.pack('f', 0.1) succeeds and quietly stores 0.100000001490116. Precision loss is " +
+				"not an error in python, and is not one here",
+		},
+		{
+			name: "float narrowing that overflows", value: 1e40, target: reflect.TypeFor[float32](),
+			refused: true,
+			python: "struct.error: argument out of range. The distinction from the row above is exactly " +
+				"python's: precision may be lost, magnitude may not",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			got, err := Convert(nil, testCase.value, testCase.target)
+
+			switch {
+			case testCase.refused && err == nil:
+				t.Errorf("Convert(%#v -> %s) = %#v, want a refusal.\npython: %s",
+					testCase.value, testCase.target, got, testCase.python)
+
+			case !testCase.refused && err != nil:
+				t.Errorf("Convert(%#v -> %s) was refused (%v), want it to convert.\npython: %s",
+					testCase.value, testCase.target, err, testCase.python)
+			}
+		})
+	}
+}
+
+// TestNumericSemantics_DeliberateDeviationsFromPython pins the places devlore does NOT follow python.
+//
+// A deviation recorded only in prose is an assumption. These rows assert the behavior we actually chose, so
+// changing one is a decision someone has to make on purpose rather than a test quietly going green.
+func TestNumericSemantics_DeliberateDeviationsFromPython(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name    string
+		value   any
+		target  reflect.Type
+		refused bool
+		python  string
+		why     string
+	}{
+		{
+			name: "bool where an integer is wanted", value: true, target: reflect.TypeFor[int](),
+			refused: true,
+			python:  "[1,2,3][True] == 2; python's bool IS an int subclass",
+			why: "STRICTER than python, deliberately. Go permits no bool-to-int conversion, so this is " +
+				"refused by the language rather than by a guard -- and a bool arriving where a number is " +
+				"expected is far likelier to be a mistake than an intent",
+		},
+		{
+			name: "integer where a bool is wanted", value: 1, target: reflect.TypeFor[bool](),
+			refused: true,
+			python:  "if 1: is truthy; python accepts any object where a bool is wanted",
+			why:     "STRICTER than python. Same reasoning: an accidental 1 should not silently mean true",
+		},
+		{
+			name: "string to bytes", value: "hi", target: reflect.TypeFor[[]byte](),
+			refused: false,
+			python:  `"hi".encode() is required; python will not implicitly encode a str to bytes`,
+			why: "LOOSER than python. Starlark has a distinct bytes type, so making this explicit is a real " +
+				"question -- and one that touches every provider method taking bytes, so it is deferred " +
+				"rather than decided here",
+		},
+		{
+			name: "bytes to string", value: []byte("hi"), target: reflect.TypeFor[string](),
+			refused: false,
+			python:  `b"hi".decode() is required`,
+			why:     "LOOSER than python, for the same reason as the row above",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			got, err := Convert(nil, testCase.value, testCase.target)
+
+			switch {
+			case testCase.refused && err == nil:
+				t.Errorf("Convert(%#v -> %s) = %#v, want a refusal.\npython: %s\nours: %s",
+					testCase.value, testCase.target, got, testCase.python, testCase.why)
+
+			case !testCase.refused && err != nil:
+				t.Errorf("Convert(%#v -> %s) was refused (%v), want it to convert.\npython: %s\nours: %s",
+					testCase.value, testCase.target, err, testCase.python, testCase.why)
+			}
+		})
+	}
+}
+
+// endregion

--- a/pkg/op/convert_struct_test.go
+++ b/pkg/op/convert_struct_test.go
@@ -4,6 +4,7 @@
 package op
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -24,13 +25,18 @@ type convertOuter struct {
 	Refs  []convertInner `json:"refs"`
 }
 
-// TestConvert_HydratesStructFromMap reconstructs a nested struct from a map[string]any, with an int from a JSON
-// float64 and slices of both scalars and structs.
+// TestConvert_HydratesStructFromMap reconstructs a nested struct from a map[string]any, with an int read from
+// a serialized number and slices of both scalars and structs.
+//
+// The count was float64(3) until 2026-08-27, which encoded a compensation rather than a contract: json has one
+// number type, so decoding yielded a float for every number and Convert truncated it back to an int. #711
+// removed the truncation and #713 removed the float -- a json document now decodes with UseNumber, so an
+// authored 3 arrives as json.Number("3") and is read against the field it fills. This fixture says that.
 func TestConvert_HydratesStructFromMap(t *testing.T) {
 
 	source := map[string]any{
 		"name":  "x",
-		"count": float64(3),
+		"count": json.Number("3"),
 		"inner": map[string]any{"tag": "t"},
 		"tags":  []any{"a", "b"},
 		"refs":  []any{map[string]any{"tag": "r1"}, map[string]any{"tag": "r2"}},

--- a/pkg/op/convert_test.go
+++ b/pkg/op/convert_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -300,6 +301,41 @@ func TestConvert_WideningAndCategoryPreservingStillWork(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, testCase.want) {
 				t.Errorf("Convert(%#v -> %s) = %#v, want %#v", testCase.value, testCase.target, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestConvert_RefusalNamesTheRemedy pins the message, not merely the refusal.
+//
+// The error is the only feedback a starlark author gets, and "int64 value is neither assignable nor
+// convertible to string" is Go's vocabulary for their mistake -- it says what failed and not what to write
+// instead. Python answers these three with a sentence that names the fix, and starlark has str(), int(), and
+// float() to offer.
+//
+// Asserting the guidance rather than just the failure is what keeps it: a test matching only "string" passes
+// whether the message helps or not.
+func TestConvert_RefusalNamesTheRemedy(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		value  any
+		target reflect.Type
+		want   string
+	}{
+		{"integer to string offers str", int64(65), reflect.TypeFor[string](), "write str(x)"},
+		{"float to integer offers int", 3.9, reflect.TypeFor[int](), "write int(x)"},
+		{"out of range says so", int64(300), reflect.TypeFor[int8](), "out of range"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			_, err := Convert(nil, testCase.value, testCase.target)
+			if err == nil {
+				t.Fatalf("Convert(%#v -> %s) succeeded; want a refusal", testCase.value, testCase.target)
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Errorf("Convert(%#v -> %s) said %q, want it to contain %q",
+					testCase.value, testCase.target, err, testCase.want)
 			}
 		})
 	}

--- a/pkg/op/convert_test.go
+++ b/pkg/op/convert_test.go
@@ -223,3 +223,86 @@ func TestTypesAreInterconvertible(t *testing.T) {
 		})
 	}
 }
+
+// region Python-shaped conversion rules (#709)
+
+// TestConvert_CrossCategoryIsAnError pins the rule starlark authors actually experience.
+//
+// [Convert] used to ask Go whether the source was ConvertibleTo the target and convert if so. Go answers a
+// question about REPRESENTABILITY, not about meaning, and it says yes to conversions that silently produce a
+// value nobody wrote: an integer becomes the rune at its code point, a wide integer wraps into a narrow one,
+// a negative reinterprets as unsigned, and a float loses its fraction.
+//
+// Starlark is python-shaped, so the rule is python's: a cross-category conversion is an error whatever the
+// value, and within the integer category the value must be in range. str(), int(), and float() exist for
+// authors who mean the conversion, and their rendering is correct by construction.
+func TestConvert_CrossCategoryIsAnError(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		value  any
+		target reflect.Type
+		why    string
+	}{
+		{"integer to string", int64(65), reflect.TypeFor[string](),
+			`yielded "A", the rune at code point 65; an author who means "65" writes str(65)`},
+
+		{"integer to string, rejected by kind not by range", int64(0), reflect.TypeFor[string](),
+			"0 round-trips through a string and back, so only a kind check can reject it"},
+
+		{"float to integer, fractional", 3.9, reflect.TypeFor[int](),
+			"yielded 3, discarding the fraction"},
+
+		{"float to integer, integral", 3.0, reflect.TypeFor[int](),
+			"python rejects [1,2,3][1.0] though 1.0 is integral: the rule is category, not value"},
+
+		{"integer too wide for the target", int64(300), reflect.TypeFor[int8](),
+			"yielded 44, wrapping around int8"},
+
+		{"negative integer to an unsigned target", int64(-1), reflect.TypeFor[uint8](),
+			"yielded 255, reinterpreting the sign bit"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			got, err := Convert(nil, testCase.value, testCase.target)
+			if err == nil {
+				t.Errorf("Convert(%#v -> %s) = %#v, want an error: %s",
+					testCase.value, testCase.target, got, testCase.why)
+			}
+		})
+	}
+}
+
+// TestConvert_WideningAndCategoryPreservingStillWork guards the other half.
+//
+// A rule that rejects everything is not a rule. Each of these is a conversion python performs, or one the
+// tree depends on, and each must survive: file.mkdir(mode=0o644) reaches an os.FileMode, which is a uint32,
+// so integer-to-integer in range cannot be rejected by kind.
+func TestConvert_WideningAndCategoryPreservingStillWork(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		value  any
+		target reflect.Type
+		want   any
+	}{
+		{"integer widens to float, as python does implicitly", int64(7), reflect.TypeFor[float64](), 7.0},
+		{"integer to a wider integer", int64(300), reflect.TypeFor[int64](), int64(300)},
+		{"file mode: integer to uint32, in range", int64(0o644), reflect.TypeFor[uint32](), uint32(0o644)},
+		{"string to bytes", "hi", reflect.TypeFor[[]byte](), []byte("hi")},
+		{"bytes to string", []byte("hi"), reflect.TypeFor[string](), "hi"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			got, err := Convert(nil, testCase.value, testCase.target)
+			if err != nil {
+				t.Fatalf("Convert(%#v -> %s): %v", testCase.value, testCase.target, err)
+			}
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("Convert(%#v -> %s) = %#v, want %#v", testCase.value, testCase.target, got, testCase.want)
+			}
+		})
+	}
+}
+
+// endregion


### PR DESCRIPTION
Closes #709. Depends on #713, merged in.

`convertDirect` asked Go whether the source was `ConvertibleTo` the target and converted if so. Go's answer is
about **representability**, not meaning, and it says yes to conversions that silently produce a value nobody
wrote.

## Four defects, found while scoping

| Conversion | Was | What happened |
| --- | --- | --- |
| `int64(65)` → `string` | `"A"` | the rune at that code point |
| `int64(300)` → `int8` | `44` | wraparound |
| `int64(-1)` → `uint8` | `255` | sign reinterpreted |
| `float64(3.9)` → `int` | `3` | fraction discarded |

All silent. `float64 → string` and `bool → string` were already refused because Go permits neither — and that
contrast is what made the integer cases read as deliberate.

## The rule

Starlark is Python-shaped, so conversions answer to Python's rule rather than Go's:

> **A cross-category conversion is an error whatever the value. Within the integer category, the value must be
> in range.**

**Why category and not a round trip.** A round-trip rule *accepts* `float(3.0) → int`, since it survives the
trip, while refusing `3.9`. Python rejects both — `[1,2,3][1.0]` is a `TypeError` though `1.0` is integral. A
rule that takes `3.0` and refuses `3.9` is one no author can predict.

**Integer → string is refused by kind, not by range.** `65` round-trips back to `65` and `0` round-trips
through `"\x00"`, so only the kinds tell the truth.

`file.mkdir(mode=0o644)` reaches an `os.FileMode` — a `uint32` — so integer-to-integer in range cannot be
refused by kind either. That pair is why the rule needs both halves.

## Two more defects, found after the rule was written and passing

The rule was implemented, merged, and covered by eight tests. Enumerating the *full* numeric surface — rather
than the six cases the rule was written from — found two more still standing.

**`float64(1e40) → float32` yielded `+Inf`.** Unguarded: `losesMeaning` covered int→string, float→int, and
int→int, and never looked at float→float.

**`uint64(max) → int64` yielded `-1`.** This one is not missing coverage but a hole in the **method**. The
round-trip check converts and converts back — and signed and unsigned of *equal width* share a bit pattern, so
`MaxUint64 → -1 → MaxUint64` compares equal and passes. The check only ever worked when the widths differed.
More rows in the same shape would never have found it.

`integerLosesValue` now asks about sign directly before falling back to the round trip.

**Precision versus magnitude** is the design content of the float fix, and it is Python's line:
`struct.pack('f', 0.1)` succeeds and quietly stores `0.100000001490116`; `1e40` raises `struct.error`. So
`0.1 → float32` still converts and `1e40 → float32` does not.

## A refused conversion names the remedy

`int64 value is neither assignable nor convertible to string` is Go's vocabulary for a Starlark author's
mistake — it says what failed, not what to write. `explainRefusal` answers each shape the way Python does,
naming a function Starlark has:

```
param msg: cannot use int64 where string is wanted: write str(x) to render it
a float64 cannot be interpreted as int: write int(x) to truncate it deliberately
300 is out of range for int8
```

The test asserts the **guidance**, matching `write str(x)` rather than `string`. A test matching only
`string` passes whether the message helps or not.

## Tests

**`TestNumericSemantics_MatchPython`** — 17 rows, accepting *and* refusing. A rule stated only by its refusals
cannot be checked for overreach. Each row names the Python behavior it mirrors, and that string prints on
failure.

**`TestNumericSemantics_DeliberateDeviationsFromPython`** — the four places we knowingly differ.
`bool ↔ int` is **stricter** than Python, whose `bool` is an `int` subclass (`[1,2,3][True] == 2`);
`string ↔ []byte` is **looser**, since Python requires `.encode()`. Splitting these out is the point: a
deviation recorded only in prose is an assumption, and here changing one is a decision someone makes on
purpose rather than a test quietly going green.

Plus the six original rows, written before the fix and each proved failing first, and `print(42)` at the
Starlark surface — which was blocked on #713 and previously printed `*`.

## Also included

`convert_struct_test.go` hydrated a struct from a map with a literal `float64` reaching an `int` field. Its own
doc comment said "an int from a JSON float64", so it encoded the compensation #711 removed rather than a
contract. Now `json.Number("3")`.

## Verified

`make check`, `make test-race`, `make test-scenario` — all pass.
