### PR TITLE
ProviderFlags: a Surfaces bit field and a Placement value, each distinctly typed

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_function_call_walk_tree.star
+++ b/cmd/devlore-test/devloretest/data/test_function_call_walk_tree.star
@@ -5,7 +5,7 @@
 #
 # `function.call` is the provider's only method, and nothing exercised it. The function resource appeared
 # solely as a callback OTHER providers accept — walk_tree's reducer, choose's lambdas — never as the thing
-# being dispatched. function is RoleAction only, so it exists in graph scope alone.
+# being dispatched. function reaches both surfaces; this exercises the workflow one.
 #
 # A graph's result is not directly assertable, so each callable's return value is observed by feeding it
 # into a write and checking the file.

--- a/cmd/devlore-test/devloretest/runner.go
+++ b/cmd/devlore-test/devloretest/runner.go
@@ -271,7 +271,7 @@ func (r *Runner) Start(ctx context.Context) (_ *Result, err error) {
 
 	spec := op.NewRuntimeEnvironmentSpec("devlore-test").
 		WithStatus(cli.UI()).
-		WithModules(receiverRegistry.Modules()...).
+		WithModules(receiverRegistry.Scripts()...).
 		WithRoot(tmpDir).
 		WithPlatform(hostPlatform).
 		WithApplication(app)

--- a/cmd/lore/lore/builder.go
+++ b/cmd/lore/lore/builder.go
@@ -108,7 +108,7 @@ func Build(cfg BuildConfig) (*BuildResult, error) {
 
 	sharedEnvironment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("lore").
 		WithStatus(cli.UI()).
-		WithModules(op.ReceiverRegistry().Modules()...).
+		WithModules(op.ReceiverRegistry().Scripts()...).
 		WithApplication(&application.Application{Name: "lore"}))
 	if err != nil {
 		return nil, fmt.Errorf("lore.Build: build runtime environment: %w", err)

--- a/cmd/lore/lore/builder_test.go
+++ b/cmd/lore/lore/builder_test.go
@@ -25,7 +25,7 @@ func TestBuildPackage_NativePackageProducesParentedPhaseSubgraph(t *testing.T) {
 
 	registry := op.ReceiverRegistry()
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(), op.NewRuntimeEnvironmentSpec("lore").
-		WithModules(registry.Modules()...).
+		WithModules(registry.Scripts()...).
 		WithApplication(&application.Application{Name: "lore"}))
 	if err != nil {
 		t.Fatalf("op.NewRuntimeEnvironment: %v", err)

--- a/cmd/star/provider/commands/gen/provider.gen.go
+++ b/cmd/star/provider/commands/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Children": {ParameterNames: []string{"parent?=\"\""}},

--- a/cmd/star/provider/config/gen/provider.gen.go
+++ b/cmd/star/provider/config/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Get": {

--- a/cmd/star/provider/goast/gen/provider.gen.go
+++ b/cmd/star/provider/goast/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Callable":         {ParameterNames: []string{"path", "name"}},

--- a/cmd/star/provider/lint/gen/provider.gen.go
+++ b/cmd/star/provider/lint/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"EnsureTools": {ParameterNames: []string{}},

--- a/cmd/star/provider/setup/gen/provider.gen.go
+++ b/cmd/star/provider/setup/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"CheckHook":        {ParameterNames: []string{"name"}},

--- a/cmd/star/provider/shellcheck/gen/provider.gen.go
+++ b/cmd/star/provider/shellcheck/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Complexity": {ParameterNames: []string{"path"}},

--- a/cmd/star/provider/staranalysis/gen/provider.gen.go
+++ b/cmd/star/provider/staranalysis/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Analyze": {ParameterNames: []string{"files", "cfg"}},

--- a/cmd/star/provider/starcode/gen/provider.gen.go
+++ b/cmd/star/provider/starcode/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Capture": {ParameterNames: []string{"pattern", "include_gitignored?=false"}},

--- a/cmd/star/provider/starcomplexity/gen/provider.gen.go
+++ b/cmd/star/provider/starcomplexity/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"ComputeComplexity": {ParameterNames: []string{"files"}},

--- a/cmd/star/provider/starindex/gen/provider.gen.go
+++ b/cmd/star/provider/starindex/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"IndexFiles": {ParameterNames: []string{"files", "with_docstrings", "with_globals"}},

--- a/cmd/star/provider/starstats/gen/provider.gen.go
+++ b/cmd/star/provider/starstats/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"ComputeStats": {ParameterNames: []string{"files", "with_bytes", "with_loc"}},

--- a/cmd/star/star/application.go
+++ b/cmd/star/star/application.go
@@ -81,7 +81,7 @@ func NewApplication(rootCmd *cobra.Command) *Application {
 
 	spec := op.NewRuntimeEnvironmentSpec("star").
 		WithApplication(app).
-		WithModules(registry.Modules()...).
+		WithModules(registry.Scripts()...).
 		WithRoot(wd)
 
 	runtimeEnvironment, err := op.NewRuntimeEnvironment(context.Background(), spec)

--- a/pkg/op/graph_executor_test.go
+++ b/pkg/op/graph_executor_test.go
@@ -76,7 +76,7 @@ func (p *compensationCleanFixture) Explode(input string) error {
 
 func init() {
 
-	AnnounceProvider(reflect.TypeFor[compensationFailingFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[compensationFailingFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &compensationFailingFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},
@@ -85,7 +85,7 @@ func init() {
 			"Explode": {ParameterNames: []string{"input"}},
 		})
 
-	AnnounceProvider(reflect.TypeFor[compensationCleanFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[compensationCleanFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &compensationCleanFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},
@@ -94,7 +94,7 @@ func init() {
 			"Explode": {ParameterNames: []string{"input"}},
 		})
 
-	AnnounceProvider(reflect.TypeFor[compensationFlakyFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[compensationFlakyFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &compensationFlakyFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},
@@ -136,7 +136,7 @@ func (p *retryHandlingFixture) Halt(activationRecord *ActivationRecord) error {
 
 func init() {
 
-	AnnounceProvider(reflect.TypeFor[retryHandlingFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[retryHandlingFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &retryHandlingFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},
@@ -170,7 +170,7 @@ func (p *callerStampFixture) Mint(activation *ActivationRecord) (string, error) 
 
 func init() {
 
-	AnnounceProvider(reflect.TypeFor[callerStampFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[callerStampFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &callerStampFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},

--- a/pkg/op/graph_number_fidelity_test.go
+++ b/pkg/op/graph_number_fidelity_test.go
@@ -26,7 +26,7 @@ func (p *numberFidelityFixture) Chmod(mode fs.FileMode) error { return nil }
 
 func init() {
 
-	AnnounceProvider(reflect.TypeFor[numberFidelityFixture](), RoleAction,
+	AnnounceProvider(reflect.TypeFor[numberFidelityFixture](), NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		func(runtimeEnvironment *RuntimeEnvironment) (any, error) {
 			return &numberFidelityFixture{ProviderBase: NewProviderBase(runtimeEnvironment)}, nil
 		},

--- a/pkg/op/planner_test.go
+++ b/pkg/op/planner_test.go
@@ -31,7 +31,7 @@ func TestActionPlanner_ExecutableUnitAssignableDispatch(t *testing.T) {
 	receiverType, err := NewProviderReceiverType(
 		reflect.TypeFor[slotDispatchProvider](),
 		func(*RuntimeEnvironment) (any, error) { return nil, nil },
-		RoleAction,
+		NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		map[string][]Parameter{"Wrap": {
 			{Name: "body", Type: reflect.TypeFor[ExecutableUnit]()},
 			{Name: "note", Type: reflect.TypeFor[string]()},
@@ -106,7 +106,7 @@ func planStringIntoResourceInterface(t *testing.T) error {
 	receiverType, err := NewProviderReceiverType(
 		reflect.TypeFor[mintProbeProvider](),
 		func(*RuntimeEnvironment) (any, error) { return nil, nil },
-		RoleAction,
+		NewProviderFlags(SurfaceWorkflow, PlacementQualified),
 		map[string][]Parameter{"Take": {{Name: "claim", Type: reflect.TypeFor[Resource]()}}},
 		nil,
 	)

--- a/pkg/op/provider/appnet/gen/provider.gen.go
+++ b/pkg/op/provider/appnet/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Download": {ParameterNames: []string{"url"}},

--- a/pkg/op/provider/archive/gen/provider.gen.go
+++ b/pkg/op/provider/archive/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Extract": {

--- a/pkg/op/provider/encryption/gen/provider.gen.go
+++ b/pkg/op/provider/encryption/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"DecryptSopsFile": {

--- a/pkg/op/provider/file/gen/provider.gen.go
+++ b/pkg/op/provider/file/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Backup": {

--- a/pkg/op/provider/flow/gen/provider.gen.go
+++ b/pkg/op/provider/flow/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleAction|op.RoleRoot,
+		op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementPromoted),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Choose": {

--- a/pkg/op/provider/flow/provider.go
+++ b/pkg/op/provider/flow/provider.go
@@ -26,8 +26,8 @@ var _ op.Provider = (*Provider)(nil) // Interface Guard
 // plan.gather) rather than nested under plan.flow.*. Starlark authors call these as plain planner primitives; Go-side
 // the planner primitives carry bare action names on the created graph nodes (choose, gather, subgraph, …).
 //
-// +devlore:root=true
-// +devlore:surface=graph
+// +devlore:placement=promoted
+// +devlore:surface=workflow
 type Provider struct {
 	op.ProviderBase
 }

--- a/pkg/op/provider/function/gen/provider.gen.go
+++ b/pkg/op/provider/function/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Call": {

--- a/pkg/op/provider/git/gen/provider.gen.go
+++ b/pkg/op/provider/git/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Checkout": {ParameterNames: []string{"repo", "ref"}},

--- a/pkg/op/provider/instance_test.go
+++ b/pkg/op/provider/instance_test.go
@@ -48,7 +48,7 @@ type unregisteredProvider struct {
 func init() {
 	op.AnnounceProvider(
 		reflect.TypeFor[fakeProvider](),
-		op.RoleAction,
+		op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementQualified),
 		func(runtimeEnvironment *op.RuntimeEnvironment) (any, error) {
 			return &fakeProvider{ProviderBase: op.NewProviderBase(runtimeEnvironment)}, nil
 		},

--- a/pkg/op/provider/json/gen/provider.gen.go
+++ b/pkg/op/provider/json/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Decode": {

--- a/pkg/op/provider/pkg/gen/provider.gen.go
+++ b/pkg/op/provider/pkg/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Install":      {ParameterNames: []string{"packages", "**kwargs"}},

--- a/pkg/op/provider/plan/gen/module.gen_test.go
+++ b/pkg/op/provider/plan/gen/module.gen_test.go
@@ -16,7 +16,10 @@ import (
 )
 
 func TestModule_AttrNames(t *testing.T) {
-	r := starlarkbridge.NewProvider(providerReceiverType(t), provider.NewProvider(newCtx(t)))
+	r, err := starlarkbridge.NewGoReceiver(provider.NewProvider(newCtx(t)))
+	if err != nil {
+		t.Fatalf("NewGoReceiver: %v", err)
+	}
 	names := r.AttrNames()
 	if len(names) == 0 {
 		t.Fatal("AttrNames() returned empty list")
@@ -29,7 +32,10 @@ func TestModule_AttrNames(t *testing.T) {
 }
 
 func TestModule_Attr(t *testing.T) {
-	r := starlarkbridge.NewProvider(providerReceiverType(t), provider.NewProvider(newCtx(t)))
+	r, err := starlarkbridge.NewGoReceiver(provider.NewProvider(newCtx(t)))
+	if err != nil {
+		t.Fatalf("NewGoReceiver: %v", err)
+	}
 	for _, name := range r.AttrNames() {
 		attr, err := r.Attr(name)
 		if err != nil {
@@ -46,7 +52,10 @@ func TestModule_Attr_Unknown(t *testing.T) {
 
 	var r starlark.HasAttrs
 	var err error
-	r = starlarkbridge.NewProvider(providerReceiverType(t), provider.NewProvider(newCtx(t)))
+	r, err = starlarkbridge.NewGoReceiver(provider.NewProvider(newCtx(t)))
+	if err != nil {
+		t.Fatalf("NewGoReceiver: %v", err)
+	}
 	_, err = r.Attr("nonexistent_method")
 	if err == nil {
 		t.Error("Attr(nonexistent_method) error = nil, want error")
@@ -54,7 +63,10 @@ func TestModule_Attr_Unknown(t *testing.T) {
 }
 
 func TestModule_Type(t *testing.T) {
-	r := starlarkbridge.NewProvider(providerReceiverType(t), provider.NewProvider(newCtx(t)))
+	r, err := starlarkbridge.NewGoReceiver(provider.NewProvider(newCtx(t)))
+	if err != nil {
+		t.Fatalf("NewGoReceiver: %v", err)
+	}
 	if got := r.Type(); got != "plan" {
 		t.Errorf("Type() = %q, want %q", got, "plan")
 	}

--- a/pkg/op/provider/plan/gen/provider.gen.go
+++ b/pkg/op/provider/plan/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule,
+		op.NewProviderFlags(op.SurfaceScript, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"AssembleDefinition": {

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -40,7 +40,7 @@ var (
 //     [newAdapter], cached in `adapters`. Each adapter is a [starlark.HasAttrs] that routes `.<method>(args, kwargs)`
 //     through [Provider.invocation].
 //   - Tier 2 — promoted methods from root-placed providers (`plan.choose`, `plan.gather`, ...). Surfaced flat under
-//     plan.* via builtins discovered from [op.ReceiverRegistry.RootProviders] at construction (any RoleAction+RoleRoot
+//     plan.* via builtins discovered from [op.ReceiverRegistry.PromotedProviders] at construction (any promoted provider reaching SurfaceWorkflow
 //     provider contributes its methods).
 //   - Tier 3 — Provider's own methods (`plan.variable`, `plan.assemble_definition`, `plan.save_definition`, ...).
 //     Surfaced by the executing receiver path that wraps plan.Provider itself as a [goReceiver].
@@ -48,14 +48,14 @@ var (
 // Any collision across the three tiers fails Provider construction with a message naming both providers and the
 // offending method. promotedBuiltins is write-once at construction; the adapters are lazily populated under
 // `adaptersMutex`.
-// +devlore:surface=module
+// +devlore:surface=script
 type Provider struct {
 	op.ProviderBase
 	invocations      *op.InvocationRegistry    // session-scoped ledger of plan-mode invocations
-	rootNames        map[string]struct{}       // names of root providers (excluded from Tier 1 resolution)
+	promotedNames    map[string]struct{}       // names of promoted providers (excluded from Tier 1 resolution)
 	adapters         map[string]*adapter       // Tier 1: per-sub-namespace adapters, lazily populated
 	adaptersMutex    sync.Mutex                // guards adapters
-	promotedBuiltins map[string]starlark.Value // Tier 2: root-placed providers' promoted method builtins, write-once
+	promotedBuiltins map[string]starlark.Value // Tier 2: promoted providers' method builtins, write-once
 }
 
 // NewProvider creates a plan Provider bound to the given runtime environment.
@@ -64,7 +64,7 @@ type Provider struct {
 // [*op.Invocation] handles registered in [Provider.invocations]. The graph is materialized
 // by [Provider.AssembleDefinition] from the supplied invocation set.
 //
-// At construction, the Provider instantiates the invocation registry, then discovers every RoleAction+RoleRoot provider
+// At construction, the Provider instantiates the invocation registry, then discovers every promoted provider reaching SurfaceWorkflow
 // via the registry to build Tier 2 builtins for their promoted methods. Any name collision across Tier 1 (sub-namespace
 // adapter names), Tier 2 (promoted method names), or Tier 3 (this Provider's own method names) is a program-init panic.
 //
@@ -79,7 +79,7 @@ func NewProvider(runtimeEnvironment *op.RuntimeEnvironment) *Provider {
 	p := &Provider{
 		ProviderBase:     op.NewProviderBase(runtimeEnvironment),
 		invocations:      op.NewInvocationRegistry(),
-		rootNames:        make(map[string]struct{}),
+		promotedNames:    make(map[string]struct{}),
 		adapters:         make(map[string]*adapter),
 		promotedBuiltins: make(map[string]starlark.Value),
 	}
@@ -576,7 +576,7 @@ func (p *Provider) Origin(scope string) op.Origin {
 // Walks the attribute tiers in order:
 //
 //  1. Tier 2: promoted method builtins (including `plan.choose`, `plan.gather`, ...) discovered from
-//     [op.ReceiverRegistry.RootProviders] at construction. `promotedBuiltins` are write-once, so the read is lock-free.
+//     [op.ReceiverRegistry.PromotedProviders] at construction. `promotedBuiltins` are write-once, so the read is lock-free.
 //
 //  2. Tier 1: sub-namespace adapters (`plan.file`, `plan.shell`,...). Looked up via op.ReceiverRegistry.PlannerByName].
 //     Root-placed providers are excluded, so their methods surface flat via Tier 2 instead. On hit, the adapter is
@@ -602,7 +602,7 @@ func (p *Provider) ResolveAttr(name string) any {
 		return builtin
 	}
 
-	if _, isRoot := p.rootNames[name]; isRoot {
+	if _, isPromoted := p.promotedNames[name]; isPromoted {
 		return nil
 	}
 
@@ -791,7 +791,7 @@ func (p *Provider) adapterFor(receiverType op.ProviderReceiverType) *adapter {
 	return fresh
 }
 
-// buildPromotedBuiltins populates promotedBuiltins from every RoleRoot provider in the registry.
+// buildPromotedBuiltins populates promotedBuiltins from every promoted provider in the registry.
 //
 // Asserts there are no collisions across Tier 1 (sub-namespace adapter names), Tier 2 (promoted methods), or Tier 3
 // (this Provider's own methods). Called exactly once from NewProvider. Panics on collision — collisions are
@@ -808,22 +808,22 @@ func (p *Provider) buildPromotedBuiltins() {
 		}
 	}
 
-	for _, rp := range registry.RootProviders() {
-		p.rootNames[rp.Name()] = struct{}{}
+	for _, rp := range registry.PromotedProviders() {
+		p.promotedNames[rp.Name()] = struct{}{}
 	}
 
 	childNames := make(map[string]struct{})
 
 	for _, pp := range registry.Planners() {
-		if _, isRoot := p.rootNames[pp.Name()]; !isRoot {
+		if _, isPromoted := p.promotedNames[pp.Name()]; !isPromoted {
 			childNames[pp.Name()] = struct{}{}
 		}
 	}
 
-	p.promoteRootMethods(selfNames, childNames, registry.RootProviders())
+	p.promoteMethods(selfNames, childNames, registry.PromotedProviders())
 }
 
-// promoteRootMethods promotes every method of every root-placed provider into promotedBuiltins, panicking on any
+// promoteMethods promotes every method of every promoted provider into promotedBuiltins, panicking on any
 // name collision across the three tiers.
 //
 // Separated from [Provider.buildPromotedBuiltins]'s registry gathering so the collision contract is testable against
@@ -833,7 +833,7 @@ func (p *Provider) buildPromotedBuiltins() {
 //   - `selfNames`: this Provider's own snake-cased method names (Tier 3).
 //   - `childNames`: the non-root planner provider names (Tier 1's sub-namespace adapters).
 //   - `roots`: the root-placed providers whose methods promote (Tier 2).
-func (p *Provider) promoteRootMethods(selfNames, childNames map[string]struct{}, roots []op.ProviderReceiverType) {
+func (p *Provider) promoteMethods(selfNames, childNames map[string]struct{}, roots []op.ProviderReceiverType) {
 
 	for _, rp := range roots {
 

--- a/pkg/op/provider/plan/provider_test.go
+++ b/pkg/op/provider/plan/provider_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/NobleFactor/devlore-cli/pkg/application"
 	"github.com/NobleFactor/devlore-cli/pkg/op"
 	"github.com/NobleFactor/devlore-cli/pkg/op/provider/file"
+
+	// ui is promoted and reaches BOTH surfaces; announcing it here is what lets this package assert the
+	// workflow half of its promotion. plan imports flow directly, so flow announces itself already.
+	_ "github.com/NobleFactor/devlore-cli/pkg/op/provider/ui/gen"
 )
 
 // resolutionProvider builds a plan Provider against the test binary's registry (file + flow + plan announced by the
@@ -26,7 +30,7 @@ func resolutionProvider(t *testing.T) *Provider {
 }
 
 // tierCollisionRootProvider is a synthetic root provider whose one method ("Variable" → snake "variable") is aimed
-// at whatever tier a test seeds into promoteRootMethods' name sets. Built as a real receiver type via
+// at whatever tier a test seeds into promoteMethods' name sets. Built as a real receiver type via
 // [op.NewProviderReceiverType]; never announced, so the process registry stays clean.
 type tierCollisionRootProvider struct{}
 
@@ -39,7 +43,7 @@ func collisionRootReceiverType(t *testing.T) op.ProviderReceiverType {
 	receiverType, err := op.NewProviderReceiverType(
 		reflect.TypeFor[tierCollisionRootProvider](),
 		func(*op.RuntimeEnvironment) (any, error) { return nil, nil },
-		op.RoleAction|op.RoleRoot,
+		op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementPromoted),
 		map[string][]op.Parameter{"Variable": {}},
 		nil,
 	)
@@ -112,6 +116,38 @@ func TestProvider_ResolveAttr_Tier2_PromotedBuiltin(t *testing.T) {
 	}
 }
 
+// TestProvider_ResolveAttr_Tier2_PromotedAcrossBothSurfaces pins the half of promotion nothing asserted.
+//
+// Placement applies to EVERY surface a provider reaches, from one declaration. flow reaches only the workflow
+// surface, so its promotion has always been visible here — plan.choose, plan.gather. ui reaches BOTH, so the
+// same declaration that makes note() a top-level global in a script also puts plan.note() in a workflow.
+//
+// That second half was documented in three doc comments and tested nowhere. It is also the half that surprised
+// its own author: #708 gave ui its placement after reasoning only about the script surface, and the workflow
+// consequence was found days later by reading buildPromotedBuiltins rather than by any failure.
+//
+// Guarding it here means a future change to placement semantics cannot quietly drop one surface.
+func TestProvider_ResolveAttr_Tier2_PromotedAcrossBothSurfaces(t *testing.T) {
+
+	p := resolutionProvider(t)
+
+	// ui reaches both surfaces and is promoted, so all six of its methods answer under plan.* as well.
+	for _, name := range []string{"error", "fail", "note", "print", "succeed", "warn"} {
+		resolved := p.ResolveAttr(name)
+		if _, ok := resolved.(*starlark.Builtin); !ok {
+			t.Errorf("ResolveAttr(%q) = %T, want *starlark.Builtin; ui is promoted, and placement applies to "+
+				"every surface it reaches — not only the script one", name, resolved)
+		}
+	}
+
+	// The contrast that makes the above meaningful: a QUALIFIED provider is reached through its own name, so
+	// its methods must NOT answer at the plan root. file.copy is not plan.copy.
+	if resolved := p.ResolveAttr("copy"); resolved != nil {
+		t.Errorf("ResolveAttr(\"copy\") = %T, want nil; file is qualified, so its methods stay under plan.file.*",
+			resolved)
+	}
+}
+
 func TestProvider_ResolveAttr_Tier1_SubNamespaceAdapter(t *testing.T) {
 
 	p := resolutionProvider(t)
@@ -143,7 +179,7 @@ func TestProvider_ResolveAttr_Tier3_OwnMethod(t *testing.T) {
 	}
 }
 
-func TestProvider_ResolveAttr_RootProviderExcludedFromTier1(t *testing.T) {
+func TestProvider_ResolveAttr_PromotedProviderExcludedFromTier1(t *testing.T) {
 
 	p := resolutionProvider(t)
 
@@ -181,7 +217,7 @@ func TestProvider_BuildPromotedBuiltins_PanicsOnCollision_PromotedVsOwn(t *testi
 	roots := []op.ProviderReceiverType{collisionRootReceiverType(t)}
 
 	wantPanicContaining(t, "collides with plan.Provider's own method", func() {
-		p.promoteRootMethods(map[string]struct{}{"variable": {}}, map[string]struct{}{}, roots)
+		p.promoteMethods(map[string]struct{}{"variable": {}}, map[string]struct{}{}, roots)
 	})
 }
 
@@ -191,11 +227,11 @@ func TestProvider_BuildPromotedBuiltins_PanicsOnCollision_PromotedVsSubNamespace
 	roots := []op.ProviderReceiverType{collisionRootReceiverType(t)}
 
 	wantPanicContaining(t, "collides with sub-namespace adapter name", func() {
-		p.promoteRootMethods(map[string]struct{}{}, map[string]struct{}{"variable": {}}, roots)
+		p.promoteMethods(map[string]struct{}{}, map[string]struct{}{"variable": {}}, roots)
 	})
 }
 
-func TestProvider_PromoteRootMethods_PanicsOnDuplicateRootMethod(t *testing.T) {
+func TestProvider_PromoteMethods_PanicsOnDuplicateMethod(t *testing.T) {
 
 	// Extra-matrix companion to rows 7–8: the third collision case — the same method promoted from two root
 	// providers.
@@ -203,7 +239,7 @@ func TestProvider_PromoteRootMethods_PanicsOnDuplicateRootMethod(t *testing.T) {
 	duplicate := collisionRootReceiverType(t)
 
 	wantPanicContaining(t, "collides with another root provider's method", func() {
-		p.promoteRootMethods(map[string]struct{}{}, map[string]struct{}{},
+		p.promoteMethods(map[string]struct{}{}, map[string]struct{}{},
 			[]op.ProviderReceiverType{duplicate, duplicate})
 	})
 }

--- a/pkg/op/provider/platform/gen/provider.gen.go
+++ b/pkg/op/provider/platform/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Arch": {

--- a/pkg/op/provider/powershell/gen/provider.gen.go
+++ b/pkg/op/provider/powershell/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Exec": {ParameterNames: []string{"command"}},

--- a/pkg/op/provider/regex/gen/provider.gen.go
+++ b/pkg/op/provider/regex/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Find": {

--- a/pkg/op/provider/service/gen/provider.gen.go
+++ b/pkg/op/provider/service/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Disable": {ParameterNames: []string{"name"}},

--- a/pkg/op/provider/shell/gen/provider.gen.go
+++ b/pkg/op/provider/shell/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Exec": {ParameterNames: []string{"command"}},

--- a/pkg/op/provider/template/gen/provider.gen.go
+++ b/pkg/op/provider/template/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"RenderBytes": {ParameterNames: []string{"content", "data"}},

--- a/pkg/op/provider/ui/gen/provider.gen.go
+++ b/pkg/op/provider/ui/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction|op.RoleRoot,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementPromoted),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Error": {

--- a/pkg/op/provider/ui/provider.go
+++ b/pkg/op/provider/ui/provider.go
@@ -29,7 +29,7 @@ import (
 // while a variadic one would receive Go natives after conversion and render True as true and None as <nil>.
 // The script renders with str() and %, which is starlark's own rendering, and hands over a finished string.
 //
-// +devlore:root=true
+// +devlore:placement=promoted
 type Provider struct {
 	op.ProviderBase
 }

--- a/pkg/op/provider/ui/root_test.go
+++ b/pkg/op/provider/ui/root_test.go
@@ -28,7 +28,7 @@ import (
 // The assertion is the mechanism rather than a proxy for it. Starlark's resolver checks predeclared names
 // BEFORE universal ones (resolve.go), so a predeclared "print" IS the replacement -- there is no separate act
 // of overriding to observe.
-func TestUIAtRoot_ReplacesTheOutputBuiltins(t *testing.T) {
+func TestUIPromoted_ReplacesTheOutputBuiltins(t *testing.T) {
 
 	receiverType, found := op.ReceiverRegistry().Type("ui")
 	if !found {
@@ -67,7 +67,7 @@ func TestUIAtRoot_ReplacesTheOutputBuiltins(t *testing.T) {
 //
 // So this executes a script that calls the bare name and asserts the narrator saw it. Registration and
 // emission are separate claims, and only this one is about the bytes.
-func TestUIAtRoot_PrintReachesTheNarrator(t *testing.T) {
+func TestUIPromoted_PrintReachesTheNarrator(t *testing.T) {
 
 	receiverType, found := op.ReceiverRegistry().Type("ui")
 	if !found {

--- a/pkg/op/provider/yaml/gen/provider.gen.go
+++ b/pkg/op/provider/yaml/gen/provider.gen.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[provider.Provider](),
-		op.RoleModule|op.RoleAction,
+		op.NewProviderFlags(op.SurfaceScript|op.SurfaceWorkflow, op.PlacementQualified),
 		func(ctx *op.RuntimeEnvironment) (any, error) { return provider.NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 			"Decode": {

--- a/pkg/op/receiver_registry.go
+++ b/pkg/op/receiver_registry.go
@@ -186,8 +186,8 @@ func (a *announcements) validatorStub() map[string]any {
 
 // AnnounceProvider registers a provider with its roles and per-method metadata.
 //
-// Called in init(). Roles are declared via [ProviderRole] flags: [RoleModule] for immediate-mode starlark globals,
-// [RoleAction] for plan-mode graph node creation.
+// Called in init(). Surfaces are declared via [ProviderFlags]: [SurfaceScript] for methods reachable from a script,
+// [SurfaceWorkflow] for methods reachable from a workflow.
 //
 // Companion methods on the provider type — [Method.Plan] via <Name>Planned, [Method.Undo] via Compensate<Name> —
 // are discovered automatically by reflection in [NewProviderReceiverType]. No registration is required.
@@ -197,11 +197,12 @@ func (a *announcements) validatorStub() map[string]any {
 //   - `roles`: the provider's declared roles.
 //   - `construct`: creates a provider instance from RuntimeEnvironment.
 //   - `methods`: codegen-emitted [MethodMetadata] per Go method, keyed by the method's Go name.
-func AnnounceProvider(providerType reflect.Type, roles ProviderRole, construct ProviderConstructor, methods map[string]MethodMetadata) {
+func AnnounceProvider(providerType reflect.Type, flags ProviderFlags, construct ProviderConstructor, methods map[string]MethodMetadata) {
 
 	label := fmt.Sprintf("AnnounceProvider(%s)", providerType)
 
-	assert.Truef(roles.Dispatch() != 0, "%s: roles must set at least one dispatch-zone bit (RoleModule or RoleAction); got %#x", label, uint(roles))
+	assert.Truef(flags.Surfaces() != 0,
+		"%s: must declare at least one surface (SurfaceScript or SurfaceWorkflow); got %#x", label, uint(flags))
 
 	methodParameters := make(map[string][]string, len(methods))
 	planners := make(map[string]Planner, len(methods))
@@ -214,7 +215,7 @@ func AnnounceProvider(providerType reflect.Type, roles ProviderRole, construct P
 	parsed, err := parseParameters(providerType, methodParameters)
 	assert.NoError(label, err)
 
-	rt, err := NewProviderReceiverType(providerType, construct, roles, parsed, planners)
+	rt, err := NewProviderReceiverType(providerType, construct, flags, parsed, planners)
 	assert.NoError(label, err)
 
 	// Stamp per-method surface modifiers from the codegen-emitted metadata. Unset entries default to ModifierNone.
@@ -231,7 +232,7 @@ func AnnounceProvider(providerType reflect.Type, roles ProviderRole, construct P
 
 // AnnounceResource registers a resource type.
 //
-// Called in init(). Resources are always RoleResource — they cannot be actions or modules. They are data types
+// Called in init(). Resources are always RoleResource — they reach no provider surface. They are data types
 // constructed by coercing a raw value (e.g., a string path becomes a file.Resource).
 //
 // Parameters:
@@ -304,17 +305,17 @@ func AnnounceType(goType reflect.Type, methods map[string]MethodMetadata) {
 
 // receiverRegistry stores receiver types in four sorted lists plus cross-cutting lookup maps.
 //
-// Actions are providers with RoleAction (graph scope). Modules are providers with RoleModule (script scope). Planners
-// mirror actions for the plan.* namespace. Resources are data types that flow through starlark code or an execution
-// graph. A provider may appear in both actions and modules.
+// Workflows are providers reaching SurfaceWorkflow. Scripts are providers reaching SurfaceScript. Planners mirror
+// workflows for the plan.* namespace. Resources are data types that flow through starlark code or an execution
+// graph. A provider may appear in both workflows and scripts.
 //
 // The byType map enables lookup by reflect.Type for marshalReflect (wrapping Go return values) and the executor
 // (dispatching graph nodes).
 type receiverRegistry struct {
-	actions   []ProviderReceiverType        // sorted by name; providers with RoleAction
-	modules   []ProviderReceiverType        // sorted by name; providers with RoleModule
-	planners  []ProviderReceiverType        // sorted by name; mirrors actions for plan.* routing
-	roots     []ProviderReceiverType        // sorted by name; providers with the RoleRoot placement-zone bit
+	workflows []ProviderReceiverType        // sorted by name; providers reaching SurfaceWorkflow
+	scripts   []ProviderReceiverType        // sorted by name; providers reaching SurfaceScript
+	planners  []ProviderReceiverType        // sorted by name; mirrors workflows for plan.* routing
+	promoted  []ProviderReceiverType        // sorted by name; providers whose placement is PlacementPromoted
 	resources []ResourceReceiverType        // sorted by name; data types
 	byName    map[string]ReceiverType       // all receiver types by name
 	byType    map[reflect.Type]ReceiverType // all receiver types by reflect.Type
@@ -379,13 +380,13 @@ func newReceiverRegistry() *receiverRegistry {
 //
 // Returns:
 //   - `[]ProviderReceiverType`: sorted by receiver name.
-func (r *receiverRegistry) Actions() []ProviderReceiverType { return r.actions }
+func (r *receiverRegistry) Workflows() []ProviderReceiverType { return r.workflows }
 
 // Modules returns all providers that can be called directly from a starlark runtime.
 //
 // Returns:
 //   - `[]ProviderReceiverType`: sorted by receiver name.
-func (r *receiverRegistry) Modules() []ProviderReceiverType { return r.modules }
+func (r *receiverRegistry) Scripts() []ProviderReceiverType { return r.scripts }
 
 // Planners returns all providers available in the plan.* namespace.
 //
@@ -393,23 +394,23 @@ func (r *receiverRegistry) Modules() []ProviderReceiverType { return r.modules }
 //   - `[]ProviderReceiverType`: sorted by receiver name.
 func (r *receiverRegistry) Planners() []ProviderReceiverType { return r.planners }
 
-// RootProviders returns every provider with the [RoleRoot] placement-zone bit set.
+// PromotedProviders returns every provider whose [Placement] is [PlacementPromoted].
 //
-// Root providers surface their methods flat at their access-defined namespace root rather than nested under the
-// provider's own name.
+// A promoted provider surfaces its methods at the namespace root of every surface it reaches, rather than
+// qualified by its own name.
 //
-// The list is NOT filtered by dispatch zone, and callers are not expected to filter it. Root placement applies to
-// every surface a provider reaches: a RoleModule|RoleAction|RoleRoot provider surfaces flat in BOTH namespaces, as
-// top-level globals for a module surface and directly under plan.* for the graph. ui is the case — note() in a
-// script and plan.note() in a graph, from one directive.
+// The list is NOT filtered by surface, and callers are not expected to filter it. Placement applies to every
+// surface a provider reaches: one reaching both surfaces is promoted on both — top-level globals for a script,
+// and directly under plan.* for a workflow. ui is the case: note() in a script and plan.note() in a workflow,
+// from one directive.
 //
-// This comment previously said callers filter to a dispatch mode and named plan.Provider as the example.
-// plan.Provider does not filter, and the behavior that describes was never implemented; corrected 2026-08-27
-// after ui became the first RoleModule|RoleAction|RoleRoot provider and made the difference observable.
+// This comment once said callers filter by surface and named plan.Provider as the example. plan.Provider does
+// not filter, and the behavior described was never implemented; corrected 2026-08-27, after ui became the first
+// provider both reaching every surface and promoted, which made the difference observable.
 //
 // Returns:
 //   - `[]ProviderReceiverType`: sorted by receiver name.
-func (r *receiverRegistry) RootProviders() []ProviderReceiverType { return r.roots }
+func (r *receiverRegistry) PromotedProviders() []ProviderReceiverType { return r.promoted }
 
 // Resources returns all resource data types.
 //
@@ -553,7 +554,7 @@ func (r *receiverRegistry) ProductTypeByID(id string) (reflect.Type, bool) {
 
 	r.productTypeOnce.Do(func() {
 		index := make(map[string]reflect.Type)
-		for _, providerType := range r.actions {
+		for _, providerType := range r.workflows {
 			for method := range providerType.Methods() {
 
 				productType := method.ResultType()
@@ -597,7 +598,7 @@ func (r *receiverRegistry) CompensatingActionByName(name string) (compensatingAc
 
 	r.compensatingActionOnce.Do(func() {
 		index := make(map[string]compensatingAction)
-		for _, providerType := range r.actions {
+		for _, providerType := range r.workflows {
 			reflectType := providerType.ProviderType()
 			if reflectType.Kind() != reflect.Pointer {
 				reflectType = reflect.PointerTo(reflectType)
@@ -737,7 +738,7 @@ func (r *receiverRegistry) ActionByPath(name string) (ProviderReceiverType, *Met
 	for _, rt := range r.byName {
 
 		prt, ok := rt.(ProviderReceiverType)
-		if !ok || prt.Roles()&RoleAction == 0 {
+		if !ok || prt.Flags().Surfaces()&SurfaceWorkflow == 0 {
 			continue
 		}
 
@@ -771,7 +772,7 @@ func (r *receiverRegistry) ActionByName(name string) (ProviderReceiverType, bool
 		return nil, false
 	}
 
-	if prt.Roles()&RoleAction == 0 {
+	if prt.Flags().Surfaces()&SurfaceWorkflow == 0 {
 		return nil, false
 	}
 
@@ -846,7 +847,7 @@ func (r *receiverRegistry) ModuleByName(name string) (ProviderReceiverType, bool
 		return nil, false
 	}
 
-	if prt.Roles()&RoleModule == 0 {
+	if prt.Flags().Surfaces()&SurfaceScript == 0 {
 		return nil, false
 	}
 
@@ -873,7 +874,7 @@ func (r *receiverRegistry) PlannerByName(name string) (ProviderReceiverType, boo
 		return nil, false
 	}
 
-	if prt.Roles()&RoleAction == 0 {
+	if prt.Flags().Surfaces()&SurfaceWorkflow == 0 {
 		return nil, false
 	}
 
@@ -991,16 +992,16 @@ func (r *receiverRegistry) registerLocked(rt ReceiverType) {
 
 	switch v := rt.(type) {
 	case ProviderReceiverType:
-		roles := v.Roles()
-		if roles&RoleModule != 0 {
-			r.modules = insertSortedProvider(r.modules, v)
+		flags := v.Flags()
+		if flags.Surfaces()&SurfaceScript != 0 {
+			r.scripts = insertSortedProvider(r.scripts, v)
 		}
-		if roles&RoleAction != 0 {
-			r.actions = insertSortedProvider(r.actions, v)
+		if flags.Surfaces()&SurfaceWorkflow != 0 {
+			r.workflows = insertSortedProvider(r.workflows, v)
 			r.planners = insertSortedProvider(r.planners, v)
 		}
-		if roles.Placement()&RoleRoot != 0 {
-			r.roots = insertSortedProvider(r.roots, v)
+		if flags.Placement() == PlacementPromoted {
+			r.promoted = insertSortedProvider(r.promoted, v)
 		}
 	case ResourceReceiverType:
 		r.resources = insertSortedResource(r.resources, v)

--- a/pkg/op/receiver_registry_test.go
+++ b/pkg/op/receiver_registry_test.go
@@ -21,26 +21,27 @@ type roleZonePlacementOnlyProvider struct{ ProviderBase }
 // trivialProviderConstructor satisfies [ProviderConstructor] for fixtures that are never instantiated.
 func trivialProviderConstructor(*RuntimeEnvironment) (any, error) { return nil, nil }
 
-// init announces the RootProviders partition fixtures before any test can materialize the registry singleton —
+// init announces the PromotedProviders partition fixtures before any test can materialize the registry singleton —
 // [ReceiverRegistry] is a sync.OnceValue that snapshots the announcements at its first call, so staging must happen
 // at package init.
 func init() {
-	AnnounceProvider(reflect.TypeFor[roleZoneRootedProvider](), RoleAction|RoleRoot, trivialProviderConstructor, nil)
-	AnnounceProvider(reflect.TypeFor[roleZoneUnrootedProvider](), RoleAction, trivialProviderConstructor, nil)
+	AnnounceProvider(reflect.TypeFor[roleZoneRootedProvider](), NewProviderFlags(SurfaceWorkflow, PlacementPromoted), trivialProviderConstructor, nil)
+	AnnounceProvider(reflect.TypeFor[roleZoneUnrootedProvider](), NewProviderFlags(SurfaceWorkflow, PlacementQualified), trivialProviderConstructor, nil)
 }
 
-func TestAnnounceProvider_PanicsWithoutDispatchBit(t *testing.T) {
+func TestAnnounceProvider_PanicsWithoutASurface(t *testing.T) {
 
 	defer func() {
 		if recover() == nil {
-			t.Error("AnnounceProvider(RoleRoot only) did not panic; a dispatch-zone bit must be required")
+			t.Error("AnnounceProvider with no surface did not panic; at least one surface must be required")
 		}
 	}()
 
-	AnnounceProvider(reflect.TypeFor[roleZonePlacementOnlyProvider](), RoleRoot, trivialProviderConstructor, nil)
+	AnnounceProvider(reflect.TypeFor[roleZonePlacementOnlyProvider](),
+		NewProviderFlags(0, PlacementPromoted), trivialProviderConstructor, nil)
 }
 
-func TestAnnounceProvider_AcceptsDispatchBit(t *testing.T) {
+func TestAnnounceProvider_AcceptsASurface(t *testing.T) {
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -48,52 +49,52 @@ func TestAnnounceProvider_AcceptsDispatchBit(t *testing.T) {
 		}
 	}()
 
-	AnnounceProvider(reflect.TypeFor[roleZoneModuleProvider](), RoleModule, trivialProviderConstructor, nil)
+	AnnounceProvider(reflect.TypeFor[roleZoneModuleProvider](), NewProviderFlags(SurfaceScript, PlacementQualified), trivialProviderConstructor, nil)
 }
 
-func TestReceiverRegistry_RootProviders_ReturnsPlacementRootOnly(t *testing.T) {
+func TestReceiverRegistry_PromotedProviders_ReturnsPromotedOnly(t *testing.T) {
 
 	names := make(map[string]bool)
-	for _, provider := range ReceiverRegistry().RootProviders() {
+	for _, provider := range ReceiverRegistry().PromotedProviders() {
 		names[provider.Name()] = true
 	}
 
 	if !names["roleZoneRootedProvider"] {
-		t.Error("RootProviders() is missing the RoleRoot-placed fixture roleZoneRootedProvider")
+		t.Error("PromotedProviders() is missing the promoted fixture roleZoneRootedProvider")
 	}
 	if names["roleZoneUnrootedProvider"] {
-		t.Error("RootProviders() includes the non-root fixture roleZoneUnrootedProvider")
+		t.Error("PromotedProviders() includes the non-root fixture roleZoneUnrootedProvider")
 	}
 }
 
-func TestRootDirective_ThreadsRoleRootThroughAnnounce(t *testing.T) {
+func TestPlacementDirective_ThreadsPlacementPromotedThroughAnnounce(t *testing.T) {
 
-	// The +devlore:root=true directive on flow.Provider must thread RoleRoot into the generated AnnounceProvider call
+	// The +devlore:placement=promoted directive on flow.Provider must thread PlacementPromoted into the generated call
 	// (flow/gen/provider.gen.go, linked into this test binary by the op_test announce shim). Inspecting the announced
 	// roles proves the directive end to end: codegen emitted it, announce carried it, and the registry placed flow at
-	// the root. (The step-2 matrix named this TestGenerate_RootDirective_ThreadsRoleRoot; renamed because no
+	// the root. (Renamed twice since the step-2 matrix named it, because no
 	// generation runs here — the checked-in generated announce is the subject.)
 	var flow ProviderReceiverType
-	for _, provider := range ReceiverRegistry().RootProviders() {
+	for _, provider := range ReceiverRegistry().PromotedProviders() {
 		if provider.Name() == "flow" {
 			flow = provider
 		}
 	}
 
 	if flow == nil {
-		t.Fatal("flow is not among RootProviders(); +devlore:root=true did not thread RoleRoot through the announce")
+		t.Fatal("flow is not among PromotedProviders(); +devlore:placement=promoted did not thread through the announce")
 	}
-	if got := flow.Roles().Dispatch(); got != RoleAction {
-		t.Errorf("flow Roles().Dispatch() = %#x, want RoleAction", uint(got))
+	if got := flow.Flags().Surfaces(); got != SurfaceWorkflow {
+		t.Errorf("flow Flags().Surfaces() = %#x, want SurfaceWorkflow", uint(got))
 	}
-	if got := flow.Roles().Placement(); got != RoleRoot {
-		t.Errorf("flow Roles().Placement() = %#x, want RoleRoot", uint(got))
+	if got := flow.Flags().Placement(); got != PlacementPromoted {
+		t.Errorf("flow Flags().Placement() = %#x, want PlacementPromoted", uint(got))
 	}
 }
 
 // --- Step 4: flow declared a root action provider ---
 
-func TestFlowProvider_RegisteredAsActionRoot(t *testing.T) {
+func TestFlowProvider_ReachesWorkflowSurfaceAndIsPromoted(t *testing.T) {
 
 	rt, ok := ReceiverRegistry().Type("flow")
 	if !ok || rt == nil {
@@ -105,24 +106,24 @@ func TestFlowProvider_RegisteredAsActionRoot(t *testing.T) {
 		t.Fatalf("flow registered as %T, want ProviderReceiverType", rt)
 	}
 
-	if got := provider.Roles(); got != RoleAction|RoleRoot {
-		t.Errorf("flow Roles() = %#x, want RoleAction|RoleRoot (0x102)", uint(got))
+	if got := provider.Flags(); got != NewProviderFlags(SurfaceWorkflow, PlacementPromoted) {
+		t.Errorf("flow Flags().Placement() = %#x, want PlacementPromoted", uint(got))
 	}
-	if got := provider.Roles().Dispatch(); got != RoleAction {
-		t.Errorf("flow Dispatch() = %#x, want RoleAction", uint(got))
+	if got := provider.Flags().Surfaces(); got != SurfaceWorkflow {
+		t.Errorf("Flags().Surfaces() = %#x, want SurfaceWorkflow", uint(got))
 	}
-	if got := provider.Roles().Placement(); got != RoleRoot {
-		t.Errorf("flow Placement() = %#x, want RoleRoot", uint(got))
+	if got := provider.Flags().Placement(); got != PlacementPromoted {
+		t.Errorf("flow Placement() = %#x, want PlacementPromoted", uint(got))
 	}
 }
 
-func TestRootProviders_IncludesFlow(t *testing.T) {
+func TestPromotedProviders_IncludesFlow(t *testing.T) {
 
-	for _, provider := range ReceiverRegistry().RootProviders() {
+	for _, provider := range ReceiverRegistry().PromotedProviders() {
 		if provider.Name() == "flow" {
 			return
 		}
 	}
 
-	t.Error("RootProviders() does not include flow; the +devlore:root=true directive did not reach the registry")
+	t.Error("PromotedProviders() does not include flow; the +devlore:root=true directive did not reach the registry")
 }

--- a/pkg/op/receiver_type.go
+++ b/pkg/op/receiver_type.go
@@ -30,71 +30,105 @@ type ReceiverType interface {
 // ProviderReceiverType extends [ReceiverType] with provider-specific capabilities.
 type ProviderReceiverType interface {
 	ReceiverType
-	Roles() ProviderRole
+	Flags() ProviderFlags
 	Construct() ProviderConstructor
 }
 
-// ProviderRole declares what roles a provider supports.
+// ProviderFlags packs the two independent answers about where a provider's methods appear in starlark.
 //
-// ProviderRole is a bitflag partitioned into two zones:
+//   - [ProviderFlags.Surfaces] — WHICH surfaces the methods reach. A bit field: one or more.
+//   - [ProviderFlags.Placement] — HOW their names are placed there. A value: exactly one.
 //
-//   - Dispatch zone (bits 0–7) declares how the provider's methods are invoked. Providers must set at least one bit in
-//     this zone; [AnnounceProvider] panics otherwise.
-//   - Placement zone (bits 8–15) modifies where the provider's methods surface in starlark. Orthogonal to the dispatch
-//     zone; optional.
+// The zones are read differently, and the difference is deliberate:
 //
-// [ProviderRole.Dispatch] and [ProviderRole.Placement] project a role value onto its respective zone.
-type ProviderRole uint
+//	flags.Surfaces()&SurfaceWorkflow != 0     // test a bit -- may hold several
+//	flags.Placement() == PlacementPromoted    // compare a value -- holds exactly one
+//
+// Each zone has its OWN type, following reflect, where flag.kind() returns Kind rather than another flag. That
+// makes flags.Placement() == SurfaceScript a compile error rather than nonsense that compiles.
+//
+// The name is deliberately generic. Its predecessor, ProviderRole, was specific and went stale: #677 changed the
+// zone from meaning *invocation mode* to meaning *surface eligibility*, and RoleAction, Dispatch(), and
+// ProviderRole all outlived what they named. A generic name cannot fail that way, and the accessors carry the
+// meaning.
+type ProviderFlags uint16
 
-// Dispatch zone — bits 0–7. Declares how the provider's methods are invoked.
+// Surfaces declares which surfaces a provider's methods reach.
+//
+// A BIT FIELD: a provider supports one or more. The plural is the signature -- an accessor returning
+// SurfaceScript|SurfaceWorkflow is a set, and naming it in the singular would read as a contradiction.
+type Surfaces uint8
+
+// Surface values — bits 0–7 of [ProviderFlags]. A provider must declare at least one; [AnnounceProvider] panics
+// otherwise.
 const (
-	// RoleModule declares a provider as an immediate-mode starlark global.
-	RoleModule ProviderRole = 1 << iota
+	// SurfaceScript declares the methods reachable from a script, executing when called.
+	SurfaceScript Surfaces = 0x01
 
-	// RoleAction declares a provider as a plan-mode graph node creator.
-	RoleAction
+	// SurfaceWorkflow declares the methods reachable from a workflow, where a call yields a node rather than an
+	// effect.
+	SurfaceWorkflow Surfaces = 0x02
 
-	// Bits 2–7 reserved for future dispatch modes.
+	// Bits 2–7 reserved for further surfaces.
 )
 
-// Placement zone — bits 8–15. Modifies where the provider's methods surface in starlark.
+// Placement declares how a provider's method names are placed on the surfaces it reaches.
+//
+// A VALUE, not a flag set: a name is promoted or qualified, never both. Nothing can express the combination --
+// not because a check rejects it, but because the zone holds one value of a type with two.
+type Placement uint8
+
+// Placement values — bits 8–15 of [ProviderFlags]. PlacementQualified is the zero value, so a provider that
+// declares nothing gets it.
 const (
-	// RoleRoot declares that the provider's methods surface flat at their access-defined namespace root, rather than
-	// nested under the provider's own name. For a RoleAction provider, this means the methods appear directly under
-	// plan.* (e.g., plan.choose) rather than plan.<provider>.* (e.g., plan.flow.choose). For a RoleModule provider,
-	// this means the methods appear as top-level starlark globals (e.g., note()) rather than under the provider name
-	// (e.g., ui.note()).
+	// PlacementQualified declares the methods reachable under the provider's own name: ui.note(), plan.flow.choose().
+	PlacementQualified Placement = 0x00
+
+	// PlacementPromoted declares the methods reachable at their surface's namespace root, unqualified: note(),
+	// plan.choose().
 	//
-	// ONE BIT, EVERY SURFACE, and deliberately. Placement is orthogonal to dispatch, so a provider holding both
-	// dispatch bits surfaces flat in both namespaces from a single +devlore:root=true. ui is that case: note() in a
-	// script AND plan.note() in a graph. There is no way to be root in one zone and nested in the other, because
-	// there is nothing a provider could mean by asking for it — a name is promoted because it reads better without
-	// its qualifier, and that is as true of a graph as of a script.
+	// ONE VALUE, EVERY SURFACE, and deliberately. Placement is orthogonal to the surfaces a provider reaches, so a
+	// provider reaching both surfaces is promoted on both from a single declaration. ui is that case: note() in a
+	// script AND plan.note() in a workflow. There is no way to be promoted on one surface and qualified on the
+	// other, because there is nothing a provider could mean by asking for it — a name is promoted because it reads
+	// better without its qualifier, and that is as true of a workflow as of a script.
 	//
-	// flow never exposed this: it is +devlore:surface=graph, so it holds one dispatch bit and one placement bit is
-	// obviously sufficient. ui, arriving 2026-08-27, was the first provider with both.
-	RoleRoot ProviderRole = 1 << (iota + 8)
-
-	// Bits 9–15 reserved for future placement modifiers.
+	// flow never exposed this: it is +devlore:surface=workflow, so it reaches one surface and the question does not
+	// arise. ui, arriving 2026-08-27, was the first provider reaching both.
+	PlacementPromoted Placement = 0x01
 )
 
-// Zone masks. Callers use these to extract the dispatch or placement bits from a role value.
+// Zone boundaries. The masks make each accessor's narrowing explicit rather than relying on the conversion to
+// truncate — which is correct today only because the zones happen to be a byte wide.
 const (
-	roleDispatchMask  ProviderRole = 0x00FF
-	rolePlacementMask ProviderRole = 0xFF00
+	placementShift               = 8
+	surfaceMask    ProviderFlags = 0x00FF
+	placementMask  ProviderFlags = 0xFF00
 )
 
-// Dispatch returns the dispatch-zone bits of r — which execution modes the provider supports.
+// Surfaces returns which surfaces the provider's methods reach.
 //
 // Returns:
-//   - ProviderRole: the role value masked to the dispatch zone.
-func (r ProviderRole) Dispatch() ProviderRole { return r & roleDispatchMask }
+//   - Surfaces: the bit field; test membership with &.
+func (f ProviderFlags) Surfaces() Surfaces { return Surfaces(f & surfaceMask) }
 
-// Placement returns the placement-zone bits of r — how the provider's methods are placed in the namespace.
+// Placement returns how the provider's method names are placed.
 //
 // Returns:
-//   - ProviderRole: the role value masked to the placement zone.
-func (r ProviderRole) Placement() ProviderRole { return r & rolePlacementMask }
+//   - Placement: the value; compare with ==, never &.
+func (f ProviderFlags) Placement() Placement { return Placement((f & placementMask) >> placementShift) }
+
+// NewProviderFlags packs surfaces and a placement into a [ProviderFlags].
+//
+// Parameters:
+//   - `surfaces`: the surfaces reached; at least one.
+//   - `placement`: how names are placed.
+//
+// Returns:
+//   - ProviderFlags: the packed value.
+func NewProviderFlags(surfaces Surfaces, placement Placement) ProviderFlags {
+	return ProviderFlags(surfaces) | ProviderFlags(placement)<<placementShift
+}
 
 // ResourceReceiverType extends [ReceiverType] with resource-specific capabilities.
 //
@@ -238,7 +272,7 @@ func (t *receiverType) Do(method string, receiver any, args []any) (result, comp
 // providerReceiverType is the concrete descriptor for providers.
 type providerReceiverType struct {
 	receiverType
-	roles     ProviderRole
+	flags     ProviderFlags
 	construct ProviderConstructor
 }
 
@@ -247,7 +281,7 @@ type providerReceiverType struct {
 // Parameters:
 //   - providerType: the provider's reflect.Type.
 //   - construct: creates a provider instance from RuntimeEnvironment.
-//   - roles: the provider's declared roles (RoleModule, RoleAction, or both).
+//   - flags: the provider's declared surfaces and placement.
 //   - methodParameters: parsed Parameter values per Go method. The parameter tokens are cracked into
 //     Parameter values upstream by parseParameters at the announce boundary.
 //
@@ -257,7 +291,7 @@ type providerReceiverType struct {
 func NewProviderReceiverType(
 	providerType reflect.Type,
 	construct ProviderConstructor,
-	roles ProviderRole,
+	flags ProviderFlags,
 	methodParameters map[string][]Parameter,
 	planners map[string]Planner,
 ) (ProviderReceiverType, error) {
@@ -270,7 +304,7 @@ func NewProviderReceiverType(
 	return &providerReceiverType{
 		receiverType: base,
 		construct:    construct,
-		roles:        roles,
+		flags:        flags,
 	}, nil
 }
 
@@ -284,11 +318,11 @@ func NewProviderReceiverType(
 //   - ProviderConstructor: the constructor.
 func (rt *providerReceiverType) Construct() ProviderConstructor { return rt.construct }
 
-// Roles returns the provider's declared roles.
+// Flags returns the provider's declared surfaces and placement.
 //
 // Returns:
-//   - ProviderRole: the role flags.
-func (rt *providerReceiverType) Roles() ProviderRole { return rt.roles }
+//   - ProviderFlags: the packed surfaces and placement.
+func (rt *providerReceiverType) Flags() ProviderFlags { return rt.flags }
 
 // endregion
 

--- a/pkg/op/receiver_type_test.go
+++ b/pkg/op/receiver_type_test.go
@@ -520,7 +520,7 @@ func TestNewProviderReceiverType(t *testing.T) {
 	pType := reflect.TypeFor[*testProvider]()
 	construct := func(runtimeEnvironment *RuntimeEnvironment) (any, error) { return &testProvider{}, nil }
 
-	rt, err := NewProviderReceiverType(pType, construct, RoleAction, mustParseParameters(t, pType, map[string][]string{
+	rt, err := NewProviderReceiverType(pType, construct, NewProviderFlags(SurfaceWorkflow, PlacementQualified), mustParseParameters(t, pType, map[string][]string{
 		"Echo": {"msg"},
 	}), nil)
 
@@ -528,8 +528,8 @@ func TestNewProviderReceiverType(t *testing.T) {
 		t.Fatalf("NewProviderReceiverType: %v", err)
 	}
 
-	if rt.Roles() != RoleAction {
-		t.Errorf("Roles() = %v, want RoleAction", rt.Roles())
+	if rt.Flags() != NewProviderFlags(SurfaceWorkflow, PlacementQualified) {
+		t.Errorf("Roles() = %v, want NewProviderFlags(SurfaceWorkflow, PlacementQualified)", rt.Flags())
 	}
 
 	p, _ := rt.Construct()(nil)
@@ -625,45 +625,51 @@ func TestReceiverRegistry_TypeByReflectionOrDerive_Concurrent(t *testing.T) {
 
 // endregion
 
-// --- ProviderRole zones (step 2) ---
+// --- ProviderFlags zones (step 2) ---
 
-func TestProviderRole_ZoneBitLayout(t *testing.T) {
+func TestProviderFlags_ZoneBitLayout(t *testing.T) {
 
-	cases := []struct {
+	for _, testCase := range []struct {
 		name string
-		got  ProviderRole
-		want ProviderRole
+		got  uint
+		want uint
 	}{
-		{"RoleModule", RoleModule, 0x01},
-		{"RoleAction", RoleAction, 0x02},
-		{"RoleRoot", RoleRoot, 0x100},
-		{"dispatch mask", roleDispatchMask, 0x00FF},
-		{"placement mask", rolePlacementMask, 0xFF00},
-	}
-
-	for _, tc := range cases {
-		if tc.got != tc.want {
-			t.Errorf("%s = %#x, want %#x", tc.name, uint(tc.got), uint(tc.want))
+		{"SurfaceScript", uint(SurfaceScript), 0x01},
+		{"SurfaceWorkflow", uint(SurfaceWorkflow), 0x02},
+		{"PlacementQualified", uint(PlacementQualified), 0x00},
+		{"PlacementPromoted", uint(PlacementPromoted), 0x01},
+		{"packed: script + qualified", uint(NewProviderFlags(SurfaceScript, PlacementQualified)), 0x0001},
+		{"packed: workflow + promoted", uint(NewProviderFlags(SurfaceWorkflow, PlacementPromoted)), 0x0102},
+		{"packed: both + promoted", uint(NewProviderFlags(SurfaceScript|SurfaceWorkflow, PlacementPromoted)), 0x0103},
+	} {
+		if testCase.got != testCase.want {
+			t.Errorf("%s = %#x, want %#x", testCase.name, testCase.got, testCase.want)
 		}
 	}
 }
 
-func TestProviderRole_Dispatch_ReturnsDispatchZoneOnly(t *testing.T) {
+// TestProviderFlags_ZonesDoNotLeak pins the packing: each accessor sees its own zone and nothing else.
+//
+// The two zones are read differently by design — Surfaces is a bit field tested with &, Placement is a value
+// compared with ==. That only holds if the packing keeps them apart, which is what this asserts.
+func TestProviderFlags_ZonesDoNotLeak(t *testing.T) {
 
-	if got := (RoleAction | RoleRoot).Dispatch(); got != RoleAction {
-		t.Errorf("(RoleAction|RoleRoot).Dispatch() = %#x, want RoleAction", uint(got))
-	}
-	if got := RoleRoot.Dispatch(); got != 0 {
-		t.Errorf("RoleRoot.Dispatch() = %#x, want 0 (placement bits must not leak into the dispatch zone)", uint(got))
-	}
-}
+	both := NewProviderFlags(SurfaceScript|SurfaceWorkflow, PlacementPromoted)
 
-func TestProviderRole_Placement_ReturnsPlacementZoneOnly(t *testing.T) {
-
-	if got := (RoleAction | RoleRoot).Placement(); got != RoleRoot {
-		t.Errorf("(RoleAction|RoleRoot).Placement() = %#x, want RoleRoot", uint(got))
+	if got := both.Surfaces(); got != SurfaceScript|SurfaceWorkflow {
+		t.Errorf("Surfaces() = %#x, want %#x; the placement must not leak in", uint(got), uint(SurfaceScript|SurfaceWorkflow))
 	}
-	if got := RoleAction.Placement(); got != 0 {
-		t.Errorf("RoleAction.Placement() = %#x, want 0 (dispatch bits must not leak into the placement zone)", uint(got))
+	if got := both.Placement(); got != PlacementPromoted {
+		t.Errorf("Placement() = %#x, want %#x; the surfaces must not leak in", uint(got), uint(PlacementPromoted))
+	}
+
+	// A provider declaring no placement gets the zero value, which IS qualified — not an absent flag.
+	qualified := NewProviderFlags(SurfaceWorkflow, PlacementQualified)
+
+	if got := qualified.Placement(); got != PlacementQualified {
+		t.Errorf("Placement() = %#x, want PlacementQualified; the zero value is the qualified value", uint(got))
+	}
+	if got := qualified.Surfaces(); got != SurfaceWorkflow {
+		t.Errorf("Surfaces() = %#x, want SurfaceWorkflow", uint(got))
 	}
 }

--- a/pkg/op/runtime_environment.go
+++ b/pkg/op/runtime_environment.go
@@ -228,7 +228,7 @@ func NewRuntimeEnvironment(ctx context.Context, spec *RuntimeEnvironmentSpec) (*
 
 	modules := spec.Modules
 	if len(modules) == 0 {
-		modules = ReceiverRegistry().Modules()
+		modules = ReceiverRegistry().Scripts()
 	}
 
 	// Preflight, not allocation: both anchors are proved usable here and released again, so a bad anchor is

--- a/pkg/op/server/integration_test.go
+++ b/pkg/op/server/integration_test.go
@@ -43,7 +43,7 @@ func (g *gate) Wait() error {
 }
 
 func init() {
-	op.AnnounceProvider(reflect.TypeFor[gate](), op.RoleAction,
+	op.AnnounceProvider(reflect.TypeFor[gate](), op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementQualified),
 		func(runtimeEnvironment *op.RuntimeEnvironment) (any, error) {
 			return &gate{ProviderBase: op.NewProviderBase(runtimeEnvironment)}, nil
 		},

--- a/pkg/op/starlarkbridge/runtime.go
+++ b/pkg/op/starlarkbridge/runtime.go
@@ -72,10 +72,10 @@ func NewRuntime(env *op.RuntimeEnvironment, options ...RuntimeOption) *Runtime {
 	//                          itself is not exposed. Reserved; no Phase 8 provider uses this row.
 	//   planned, root=false → NOT registered; reached via plan.<provider>.<method> through plan.Provider's
 	//                         sub-namespace dispatch (status quo for file, git, service, …).
-	//   planned, root=true → NOT registered; plan.Provider discovers the provider via registry.RootProviders() and
+	//   workflow-only + promoted → NOT registered; plan.Provider discovers it via registry.PromotedProviders() and
 	//                        hosts its methods flat at the plan namespace root via Tier 2 dispatch (flow).
 	//
-	// Providers that declare both RoleModule and RoleAction (access=both) register their module side per the
+	// Providers reaching both SurfaceScript and SurfaceWorkflow register their script side per the
 	// dispatch-zone rows above; their planned side is reached via plan.* regardless of placement.
 
 	predeclared := starlark.StringDict{}
@@ -333,10 +333,10 @@ func (rt *Runtime) partitionMethods(module op.ProviderReceiverType) (admitted in
 //   - `predeclared`: the surface under construction, mutated in place.
 func (rt *Runtime) placeModule(module op.ProviderReceiverType, predeclared starlark.StringDict) {
 
-	dispatch := module.Roles().Dispatch()
-	isRoot := module.Roles().Placement()&op.RoleRoot != 0
+	surfaces := module.Flags().Surfaces()
+	isPromoted := module.Flags().Placement() == op.PlacementPromoted
 
-	if dispatch&op.RoleModule == 0 {
+	if surfaces&op.SurfaceScript == 0 {
 		// Not eligible for a module surface; the provider is reached through plan.* dispatch instead. flow is
 		// the case: its methods ARE the graph combinators and mean nothing outside a graph.
 		rt.selection = append(rt.selection, moduleSelection{name: module.Name()})
@@ -359,7 +359,7 @@ func (rt *Runtime) placeModule(module op.ProviderReceiverType, predeclared starl
 		return
 	}
 
-	if !isRoot {
+	if !isPromoted {
 		sv := rt.buildOne(module)
 		if sv == nil {
 			return
@@ -406,7 +406,7 @@ func (rt *Runtime) placeModule(module op.ProviderReceiverType, predeclared starl
 		// not yet reached. [ReceiverType.Methods] yields sorted by name, so the loss was deterministic
 		// rather than random -- every method sorting AFTER the refused one vanished, which is worse: a
 		// stable wrong answer reads as intended behavior. It never fired, because no provider was
-		// RoleModule|RoleRoot until ui, and ui claims deterministic on all six, so nothing refuses them.
+		// promoted on a script surface until ui, and ui claims deterministic on all six, so nothing refuses them.
 		if refused[snake] {
 			continue
 		}
@@ -421,7 +421,7 @@ func (rt *Runtime) placeModule(module op.ProviderReceiverType, predeclared starl
 		attr, err := hasAttrs.Attr(snake)
 
 		// Inverted before 2026-07-03: the assertion required err != nil — a SUCCESSFUL Attr would have panicked.
-		// The branch is reserved (no phase-8 provider is RoleModule|RoleRoot), so the inversion sat latent until
+		// The branch was reserved (no phase-8 provider was promoted on a script surface), so the inversion sat latent until
 		// step 6's registration tests exercised it.
 		assert.Truef(err == nil && attr != nil,
 			"provider %q: method %q (snake_case %q) registered in receiver type but Attr(%q) failed — registry/Attr mismatch: %v",

--- a/pkg/op/starlarkbridge/runtime_test.go
+++ b/pkg/op/starlarkbridge/runtime_test.go
@@ -268,7 +268,7 @@ type bridgeNoClaimFixture struct{ op.ProviderBase }
 func (*bridgeNoClaimFixture) Reach() string { return "reach" }
 
 func init() {
-	op.AnnounceProvider(reflect.TypeFor[bridgeMixedClaimFixture](), op.RoleModule,
+	op.AnnounceProvider(reflect.TypeFor[bridgeMixedClaimFixture](), op.NewProviderFlags(op.SurfaceScript, op.PlacementQualified),
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeMixedClaimFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		},
@@ -277,7 +277,7 @@ func init() {
 			"Impure": {ParameterNames: []string{}},
 		})
 
-	op.AnnounceProvider(reflect.TypeFor[bridgeRootMixedClaimFixture](), op.RoleModule|op.RoleRoot,
+	op.AnnounceProvider(reflect.TypeFor[bridgeRootMixedClaimFixture](), op.NewProviderFlags(op.SurfaceScript, op.PlacementPromoted),
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeRootMixedClaimFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		},
@@ -287,33 +287,33 @@ func init() {
 			"Charlie": {ParameterNames: []string{}, Claims: op.ClaimDeterministic},
 		})
 
-	op.AnnounceProvider(reflect.TypeFor[bridgeNoClaimFixture](), op.RoleModule,
+	op.AnnounceProvider(reflect.TypeFor[bridgeNoClaimFixture](), op.NewProviderFlags(op.SurfaceScript, op.PlacementQualified),
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeNoClaimFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		},
 		map[string]op.MethodMetadata{"Reach": {ParameterNames: []string{}}})
 
-	announce := func(providerType reflect.Type, roles op.ProviderRole, method string, construct op.ProviderConstructor) {
+	announce := func(providerType reflect.Type, roles op.ProviderFlags, method string, construct op.ProviderConstructor) {
 		op.AnnounceProvider(providerType, roles, construct,
 			map[string]op.MethodMetadata{method: {ParameterNames: []string{}}})
 	}
-	announce(reflect.TypeFor[bridgeModuleFixture](), op.RoleModule, "Ping",
+	announce(reflect.TypeFor[bridgeModuleFixture](), op.NewProviderFlags(op.SurfaceScript, op.PlacementQualified), "Ping",
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeModuleFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		})
-	announce(reflect.TypeFor[bridgeRootModuleFixtureA](), op.RoleModule|op.RoleRoot, "Greet",
+	announce(reflect.TypeFor[bridgeRootModuleFixtureA](), op.NewProviderFlags(op.SurfaceScript, op.PlacementPromoted), "Greet",
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeRootModuleFixtureA{ProviderBase: op.NewProviderBase(re)}, nil
 		})
-	announce(reflect.TypeFor[bridgeRootModuleFixtureB](), op.RoleModule|op.RoleRoot, "Greet",
+	announce(reflect.TypeFor[bridgeRootModuleFixtureB](), op.NewProviderFlags(op.SurfaceScript, op.PlacementPromoted), "Greet",
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgeRootModuleFixtureB{ProviderBase: op.NewProviderBase(re)}, nil
 		})
-	announce(reflect.TypeFor[bridgePlannedFixture](), op.RoleAction, "Deploy",
+	announce(reflect.TypeFor[bridgePlannedFixture](), op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementQualified), "Deploy",
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgePlannedFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		})
-	announce(reflect.TypeFor[bridgePlannedRootFixture](), op.RoleAction|op.RoleRoot, "Launch",
+	announce(reflect.TypeFor[bridgePlannedRootFixture](), op.NewProviderFlags(op.SurfaceWorkflow, op.PlacementPromoted), "Launch",
 		func(re *op.RuntimeEnvironment) (any, error) {
 			return &bridgePlannedRootFixture{ProviderBase: op.NewProviderBase(re)}, nil
 		})
@@ -357,28 +357,28 @@ func TestNewRuntime_PlannedOnlyProvider_NotRegistered(t *testing.T) {
 	}
 }
 
-func TestNewRuntime_ModuleNonRoot_RegisteredUnderName(t *testing.T) {
+func TestNewRuntime_Qualified_RegisteredUnderName(t *testing.T) {
 
 	env := &op.RuntimeEnvironment{Modules: bridgeFixtureModules(t, "bridgeModuleFixture")}
 
 	predeclared := NewRuntime(env).Predeclared()
 
 	if _, present := predeclared["bridgeModuleFixture"]; !present {
-		t.Error(`predeclared lacks "bridgeModuleFixture"; a RoleModule non-root provider registers under its name`)
+		t.Error(`predeclared lacks "bridgeModuleFixture"; a NewProviderFlags(SurfaceScript, PlacementQualified) non-root provider registers under its name`)
 	}
 	if _, present := predeclared["ping"]; present {
 		t.Error(`predeclared contains "ping"; a non-root module's methods must not install as top-level globals`)
 	}
 }
 
-func TestNewRuntime_ModuleRoot_InstallsEachMethodAndPanicsOnCollision(t *testing.T) {
+func TestNewRuntime_Promoted_InstallsEachMethodAndPanicsOnCollision(t *testing.T) {
 
 	env := &op.RuntimeEnvironment{Modules: bridgeFixtureModules(t, "bridgeRootModuleFixtureA")}
 
 	predeclared := NewRuntime(env).Predeclared()
 
 	if _, present := predeclared["greet"]; !present {
-		t.Error(`predeclared lacks "greet"; a RoleModule|RoleRoot provider installs each method as its own global`)
+		t.Error(`predeclared lacks "greet"; a NewProviderFlags(SurfaceScript, PlacementPromoted) provider installs each method as its own global`)
 	}
 	if _, present := predeclared["bridgeRootModuleFixtureA"]; present {
 		t.Error(`predeclared contains the provider name; a root module exposes methods, not itself`)
@@ -401,9 +401,9 @@ func TestNewRuntime_ModuleRoot_InstallsEachMethodAndPanicsOnCollision(t *testing
 //
 // placeModule's root path skips a refused method and keeps going. It did not always: until 2026-08-27 the skip
 // was a `return`, which abandoned every method the loop had not yet reached. The branch carried no traffic --
-// no provider was RoleModule|RoleRoot, and ui claims deterministic on all six of its methods -- so nothing
+// no provider was NewProviderFlags(SurfaceScript, PlacementPromoted), and ui claims deterministic on all six of its methods -- so nothing
 // refused anything and the defect never surfaced. Putting ui at root is what arms it.
-func TestNewRuntime_ModuleRoot_RefusedMethodDoesNotDropTheRest(t *testing.T) {
+func TestNewRuntime_Promoted_RefusedMethodDoesNotDropTheRest(t *testing.T) {
 
 	env := &op.RuntimeEnvironment{Modules: bridgeFixtureModules(t, "bridgeRootMixedClaimFixture")}
 

--- a/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
+++ b/star/extensions/com.noblefactor.devlore.Actions/commands/generate.star
@@ -124,48 +124,52 @@ def lc_first(name):
 def struct_surface(path):
     """Extract the +devlore:surface directive from the Provider struct's doc comment.
 
-    A provider is eligible for both surfaces by default -- the graph, and the module surface of any
-    starlarkbridge.Runtime that selects it. Two providers are not, and they are opposites:
+    A provider reaches BOTH surfaces by default. Two do not, and they are opposites:
 
-      +devlore:surface=graph   flow -- its methods ARE the graph combinators and mean nothing outside a graph
-      +devlore:surface=module  plan -- there is no scenario for planning the planner
+      +devlore:surface=workflow  flow -- its methods ARE the workflow combinators and mean nothing outside one
+      +devlore:surface=script    plan -- there is no scenario for planning the planner
 
-    Returns "graph", "module", or "" for the default. The value maps onto the dispatch zone of ProviderRole:
-    graph is RoleAction alone, module is RoleModule alone, and the default is both. Which METHODS of an eligible
-    provider reach a given runtime is a separate question, answered per-runtime from their claims.
+    The value is a LIST: surface is a bit field, and a provider reaches one or more. Returns a list of
+    surface names, or [] for the default (both). Which METHODS of a reaching provider are admitted by a
+    given runtime is a separate question, answered per-runtime from their claims.
     """
     doc = goast.type_doc(path)
     for line in doc.split("\n"):
         line = line.strip().lstrip("/").strip()
         if "+devlore:surface=" in line:
             idx = line.index("+devlore:surface=")
-            value = line[idx + len("+devlore:surface="):].strip()
-            if value not in ["graph", "module"]:
-                fail("invalid +devlore:surface value %r on Provider struct (valid: graph, module; omit for both)" % value)
-            return value
-    return ""
+            raw = line[idx + len("+devlore:surface="):].strip()
+            values = [v.strip() for v in raw.split("|")]
+            for value in values:
+                if value not in ["script", "workflow"]:
+                    fail("invalid +devlore:surface value %r on Provider struct (valid: script, workflow; omit for both)" % value)
+            return values
+    return []
 
-def struct_root(path):
-    """Extract the +devlore:root flag from the Provider struct's doc comment.
+def struct_placement(path):
+    """Extract the +devlore:placement directive from the Provider struct's doc comment.
 
-    The +devlore:root=true directive sets the RoleRoot placement-zone bit on
-    the generated AnnounceProvider call, causing the provider's methods to
-    surface flat at their access-defined namespace root rather than nested
-    under the provider's own name. See Phase 8 D12 for the semantics.
+    Placement is a VALUE, not a flag set: a name is promoted or qualified, never both.
 
-    Returns False if no directive is found (the default — methods surface
-    nested under the provider's name).
+      +devlore:placement=promoted  methods surface at the namespace root of every surface the provider
+                                   reaches, unqualified -- note() in a script AND plan.note() in a workflow
+
+    ONE VALUE, EVERY SURFACE, and deliberately: there is nothing a provider could mean by asking to be
+    promoted on one surface and qualified on the other. A name is promoted because it reads better without
+    its qualifier, and that is as true of a workflow as of a script.
+
+    Returns "promoted" or "qualified", defaulting to "qualified" when no directive is found.
     """
     doc = goast.type_doc(path)
     for line in doc.split("\n"):
         line = line.strip().lstrip("/").strip()
-        if "+devlore:root=" in line:
-            idx = line.index("+devlore:root=")
-            value = line[idx + len("+devlore:root="):].strip()
-            if value not in ["true", "false"]:
-                fail("invalid +devlore:root value %r on Provider struct (valid: true, false)" % value)
-            return value == "true"
-    return False
+        if "+devlore:placement=" in line:
+            idx = line.index("+devlore:placement=")
+            value = line[idx + len("+devlore:placement="):].strip()
+            if value not in ["promoted", "qualified"]:
+                fail("invalid +devlore:placement value %r on Provider struct (valid: promoted, qualified)" % value)
+            return value
+    return "qualified"
 
 def parse_defaults(doc, method_name):
     """Parse +devlore:defaults from a method doc comment.
@@ -1031,7 +1035,7 @@ def compute_provider_import(path):
         return module_path + "/" + rel
     return module_path
 
-def emit_provider_receiver(command, path, provider, struct_short, struct_name, surface, root,
+def emit_provider_receiver(command, path, provider, struct_short, struct_name, surfaces, placement,
                       all_method_names, provider_descriptors,
                       output_dir, write_files):
     """Generate receivers in gen/ mode with type graph walking."""
@@ -1123,8 +1127,8 @@ def emit_provider_receiver(command, path, provider, struct_short, struct_name, s
     # Generate: Provider immediate receiver (gen/immediate.gen.go)
     # -------------------------------------------------------------------------
     namespace = provider
-    if surface == "graph":
-        # A graph-only provider is reached through plan.<provider> in gen/ mode
+    if surfaces == ["workflow"]:
+        # A workflow-only provider is reached through plan.<provider> in gen/ mode
         namespace = "plan." + provider
 
     # Collect cross-package imports from provider method result_exprs and struct_params
@@ -1140,8 +1144,8 @@ def emit_provider_receiver(command, path, provider, struct_short, struct_name, s
         "provider_import": provider_import,
         "methods": provider_method_descs,
         "all_methods": list(all_names_raw.keys()),
-        "surface": surface,
-        "root": root,
+        "surfaces": surfaces,
+        "placement": placement,
     }
     if provider_cross_imports:
         provider_desc["cross_package_imports"] = provider_cross_imports
@@ -1153,20 +1157,20 @@ def emit_provider_receiver(command, path, provider, struct_short, struct_name, s
     emit_file(command, "receiver_type_test", provider_desc, "gen/receiver_type.gen_test.go",
              struct_short, len(provider_method_descs), output_dir, write_files)
 
-    # Generate module tests (starlark module protocol).
-    if surface != "graph":
+    # Generate script-surface tests (starlark module protocol).
+    if len(surfaces) == 0 or "script" in surfaces:
         emit_file(command, "module_test", provider_desc, "gen/module.gen_test.go",
                  struct_short, len(provider_method_descs), output_dir, write_files)
 
-    # Generate action tests (action wrappers — dry-run, compensable, undo).
-    if surface != "module":
+    # Generate workflow-surface tests (action wrappers — dry-run, compensable, undo).
+    if len(surfaces) == 0 or "workflow" in surfaces:
         emit_file(command, "action_test", provider_desc, "gen/action.gen_test.go",
                  struct_short, len(provider_method_descs), output_dir, write_files)
 
     # Generate action-name consts (step 32) into the PACKAGE ROOT — one op.ActionName per plan-mode action, so
     # callers write plan.Plan(file.WriteText, …) instead of a string literal. Gated on the same surface that gives
     # a provider actions; the collision guard fails loudly if a const name shadows a package-level identifier.
-    if surface != "module":
+    if len(surfaces) == 0 or "workflow" in surfaces:
         action_const_names = [d["name"] for d in provider_method_descs]
         validate_action_name_consts(path, provider, action_const_names)
         emit_file(command, "action_names", provider_desc, "action_names.gen.go",
@@ -1404,24 +1408,30 @@ def prepare_render_data(descriptor, template_name):
 
     # Pre-compute descriptor fields for provider template
     if template_name == "provider":
-        # Surface eligibility, not invocation mode. Every provider reaches both the graph and a runtime's module
-        # surface unless it declares otherwise, because a graph accepts anything with an action signature and
-        # module membership is decided per METHOD, per runtime, from the claims -- never per provider. The two
-        # exceptions are opposites: flow is graph-only, plan is module-only.
-        surface = desc.get("surface", "")
-        root = desc.get("root", False)
-        desc["has_actions"] = surface != "module"
-        desc["has_planned"] = surface != "module"
-        desc["has_immediate"] = surface != "graph"
-        if surface == "graph":
-            roles = "op.RoleAction"
-        elif surface == "module":
-            roles = "op.RoleModule"
-        else:
-            roles = "op.RoleModule|op.RoleAction"
-        if root:
-            roles = roles + "|op.RoleRoot"
-        desc["roles"] = roles
+        # Which surfaces a provider REACHES, not how its methods are invoked. Every provider reaches both
+        # unless it declares otherwise, because a workflow accepts anything with an action signature and
+        # script membership is decided per METHOD, per runtime, from the claims -- never per provider. The two
+        # exceptions are opposites: flow is workflow-only, plan is script-only.
+        surfaces = desc.get("surfaces", [])
+        placement = desc.get("placement", "qualified")
+
+        reaches_script = len(surfaces) == 0 or "script" in surfaces
+        reaches_workflow = len(surfaces) == 0 or "workflow" in surfaces
+
+        desc["has_actions"] = reaches_workflow
+        desc["has_planned"] = reaches_workflow
+        desc["has_immediate"] = reaches_script
+
+        # Surfaces is a bit field -- one or more, joined. Placement is a value -- exactly one.
+        surface_terms = []
+        if reaches_script:
+            surface_terms.append("op.SurfaceScript")
+        if reaches_workflow:
+            surface_terms.append("op.SurfaceWorkflow")
+
+        placement_term = "op.PlacementPromoted" if placement == "promoted" else "op.PlacementQualified"
+
+        desc["flags"] = "op.NewProviderFlags(%s, %s)" % ("|".join(surface_terms), placement_term)
 
     # Add derived fields to each method. Sort by name first so the emitted op.MethodMetadata map is deterministic:
     # Go map iteration order is randomized, so without a stable sort the generated *.gen.go reshuffle on every run.
@@ -1538,16 +1548,15 @@ def run(command, ctx):
     note("Found " + str(len(filtered)) + " methods for " + struct_name)
 
     # -------------------------------------------------------------------------
-    # Derive names and surface/root from struct directives
+    # Derive names, surfaces, and placement from struct directives
     # -------------------------------------------------------------------------
     provider = path.split("/")[-1]
     struct_short = provider.title()
-    surface = struct_surface(path)
-    root = struct_root(path)
+    surfaces = struct_surface(path)
+    placement = struct_placement(path)
 
-    note("Provider surface: " + (surface if surface else "graph and module"))
-    if root:
-        note("Provider root: true")
+    note("Provider surfaces: " + ("|".join(surfaces) if surfaces else "script|workflow"))
+    note("Provider placement: " + placement)
 
     # -------------------------------------------------------------------------
     # Build basic method descriptors (without defaults applied)
@@ -1595,6 +1604,6 @@ def run(command, ctx):
     if not gen_mode:
         fail("--gen is required")
 
-    emit_provider_receiver(command, path, provider, struct_short, struct_name, surface, root,
+    emit_provider_receiver(command, path, provider, struct_short, struct_name, surfaces, placement,
                       all_method_names, all_descriptors,
                       output_dir, write_files)

--- a/star/extensions/com.noblefactor.devlore.Actions/templates/provider.gen.go.template
+++ b/star/extensions/com.noblefactor.devlore.Actions/templates/provider.gen.go.template
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	op.AnnounceProvider(reflect.TypeFor[{{.provider_type_prefix}}Provider](),
-		{{.roles}},
+		{{.flags}},
 		func(ctx *op.RuntimeEnvironment) (any, error) { return {{.provider_type_prefix}}NewProvider(ctx), nil },
 		map[string]op.MethodMetadata{
 {{- range .methods}}


### PR DESCRIPTION
Closes #715. Plan: `docs/plans/role-vocabulary.md` (merged as #723).

**Breaking.** `ProviderRole`, `RoleModule`, `RoleAction`, `RoleRoot`, `Dispatch()`, `Roles()`, `Modules()`,
`Actions()`, and `RootProviders()` are all replaced.

## The defect

`+devlore:surface=graph` produced `RoleAction`; `+devlore:surface=module` produced `RoleModule` — two
vocabularies for one idea, connected only by a switch in `generate.star`. An author wrote `graph` and the
generated code said `Action`.

The `op → workflow` rename forces it: `Graph` becomes `Definition`, so `surface=graph` would name a type that
no longer exists, and `module` is Starlark's word for a namespace rather than a term in the new taxonomy.

```go
+devlore:surface=script|workflow     // a list; default both
+devlore:placement=promoted          // one value; default qualified

type ProviderFlags uint16   // packs both
type Surfaces      uint8    // BIT FIELD — SurfaceScript, SurfaceWorkflow
type Placement     uint8    // VALUE — PlacementQualified, PlacementPromoted
```

## The zones are not the same kind of thing

**Plural for the set, singular for the value.** `flags.Surfaces()` returning `SurfaceScript|SurfaceWorkflow`
reads correctly; `flags.Surface()` returning two things would read as a contradiction. The accessor signatures
alone say which zone is which.

**Distinct types per zone**, following `reflect`, where `flag.kind()` returns `Kind` rather than another
`flag`. `flags.Placement() == SurfaceScript` is now a compile error rather than nonsense that compiles. C#
disagrees — `MethodAttributes` packs a `MemberAccessMask` zone and flag bits in one enum — and Go's answer was
taken for the type safety.

**`PlacementQualified = 0x00`** is the zero *value* of an enumeration, not an absent flag. Nothing can express
"promoted and qualified" — not because a check rejects it, but because the zone holds one value of a type with
two.

## Why `ProviderFlags` and not something specific

`ProviderRole` was *specific* and went stale: #677 changed the zone from *invocation mode* to *surface
eligibility*, and `RoleAction`, `Dispatch()`, and `ProviderRole` all outlived what they named. A generic name
cannot fail that way, and the accessors carry the meaning. Precedent: 14 `*Flag`/`*Flags` types in Go's
stdlib, and C#'s `BindingFlags`.

`Dispatch()` → `Surfaces()` for the same reason.

## The bootstrap had no two-pass escape

`generate.star` emits the constant names into every `.gen.go`. Renaming them broke all 58 generated references
at once — the tree stopped compiling, `star` could not rebuild, and codegen, the only thing that could rewrite
those files, could not run. Unlike #708 no ordering avoids it: the constant name and its generated use must
change together.

`make star-lkg` first, so a prebuilt `star` could regenerate a tree it could not itself compile. It took five
iterations of `generate.star` scope errors to get through, and the tree was uncompilable during all of them —
each unrecoverable without it. The LKG was then removed, and a source-built `star` reproduced all 159 files
identically, proving it an escape hatch rather than load-bearing.

## A property documented three times and tested zero times

#717 established that `ui`, reaching both surfaces, promotes six names into `plan.*` as well as installing six
globals. That claim lived in three doc comments and **no test** — and it is the half of placement this rename
routes through new code.

`TestProvider_ResolveAttr_Tier2_PromotedAcrossBothSurfaces` now asserts it, with a negative case proving
`file.copy` stays qualified. Without the negative half it would pass on a change that promoted everything.

It also failed on first run for the wrong reason: `ui` was not announced in that test binary, since `plan`
imports `flow` directly but not `ui`. A fixture gap wearing the costume of a behavioral finding.

## What was deliberately NOT renamed

`fsroot`, the run root, scoped-root tests, and git root all contain "root" in a **filesystem** sense. A
word-level sweep would break their meaning without breaking the build. #725 tracks the last two artifacts that
do carry the retired placement vocabulary.

Two doc comments deliberately retain `ProviderRole` / `RoleAction` / `Dispatch()` in historical notes
explaining why the rename happened.

## Also

The accessors mask explicitly rather than relying on the conversion to truncate — `gosec` G115 caught that the
bare form is correct only while both zones happen to be a byte wide.

## Verified

`make check`, `make test-race`, `make test-scenario` — all pass, on the current `develop` tip (`a3b4d7b8`,
after #719).
