### PR TITLE
Plan the docker package rewrite, and charter the two defects writing it exposed

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_choose_then_action.star
+++ b/cmd/devlore-test/devloretest/data/test_choose_then_action.star
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_choose_then_action.star — then= and default= carry ACTIONS, not just value lambdas.
+#
+# Every other choose fixture passes value-returning lambdas to then= and default= (lambda: "found"), so the
+# action-bodied shape was uncovered. A package that must install software only when a predicate holds needs the
+# branch to perform work rather than compute a string, and this proves it can.
+#
+# Deliberately lambda-free. A lambda is archived as a content-addressed function.Resource at plan time, and any
+# graph carrying one currently fails receipt writing — see the choose fixtures that do use lambdas, which pass
+# their expectations and then exit 1. Building the decision tree entirely from invocations avoids that, and is
+# the shape package phase scripts should use.
+
+dest    = t.tmp("choose_target.txt")
+marker  = t.tmp("choose_marker.txt")
+fallout = t.tmp("choose_default.txt")
+
+written = plan.file.write_text(destination_path=dest, content="here", mode=0o644)
+exists  = plan.file.exists(path=dest)
+
+choice = plan.choose(
+    plan.case(when=exists, then=plan.file.write_text(destination_path=marker, content="then-fired", mode=0o644)),
+    default=plan.file.write_text(destination_path=fallout, content="default-fired", mode=0o644),
+)
+
+graph = plan.assemble_definition([written, choice])
+
+# The predicate holds, so the then-body runs and the default-body is never dispatched.
+t.expect_file(marker, content="then-fired")
+t.expect_no_file(fallout)
+
+t.run(graph)

