### PR TITLE
Root applies to every surface, and the rename plan says what is stale about it

### DIFF
--- a/docs/architecture/3.6-method-classification.md
+++ b/docs/architecture/3.6-method-classification.md
@@ -141,6 +141,19 @@ runtime being built:
 scenario for planning the planner. Absent, a provider is eligible for both. The value maps onto `ProviderRole`'s
 dispatch zone, so `RoleModule` now means *eligible for a module surface* rather than *immediate mode*.
 
+The composition with `+devlore:root=true`, which sets the orthogonal placement bit:
+
+| `+devlore:surface=` | Roles | with `+devlore:root=true` |
+| --- | --- | --- |
+| *absent* — the default | `RoleModule\|RoleAction` | `RoleModule\|RoleAction\|RoleRoot` |
+| `graph` | `RoleAction` | `RoleAction\|RoleRoot` |
+| `module` | `RoleModule` | `RoleModule\|RoleRoot` |
+
+**Root applies to every surface the provider reaches**, from the one bit. `flow` is `surface=graph`, so its
+root placement shows only under `plan.*`; `ui` holds both dispatch bits, so `+devlore:root=true` gives a script
+`note(...)` *and* a graph `plan.note(...)`. Intended: a name is promoted because it reads better without its
+qualifier, which is as true of a graph as of a script.
+
 `starlarkbridge.Hermetic()` applies the filter at install time. A provider with nothing to offer is skipped in
 silence; a provider whose every method is refused installs with each attribute denied, so the author hears about
 it where they reached for it — `shell.exec is not available in this runtime: this runtime is hermetic and the

--- a/docs/guides/provider-development.md
+++ b/docs/guides/provider-development.md
@@ -57,6 +57,29 @@ type Provider struct {
 |---|---|---|
 | `+devlore:lifetime` | `stateless`, `phase`, `session` | `stateless` |
 | `+devlore:bind` | `Field=CfgField` | none |
+| `+devlore:surface` | `graph`, `module` | both |
+| `+devlore:root` | `true` | `false` |
+
+### How `surface` and `root` become roles
+
+`+devlore:surface=` decides which **dispatch** zones a provider holds; `+devlore:root=true` sets the
+**placement** bit. The two are orthogonal, and the generator composes them:
+
+| `+devlore:surface=` | Roles | with `+devlore:root=true` |
+|---|---|---|
+| *absent* — the default | `RoleModule\|RoleAction` | `RoleModule\|RoleAction\|RoleRoot` |
+| `graph` | `RoleAction` | `RoleAction\|RoleRoot` |
+| `module` | `RoleModule` | `RoleModule\|RoleRoot` |
+
+Absent is the default because a graph accepts anything with an action signature, and module membership is
+decided per **method** per runtime from its claims — never per provider. Only two providers declare a surface,
+and they are opposites: `flow` is `graph` (its methods *are* the graph combinators and mean nothing outside
+one) and `plan` is `module` (there being no scenario for planning the planner).
+
+**`root` applies to every surface the provider reaches.** One bit, both namespaces. A provider with the
+default surface and `root=true` surfaces flat in both: `ui` gives a script `note(...)` and a graph
+`plan.note(...)` from a single directive. That is intended — a name is promoted because it reads better
+without its qualifier, and that is as true of a graph as of a script.
 
 ## Method directives
 

--- a/docs/plans/workflow-rename.md
+++ b/docs/plans/workflow-rename.md
@@ -8,6 +8,17 @@ updated: 2026-05-30
 
 # Plan: Rename op → workflow
 
+> **Read this first.** The prerequisite below is **satisfied** — `refactor/extract-starlark-from-op.phase-8`
+> merged long ago — but the plan has not been revisited since **2026-05-26**, and every quantity in its
+> Current State is now wrong. See §Staleness. Two issues carry the work to fix that:
+>
+> - [#716](https://github.com/NobleFactor/devlore-cli/issues/716) — re-audit, and write the name-mapping
+>   appendix this plan lacks
+> - [#715](https://github.com/NobleFactor/devlore-cli/issues/715) — rename the provider roles, which belongs
+>   in the same window; #716 blocks it
+>
+> Do not start a phase from the numbers below.
+
 ## Summary
 
 Rename the `op` package to `workflow` and adopt a coherent flow-control vocabulary across its core types. `ExecutableUnit` becomes `Node` — the abstract vertex — and its two variants become `Step` (the leaf, was `Node`) and `Block` (the composite, was `Subgraph`). The durable execution record `RecoveryStack` becomes `Ledger`. The container/driver pair `Graph` / `GraphExecutor` becomes `Definition` / `Executor`, making the intent-vs-reality dichotomy explicit at the type level.
@@ -25,9 +36,11 @@ This is a pure rename project. No behavior changes, no signature changes, no sco
 
 ## Prerequisites
 
-This work cannot start until the in-flight upstream PR (`refactor/extract-starlark-from-op.phase-8`) merges to `develop`. Starting earlier creates intractable merge conflicts in `pkg/op/`.
+~~This work cannot start until the in-flight upstream PR (`refactor/extract-starlark-from-op.phase-8`) merges to `develop`.~~ **Satisfied.** That branch is gone from the remote and phase 8 has landed.
 
-The plan stays in `draft` status until then. Branch creation, GitHub issue creation, and the first phase begin only after develop is current.
+The real prerequisite now is [#716](https://github.com/NobleFactor/devlore-cli/issues/716): the plan's own
+facts are three months stale, and a phase started from them would be scoped against a package 74% smaller than
+the one that exists.
 
 ## Current State (audited 2026-05-26)
 
@@ -49,6 +62,32 @@ The plan stays in `draft` status until then. Branch creation, GitHub issue creat
 | Qualified `op.X` references | ~2,499 | non-test + test combined | |
 | Generated files in scope | 29 `.gen.go` | `pkg/op/provider/*/gen/` + `pkg/op/inventory/` | regenerate via `make build` |
 | Name collisions for new names | `Step` (cross-package only) | repo-wide | `Block`, `Ledger`, `Workflow`, `Definition`, `Executor` are all unused elsewhere. `Step` has no language-level clash: the only existing type is `console.Step` in `internal/console` (a TUI session step, different package); the `pkg/op` "Step" hits are comment prose ("Step 3 fires…"), not identifiers. |
+
+### Staleness (measured 2026-08-27)
+
+Every quantity above is wrong. [#716](https://github.com/NobleFactor/devlore-cli/issues/716) re-audits it.
+
+| Element | Audited 2026-05-26 | Measured 2026-08-27 | |
+| --- | --- | --- | --- |
+| `pkg/op/` root `.go` files | 62 | **108** | +74% |
+| `provider/` files | 76 | **238** | +213% |
+| `starlarkbridge/` files | 5 | **8** | +60% |
+| Generated `.gen.go` | 29 | **48** | +66% |
+| Qualified `op.X` references | ~2,499 | **3,880** | +55% |
+| Files importing `pkg/op` | ~200 | 130 | methodology may differ |
+
+**The subpackage list is wrong in both directions.** Audited as `provider/`, `starlarkbridge/`, `inventory/`,
+`sops/`. Today: `claimcheck/`, `inventory/`, `provider/`, `server/`, `starlarkbridge/` — `sops/` has left, and
+`claimcheck/` and `server/` arrived afterwards. Every line reference in the table above has shifted.
+
+**What still holds.** All five renames remain well-formed, and the collision claim survives: `Step` is declared
+only in `internal/console`, while `Block`, `Ledger`, `Definition`, `Executor`, and `Workflow` are declared
+nowhere. Phase 1 before Phase 2 is still the only ordering constraint.
+
+**New evidence for the target.** `plan.Provider` now exposes `AssembleDefinition`, `LoadDefinition`, and
+`SaveDefinition` — all returning `*op.Graph` — and scripts read `plan.assemble_definition(...)`. The API
+already calls a graph a *definition* while the Go type is still `Graph`. The rename closes a gap that has
+widened on its own since the audit, rather than imposing a new word.
 
 ## Taxonomy Target
 
@@ -77,6 +116,51 @@ workflow
 | 5 | package `op` | package `workflow` | package + directory move | confirmed |
 
 Sequencing is collision-safe: Phase 1 must precede Phase 2 (frees the name `Node`). All other phases are independent.
+
+### Appendix: Name Mapping — TO BE WRITTEN
+
+The table above is five rows: the top-level types, one per phase. **Nothing maps the derived identifiers**, and
+goal 4 promises "each phase is a pure rename so reviewers can verify by inspection" — without the appendix a
+reviewer has no reference to inspect the diff against.
+
+It is derivable, since there are no structural changes. Scope, measured 2026-08-27:
+
+| Word | Exported identifiers containing it |
+| --- | --- |
+| `Graph` | **53** |
+| `Subgraph` | **37** |
+| `RecoveryStack` | **18** |
+| `ExecutableUnit` | 3 |
+
+Plus **14 files** whose names carry a renamed word: `graph.go`, `graph_executor.go`, `subgraph.go`,
+`nodeid.go`, `executable_unit.go`, `recovery_stack.go`, and their tests.
+
+**Three classes need judgment, not derivation.**
+
+`Node` is ambiguous by construction — it maps to `Step` *and* is the target of `ExecutableUnit`, so it appears
+on both sides of the mapping. Every identifier containing it needs a decision about which sense it carries.
+The proof is `GenerateNodeID`, whose doc says "unique node IDs across all plan bindings" and which
+`pkg/op/provider/flow/helpers.go` calls as:
+
+```go
+GenerateNodeID(string(Subgraph))
+```
+
+It mints ids for **subgraphs too**, so it names the abstract vertex — which under the new taxonomy is `Node`,
+meaning **it keeps its name**. A mechanical `Node → Step` sweep would rename it `GenerateStepID` and quietly
+make it wrong: an identifier claiming to mint leaf ids while minting them for `Block`s as well. Phase 1 before
+Phase 2 protects the *types* from this collision; nothing protects derived identifiers.
+
+File names are not all mechanical either. `graph.go` → `definition.go` and `graph_executor.go` → `executor.go`
+are clear; `nodeid.go` follows whatever `GenerateNodeID` decides.
+
+And prose inside identifiers — `SerializeGraphs`, `descendantNodes`, `SubgraphChild`, `NewGraphSpec` — reads
+differently after the swap, some of it carrying the same ambiguity.
+
+**Identifiers that KEEP their name must be listed explicitly.** A table of only the changes cannot distinguish
+"correctly unchanged" from "missed", and `GenerateNodeID` is exactly that case.
+
+Written under [#716](https://github.com/NobleFactor/devlore-cli/issues/716).
 
 ## Implementation Phases
 
@@ -190,6 +274,20 @@ Method: I grep each old name → enumerate locations → produce one batched edi
 - **`RecoverySite` rename.** The name is accurate as-is (a persistent stash from which content can be recovered). Family-coherence with `Ledger` is not a reason to rename.
 - **Materializing a concrete `Slot` type.** Currently only `SlotValue` interface exists. Promoting `Slot` to a real type is a design change, not a rename — separate effort.
 - **Other vocabulary cleanup.** Anything not in the rename mapping above.
+
+## Related Rename: the provider roles
+
+`+devlore:surface=graph` produces `RoleAction` and `+devlore:surface=module` produces `RoleModule` — two
+vocabularies for one idea, connected only by a switch in `generate.star`. An author writes `graph`, the
+generated code says `Action`.
+
+This rename forces the issue: `Graph` becomes `Definition`, so `surface=graph` will name a type that no longer
+exists, and `module` is starlark's word for a namespace rather than a term in the new taxonomy. **Neither
+current word survives.**
+
+Belongs in this window rather than before or after it — doing it separately means renaming twice, and doing it
+after means shipping a constant named for the type it replaced. Tracked as
+[#715](https://github.com/NobleFactor/devlore-cli/issues/715), blocked on #716.
 
 ## Open Questions
 

--- a/pkg/op/receiver_registry.go
+++ b/pkg/op/receiver_registry.go
@@ -396,8 +396,16 @@ func (r *receiverRegistry) Planners() []ProviderReceiverType { return r.planners
 // RootProviders returns every provider with the [RoleRoot] placement-zone bit set.
 //
 // Root providers surface their methods flat at their access-defined namespace root rather than nested under the
-// provider's own name. Callers that need a specific dispatch mode filter the returned slice further via
-// [ProviderRole.Dispatch] — e.g., plan.Provider filters to RoleAction to discover its planner-primitive peers.
+// provider's own name.
+//
+// The list is NOT filtered by dispatch zone, and callers are not expected to filter it. Root placement applies to
+// every surface a provider reaches: a RoleModule|RoleAction|RoleRoot provider surfaces flat in BOTH namespaces, as
+// top-level globals for a module surface and directly under plan.* for the graph. ui is the case — note() in a
+// script and plan.note() in a graph, from one directive.
+//
+// This comment previously said callers filter to a dispatch mode and named plan.Provider as the example.
+// plan.Provider does not filter, and the behavior that describes was never implemented; corrected 2026-08-27
+// after ui became the first RoleModule|RoleAction|RoleRoot provider and made the difference observable.
 //
 // Returns:
 //   - `[]ProviderReceiverType`: sorted by receiver name.

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -64,6 +64,15 @@ const (
 	// plan.* (e.g., plan.choose) rather than plan.<provider>.* (e.g., plan.flow.choose). For a RoleModule provider,
 	// this means the methods appear as top-level starlark globals (e.g., note()) rather than under the provider name
 	// (e.g., ui.note()).
+	//
+	// ONE BIT, EVERY SURFACE, and deliberately. Placement is orthogonal to dispatch, so a provider holding both
+	// dispatch bits surfaces flat in both namespaces from a single +devlore:root=true. ui is that case: note() in a
+	// script AND plan.note() in a graph. There is no way to be root in one zone and nested in the other, because
+	// there is nothing a provider could mean by asking for it — a name is promoted because it reads better without
+	// its qualifier, and that is as true of a graph as of a script.
+	//
+	// flow never exposed this: it is +devlore:surface=graph, so it holds one dispatch bit and one placement bit is
+	// obviously sufficient. ui, arriving 2026-08-27, was the first provider with both.
 	RoleRoot ProviderRole = 1 << (iota + 8)
 
 	// Bits 9–15 reserved for future placement modifiers.


### PR DESCRIPTION
Documentation only. Two commits, independently reviewable.

## 1. Three corrections in `pkg/op`, all surfaced by `ui`

`ui` became the first `RoleModule|RoleAction|RoleRoot` provider in #708, which made three differences
observable that had never been exercised.

**`RootProviders` described a filter that does not exist.** Its doc said callers filter the returned slice by
dispatch zone, and named `plan.Provider` as the example that "filters to RoleAction". It does not —
`buildPromotedBuiltins` passes `registry.RootProviders()` through untouched, so every method of every root
provider is promoted into `plan.*`. **The code is correct; the comment described an intent never implemented.**

Why nobody noticed: `flow` is the only other root provider and it is `surface=graph`, so it holds one dispatch
bit. The distinction between "root everywhere" and "root on the action surface" had no observable consequence
until a provider held both.

**`RoleRoot` now states its intent.** One bit, every surface, deliberately. A provider holding both dispatch
bits surfaces flat in both namespaces from a single `+devlore:root=true` — `note()` in a script *and*
`plan.note()` in a graph. There is no way to be root in one zone and nested in the other, and nothing a
provider could mean by asking: a name is promoted because it reads better without its qualifier, and that is
as true of a graph as of a script.

**The surface-to-role mapping existed only in `generate.star`,** as a switch, with no prose anywhere. The
provider-development guide's directive table listed `lifetime` and `bind` and omitted **both** `surface` and
`root`.

| `+devlore:surface=` | Roles | with `+devlore:root=true` |
| --- | --- | --- |
| *absent* — the default | `RoleModule\|RoleAction` | `RoleModule\|RoleAction\|RoleRoot` |
| `graph` | `RoleAction` | `RoleAction\|RoleRoot` |
| `module` | `RoleModule` | `RoleModule\|RoleRoot` |

Now in the guide and in `3.6-method-classification.md`, both carrying the root-applies-everywhere rule, so a
reader arriving at either gets it.

## 2. The rename plan says what is stale about it

`docs/plans/workflow-rename.md` presented 2026-05-26 measurements as current and claimed a prerequisite
satisfied months ago. Every finding lived in issues the plan did not reference, so a reader arriving there got
stale facts with no sign a re-audit was chartered.

| Element | Audited 2026-05-26 | Measured 2026-08-27 | |
| --- | --- | --- | --- |
| `pkg/op/` root `.go` files | 62 | **108** | +74% |
| `provider/` files | 76 | **238** | +213% |
| Qualified `op.X` references | ~2,499 | **3,880** | +55% |

The subpackage list is wrong in both directions — `sops/` has left, `claimcheck/` and `server/` arrived.

**What still holds:** all five renames are well-formed, and the collision claim survives (`Step` declared only
in `internal/console`).

**New evidence for the target:** `plan.Provider` now exposes `AssembleDefinition`, `LoadDefinition`, and
`SaveDefinition`, all returning `*op.Graph`, and scripts read `plan.assemble_definition(...)`. The API already
calls a graph a *definition* while the Go type is still `Graph`. The rename closes a gap that widened on its
own, rather than imposing a new word.

**Appendix: Name Mapping — TO BE WRITTEN.** The Rename Mapping section is five rows of top-level types;
nothing maps the derived identifiers. 53 exported identifiers contain `Graph`, 37 contain `Subgraph`, 18
contain `RecoveryStack`, and 14 files carry a renamed word in their name. Goal 4 promises reviewers can verify
by inspection — without this appendix there is nothing to inspect against.

The section works through why it needs judgment rather than derivation. `Node` is ambiguous by construction:
it maps to `Step` **and** is the target of `ExecutableUnit`. `GenerateNodeID` is the proof —
`flow/helpers.go` calls it as `GenerateNodeID(string(Subgraph))`, so it mints ids for subgraphs and names the
**abstract vertex**, which under the new taxonomy keeps the name `Node`. A mechanical `Node → Step` sweep
would rename it `GenerateStepID` and quietly make it wrong.

Status stays `draft`. Leaving draft is #716's last acceptance item and should not happen while the numbers are
annotated rather than re-measured.

## Tracked

- **#715** — rename the provider roles: `surface=graph` produces `RoleAction`, and the rename retires both words
- **#716** — re-audit the plan and write the appendix; blocks #715

## Verified

`make check`, `make test-race`, and `scripts/Test-GuideFrontmatter.sh` all pass.
