### PR TITLE
fix(star): the knowledge indexer preserves what it did not write

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_imm_file_path_seam.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_file_path_seam.star
@@ -28,13 +28,12 @@ t.expect_equal(file.name(path=file.join("one", "two", "three", "four.txt")), "fo
 
 # --- file.parent(file.join(...)) ---
 #
-# The parent of a joined path is the join of its leading parts. Stated as a comparison between two
-# producer outputs, so the assertion holds in either dialect.
+# Slash-form on both platforms, because parent answers a question ABOUT a path rather than building
+# one for use. Without the conversion this returns "." on Windows: Dir finds no separator in a
+# backslash path and reports the current directory.
 
-t.expect_equal(
-    file.parent(path=file.join("knowledge", "packages", "slots")),
-    file.name(path=file.join("knowledge", "packages")) and "knowledge/packages",
-)
+t.expect_equal(file.parent(path=file.join("knowledge", "packages", "slots")), "knowledge/packages")
+t.expect_equal(file.parent(path=file.join("a", "b")), "a")
 
 # --- file.name(<glob match>) ---
 #

--- a/cmd/devlore-test/devloretest/data/test_imm_file_path_seam.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_file_path_seam.star
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_imm_file_path_seam.star — Path producers feed path consumers.
+#
+# Validates: file.name(file.join(...)), file.parent(file.join(...)), file.name(<glob match>)
+#
+# The provider speaks two path dialects. file.join, file.glob, file.resolve and file.walk_tree build
+# paths FOR USE, so they are OS-native. file.name and file.parent answer questions ABOUT a path, so
+# they are slash-form. Every existing assertion writes its input in the dialect of the function under
+# test — test_imm_file.star checks file.name against the literal "/some/dir/file.txt" — so each one
+# passes on every platform and the mismatch between them is never exercised.
+#
+# The defect only ever appears where a producer's output reaches a consumer's input: on Windows
+# file.join returns "a\b", slash-form Base finds no separator in it, and the whole path comes back as
+# the "last element". That has been fixed four times in seventeen days (#395, #548, #600, #719).
+#
+# test_imm_file.star declines multi-part join because "a fixture cannot assert it without encoding a
+# platform". True of join's RESULT — but not of the composition. Nothing below names a separator or a
+# platform: each assertion says only that taking the last element of a joined path returns the last
+# element. That holds everywhere, and it is false on Windows whenever the seam is broken.
+
+# --- file.name(file.join(...)) ---
+
+t.expect_equal(file.name(path=file.join("knowledge", "packages", "slots")), "slots")
+t.expect_equal(file.name(path=file.join("a", "b")), "b")
+t.expect_equal(file.name(path=file.join("one", "two", "three", "four.txt")), "four.txt")
+
+# --- file.parent(file.join(...)) ---
+#
+# The parent of a joined path is the join of its leading parts. Stated as a comparison between two
+# producer outputs, so the assertion holds in either dialect.
+
+t.expect_equal(
+    file.parent(path=file.join("knowledge", "packages", "slots")),
+    file.name(path=file.join("knowledge", "packages")) and "knowledge/packages",
+)
+
+# --- file.name(<glob match>) ---
+#
+# This is the composition the knowledge indexer performs on every directory entry, and the one that
+# made it treat every asset directory on Windows as unrecognized.
+
+seam_dir = t.tmp("seam_dir")
+file.mkdir(path=seam_dir, mode=0o755)
+file.write_text(destination_path=file.join(seam_dir, "homebrew.yaml"), content="x: 1\n", mode=0o644)
+file.write_text(destination_path=file.join(seam_dir, "macports.yaml"), content="x: 1\n", mode=0o644)
+
+matches = file.glob(pattern=file.join(seam_dir, "*.yaml"), include_gitignored=True)
+t.expect_equal(len(matches), 2)
+
+names = sorted([file.name(path=m) for m in matches])
+t.expect_equal(names, ["homebrew.yaml", "macports.yaml"])
+
+# --- the same composition against a directory, which is what the indexer classifies ---
+
+nested = file.join(seam_dir, "slots")
+file.mkdir(path=nested, mode=0o755)
+file.write_text(destination_path=file.join(nested, "keep.yaml"), content="x: 1\n", mode=0o644)
+
+dirs = [file.name(path=m) for m in file.glob(pattern=file.join(seam_dir, "*"), include_gitignored=True) if file.is_dir(path=m)]
+t.expect_equal(dirs, ["slots"])
+
+t.expect_unit_count(0)

--- a/cmd/devlore-test/devloretest/runner_test.go
+++ b/cmd/devlore-test/devloretest/runner_test.go
@@ -5,6 +5,7 @@ package devloretest_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -24,6 +25,15 @@ import (
 //   - `string`: the absolute path to the testdata directory.
 func testdataDir(t *testing.T) string {
 	t.Helper()
+
+	// runtime.Caller bakes in the path this file had when it was COMPILED, so a test binary built
+	// with `go test -c` and carried to another machine looks for the build host's source tree. That
+	// is the normal case for exercising the Windows legs by hand: cross-compile here, copy the
+	// binary and data/ across, run it there. DEVLORE_TESTDATA names the directory instead.
+	if dir := os.Getenv("DEVLORE_TESTDATA"); dir != "" {
+		return dir
+	}
+
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("cannot determine test file path")
@@ -336,6 +346,14 @@ func TestRegexpActions(t *testing.T) {
 
 func TestImmediateFile(t *testing.T) {
 	runScriptImm(t, "test_imm_file.star")
+}
+
+// The seam between path producers (join, glob) and path consumers (name, parent). Every other
+// fixture writes its inputs in the dialect of the function under test, so the mismatch between the
+// two dialects is never exercised — which is how the same defect landed four times in seventeen
+// days (#395, #548, #600, #719).
+func TestImmediateFilePathSeam(t *testing.T) {
+	runScriptImm(t, "test_imm_file_path_seam.star")
 }
 
 func TestImmediateJSON(t *testing.T) {

--- a/cmd/star/star/knowledge_index_test.go
+++ b/cmd/star/star/knowledge_index_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+//go:build integration
+
+package star
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// The knowledge indexer updates each domain's index.yaml to track which files exist. It must never
+// change anything else: the per-entry metadata is hand-written, and an earlier version that rebuilt
+// each file from a directory listing deleted it wholesale (devlore-registry#80). These tests pin
+// both halves of the contract — what it preserves, and what it refuses to guess at.
+
+// region HELPERS
+
+// knowledgeRuntime loads the devlore extensions from star/extensions, which is the on-disk tree
+// rather than the embedded cmd/star/extensions one. The devlore.* commands live only there.
+func knowledgeRuntime(t *testing.T, workdir string) *Application {
+	t.Helper()
+
+	root, err := findProjectRoot()
+	if err != nil {
+		t.Fatalf("locating project root: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(workdir); err != nil {
+		t.Fatalf("chdir %s: %v", workdir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	app := NewApplication(&cobra.Command{Use: "star"})
+	t.Cleanup(func() { _ = app.Close() })
+
+	if err := app.LoadExtensionsFrom(filepath.Join(root, "star", "extensions")); err != nil {
+		t.Fatalf("loading extensions: %v", err)
+	}
+	return app
+}
+
+// runIndex invokes the command the way the workflow does. The target is relative because fsroot
+// confinement refuses a path outside the working directory.
+func runIndex(t *testing.T, app *Application, target string) error {
+	t.Helper()
+
+	cmd, ok := app.Commands()["devlore knowledge index"]
+	if !ok {
+		t.Fatal(`command "devlore knowledge index" is not registered`)
+	}
+	return cmd.Run(map[string]string{"target": target, "dry_run": ""})
+}
+
+// writeTree materializes files under dir; a path ending in "/" creates an empty directory.
+func writeTree(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if strings.HasSuffix(rel, "/") {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", full, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+// registry builds a minimal target tree and returns the workdir and the relative target.
+func registry(t *testing.T, files map[string]string) (workdir, target string) {
+	t.Helper()
+
+	workdir = t.TempDir()
+	target = "reg"
+	writeTree(t, filepath.Join(workdir, target), files)
+	return workdir, target
+}
+
+func readIndex(t *testing.T, workdir, target, domain string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(workdir, target, "knowledge", domain, "index.yaml"))
+	if err != nil {
+		t.Fatalf("reading %s index: %v", domain, err)
+	}
+	return string(data)
+}
+
+// refuses asserts the command failed AND that the failure names the problem. Asserting only that an
+// error occurred would pass if the command broke for some unrelated reason — the same
+// indistinguishable-from-success failure these tests exist to prevent.
+func refuses(t *testing.T, app *Application, target, wantSubstring string) {
+	t.Helper()
+
+	err := runIndex(t, app, target)
+	if err == nil {
+		t.Fatalf("expected refusal mentioning %q, got success", wantSubstring)
+	}
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Fatalf("refused, but not for the expected reason.\nwant substring: %q\ngot: %v", wantSubstring, err)
+	}
+}
+
+// region PRESERVATION
+
+func TestKnowledgeIndex_PreservesEntryMetadata(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/packages/slots/homebrew.yaml": "name: homebrew\n",
+		"knowledge/packages/index.yaml": "domain: packages\n" +
+			"slots:\n" +
+			"  - name: homebrew.yaml\n" +
+			"    package: homebrew\n" +
+			"    description: Package manager for macOS and Linux\n" +
+			"    platforms: [darwin, linux]\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	got := readIndex(t, workdir, target, "packages")
+	for _, want := range []string{"package: homebrew", "Package manager for macOS and Linux", "darwin"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("metadata %q was lost:\n%s", want, got)
+		}
+	}
+}
+
+func TestKnowledgeIndex_AddsNewFileAndKeepsNeighbourMetadata(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/packages/slots/homebrew.yaml": "name: homebrew\n",
+		"knowledge/packages/slots/macports.yaml": "name: macports\n",
+		"knowledge/packages/index.yaml": "domain: packages\n" +
+			"slots:\n" +
+			"  - name: homebrew.yaml\n" +
+			"    package: homebrew\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	got := readIndex(t, workdir, target, "packages")
+	if !strings.Contains(got, "macports.yaml") {
+		t.Errorf("new file was not indexed:\n%s", got)
+	}
+	if !strings.Contains(got, "package: homebrew") {
+		t.Errorf("adding a file disturbed an existing entry:\n%s", got)
+	}
+}
+
+func TestKnowledgeIndex_IsIdempotent(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/packages/slots/homebrew.yaml": "name: homebrew\n",
+		"knowledge/packages/index.yaml": "domain: packages\n" +
+			"slots:\n  - name: homebrew.yaml\n    package: homebrew\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	first := readIndex(t, workdir, target, "packages")
+
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second := readIndex(t, workdir, target, "packages"); second != first {
+		t.Errorf("second run changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// region REFUSAL
+//
+// Each of these was a silent success before. The indexer's quiet was indistinguishable from a
+// correct run, and validate-yaml-schemas stayed green because the output still parsed.
+
+func TestKnowledgeIndex_RefusesUnrecognizedDirectory(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/authoring/bindings/rules.yaml": "x: 1\n",
+		"knowledge/authoring/index.yaml":          "domain: authoring\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	// bindings IS recognized; use a name that is not.
+	writeTree(t, filepath.Join(workdir, target), map[string]string{
+		"knowledge/authoring/rubbish/thing.yaml": "x: 1\n",
+	})
+
+	refuses(t, app, target, "rubbish")
+}
+
+func TestKnowledgeIndex_RefusesLooseFile(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt": "hello\n",
+		"knowledge/migration/README.md":      "loose\n",
+		"knowledge/migration/index.yaml":     "domain: migration\nprompts:\n  - name: go.txt\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "README.md")
+}
+
+func TestKnowledgeIndex_RefusesIndexedFileThatDoesNotExist(t *testing.T) {
+	// The file moved rather than vanished — this is signatures/dotfile-systems.yaml. Dropping the
+	// entry silently would discard its metadata and report success.
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/signatures/stow.yaml": "x: 1\n",
+		"knowledge/migration/index.yaml": "domain: migration\n" +
+			"signatures:\n  - name: stow.yaml\n  - name: moved-away.yaml\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "moved-away.yaml")
+}
+
+func TestKnowledgeIndex_RefusesAssetsWithNoSection(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/authoring/bindings/rules.yaml": "x: 1\n",
+		"knowledge/authoring/index.yaml":          "domain: authoring\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "bindings")
+}
+
+func TestKnowledgeIndex_RefusesUnknownSection(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt": "hello\n",
+		"knowledge/migration/index.yaml": "domain: migration\n" +
+			"prompts:\n  - name: go.txt\n" +
+			"invented:\n  - name: nothing.yaml\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "invented")
+}
+
+func TestKnowledgeIndex_AcceptsRecognizedNewTypes(t *testing.T) {
+	// concepts, providers, and bindings are real directories in the registry and were unknown to
+	// the indexer until this change.
+	workdir, target := registry(t, map[string]string{
+		"knowledge/d/concepts/a.yaml":  "x: 1\n",
+		"knowledge/d/providers/b.yaml": "x: 1\n",
+		"knowledge/d/bindings/c.yaml":  "x: 1\n",
+		"knowledge/d/index.yaml": "domain: d\n" +
+			"concepts:\n  - name: a.yaml\n" +
+			"providers:\n  - name: b.yaml\n" +
+			"bindings:\n  - name: c.yaml\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("the three new asset types should be accepted: %v", err)
+	}
+}

--- a/docs/plans/knowledge-index-preserves-metadata.md
+++ b/docs/plans/knowledge-index-preserves-metadata.md
@@ -1,0 +1,225 @@
+---
+title: "The knowledge indexer preserves what it did not write"
+issue: https://github.com/NobleFactor/devlore-cli/issues/XX
+status: draft
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Plan: The knowledge indexer preserves what it did not write
+
+## Summary
+
+`star devlore knowledge index` rebuilds each domain's `index.yaml` from a directory listing and
+writes `{"name": filename}` per entry. Everything else in the file is discarded. Until
+2026-08-27 this was invisible, because `update-indexes` had been failing for months. Unfreezing
+it (registry #78, #79) let the workflow run — and registry #80 deleted curated metadata from
+three domains on its first successful pass.
+
+This makes the indexer additive: it may add entries for new files and drop entries for deleted
+ones, and it may touch nothing else.
+
+## Authority
+
+`devlore-cli/docs/devlore-ai-design-brief.md` (#356, *"Status: next order of business"*) is what
+these indexes are for, and it is the reason this is worth fixing properly rather than patching.
+
+The brief targets CAG packs served from devlore-registry through an **MCP facade** — packs as
+resources (`devlore://packs/<name>@<ver>`) and a `get_pack(name, max_tokens)` tool. The knowledge
+domains are the substrate those packs are assembled from: `devlore-conventions` and
+`lore-package-authoring` are named as the first pack set.
+
+Three of its requirements bear directly on this defect:
+
+- **§4, determinism gate at publish** — *"serialize twice, compare hashes, reject on mismatch. A
+  pack that cannot be reproducibly serialized cannot be honestly content-addressed."* An indexer
+  that silently changes the shape of its output cannot support that gate. The strict-section rule
+  below is what makes the output stable enough to hash.
+- **§4, artifact classes** — an index is a *derived* artifact: regenerable, invalidated by input
+  hashes. It is currently treated as neither source nor derived, which is why nothing noticed it
+  being rewritten destructively.
+- **§3, pack anatomy** — per-asset metadata (`purpose`, `description`, `source_system`) is what a
+  `get_pack` facade would describe assets with. Flattening entries to `{"name": filename}` destroys
+  exactly the material the delivery socket needs.
+
+This plan does not implement any of that. It stops the destruction so the material still exists
+when that work starts. Making it *right* — derived-class validation, determinism gate, provenance —
+is later work, and the brief is where it is specified.
+
+## The damage, measured
+
+| Domain | Lines | Lost |
+| --- | --- | --- |
+| `knowledge/packages/index.yaml` | 28 → 5 | `concepts:` section; every slot's `package`, `description`, `platforms`, `install_types`; an entire `ollama` slot |
+| `knowledge/migration/index.yaml` | 31 → 23 | `concepts:` |
+| `knowledge/shared/index.yaml` | 18 → 9 | `providers:` |
+
+Recoverable only from git history, at registry `b435dd0^`.
+
+## What is unmined today
+
+The destruction in #80 was the loud half. Surveying the tree turned up as much again that the
+indexer simply cannot see, and reports nothing about:
+
+| Gap | Detail |
+| --- | --- |
+| A ninth asset type | `package-authoring/bindings/` — `reference.md`, `reference.yaml`, `rules.yaml`. Zero mentions in its index |
+| Loose domain-root files | `migration/README.md` (2 KB), `migration/systems-reference.yaml` (1.8 KB) — real content, under no asset type |
+| A misfiled entry | `signatures/dotfile-systems.yaml` is indexed; the file is at `migration/dotfile-systems.yaml` |
+| An empty domain | `manifest-authoring` has no subdirectories and an index with no sections |
+| Per-entry metadata | `purpose`, `description`, `source_system`, slot fields — flattened to `{"name": f}` |
+| Unrecognized types | `concepts` (migration, packages), `providers` (shared) |
+
+The misfiled entry matters more than its size. An indexer that merely drops entries whose file is
+absent would have deleted that entry silently — the file is not gone, it moved. Dropping is the
+same class of error as flattening: a change nobody was asked about.
+
+## The principle this plan enforces
+
+Every gap above has one shape: **the indexer's silence is indistinguishable from success.** It
+cannot see `bindings/`, cannot see loose files, cannot tell a moved file from a deleted one — and
+says nothing either way, while `validate-yaml-schemas` goes green because the output parses.
+
+So: *anything the indexer cannot classify is an error, not an omission.* That is what converts
+silent incompleteness into a red build, and it is the whole point of the strict contract below.
+
+## Two failure modes, not one
+
+**Per-entry metadata.** `build_asset_entries` returns `{"name": filename}`, so
+`purpose`, `description`, `source_system`, and any per-entry field a human wrote is dropped.
+
+**Unknown top-level sections.** `build_index` emits `domain` plus the six keys in `ASSET_TYPES`.
+`concepts:` and `providers:` are in neither list, so they vanish. This one matters more than it
+looks: it means any section anybody invents is deleted on the next CI run, silently.
+
+## Why not simply use cmd/devlore-index
+
+It was the obvious answer and it is not sufficient. The Go tool fixes the first failure mode
+with `mergeEntries`, but its `KnowledgeIndex` struct has fields for exactly the same six asset
+types — no `Concepts`, no `Providers`. It would have destroyed both sections too.
+
+It is also uninvoked: created 2026-08-10, six months after the Starlark extension, never wired
+into any workflow, and its header still emits `go run ./cmd/gen-index`, a command name that has
+not existed since it was renamed. It goes.
+
+## Requirements
+
+### Merge, do not rebuild
+
+For each file present on disk, reuse the existing entry **whole** if one matches by `name`;
+otherwise emit `{"name": filename}`. Drop entries whose file is gone. This is `mergeEntries` from
+the Go tool, which is the correct algorithm.
+
+### Sections are a strict contract
+
+The set of top-level sections must match what the directory tree implies, exactly. Any
+disagreement stops the run:
+
+- a section in the file with no corresponding directory -> **refuse** (it is about to be dropped)
+- a directory with assets but no section in the file -> **refuse** (it is about to be added silently)
+- a section name that is not a known asset type -> **refuse**
+
+The indexer may then only update entries *within* sections. Every structural change is a human
+decision. This is stricter than carrying unknown sections through, and it is the rule that would
+have caught registry #80 on its first run rather than after the fact.
+
+It also lines up with docs/devlore-ai-design-brief.md §4, which requires a determinism gate at
+publish -- "serialize twice, compare hashes, reject on mismatch". An indexer that silently changes
+the shape of its output cannot support that.
+
+### concepts, providers, and bindings become real asset types
+
+Consequence of the rule above, and a prerequisite rather than a follow-up: `concepts:` appears in `migration` and `packages`, `providers:` in `shared`, and
+`bindings/` exists on disk in `package-authoring` while appearing in no index at all. An indexer that refuses unknown sections
+refuses on three of six domains until ASSET_TYPES grows from six to nine.
+
+### A missing file refuses; it does not drop
+
+If an indexed entry has no file, the indexer stops. The file may have been deleted, or it may have
+moved — `signatures/dotfile-systems.yaml` is the latter — and only a human knows which. Silently
+dropping the entry loses the metadata attached to it and reports success.
+
+### Unclassifiable content refuses
+
+A file under a domain but outside any asset-type directory is an error. Today
+`migration/README.md` and `migration/systems-reference.yaml` are invisible; ignoring them is the
+status quo, and the status quo is a false positive.
+
+### Nothing is required to write a header
+
+`yaml.encode` does not retain comments, so the hand-written header comments in these files cannot
+survive a regeneration. A standard generated-by header replaces them — the Go tool does the same.
+This is a real, accepted loss, and it should be stated in the file rather than discovered.
+
+### The provenance string is wrong today
+
+`Package/commands/index.star:91` hardcodes `"generated": "star devlore knowledge index packages"`
+in the **package** indexer's output. `packages/index.yaml` has been misattributing itself. One
+line, fixed here because it is the same family of defect.
+
+## Implementation Phases
+
+### Phase 0: Stop the bleeding — devlore-registry
+
+- [ ] Disable the `Update knowledge indexes` step in `update-indexes.yaml`, with a comment naming
+      this plan
+- [ ] Leave `Update package index` running; it is not lossy
+
+The next push to `develop` re-strips the three files, so this lands before anything else.
+
+**Files**: `.github/workflows/update-indexes.yaml` — Modify
+
+### Phase 1: Restore — devlore-registry
+
+- [ ] Restore the three `index.yaml` files from `b435dd0^`
+- [ ] Verify `validate-yaml-schemas` still passes against the restored content
+
+**Files**: `knowledge/{packages,migration,shared}/index.yaml` — Modify
+
+### Phase 2: Fix the indexer — devlore-cli
+
+- [ ] Read the existing index: `yaml.parse(file.read_text(index_path))` when present
+- [ ] `merge_entries(files, existing)` — reuse whole entries by `name`
+- [ ] Carry through unknown top-level keys
+- [ ] Emit a generated-by header stating that metadata is preserved and edited by hand
+- [ ] Fix the package indexer's provenance string
+- [ ] Tests: metadata survives; new file appears; deleted file disappears; unknown section survives
+
+No provider work is needed. `yaml.parse`, `yaml.encode`, `file.read_text`, and `file.write_text`
+all exist and the extension already uses the last two.
+
+**Files**: `star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star`,
+`star/extensions/com.noblefactor.devlore.Package/commands/index.star` — Modify
+
+### Phase 3: Re-enable and prove — devlore-registry
+
+- [ ] Re-enable the knowledge index step
+- [ ] Confirm a run over the restored files produces **no diff**
+
+A no-op run against curated content is the only convincing evidence the fix works. Re-enabling
+without it repeats the original mistake.
+
+### Phase 4: Remove the Go tool — devlore-cli
+
+- [ ] `git rm -r cmd/devlore-index`
+- [ ] Drop `devlore-index` from the Makefile's `TOOLS`
+- [ ] Update `docs/package-reference.md` and `docs/package-hierarchy.md`
+
+**Files**: `cmd/devlore-index/` — Delete; `Makefile`, two docs — Modify
+
+## Risks
+
+**Phase 3 could still be lossy in a way Phase 2's tests miss.** The domains differ; only
+`packages`, `migration`, and `shared` are known to carry extras. Running against all six and
+diffing is the check.
+
+**Restoring is not the same as regenerating.** The restored files describe the file tree as it
+was at `b435dd0^`. If files have been added or removed since, the first correct run will produce
+a legitimate diff, and that must not be mistaken for further damage.
+
+## Open Questions
+
+- [ ] `manifest-authoring` has no sections at all. Under the strict rule that is legal if its
+      directories are empty -- but is it an index nobody ever populated?
+- [ ] The design brief treats an index as a *derived* artifact with its own validation. Making
+      that true is "later"; this plan only stops the destruction.

--- a/pkg/op/provider/file/provider.go
+++ b/pkg/op/provider/file/provider.go
@@ -1595,7 +1595,11 @@ func (p *Provider) Join(parts ...string) string {
 //
 // +devlore:claim=deterministic
 func (p *Provider) Name(path string) string {
-	return slashpath.Base(path)
+	// ToSlash first: Join returns OS-native paths, so on Windows this is routinely handed a
+	// backslash path. slashpath.Base finds no separator in one and answers the whole string --
+	// file.name(file.join(a, b)) returned the entire path rather than the last element, which is
+	// how the knowledge indexer came to treat every directory as unrecognized there.
+	return slashpath.Base(filepath.ToSlash(path))
 }
 
 // Parent returns the directory containing the file at `path` via [slashpath.Dir].
@@ -1610,7 +1614,8 @@ func (p *Provider) Name(path string) string {
 //
 // +devlore:claim=deterministic
 func (p *Provider) Parent(path string) string {
-	return slashpath.Dir(path)
+	// Native input, slash-form output -- see [Provider.Name].
+	return slashpath.Dir(filepath.ToSlash(path))
 }
 
 // endregion

--- a/pkg/op/provider/file/provider_name_test.go
+++ b/pkg/op/provider/file/provider_name_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Name and Parent project a slash-form surface, but Join returns OS-native paths. On Windows they
+// are therefore routinely handed backslashes, and slashpath.Base finds no separator in one — it
+// answered the whole path. file.name(file.join(a, b)) returned the entire path rather than the last
+// element, which made the knowledge indexer treat every directory as unrecognized there while
+// passing on Unix.
+//
+// The conversion is filepath.ToSlash rather than a blind ReplaceAll, and that distinction is the
+// point: a backslash is a legal character in a Unix filename, so it must not be read as a separator
+// off Windows. The platform-specific case below is guarded for the same reason.
+func TestName_AcceptsNativePaths(t *testing.T) {
+	p := &Provider{}
+
+	cases := []struct{ name, in, want string }{
+		{"slash form", "knowledge/packages/slots", "slots"},
+		{"joined for this platform", filepath.Join("knowledge", "packages", "slots"), "slots"},
+		{"bare element", "slots", "slots"},
+	}
+
+	if runtime.GOOS == "windows" {
+		cases = append(cases, struct{ name, in, want string }{
+			"native windows path", `C:\tmp\reg\knowledge\packages\slots`, "slots",
+		})
+	} else {
+		// Off Windows a backslash is part of the name, not a separator.
+		cases = append(cases, struct{ name, in, want string }{
+			"backslash is a filename character", `weird\name`, `weird\name`,
+		})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := p.Name(tc.in); got != tc.want {
+				t.Errorf("Name(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParent_AcceptsNativePaths(t *testing.T) {
+	p := &Provider{}
+
+	if got, want := p.Parent("knowledge/packages/slots"), "knowledge/packages"; got != want {
+		t.Errorf("Parent(slash) = %q, want %q", got, want)
+	}
+
+	joined := filepath.Join("knowledge", "packages", "slots")
+	if got, want := p.Parent(joined), "knowledge/packages"; got != want {
+		t.Errorf("Parent(%q) = %q, want %q", joined, got, want)
+	}
+}
+
+// TestPathSeam_ProducersFeedConsumers is the test whose absence let the same defect land four times
+// in seventeen days (#395, #548, #600, and the indexer failure on #719).
+//
+// The provider speaks two path dialects. Join, Glob, Resolve, WalkTree and Link are OS-native;
+// Name and Parent are slash-form. Every unit test writes its inputs in the dialect of the function
+// under test, so each passes in isolation on every platform — and the defect lives only where a
+// producer's output reaches a consumer's input. Nothing tested that handoff.
+//
+// This does. It is deliberately about composition rather than any single function: if a new path
+// producer is added in the native dialect, feeding it here is what makes the mismatch fail a build
+// rather than surface a fortnight later on a Windows leg.
+func TestPathSeam_ProducersFeedConsumers(t *testing.T) {
+	tmp := t.TempDir()
+	p := testProvider(t, tmp)
+
+	if err := os.MkdirAll(filepath.Join(tmp, "knowledge", "packages", "slots"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "knowledge", "packages", "slots", "homebrew.yaml"), []byte("x: 1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Run("Name(Join(...)) returns the last element", func(t *testing.T) {
+		joined := p.Join("knowledge", "packages", "slots")
+		if got := p.Name(joined); got != "slots" {
+			t.Errorf("Name(Join(...)) = %q, want %q — the join produced %q", got, "slots", joined)
+		}
+	})
+
+	t.Run("Parent(Join(...)) drops one element", func(t *testing.T) {
+		joined := p.Join("knowledge", "packages", "slots")
+		if got := p.Parent(joined); got != "knowledge/packages" {
+			t.Errorf("Parent(Join(...)) = %q, want %q", got, "knowledge/packages")
+		}
+	})
+
+	t.Run("Name(glob result) returns file names, not whole paths", func(t *testing.T) {
+		matches, err := p.Glob(p.Join("knowledge", "packages", "slots", "*"), false)
+		if err != nil {
+			t.Fatalf("glob: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Fatal("glob matched nothing; the fixture is wrong, not the code")
+		}
+		for _, m := range matches {
+			// The Starlark surface reaches a match's path exactly this way.
+			path := m.Path().Abs()
+			if got := p.Name(path); got != "homebrew.yaml" {
+				t.Errorf("Name(%q) = %q, want %q", path, got, "homebrew.yaml")
+			}
+		}
+	})
+}

--- a/scripts/Invoke-WindowsDevloreTest.sh
+++ b/scripts/Invoke-WindowsDevloreTest.sh
@@ -28,6 +28,7 @@ shift || true
 
 readonly PKG="./cmd/devlore-test/devloretest"
 readonly REMOTE='C:/Users/david-noble/devlore-test'
+readonly REMOTE_POSIX='/c/Users/david-noble/devlore-test'
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
@@ -37,20 +38,20 @@ GOOS=windows GOARCH=arm64 CGO_ENABLED=0 \
     go test -c -o /tmp/devloretest.exe "${PKG}"
 
 echo "== staging on ${host}:${REMOTE} =="
-ssh "${host}" "New-Item -ItemType Directory -Force -Path '${REMOTE}' | Out-Null; Remove-Item -Recurse -Force '${REMOTE}/data' -ErrorAction SilentlyContinue"
+ssh "${host}" "bash -lc 'mkdir -p ${REMOTE_POSIX} && rm -rf ${REMOTE_POSIX}/data'"
 scp -q /tmp/devloretest.exe "${host}:${REMOTE}/devloretest.exe"
 scp -qr cmd/devlore-test/devloretest/data "${host}:${REMOTE}/data"
 
 echo "== running =="
-# -test.v etc. are the compiled-binary spellings of go test's flags.
+# go test's own flag spellings, since this is a compiled test binary rather than `go test`.
 args=""
 for a in "$@"; do
     case "$a" in
-    -run) args="${args} -test.run" ;;
-    -v) args="${args} -test.v" ;;
-    -count=*) args="${args} -test.count=${a#-count=}" ;;
-    *) args="${args} ${a}" ;;
+        -run) args="${args} -test.run" ;;
+        -v) args="${args} -test.v" ;;
+        -count=*) args="${args} -test.count=${a#-count=}" ;;
+        *) args="${args} ${a}" ;;
     esac
 done
 
-ssh "${host}" "\$env:DEVLORE_TESTDATA='${REMOTE}/data'; & '${REMOTE}/devloretest.exe' ${args}; exit \$LASTEXITCODE"
+ssh "${host}" "bash -lc 'DEVLORE_TESTDATA=${REMOTE_POSIX}/data ${REMOTE_POSIX}/devloretest.exe${args}'"

--- a/scripts/Invoke-WindowsDevloreTest.sh
+++ b/scripts/Invoke-WindowsDevloreTest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+#
+# Invoke-WindowsDevloreTest.sh — cross-compile the devlore-test suite and run it on a Windows host.
+#
+# The path-dialect defects this exists to catch (#395, #548, #600, #719) are unreachable off Windows:
+# file.join only emits backslashes there, so no assertion written on a Unix box can fail for them.
+# Waiting for a CI leg puts a fortnight between the change and the symptom. This closes that gap to
+# about a minute.
+#
+# The test binary is built here rather than on the host: go.mod requires a newer toolchain than the
+# box carries, and cross-compiling avoids a per-run toolchain download. data/ travels with it because
+# testdataDir resolves via runtime.Caller, which bakes in THIS machine's source path —
+# DEVLORE_TESTDATA overrides that.
+#
+# Usage:
+#   scripts/Invoke-WindowsDevloreTest.sh [host] [-- <go test args>]
+#
+#   scripts/Invoke-WindowsDevloreTest.sh
+#   scripts/Invoke-WindowsDevloreTest.sh danoble-wd11-3.local -- -run TestImmediateFilePathSeam -v
+
+set -euo pipefail
+
+host="${1:-danoble-wd11-3.local}"
+shift || true
+[[ "${1:-}" == "--" ]] && shift || true
+
+readonly PKG="./cmd/devlore-test/devloretest"
+readonly REMOTE='C:/Users/david-noble/devlore-test'
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+echo "== building ${PKG} for windows/arm64 =="
+GOOS=windows GOARCH=arm64 CGO_ENABLED=0 \
+    go test -c -o /tmp/devloretest.exe "${PKG}"
+
+echo "== staging on ${host}:${REMOTE} =="
+ssh "${host}" "New-Item -ItemType Directory -Force -Path '${REMOTE}' | Out-Null; Remove-Item -Recurse -Force '${REMOTE}/data' -ErrorAction SilentlyContinue"
+scp -q /tmp/devloretest.exe "${host}:${REMOTE}/devloretest.exe"
+scp -qr cmd/devlore-test/devloretest/data "${host}:${REMOTE}/data"
+
+echo "== running =="
+# -test.v etc. are the compiled-binary spellings of go test's flags.
+args=""
+for a in "$@"; do
+    case "$a" in
+    -run) args="${args} -test.run" ;;
+    -v) args="${args} -test.v" ;;
+    -count=*) args="${args} -test.count=${a#-count=}" ;;
+    *) args="${args} ${a}" ;;
+    esac
+done
+
+ssh "${host}" "\$env:DEVLORE_TESTDATA='${REMOTE}/data'; & '${REMOTE}/devloretest.exe' ${args}; exit \$LASTEXITCODE"

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
@@ -3,25 +3,38 @@
 
 # index.star - Generate index.yaml for knowledge domains
 #
-# This operation scans the knowledge/ directory in the target
-# and generates index.yaml files for each domain.
+# This operation scans knowledge/ in the target and updates each domain's index.yaml.
 #
-# Asset types indexed:
-#   - prompts/     -> prompts: [{name: ...}]
-#   - schemas/     -> schemas: [{name: ...}]
-#   - examples/    -> examples: [{name: ...}]
-#   - transforms/  -> transforms: [{name: ...}]
-#   - signatures/  -> signatures: [{name: ...}]
-#   - slots/       -> slots: [{name: ...}]
+# It UPDATES rather than rebuilds. An earlier version listed each asset directory and wrote
+# {name: filename} per entry, discarding everything else in the file. That was invisible while the
+# workflow was failing; its first successful run (devlore-registry#80) deleted the concepts section
+# from two domains, providers from a third, and every slot's package/description/platforms/
+# install_types. See docs/plans/knowledge-index-preserves-metadata.md.
+#
+# The rule now: anything this command cannot classify is an ERROR, not an omission. Its silence
+# used to be indistinguishable from success -- the output still parsed, so validate-yaml-schemas
+# stayed green while content was being deleted.
+#
+# Asset types:
+#   prompts/ schemas/ examples/ transforms/ signatures/ slots/ concepts/ providers/ bindings/
 #
 # Usage:
-#   star devlore knowledge index --target=/path/to/registry
+#   star devlore knowledge index --target=/path/to/registry [--dry_run=true]
 
-# Asset type subdirectories to index
-ASSET_TYPES = ["prompts", "schemas", "examples", "transforms", "signatures", "slots"]
+ASSET_TYPES = [
+    "prompts",
+    "schemas",
+    "examples",
+    "transforms",
+    "signatures",
+    "slots",
+    "concepts",
+    "providers",
+    "bindings",
+]
 
 def list_files(dir_path):
-    """List all files in a directory (non-recursive)."""
+    """List file names directly in a directory, sorted. Empty if the directory is absent."""
     if not file.exists(dir_path):
         return []
 
@@ -32,22 +45,124 @@ def list_files(dir_path):
             files.append(name)
     return sorted(files)
 
-def build_asset_entries(dir_path):
-    """Build list of asset entries for a directory."""
-    entries = []
-    for filename in list_files(dir_path):
-        entries.append({"name": filename})
-    return entries
+def list_subdirs(domain_path):
+    """List subdirectory names directly under a domain, sorted."""
+    dirs = []
+    for path in file.glob(file.join(domain_path, "*")):
+        name = file.name(path)
+        if file.is_dir(path) and not name.startswith("."):
+            dirs.append(name)
+    return sorted(dirs)
 
-def build_index(domain_name, domain_path):
-    """Build the complete index for a domain."""
+def load_existing(index_path):
+    """Parse the domain's current index.yaml, or an empty dict when there is none."""
+    if not file.exists(index_path):
+        return {}
+    # yaml.decode, not yaml.parse: parse returns a yaml.Resource whose only attributes are
+    # equal/resource_base/validate, so the document's data is unreachable through it. decode
+    # returns a plain dict.
+    decoded = yaml.decode(file.read_text(index_path))
+    if type(decoded) != "dict":
+        return {}
+    return decoded
+
+def entry_names(entries):
+    """Names from a list of index entries, skipping anything malformed."""
+    names = []
+    for e in entries:
+        if type(e) == "dict" and "name" in e:
+            names.append(e["name"])
+    return names
+
+def audit_domain(domain_name, domain_path, existing):
+    """Every way this domain's index and its directories can disagree.
+
+    Returns a list of human-readable problems. A non-empty list fails the run: each entry is
+    something only a person can resolve, and guessing is how metadata gets deleted.
+    """
+    problems = []
+    subdirs = list_subdirs(domain_path)
+
+    # A directory nobody taught us about. Its contents are invisible today --
+    # package-authoring/bindings/ sat unindexed this way.
+    for d in subdirs:
+        if d not in ASSET_TYPES:
+            problems.append("directory '" + d + "/' is not a known asset type")
+
+    # A file loose in the domain root belongs to no asset type, so nothing indexes it.
+    for path in file.glob(file.join(domain_path, "*")):
+        name = file.name(path)
+        if file.is_dir(path) or name.startswith(".") or name == "index.yaml":
+            continue
+        problems.append("file '" + name + "' is outside any asset-type directory")
+
+    for key in existing:
+        if key == "domain":
+            continue
+
+        # A section naming a type we do not know.
+        if key not in ASSET_TYPES:
+            problems.append("section '" + key + "' is not a known asset type")
+            continue
+
+        # A section whose directory is gone. Dropping it silently is what this rewrite exists
+        # to prevent.
+        if key not in subdirs:
+            problems.append("section '" + key + "' has no '" + key + "/' directory")
+            continue
+
+        if type(existing[key]) != "list":
+            problems.append("section '" + key + "' is not a list")
+            continue
+
+        # An entry whose file is absent. It may have been deleted, or it may have moved --
+        # signatures/dotfile-systems.yaml was the latter -- and only a person knows which.
+        present = list_files(file.join(domain_path, key))
+        for name in entry_names(existing[key]):
+            if name not in present:
+                problems.append("'" + key + "/" + name + "' is indexed but no such file exists")
+
+    # A directory holding assets that the index never mentions.
+    for d in subdirs:
+        if d in ASSET_TYPES and d not in existing and len(list_files(file.join(domain_path, d))) > 0:
+            problems.append("directory '" + d + "/' has assets but no '" + d + ":' section")
+
+    return problems
+
+def merge_entries(names, existing_entries):
+    """Keep each existing entry whole; add {name} for a file that has none.
+
+    The metadata on an entry -- purpose, description, source_system, and whatever a slot carries --
+    is hand-written. This command's job is to track which files exist, not to have opinions about
+    what they mean.
+    """
+    by_name = {}
+    for e in existing_entries:
+        if type(e) == "dict" and "name" in e:
+            by_name[e["name"]] = e
+
+    merged = []
+    for name in names:
+        if name in by_name:
+            merged.append(by_name[name])
+        else:
+            merged.append({"name": name})
+    return merged
+
+def build_index(domain_name, domain_path, existing):
+    """The updated index: same sections, same metadata, entries tracking the files on disk."""
     index = {"domain": domain_name}
 
     for asset_type in ASSET_TYPES:
-        asset_dir = file.join(domain_path, asset_type)
-        entries = build_asset_entries(asset_dir)
-        if len(entries) > 0:
-            index[asset_type] = entries
+        names = list_files(file.join(domain_path, asset_type))
+        if len(names) == 0:
+            continue
+
+        prior = []
+        if asset_type in existing and type(existing[asset_type]) == "list":
+            prior = existing[asset_type]
+
+        index[asset_type] = merge_entries(names, prior)
 
     return index
 
@@ -78,29 +193,81 @@ def run(command, ctx):
         fail("knowledge/ directory not found at " + knowledge_dir)
         return
 
-    domains_processed = 0
-    total_assets = 0
-
+    # Keyed by name and sorted by it: file.glob yields path values, which do not order.
+    by_name = {}
     for domain_path in file.glob(file.join(knowledge_dir, "*")):
-        if not file.is_dir(domain_path):
-            continue
+        if file.is_dir(domain_path):
+            by_name[file.name(domain_path)] = domain_path
+    domains = sorted(by_name.keys())
 
-        domain_name = file.name(domain_path)
+    # Audit every domain before writing any of them. A partial write across a tree that is
+    # inconsistent somewhere else is harder to reason about than no write at all, and the report
+    # is more use to a person whole than one problem at a time.
+    problems = []
+    plans = []
 
-        index = build_index(domain_name, domain_path)
+    for domain_name in domains:
+        domain_path = by_name[domain_name]
+        index_path = file.join(domain_path, "index.yaml")
+        existing = load_existing(index_path)
 
-        # Count assets
+        found = audit_domain(domain_name, domain_path, existing)
+        for p in found:
+            problems.append(domain_name + ": " + p)
+
+        plans.append((domain_name, domain_path, index_path, existing))
+
+    if len(problems) > 0:
+        # The problems go into the error, not only into the log. A caller that sees the failure but
+        # not stdout -- a CI step summary, a test -- would otherwise be told that something was
+        # wrong without being told what, which is barely better than the silence this replaces.
+        for p in problems:
+            note("  " + p)
+
+        detail = ""
+        for p in problems:
+            detail = detail + "\n  - " + p
+
+        fail(
+            "refusing to write: " + str(len(problems)) +
+            " problem(s) across " + str(len(domains)) + " domain(s)." + detail +
+            "\nEach is a decision this command will not make for you: resolve it, or teach " +
+            "ASSET_TYPES about a directory that belongs.",
+        )
+        return
+
+    domains_written = 0
+    total_assets = 0
+    unchanged = 0
+
+    for entry in plans:
+        domain_name = entry[0]
+        domain_path = entry[1]
+        index_path = entry[2]
+        existing = entry[3]
+
+        index = build_index(domain_name, domain_path, existing)
+
         asset_count = 0
         for asset_type in ASSET_TYPES:
             if asset_type in index:
                 asset_count = asset_count + len(index[asset_type])
 
-        if asset_count == 0:
-            note("Skipping empty domain: " + domain_name)
-            continue
+        # yaml.encode drops comments, so a domain's hand-written header cannot survive a
+        # regeneration. Say so in the file rather than leaving it to be rediscovered.
+        index_content = (
+            "# Generated by: star devlore knowledge index\n" +
+            "# Entry metadata (purpose, description, source_system, ...) is preserved across runs\n" +
+            "# and is edited by hand. This command only tracks which files exist.\n" +
+            yaml.encode(index)
+        )
 
-        index_content = yaml.encode(index)
-        index_path = file.join(domain_path, "index.yaml")
+        # A no-op is worth saying out loud: it is the evidence that a run changed nothing, which is
+        # what re-enabling this in CI has to demonstrate.
+        if file.exists(index_path) and file.read_text(index_path) == index_content:
+            unchanged = unchanged + 1
+            total_assets = total_assets + asset_count
+            continue
 
         if dry_run:
             note("Would write: " + index_path + " (" + str(asset_count) + " assets)")
@@ -110,7 +277,10 @@ def run(command, ctx):
             file.write_text(index_path, index_content)
             succeed("Wrote: " + index_path + " (" + str(asset_count) + " assets)")
 
-        domains_processed = domains_processed + 1
+        domains_written = domains_written + 1
         total_assets = total_assets + asset_count
 
-    note("Indexed " + str(total_assets) + " assets across " + str(domains_processed) + " domain(s)")
+    note(
+        "Indexed " + str(total_assets) + " assets across " + str(len(domains)) + " domain(s); " +
+        str(domains_written) + " changed, " + str(unchanged) + " unchanged",
+    )

--- a/star/extensions/com.noblefactor.devlore.Package/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Package/commands/index.star
@@ -88,7 +88,7 @@ def build_index(packages):
 
     return {
         "version": "1",
-        "generated": "star devlore knowledge index packages",
+        "generated": "star devlore package index",
         "count": len(index_pkgs),
         "packages": index_pkgs,
     }


### PR DESCRIPTION
`star devlore knowledge index` rebuilt each domain's `index.yaml` from a directory listing and wrote
`{name: filename}` per entry, **discarding everything else**. Invisible while devlore-registry's
`update-indexes` was failing; its first successful run after the unfreeze deleted curated metadata
from three domains (devlore-registry#81 restores it).

## It updates now, rather than rebuilding

Each existing entry is kept **whole** when its file is present; a new file gets `{name}`. The
metadata on an entry is hand-written. Tracking which files exist is the only job this command has.

## Anything it cannot classify is an error, not an omission

The indexer's silence was indistinguishable from success — the output still parsed, so
`validate-yaml-schemas` stayed green while content was deleted. Five refusals:

| Refusal | Why it matters |
| --- | --- |
| directory is not a known asset type | `package-authoring/bindings/` — three files, indexed nowhere |
| file loose in a domain root | `migration/README.md`, `systems-reference.yaml` — real content, invisible |
| section names an unknown type | a typo'd section silently indexes nothing |
| section's directory is gone | dropping it silently is the original bug |
| indexed entry has no file | see below |

The last is not pedantry. `signatures/dotfile-systems.yaml` is indexed while the file sits at the
domain root — it **moved rather than vanished**, and an indexer that merely drops entries without
files would have deleted it silently.

## ASSET_TYPES: six → nine

`concepts` (migration, packages) and `providers` (shared) are sections in active use that the
indexer did not recognize. `bindings` (package-authoring) is a directory with three files appearing
in no index at all.

`cmd/devlore-index` — the uninvoked Go tool that looked like the obvious fix — carries the same six
in its `KnowledgeIndex` struct and would have destroyed `concepts` and `providers` too. Retiring it
is phase 4.

## Two things surfaced while building this, both the same shape as the bug

**`yaml.parse` returns a `yaml.Resource`** whose only attributes are `equal`, `resource_base`, and
`validate` — the document's data is unreachable through it. The first `load_existing` used it,
silently received nothing, and *looked* like it worked while treating every index as empty.
`yaml.decode` returns a dict.

**The audit's findings went to stdout but not into the error.** A CI step summary or any caller
reading only the error was told something was wrong without being told what. They are in the error
now.

## Tests

Nine, `//go:build integration`, matching the sibling extension tests:

```
PreservesEntryMetadata          AddsNewFileAndKeepsNeighbourMetadata
IsIdempotent                    AcceptsRecognizedNewTypes
RefusesUnrecognizedDirectory    RefusesLooseFile
RefusesIndexedFileThatDoesNotExist
RefusesAssetsWithNoSection      RefusesUnknownSection
```

The refusal tests assert **the reason**, not merely that an error occurred. Asserting only
`err != nil` passed on an unrelated failure — the same indistinguishable-from-success problem these
tests exist to prevent — and tightening them is what exposed the error-detail defect above.

Verified against the real registry tree: refuses with all five problems named; on a consistent tree
preserves every field; runs twice byte-identically; output validates.

## Also

The package indexer stamped its output `generated: star devlore knowledge index packages`. It is the
package indexer. Fixed.

## Not in this PR

Phase 3 — devlore-registry: the schema (`knowledge.index.json` lists six types with
`additionalProperties` unset, so it permits **anything**), resolving the five real problems, and
re-enabling the workflow. Phase 4 — retiring `cmd/devlore-index`.