--- a/docs/plans/docker.devlore-package.md
+++ b/docs/plans/docker.devlore-package.md
@@ -1,0 +1,501 @@
+---
+title: "Docker devlore Package — a clean-slate rewrite that proves the lifecycle"
+issue: TBD
+status: draft
+created: 2026-08-26
+updated: 2026-08-26
+---
+
+# Plan: Docker devlore Package
+
+## Summary
+
+Replace the `docker` package in devlore-registry with a hand-written rewrite whose only source of
+truth is the bash that deploys Docker today: `Home/noblefactor.Unix/.local/bin/Install-Docker` and
+`Tools/Debian/Initialize-Debian` in the Personal repository. The existing package is discarded
+entirely — it targets an API that no longer exists, and it describes a Darwin installation the user
+does not perform. The rewrite exists to prove three lifecycle operations end to end (deploy,
+upgrade, decommission) and to state precisely why the fourth (reconcile) cannot yet be proven by a
+package.
+
+## Goals
+
+1. **Fidelity**: every step traces to a line of bash that runs today, or is deliberately marked as
+   an addition with a reason.
+2. **Current API only**: no call that the provider tree does not implement as of this branch.
+3. **Receipts throughout**: every mutating step is compensable, because decommission is
+   compensation in reverse receipt order rather than a hand-written teardown.
+4. **Honest scope**: reconcile is described, not faked.
+
+## Current State
+
+### The package being replaced
+
+`devlore-registry/packages/docker/` — 28 `.star` files across `Darwin`, `Linux.Debian`,
+`Linux.Fedora`, and `Windows`, plus `README.md` (199 lines) and `lifecycle.yaml` (90 lines).
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| `plan.package.install("a", "b")` | Broken | Namespace is `pkg`; takes a list, not varargs |
+| `plan.verify(name, check=…)` | Broken | No `Verify` method on any provider |
+| `plan.file.write(path=…)` | Broken | It is `plan.file.write_text(destination_path=…, content=…, mode=…)` |
+| `plan.user.add_to_group(…)` | Broken | Does not exist |
+| `phase.env("USER")` | Broken | Does not exist |
+| `plan.download(url, dest)` | Broken | `appnet.download(url)` returns bytes; there is no dest form |
+| `plan.notify(…)` | Broken | Does not exist |
+| All four `verify.star` | Dead | Bodies are entirely `plan.verify` calls |
+| Darwin phases | Wrong | Describe a Docker Desktop DMG install that is not performed |
+| `plan.service.enable/start` | Correct | Retained |
+| `package.has_feature()` / `package.setting()` | Correct | Retained |
+
+### The API that does exist
+
+Verified against provider source on this branch.
+
+| Surface | Members |
+| --- | --- |
+| `plan.pkg.*` | `install`, `installed`, `not_installed`, `observe`, `remove`, `update`, `upgrade`, `version_gte` |
+| `plan.service.*` | `disable`, `enable`, `enabled`, `exists`, `restart`, `running`, `start`, `stop` |
+| `plan.shell.*` | `exec` |
+| `plan.file.*` | `copy`, `write_text`, and the rest of the mutating surface |
+| `package.*` | `dry_run`, `features`, `has_feature`, `name`, `settings`, `setting`, `source_root`, `target_root`, `version` |
+| Denied in phase scripts | `plan.assemble`, `plan.clear`, `plan.load`, `plan.run`, `plan.save` (`cmd/lore/lore/builder.go:31`) |
+
+`service.Enable`, `service.Start`, `service.Stop`, and `service.Disable` each return
+`(Resource, *Receipt, error)` — the receipt is what makes decommission mechanical.
+
+The package-manager router wires **apt, brew, port, winget**. There is **no dnf**.
+
+### The bash that is the source of truth
+
+Two tiers, and the split matters:
+
+- `Tools/Debian/Initialize-Debian` — root, machine scope, re-runnable. Writes
+  `/etc/apt/keyrings/docker.asc` (`:231`) and `/etc/apt/sources.list.d/docker.sources` in deb822
+  form with `Signed-By:` (`:256`). Upgrades the whole system with `apt-get full-upgrade --yes`
+  (`:120`).
+- `Home/noblefactor.Unix/.local/bin/Install-Docker` — user scope, 84 lines, **assumes the repo
+  already exists**. Removes seven conflicts guarded by `dpkg-query`, installs six packages
+  including `lshw`, then verifies against detected hardware.
+
+Idempotence is by guard, never by recorded state: `[[ -f … ]] || curl …`,
+`command -v … || install …`, `dpkg-query -W … && remove …`. Re-running the script *is* the update
+mechanism.
+
+## Rulings
+
+These were decided in session. Each is overturnable; none is a discovery.
+
+1. **The package owns repository setup.** *Confirmed by the user, 2026-08-26: the `.sources` file and
+   the keyring are ours, and they are prerequisites belonging to the first phase of deployment.*
+   `docs/guides/lore/pipeline.md` assigns "Add package
+   repository sources" and "Import GPG signing keys" to Phase 1 (Prepare). The bash splits it out
+   only because `Initialize-Debian` batches every third-party repo at machine bootstrap. A package
+   that assumed the repo would fail on any machine not already initialized by personal tooling,
+   which is useless to a customer.
+2. **Darwin ensures a runtime; it does not install Colima.** Colima is chosen for **licensing**:
+   Docker Desktop requires a paid subscription above 250 employees or $10M revenue, and OrbStack has
+   a paid commercial tier. The bash accepts any of the three and installs Colima only when none is
+   present. Colima being scriptable makes it a far easier install to automate, but that is a
+   consequence, not the reason.
+3. **MacPorts before Homebrew.** `Install-Dependencies` tries `port` first and falls back to `brew`.
+4. **`Linux.Fedora` is not in this package.** No dnf in the router. Driving it through
+   `plan.shell.exec` would work but forfeits receipts, which would defeat the decommission proof.
+   Chartered separately.
+5. **`Windows` is not in this pass.** `winget` is wired, so it is viable later; it is simply not
+   what the source bash covers.
+6. **No `rootless`, no docker-group membership.** Neither appears in the bash. Everything is
+   `sudo docker`.
+7. **The package names no package manager.** `pkg/platform/defaults.go:72` gives Darwin
+   `managers: []leaf{brew, port}` with `defaultManager: brew`, while `Install-Dependencies` tries
+   `port` first. The development Mac has both. A registry package should not encode a manager
+   preference — that is machine policy, and every leaf carries a purl type (`port`, `brew`) usable
+   as an explicit routing prefix when someone genuinely needs one. Resources stay unprefixed and the
+   router decides. If MacPorts should win on Darwin, the fix is `defaults.go:73`, which corrects it
+   for every package rather than for docker alone. **Pending the user's ruling** — this diverges
+   from the bash.
+
+## Verified API shapes
+
+Read off the generated bindings on this branch, not from documentation.
+
+| Call | Starlark parameters |
+| --- | --- |
+| `plan.pkg.install` | `packages`, `**kwargs` |
+| `plan.pkg.remove` | `packages`, `**kwargs` |
+| `plan.pkg.upgrade` | `packages`, `**kwargs` |
+| `plan.pkg.update` | none |
+| `plan.pkg.installed` / `not_installed` | `name` |
+| `plan.pkg.observe` | `resource` |
+| `plan.pkg.version_gte` | `name`, `version` |
+| `plan.file.write_text` | `destination_path`, `content`, `mode` |
+| `plan.choose` | `*cases`, `default=` |
+| `plan.case` | `when=`, `then=` |
+
+`kwargs` are opaque native-installer flags forwarded to the routed leaf —
+`pkg/op/provider/pkg/provider.go:44` names `cask` as the example.
+
+## Resolved by probe, 2026-08-26
+
+### `then=` and `default=` carry actions — Scenario 4's guard is expressible
+
+**Answered: yes.** `cmd/devlore-test/devloretest/data/test_choose_then_action.star` gives both
+branches live invocations instead of value lambdas, and passes: the then-body's `write_text` fires,
+the default-body is never dispatched. The fixture is kept — it covers a shape the other nine
+`test_choose_*` fixtures do not.
+
+So the Darwin guard is:
+
+```
+plan.choose(
+    plan.case(when=<runtime present?>, then=<no-op>),
+    default=plan.pkg.install(packages=["colima", "docker"]),
+)
+```
+
+### The receipt writer fails on any graph carrying a Starlark lambda
+
+Found while probing, and material enough to gate authoring.
+
+| Fixture | Lambdas | Expectations | Exit |
+| --- | --- | --- | --- |
+| `test_compensation.star` | none | pass | 0 |
+| `test_choose_then_action.star` (lambda-free) | none | pass | 0 |
+| `test_choose_lambdas.star` | many | pass | **1** |
+| `test_choose_exists.star` | `default=lambda:` | pass | **1** |
+
+The failure is `writing receipt: … function.Resource: mmap <session-root>/.devlore/function/resource/
+sha256/…: no such file or directory`. A lambda is archived as a content-addressed
+`function.Resource` at plan time; at receipt-write time the file is not on disk. Routing the receipt
+to a real path rather than `/dev/null` makes no difference.
+
+**Why CI does not see it**: `cmd/devlore-test/cli_test.go` exercises exactly one fixture,
+`test_hello.star`, and contains zero references to choose. The remaining 103 fixtures are driven
+in-process, where receipts are not written. Expectations pass either way, so the suite is green
+while the receipt is unwritable — the same shape as a green knowledge-extract that emits a constant
+artifact.
+
+**Why it matters here**: receipts are the entire mechanism for Scenarios 3 and 5. A package whose
+graph contains one lambda produces no receipt and therefore cannot be decommissioned by
+compensation.
+
+**Ruling 8 — package phase scripts contain no Starlark lambdas.** Build decision trees from
+invocations only. This is an authoring constraint until the defect is fixed, and it costs nothing:
+the lambda-free form is strictly more useful, since a branch that performs work beats one that
+computes a string.
+
+**Charter**: the `function.Resource` receipt defect needs its own issue and fix, and
+`cli_test.go` needs to drive more than one fixture — the coverage gap is what let this sit.
+
+### Superseded question — kept for the record
+
+#### Can a `then=` body carry an action?
+
+Scenario 4 needs "install Colima only when no runtime is present." The predicate half is settled:
+`when=` accepts a live invocation, demonstrated by `plan.file.exists(path=…)` in
+`test_choose_exists.star`, and `plan.file.is_dir` works the same way — enough to test for
+`/Applications/OrbStack.app`.
+
+The branch half is not. All nine `test_choose_*` fixtures pass **value-returning lambdas** to
+`then=` and `default=`, and the fixture comments explain why: *"A lambda body desugars to a
+function.call leaf: the lambda is archived as a content-addressed function.Resource at plan time and
+invoked at dispatch."* That computes a value at dispatch; it is not a subgraph builder. Nothing
+demonstrates `then=plan.pkg.install([…])`.
+
+`cmd/devlore-test/devloretest/data/test_choose_then_action.star` was added to answer this. It gives
+`then=` a live `plan.file.write_text` invocation and asserts the file appears. If it passes, the
+fixture is worth keeping as coverage for a shape nothing else covers. If it fails, Scenario 4 cannot
+express the guard and the fallbacks are: `plan.shell.exec` doing test-and-install as one opaque
+command — which forfeits the install receipt and therefore Scenario 5's asymmetric decommission — or
+new provider work.
+
+Note this brushes against a stated intent. The demo milestone says *"NOT on this scenario's path:
+`plan.choose` — adaptation is directory resolution, not a Starlark conditional."* That holds for
+**platform** adaptation, which directories do handle. Runtime detection is not platform adaptation:
+no directory layout can express "some container runtime is already present."
+
+## Scenarios
+
+Each scenario states preconditions, the graph the phase scripts contribute, the receipts produced,
+verification, and postconditions. A scenario is proven when it runs end to end on a disposable
+target and its postconditions hold.
+
+### Scenario 1 — Deploy Docker on Linux.Debian
+
+**Precondition**: a Debian or Ubuntu host with no Docker present, and no Docker apt repository
+configured. Distribution packages (`docker.io`, `podman-docker`, …) may or may not be installed.
+
+**Prepare** — `Linux.Debian/Deploy/prepare.star`
+
+1. Remove the seven conflicting packages, each guarded so absence is not an error:
+   `containerd`, `docker-compose`, `docker-compose-v2`, `docker-doc`, `docker.io`,
+   `podman-docker`, `runc`. Contributed as `plan.pkg.remove([...])`.
+2. Write `/etc/apt/keyrings/docker.asc` from `https://download.docker.com/linux/debian/gpg`.
+3. Write `/etc/apt/sources.list.d/docker.sources` in deb822 form, `Suites:` bound to the detected
+   distribution codename, `Signed-By:` pointing at the keyring.
+4. `plan.pkg.update()`.
+
+**Install** — `Linux.Debian/Deploy/install.star`
+
+`plan.pkg.install(["containerd.io", "docker-buildx-plugin", "docker-ce", "docker-ce-cli",
+"docker-compose-plugin", "lshw"])`.
+
+`lshw` is not a Docker dependency. It is installed because verification is hardware-gated, and the
+bash installs it for exactly that reason.
+
+**Provision** — `Linux.Debian/Deploy/provision.star`
+
+`plan.service.enable("docker")` then `plan.service.start("docker")`.
+
+The bash does neither, because apt's `docker-ce` postinst already enables and starts the unit.
+These are retained anyway: they are idempotent, they make the desired state explicit in the graph
+rather than implicit in a maintainer script, and they are the only steps that emit a service
+receipt — without them, decommission has nothing to compensate for the running daemon.
+
+**Verify** — declarative, in `lifecycle.yaml`
+
+```yaml
+verification:
+  command: docker --version
+  pattern: "Docker version \\d+\\.\\d+"
+```
+
+There is no `verify.star`. `plan.verify` does not exist, and the milestone already specifies that
+receipt verify status comes from matching `verification.pattern`.
+
+**Hardware gate** — the one step with a non-binary outcome. The bash reads
+`sudo lshw -json | jq -r '.product'` and branches:
+
+| Detected product | Outcome |
+| --- | --- |
+| `ODROID-C4*`, `ODROID-C5*` | Check `/media/boot/boot.ini` for `systemd.unified_cgroup_hierarchy=0`. If absent, print numbered remediation and **exit 0** — degraded, not failed |
+| `Raspberry Pi 5*` | Known good, no action |
+| anything else | Warn "Untested product", continue |
+
+**Postconditions**: `docker --version` matches the pattern; the `docker` service is enabled and
+running; `docker run hello-world` succeeds, or the run is reported degraded with remediation on
+ODROID hardware lacking the boot argument.
+
+**Receipts produced**: one per removed conflict, one per installed package, one for `enable`, one
+for `start`.
+
+### Scenario 2 — Upgrade Docker on Linux.Debian
+
+**Precondition**: Scenario 1 has run; a trace exists supplying the from-state.
+
+**Prepare**: `plan.pkg.update()` — refresh the index only. The repository and keyring are already
+correct, and re-writing them is Scenario 1's job.
+
+**Install**: `plan.pkg.upgrade([...])` over the same six packages.
+
+**Verify**: `plan.pkg.version_gte("docker-ce", <from-state version>)` — the assertion that
+distinguishes an upgrade from a no-op, using the prior receipt's recorded version.
+
+**Postconditions**: installed version is greater than or equal to the recorded from-state version;
+the service is still enabled and running.
+
+**Note on scope**: the bash has no upgrade path for Docker specifically. Its upgrade is
+`apt-get full-upgrade --yes` across the whole machine (`Initialize-Debian:120`). This scenario is
+therefore an *addition* to what the bash does, and is the first place the package is more precise
+than its source.
+
+### Scenario 3 — Decommission Docker on Linux.Debian
+
+**Precondition**: Scenario 1 has run and its receipts are durable.
+
+This scenario is the reason receipts matter: it should require **no teardown script**. Compensation
+in reverse receipt order gives `service.stop`, `service.disable`, then `pkg.remove` of exactly the
+packages that were installed — and critically, it does **not** reinstall the conflicting packages
+that prepare removed, unless those removals recorded receipts that say to.
+
+**Open**: whether conflict removal in prepare should be compensable. Reinstating `docker.io` on
+decommission is arguably correct restoration and arguably unwanted. Decide before writing prepare.
+
+**`purge-data` feature**: when enabled, additionally remove `/var/lib/docker` and
+`/var/lib/containerd`. Not compensable — this is the one deliberately irreversible step, and must
+be declared as such.
+
+**Postconditions**: `docker` is absent from `PATH`; the service unit no longer exists; with
+`purge-data`, the data directories are gone; without it, they remain.
+
+### Scenario 4 — Deploy Docker on Darwin
+
+**Precondition**: macOS with MacPorts or Homebrew present.
+
+**The development Mac, as measured 2026-08-26**:
+
+| Fact | Value |
+| --- | --- |
+| `orbctl` | `/usr/local/bin/orbctl` → `/Applications/OrbStack.app/Contents/MacOS/bin/orbctl` |
+| `docker` | `/usr/local/bin/docker` → `/Applications/OrbStack.app/Contents/MacOS/xbin/docker` |
+| Live daemon | OrbStack — `docker info` reports server 29.4.0, name `orbstack` |
+| `/Applications/Docker.app` | **Present**, Docker Desktop 4.37.0, dated 2024-10-30, dormant |
+| Homebrew | `/opt/homebrew/bin/brew`; cask `orbstack` 2.2.3, `auto_updates`, installed 2026-08-11 |
+| MacPorts | `/opt/local/bin/port` — both managers present, so the port-first rule applies here |
+
+Two consequences the scenario has to account for.
+
+**Binary presence is the wrong predicate.** `command -v docker` succeeds, but it resolves into
+OrbStack.app; and `/Applications/Docker.app` is present while serving nothing. The bash's three-way
+`(colima || orbctl || Docker.app)` test therefore reports "a runtime exists" on the strength of a
+dormant 2024 application. The honest predicate is **does a docker endpoint answer** — `docker info`
+succeeding — which `Install-Dependencies` already runs after starting Colima, just not as the gate.
+
+**Removing OrbStack is not sufficient to reach the install branch.** After
+`brew uninstall --cask orbstack`, the `/usr/local/bin` symlinks dangle and Docker Desktop 4.37.0
+remains in `/Applications`, so a directory-presence test still fires. Reaching the Colima branch on
+this machine means clearing Docker.app as well — and Docker.app is **not** a Homebrew cask (only
+`orbstack` is), so it came from Docker's own installer and needs its own removal.
+
+**Prepare**: assert a package manager exists. The bash errors with install instructions for both
+when neither is found; the package should fail with the same actionable message.
+
+**Install** — the branch that makes this scenario different from every other:
+
+```
+if not (colima present or orbctl present or /Applications/Docker.app present):
+    plan.pkg.install(["colima", "docker"])   # port first, brew fallback
+```
+
+The package **ensures a runtime exists**. It never displaces an installed Docker Desktop or
+OrbStack, because the whole point is to avoid putting a licensed product on the machine, not to
+prefer Colima on its merits.
+
+**Provision**: `plan.shell.exec("colima start …")` — only on the branch where Colima was installed.
+The flags are tribal knowledge worth encoding: `--vm-type vz --mount-type virtiofs` for file-sharing
+performance and `--vz-rosetta` for x86 images on Apple Silicon. The bash currently passes only
+`--cpu 2 --memory 4`; adding the others is a deliberate improvement, flagged here as such.
+
+There is no `plan.service.*` on this path. Colima is a foreground-launched VM manager, not a launchd
+service under the name `docker`.
+
+**Postconditions**: `docker info` succeeds; `docker run --rm hello-world` succeeds.
+
+### Scenario 5 — Upgrade and Decommission on Darwin
+
+**Upgrade**: `plan.pkg.upgrade(["colima", "docker"])`, then `colima stop && colima start` to pick up
+the new binary.
+
+**Decommission**: asymmetric by construction. Compensation removes only what deploy installed —
+so a machine where Docker Desktop was already present is left exactly as found, and a machine where
+Colima was installed gets `colima stop`, `colima delete`, and `pkg.remove`. This asymmetry needs no
+feature flag; it falls out of the receipt boundary.
+
+### Corrections from `cmd/internal/lorepackage/lifecycle.go`, 2026-08-27
+
+Reading the manifest struct before writing the manifest falsified three things above. They are left
+visible rather than silently patched.
+
+1. **Reconcile *is* package-authored.** `Reconcile Action = "Reconcile"` is a first-class action and
+   `ReconcilePhaseOrder = []string{"scan", "repair", "verify"}` exists. A package can contribute
+   `Reconcile/scan.star`, `Reconcile/repair.star`, and `Reconcile/verify.star`. Scenario 6 below is
+   wrong about the package surface — what remains unimplemented is the engine-side convergence loop
+   (`5.1`'s `ExecutionEvent` / `Reconcile` triangle), not the authoring surface.
+2. **Upgrade phases are `prepare`, `upgrade`, `migrate`, `verify`** — not `install`. The discarded
+   package's `Upgrade/install.star` names a phase that does not exist, and `migrate` (version-specific
+   config or data migration) was entirely unknown to this plan. Scenario 2 needs rewriting against
+   the real order.
+3. **`verify` is a real phase** in the Deploy, Upgrade, and Reconcile orders. This plan earlier
+   concluded "there is no `verify.star`" — wrong. What does not exist is the `plan.verify()`
+   builtin. The phase is ordinary graph work, and `lifecycle.yaml`'s `verification:` block is a
+   separate, additional mechanism.
+
+All other manifest fields the discarded package used — `hardware_provisions`, `features`,
+`settings`, `notes`, `tags`, `aliases`, `signatures` — are parsed. That part was not fiction.
+
+### Scenario 6 — Reconcile: why this one is not proven here
+
+**Superseded by correction 1 above — the premise of this section is wrong.** Reconcile is
+package-authored after all.
+
+The predicates exist and are sufficient to *detect* drift: `plan.pkg.installed`,
+`plan.pkg.version_gte`, `plan.pkg.observe`, `plan.service.enabled`, `plan.service.running`.
+`docs/architecture/5.1-reconciliation.md` records that `writ status` with Etag/Digest drift
+attribution landed in steps 47–48, but that the `ExecutionEvent` / `Reconcile` triangle is
+"Not implemented — preserved as design."
+
+So drift detection exists; the convergence loop does not. Proving reconcile is engine work, not a
+package. What this package contributes is the observable surface a convergence loop would read.
+
+## Implementation Phases
+
+### Phase 1: Remove the old package
+
+- [ ] User deletes `devlore-registry/packages/docker/` in the registry worktree
+- [ ] Confirm nothing else references it (`packages/cross-reference.yaml`, `INDEX.yaml`)
+
+### Phase 2: lifecycle.yaml
+
+- [ ] Rewrite from the bash: signatures, conflicts, features (`purge-data` only), settings,
+      verification block
+- [ ] Drop `rootless`; drop platforms not in this pass
+
+### Phase 3: Darwin
+
+Darwin goes first. It is the machine under the author's hands, so every scenario is runnable the
+moment it is written, and the runtime-detection branch is exercised immediately (see Scenario 4).
+
+- [ ] `Deploy/prepare.star`, `Deploy/install.star`, `Deploy/provision.star`
+- [ ] `Upgrade/*`
+
+### Phase 4: Prove Darwin
+
+- [ ] Scenario 4 on the development Mac — detection branch, which is the only branch that machine
+      can take while OrbStack is installed
+- [ ] Scenario 4 install branch on a Mac with no runtime, or with detection forced
+- [ ] Scenario 5
+- [ ] Record what each scenario actually did, and correct this document
+
+### Phase 5: Linux.Debian
+
+- [ ] `Deploy/prepare.star`, `Deploy/install.star`, `Deploy/provision.star`
+- [ ] `Upgrade/prepare.star`, `Upgrade/install.star`
+- [ ] Decommission: prove it needs no scripts, or write the minimum that compensation cannot express
+
+### Phase 6: Prove Linux.Debian
+
+- [ ] Scenarios 1–3 against a disposable Debian target
+- [ ] Record what each scenario actually did, and correct this document
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `devlore-registry/packages/docker/**` | Delete | Clean slate; user performs the deletion |
+| `devlore-registry/packages/docker/lifecycle.yaml` | Create | Manifest rewritten from the bash |
+| `devlore-registry/packages/docker/README.md` | Create | Tribal knowledge, sourced and dated |
+| `devlore-registry/packages/docker/Linux.Debian/**` | Create | Deploy and Upgrade phases |
+| `devlore-registry/packages/docker/Darwin/**` | Create | Deploy and Upgrade phases |
+
+## Related Documents
+
+- [Demo milestone](./extract-starlark-from-op/demo-milestone.md) — Scenario 1 there predates this
+  work and describes the discarded DMG approach; it needs correcting
+- [Reconciliation](../architecture/5.1-reconciliation.md) — why Scenario 6 is blocked
+- [The pipeline](../guides/lore/pipeline.md) — the four-phase model; its Docker examples use the
+  broken `plan.package.*` API and need correcting
+- `devlore-registry/AUTHORING.md` — the ABNF for package layout, including the unused `Common` and
+  `Unix` platform tokens
+
+## Open Questions
+
+- [ ] **How is any of this actually run?** Every "prove it" phase assumes `lore deploy docker`
+      resolves a package out of devlore-registry and executes it. `lore` is characterized as mostly
+      untested, and the milestone's criterion 5 (sealed graph plus lore consumer migration) was ⬜
+      as of 2026-06-02. If `lore deploy` does not yet run end to end, the scripts can be written and
+      reviewed but no scenario can be *proven*, and that is a prerequisite this plan does not own.
+- [ ] Does `lifecycle.yaml`'s `verification:` block actually drive receipt verify status? The
+      struct exists at `cmd/internal/lorepackage/lifecycle.go:61` and the milestone describes the
+      behavior, but the consuming code path is unread. The plan currently assumes it.
+- [ ] Should MacPorts precede Homebrew on Darwin (`pkg/platform/defaults.go:73`)? Ruling 7 leaves
+      the router's brew default in place, which diverges from `Install-Dependencies`.
+- [ ] How is Scenario 4's install branch proven, given OrbStack occupies the development Mac? A
+      second Mac, a VM, or a supported override that makes runtime detection miss? Note that
+      removing OrbStack alone is insufficient — Docker Desktop 4.37.0 remains in `/Applications`.
+- [ ] Should conflict removal in prepare be compensable, reinstating `docker.io` on decommission?
+- [ ] Does `Common/` or `Unix/` reduce duplication once Fedora and Windows return, or does the
+      per-platform split stay?
+- [ ] Where does the ODROID degraded outcome attach — which flow-control construct does
+      `test_flow_degraded.star` demonstrate, and is it reachable from a phase script?
+- [ ] Does `plan.pkg.remove` on an absent package fail, or is the `dpkg-query` guard's job already
+      done by the router?

--- a/docs/plans/extract-starlark-from-op/phase-8/steps/57-mine-the-workflow-rename-worktree.md
+++ b/docs/plans/extract-starlark-from-op/phase-8/steps/57-mine-the-workflow-rename-worktree.md
@@ -2,12 +2,31 @@
 step: 57
 issue: https://github.com/NobleFactor/devlore-cli/issues/517
 title: "Mine the workflow-rename-plan worktree before retiring it"
-status: charter — chartered 2026-08-14; do before the rename window (step 56)
-proof_run: TBD — each item below carries a keep/discard verdict, then the worktree is removed
+status: abandoned
+proof_run: none — the premise was falsified before any verdict was needed
 parent: ../../phase-8.md
 ---
 
 # Step 57 — Mine the `workflow-rename-plan` worktree before retiring it
+
+> **SUPERSEDED 2026-08-27 — the premise of this step is false, and [#517](https://github.com/NobleFactor/devlore-cli/issues/517)
+> is closed as invalid.** Nothing in the worktree exists only there. Every item in the table below was
+> either moved or deliberately removed on `develop` between 2026-08-10 and 2026-08-12 — two days
+> *before* this step was chartered:
+>
+> | Item | What actually happened |
+> | --- | --- |
+> | `tools/New-OpInventory/main.go` | **Renamed** to `cmd/devlore-inventory/main.go` — `b64a4fe0` (#360) |
+> | `prototype/bindgen/` | **Removed**, all 12 files — `10b4f8cd`, "chore: remove the bindgen prototype" (#386) |
+> | `CODE-CONSOLIDATION-ANALYSIS.md` | **Removed** — `030a8790`, "clean repo root" (#390) |
+> | `GITHUB-ISSUES.md` | **Removed** — `030a8790` (#390) |
+> | `ARCHITECTURE-STATUS.md` | **Removed** — `030a8790` (#390) |
+> | `draft-llm-cache-augmented-generation.md` | **Removed** — `33f7635e`, "relicense to Apache-2.0, retract SSPL-era tags" (#389) |
+> | `draft-llm-long-context-prompting.md` | **Removed** — `33f7635e` (#389) |
+>
+> The error was method, not diligence: this step compared two working trees and read "absent from
+> `develop`" as "exists nowhere else." It never consulted history. Anything wanted from the list is
+> recoverable from the commits above, and the worktree is safe to retire.
 
 **Status:** `charter` — chartered 2026-08-14. A stale worktree is holding content that exists nowhere else, and
 it will be deleted at some point by someone tidying up. Read it first.

--- a/docs/plans/function-resource-receipts.md
+++ b/docs/plans/function-resource-receipts.md
@@ -1,0 +1,135 @@
+---
+issue: https://github.com/NobleFactor/devlore-cli/issues/720
+title: "A graph carrying a Starlark lambda cannot write its receipt, and one fixture hides it"
+status: draft
+proof_run: TBD — defined by the charter's own decision (see Exit criteria)
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Charter — the `function.Resource` receipt defect, and the coverage gap that hid it
+
+**Chartered 2026-08-27** from the docker package rewrite
+([docker.devlore-package.md](docker.devlore-package.md)), while probing whether `plan.choose` could
+express a runtime-detection guard. The probe succeeded; it also surfaced this.
+
+**No solution is assumed.** Two findings are chartered together because the second is why the first
+survived: the defect is real, and nothing in the suite can see it.
+
+## Finding 1 — receipt writing fails whenever the graph holds a lambda
+
+Measured against `build/devlore-test` on 2026-08-27, `feature/docker.devlore-package`:
+
+| Fixture | Lambdas in graph | Expectations | Exit |
+| --- | --- | --- | --- |
+| `test_compensation.star` | none | pass | 0 |
+| `test_choose_then_action.star` | none | pass | 0 |
+| `test_choose_exists.star` | one, `default=lambda:` | pass | **1** |
+| `test_choose_lambdas.star` | many | pass | **1** |
+
+The error, verbatim:
+
+```
+Error: writing receipt: op.Graph: pack tag:devlore.noblefactor.com,2026-01-01:sha256:<hash>
+#github.com/NobleFactor/devlore-cli/pkg/op/provider/function.Resource: function.Resource: pack …:
+mmap <session-root>/.devlore/function/resource/sha256/<xx>/<hash>: no such file or directory
+```
+
+A Starlark lambda is archived as a content-addressed `function.Resource` at plan time. At
+receipt-write time the file is not on disk. Routing the receipt to a real path rather than
+`/dev/null` changes nothing, so this is not an artifact of the output destination.
+
+**Expectations pass in every case.** The graph plans, executes, and satisfies its assertions. Only
+the receipt fails, and only afterwards.
+
+## Finding 2 — one fixture is exercised through the CLI
+
+`cmd/devlore-test/cli_test.go` drives exactly one script — `test_hello.star` — and contains zero
+references to `choose`. The other 103 fixtures under
+`cmd/devlore-test/devloretest/data/` are driven in-process, where receipts are apparently not
+written at all.
+
+So the suite is green while the receipt is unwritable. This is the same failure shape as the
+knowledge extractor that passes CI continuously while emitting a near-constant artifact: a success
+signal that does not cover the thing it appears to certify.
+
+## Why this matters
+
+Receipts are the mechanism compensation reads. A package whose graph carries one lambda produces no
+receipt, and therefore cannot be decommissioned by compensation — which is the entire proof the
+docker package exists to demonstrate.
+
+The exposure is not hypothetical. All nine `test_choose_*` fixtures use `default=lambda: …`, so the
+**idiomatic** way to write a decision tree is the failing way. The docker package works around it
+with Ruling 8 (phase scripts contain no lambdas), building every branch from invocations instead.
+That workaround is sound on its own merits — a branch that performs work beats one that computes a
+string — but it should not be load-bearing for a defect.
+
+## Diagnosis — found 2026-08-27, cause confirmed
+
+`cmd/devlore-test/devloretest/commands.go`:
+
+```go
+result, err := runner.Start(cmd.Context())      // line 153
+...
+if err := writeReceipt(outputs.entries["receipt"], receiptFmt, runner.Graph()); err != nil {
+    return fmt.Errorf("writing receipt: %w", err)   // line 166
+}
+```
+
+`Runner.Start` opens its workspace with `fsroot.OpenScratch("devlore-test-*")` under
+`defer iox.Close(&err, workspace)`, and its own comment states the consequence: *"a scratch root, so
+the tree is removed by the same Close that releases it."*
+
+So the workspace — including `.devlore/function/resource/sha256/…` — is **deleted when `Start`
+returns**, and the receipt is written afterwards. Packing the graph then tries to read the function
+pack off a path that no longer exists.
+
+Graphs without lambdas are unaffected because nothing in them requires a disk read at pack time.
+A `function.Resource` is deliberately metadata-only: `newFromURI` in
+`pkg/op/provider/function/resource.go` documents that *"No content is archived — the on-disk pack is
+the source of truth, rehydrated lazily."* The pack itself is written correctly at plan time
+(`resource.go:396-410`, `WriteFile(sp, packBuf.Bytes(), 0o600)`). Nothing about the archiving is
+broken; only the read outlives the tree it reads from.
+
+**Production is not affected.** `lore` and `writ` run against durable roots, not `OpenScratch`, so
+their `.devlore/` survives the run and a function pack is still readable when the receipt is
+written. This answers the severity question this charter originally listed as needing to be settled
+first: the defect is confined to `devlore-test`.
+
+## Candidate fixes
+
+Not a shortlist to choose from.
+
+1. **Write the receipt inside `Start`**, before the workspace closes. Smallest change; makes the
+   receipt part of the run rather than of the command.
+2. **Defer workspace teardown past receipt writing** — hand the caller a closer rather than closing
+   in `Start`. Keeps the receipt in the command layer, moves the lifetime.
+3. **Pack function resources eagerly at seal time** rather than lazily at receipt time, so the graph
+   document is self-contained and no read is needed later. Largest change; also the one that would
+   make receipts robust to any root going away, not just this one.
+
+## What remains to be discovered
+
+- [ ] Should `cli_test.go` drive every fixture, a representative subset, or a characteristic-based
+      selection? Driving all 104 through the CLI has a runtime cost worth measuring.
+- [ ] Does any other resource type share the metadata-only-plus-lazy-read shape, and would it fail
+      the same way? `mem.Resource` also uses `op.ContentAddressedReader`.
+
+## Exit criteria
+
+- [ ] A fixture whose graph contains a lambda writes its receipt and exits 0.
+- [ ] `cli_test.go` exercises at least one lambda-bearing graph through the CLI, and that test is
+      **proved to fail before it is trusted** — reverting the fix must turn it red.
+- [ ] Ruling 8 in the docker plan is revisited: with the cause known to be harness-confined, a
+      no-lambdas rule for package scripts may no longer be needed for receipt reasons — though it
+      may still stand on its own merits, since a branch that performs work beats one that computes
+      a string.
+
+## Related
+
+- [Docker devlore package](docker.devlore-package.md) — Ruling 8 and the probe that found this
+- [LintStarlark charter](lint-starlark.md) — whether a linter should flag lambdas depends on
+  whether this fix lands first
+- `cmd/devlore-test/devloretest/data/test_choose_then_action.star` — the lambda-free fixture added
+  during the probe; passes and writes its receipt

--- a/docs/plans/lint-starlark.md
+++ b/docs/plans/lint-starlark.md
@@ -1,0 +1,124 @@
+---
+issue: https://github.com/NobleFactor/devlore-cli/issues/721
+title: "Nothing checks Starlark, and dead API calls survive for months"
+status: draft
+proof_run: TBD — defined by the charter's own decision (see Exit criteria)
+created: 2026-08-27
+updated: 2026-08-27
+---
+
+# Charter — `LintStarlark`
+
+**Status:** `charter` — chartered 2026-08-27 from the docker package rewrite
+([docker.devlore-package.md](docker.devlore-package.md)), where every phase script in the shipped
+package turned out to call an API that no longer exists.
+
+**No solution is assumed.** This charter states the problem, the evidence, and what has to be
+discovered. The approaches at the end are candidates to evaluate.
+
+## The observed failure
+
+`devlore-registry/packages/docker/` shipped 28 `.star` files. Reading them against the provider tree
+on 2026-08-26 found that the deploy path could not execute on any platform:
+
+| Written in the package | Reality |
+| --- | --- |
+| `plan.package.install("docker-ce", "docker-ce-cli")` | No `package` namespace — it is `pkg`, and it takes a list, not varargs |
+| `plan.verify(name, check=…, optional=True)` | No `Verify` method on any provider. **All four `verify.star` files are entirely these calls** |
+| `plan.file.write(path=…, content=…)` | It is `plan.file.write_text(destination_path=…, content=…, mode=…)` |
+| `plan.user.add_to_group(user, "docker")` | No `user` provider |
+| `plan.download(url, dest)` | `appnet.download(url)` returns bytes; there is no dest form |
+| `plan.notify(…)` | Does not exist |
+| `Upgrade/install.star` | `UpgradePhaseOrder` is `{prepare, upgrade, migrate, verify}` — `install` is not an upgrade phase |
+
+The registry's own CI validates knowledge schemas and package structure. None of it reads a `.star`
+file's contents, so all of the above passed continuously.
+
+## Why a syntax checker would not have helped
+
+Every one of those lines is **syntactically valid Starlark**. `buildifier` — already installed at
+`/opt/homebrew/bin/buildifier` — parses all of them without complaint, and always would have. The
+defects are *resolution* errors: wrong namespace, absent method, wrong arity, wrong parameter name.
+A general-purpose Starlark formatter knows nothing about devlore's provider surface and structurally
+cannot see them.
+
+This is the load-bearing observation. The cheap check is available today and would have caught
+nothing. The check that matters requires knowing what `plan.*` actually offers.
+
+## Why the cost is low
+
+The machinery is already in the tree:
+
+1. `go.starlark.net` is a direct dependency in `go.mod`; `go.starlark.net/syntax` is imported by ten
+   files.
+2. `cmd/star/provider/starindex/provider.go` **already parses Starlark** — `syntax.FileOptions{}`,
+   walking `DefStmt`, `LoadStmt`, and `AssignStmt`. Its package doc is "AST-based indexing of
+   Starlark source files."
+3. The resolution ground truth is **generated**: `action_names.gen.go` per provider enumerates every
+   valid `<namespace>.<method>`, and the `ParameterNames` tables in each `gen/provider.gen.go`
+   enumerate every valid keyword argument. A checker that reads these cannot drift from codegen —
+   which is the same discipline `Knowledge/extract.star` already applies to Go.
+4. There is a home and a conspicuous hole: the star extension family carries `LintCopyright`,
+   `LintGo`, `LintGoStyle`, `LintMarkdown`, `LintShell`, and `LintTools` — and no `LintStarlark`,
+   across 162 `.star` files.
+
+## Rules worth considering beyond dead references
+
+Discovered while writing the Darwin package; each needs its own justification before adoption.
+
+- **Lifecycle verbs in phase scripts.** `cmd/lore/lore/builder.go:31` denies `plan.assemble`,
+  `plan.clear`, `plan.load`, `plan.run`, and `plan.save` to package scripts at runtime. A checker
+  could reject them at author time instead of at execution.
+- **Lambdas in package graphs.** A Starlark lambda is archived as a content-addressed
+  `function.Resource`, and a graph carrying one currently fails receipt writing with
+  `mmap …/.devlore/function/resource/sha256/…: no such file or directory`. Since receipts are what
+  decommission compensates from, a package with a lambda cannot be removed. This is a separate
+  defect that must be fixed on its own merits; whether the linter should also flag it depends on
+  whether the fix lands first.
+- **Phase entry point.** Every phase script must define `def <phase>(package, phase)` matching its
+  filename and the phase order for its action directory.
+
+## What has to be discovered
+
+- [ ] How much of `plan.<namespace>.<method>(…)` resolution is tractable statically? Starlark is
+      dynamic and `plan` sub-namespaces are attribute lookups. Handling the literal call shape
+      likely covers every real package script, but the coverage should be measured, not assumed.
+- [ ] Does the checker live as a star extension (`LintStarlark`, joining `make check` through
+      `LintAll`), as a Go analyzer, or as a `star` subcommand? The extension family is the obvious
+      home, but `star` currently fails to load its own extensions.
+- [ ] Does it run against `devlore-registry` as well as `devlore-cli`? The failure that motivated
+      this charter is in the registry, a separate repository, whose CI would need the checker
+      available as a built artifact.
+- [ ] Should `buildifier` be adopted alongside it as a parse gate, and if so with what warning set?
+      `-module-docstring` and `-unused-variable` are both wrong for devlore — the latter fires on
+      the mandated `(package, phase)` signature of every phase script ever written. Note also that
+      buildifier's formatter rewrites `kwarg=value` to `kwarg = value`, which no file in the corpus
+      uses and which buildifier cannot be configured to skip.
+
+## Candidate approaches
+
+Not a shortlist to choose from — each needs evaluating against the discovery items above.
+
+1. **Star extension reading generated tables.** Parse with `go.starlark.net/syntax`, resolve calls
+   against `action_names.gen.go` and `ParameterNames`. Joins `make check` via `LintAll`.
+2. **Go analyzer in `cmd/star/provider/`.** A sibling of `starindex`, reusing its walker, surfaced
+   as a `lint.*` action.
+3. **Extend `starindex` itself.** It already extracts functions, loads, and globals; call-site
+   resolution is an addition rather than a new component.
+4. **buildifier only.** Rejected as sufficient by the evidence above, but retained here as the
+   do-nothing-more baseline any other option must beat.
+
+## Exit criteria
+
+- [ ] Running the checker over `devlore-registry/packages/docker/` **as it stood on 2026-08-26**
+      reports every row in the table at the top of this charter. That corpus is the regression
+      fixture, and it is why the discarded scripts should be preserved somewhere before deletion.
+- [ ] The checker reads the generated tables rather than a hand-maintained surface list, proven by
+      adding a provider method and observing the checker accept it with no edit.
+- [ ] Zero false positives across the 162 `.star` files in `devlore-cli`.
+
+## Related
+
+- [Docker devlore package](docker.devlore-package.md) — the rewrite that surfaced this
+- `cmd/star/provider/starindex/provider.go` — the existing Starlark AST walker
+- `cmd/lore/lore/builder.go:31` — the runtime denial this could enforce at author time


### PR DESCRIPTION
Planning work for the `docker` package rewrite in devlore-registry, plus the two defects that
writing it uncovered. No production code changes here — one test fixture, three documents.

## The plan

`docs/plans/docker.devlore-package.md`. The existing docker package is discarded rather than
repaired: every phase script calls an API that no longer exists. Its only source of truth is the
bash that deploys Docker today — `Home/noblefactor.Unix/.local/bin/Install-Docker` and
`Tools/Debian/Initialize-Debian` in the Personal repository.

Six scenarios, each with preconditions, contributed graph, receipts, verification, and
postconditions. Eight rulings, including two the reader should not have to infer:

- **Darwin uses Colima for licensing, and only licensing.** Docker Desktop needs a paid subscription
  above 250 employees or $10M revenue; OrbStack has a paid commercial tier. The package therefore
  *ensures a runtime exists* rather than installing Colima — an existing Desktop or OrbStack is left
  exactly as found.
- **The package names no package manager.** `pkg/platform/defaults.go:72` defaults Darwin to brew
  while `Install-Dependencies` prefers port. Manager preference is machine policy; if MacPorts should
  win, `defaults.go:73` is the fix, and it fixes every package rather than this one.

The plan records its own corrections rather than quietly patching them — reading
`cmd/internal/lorepackage/lifecycle.go` before writing the manifest falsified three earlier
conclusions, including that reconcile is not package-authored. It is: `ReconcilePhaseOrder` is
`{scan, repair, verify}`.

## The fixture

`test_choose_then_action.star` answers a question nothing else covered: can a `plan.case` `then=`
body carry an **action**, or only a value-returning lambda? All nine existing `test_choose_*`
fixtures pass lambdas. This one passes live invocations to both `then=` and `default=`, and asserts
the unchosen branch never fires.

It matters because a package that must install software only when a predicate holds needs the branch
to perform work, not compute a string. It is deliberately lambda-free — see #720.

## The charters

- **#720** — `docs/plans/function-resource-receipts.md`. `devlore-test` writes the receipt *after*
  deleting the workspace it reads from. Cause confirmed: `Runner.Start` opens an
  `fsroot.OpenScratch` workspace under `defer iox.Close`, and `commands.go:166` writes the receipt
  after `Start` returns. Any graph carrying a Starlark lambda then fails, because a
  `function.Resource` is metadata-only and packing it requires reading the pack back off disk.
  Production is unaffected — `lore` and `writ` use durable roots.

  Filed with it: `cli_test.go` drives exactly one fixture and never mentions `choose`, which is why
  this sat unseen. The suite is green while the receipt is unwritable.

- **#721** — `docs/plans/lint-starlark.md`. Nothing checks Starlark, and dead API calls survive for
  months. Every defect in the discarded docker package is *syntactically valid* — `buildifier` parses
  all of them and always would have. The failures are resolution errors, and resolution needs
  knowledge of devlore's provider surface. That surface is already generated
  (`action_names.gen.go`, `ParameterNames`), and `starindex` already parses Starlark, so the cost is
  low. The lint family has `LintGo`, `LintShell`, `LintMarkdown` and no `LintStarlark`, across 162
  files.
