### PR TITLE
feat(star): the knowledge indexer records provenance, and stops scraping a function that is gone

### DIFF
--- a/cmd/star/star/knowledge_index_test.go
+++ b/cmd/star/star/knowledge_index_test.go
@@ -125,6 +125,7 @@ func TestKnowledgeIndex_PreservesEntryMetadata(t *testing.T) {
 		"knowledge/packages/index.yaml": "domain: packages\n" +
 			"slots:\n" +
 			"  - name: homebrew.yaml\n" +
+			"    generated: false\n" +
 			"    package: homebrew\n" +
 			"    description: Package manager for macOS and Linux\n" +
 			"    platforms: [darwin, linux]\n",
@@ -150,6 +151,7 @@ func TestKnowledgeIndex_AddsNewFileAndKeepsNeighbourMetadata(t *testing.T) {
 		"knowledge/packages/index.yaml": "domain: packages\n" +
 			"slots:\n" +
 			"  - name: homebrew.yaml\n" +
+			"    generated: false\n" +
 			"    package: homebrew\n",
 	})
 
@@ -171,7 +173,7 @@ func TestKnowledgeIndex_IsIdempotent(t *testing.T) {
 	workdir, target := registry(t, map[string]string{
 		"knowledge/packages/slots/homebrew.yaml": "name: homebrew\n",
 		"knowledge/packages/index.yaml": "domain: packages\n" +
-			"slots:\n  - name: homebrew.yaml\n    package: homebrew\n",
+			"slots:\n  - name: homebrew.yaml\n    generated: false\n    package: homebrew\n",
 	})
 
 	app := knowledgeRuntime(t, workdir)
@@ -210,13 +212,28 @@ func TestKnowledgeIndex_RefusesUnrecognizedDirectory(t *testing.T) {
 
 func TestKnowledgeIndex_RefusesLooseFile(t *testing.T) {
 	workdir, target := registry(t, map[string]string{
-		"knowledge/migration/prompts/go.txt": "hello\n",
-		"knowledge/migration/README.md":      "loose\n",
-		"knowledge/migration/index.yaml":     "domain: migration\nprompts:\n  - name: go.txt\n",
+		"knowledge/migration/prompts/go.txt":         "hello\n",
+		"knowledge/migration/systems-reference.yaml": "loose\n",
+		"knowledge/migration/index.yaml":             "domain: migration\nprompts:\n  - name: go.txt\n    generated: false\n",
 	})
 
 	app := knowledgeRuntime(t, workdir)
-	refuses(t, app, target, "README.md")
+	refuses(t, app, target, "systems-reference.yaml")
+}
+
+func TestKnowledgeIndex_AllowsDomainReadme(t *testing.T) {
+	// README.md is orientation addressed to a reader, not an asset. Everything else loose in a
+	// domain root is still refused, so admitting it does not open the door generally.
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt": "hello\n",
+		"knowledge/migration/README.md":      "# Migration\n",
+		"knowledge/migration/index.yaml":     "domain: migration\nprompts:\n  - name: go.txt\n    generated: false\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("a domain README should be allowed: %v", err)
+	}
 }
 
 func TestKnowledgeIndex_RefusesIndexedFileThatDoesNotExist(t *testing.T) {
@@ -225,7 +242,7 @@ func TestKnowledgeIndex_RefusesIndexedFileThatDoesNotExist(t *testing.T) {
 	workdir, target := registry(t, map[string]string{
 		"knowledge/migration/signatures/stow.yaml": "x: 1\n",
 		"knowledge/migration/index.yaml": "domain: migration\n" +
-			"signatures:\n  - name: stow.yaml\n  - name: moved-away.yaml\n",
+			"signatures:\n  - name: stow.yaml\n    generated: false\n  - name: moved-away.yaml\n    generated: false\n",
 	})
 
 	app := knowledgeRuntime(t, workdir)
@@ -246,12 +263,63 @@ func TestKnowledgeIndex_RefusesUnknownSection(t *testing.T) {
 	workdir, target := registry(t, map[string]string{
 		"knowledge/migration/prompts/go.txt": "hello\n",
 		"knowledge/migration/index.yaml": "domain: migration\n" +
-			"prompts:\n  - name: go.txt\n" +
-			"invented:\n  - name: nothing.yaml\n",
+			"prompts:\n  - name: go.txt\n    generated: false\n" +
+			"invented:\n  - name: nothing.yaml\n    generated: false\n",
 	})
 
 	app := knowledgeRuntime(t, workdir)
 	refuses(t, app, target, "invented")
+}
+
+func TestKnowledgeIndex_RefusesUndeclaredProvenance(t *testing.T) {
+	// Whether a file is authored or emitted by a pipeline is not derivable from its path:
+	// package-authoring/bindings/ holds pipeline output while its siblings hold hand-written
+	// material. Guessing it wrong is how a regeneration overwrites something a person wrote, which
+	// is what devlore-registry#80 did.
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt": "hello\n",
+		"knowledge/migration/index.yaml":     "domain: migration\nprompts:\n  - name: go.txt\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "does not declare generated")
+}
+
+func TestKnowledgeIndex_RefusesNonBooleanProvenance(t *testing.T) {
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt": "hello\n",
+		"knowledge/migration/index.yaml": "domain: migration\nprompts:\n" +
+			"  - name: go.txt\n    generated: \"yes\"\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	refuses(t, app, target, "non-boolean generated")
+}
+
+func TestKnowledgeIndex_NewFileDefaultsToAuthored(t *testing.T) {
+	// The default is not a guess dressed up as knowledge; it is a choice about which way to be
+	// wrong. Calling a generated file authored costs one needless review. Calling an authored file
+	// generated invites a pipeline to overwrite it -- devlore-registry#80. The run says what it did.
+	workdir, target := registry(t, map[string]string{
+		"knowledge/migration/prompts/go.txt":  "hello\n",
+		"knowledge/migration/prompts/new.txt": "appeared\n",
+		"knowledge/migration/index.yaml": "domain: migration\nprompts:\n" +
+			"  - name: go.txt\n    generated: false\n",
+	})
+
+	app := knowledgeRuntime(t, workdir)
+	if err := runIndex(t, app, target); err != nil {
+		t.Fatalf("a new file should be recorded, not refused: %v", err)
+	}
+
+	got := readIndex(t, workdir, target, "migration")
+	if !strings.Contains(got, "new.txt") {
+		t.Errorf("the new file was not indexed:\n%s", got)
+	}
+	// Two entries, two declarations: the index it writes satisfies the rule it enforces.
+	if strings.Count(got, "generated:") != 2 {
+		t.Errorf("every entry must declare provenance:\n%s", got)
+	}
 }
 
 func TestKnowledgeIndex_AcceptsRecognizedNewTypes(t *testing.T) {
@@ -262,9 +330,9 @@ func TestKnowledgeIndex_AcceptsRecognizedNewTypes(t *testing.T) {
 		"knowledge/d/providers/b.yaml": "x: 1\n",
 		"knowledge/d/bindings/c.yaml":  "x: 1\n",
 		"knowledge/d/index.yaml": "domain: d\n" +
-			"concepts:\n  - name: a.yaml\n" +
-			"providers:\n  - name: b.yaml\n" +
-			"bindings:\n  - name: c.yaml\n",
+			"concepts:\n  - name: a.yaml\n    generated: false\n" +
+			"providers:\n  - name: b.yaml\n    generated: false\n" +
+			"bindings:\n  - name: c.yaml\n    generated: true\n",
 	})
 
 	app := knowledgeRuntime(t, workdir)

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/extract.star
@@ -561,63 +561,30 @@ def _parse_migrate_knowledge(path):
                 elif type_name == "RepoLayer":
                     repo_layers.append(entry)
 
-    # Extract system prompt and platforms from plan.go
+    # The platforms section is gone, not merely empty. It parsed a buildSystemPrompt function in
+    # plan.go for a line reading "Known platforms:", and neither the function nor that string exists
+    # in cmd/writ/writ/migrate any more. Two guards -- file.exists(plan_path) and the empty func_list
+    # -- turned that into an empty list reported as success, so every generated reference has carried
+    # `platforms: []` while the other three sections populated correctly.
+    #
+    # Dropped rather than repaired: nothing has consumed it, and a section that silently reports
+    # nothing is worse than one that is absent. If platform vocabulary is wanted, it should be
+    # extracted from a constant family the way the other three are, not scraped from prose.
     system_prompt = ""
-    platforms = []
     if file.exists(plan_path):
         prompt_funcs = goast.funcs(plan_path, name="buildSystemPrompt")
         func_list = list(prompt_funcs)
         if len(func_list) > 0:
             system_prompt = str(goast.raw_string(func_list[0].scope))
-            platforms = _extract_platforms(system_prompt)
 
     return {
         "source_systems": source_systems,
         "encryption_systems": encryption_systems,
         "repo_layers": repo_layers,
-        "platforms": platforms,
         "system_prompt": system_prompt,
     }
 
 
-def _extract_platforms(prompt_text):
-    """Extract platform names from system prompt text."""
-    platforms = []
-    lines = prompt_text.split("\n")
-    in_platform_section = False
-
-    for i, line in enumerate(lines):
-        if "Known platforms:" in line:
-            colon_idx = line.find(":")
-            if colon_idx >= 0:
-                platform_str = line[colon_idx + 1:].strip()
-                if platform_str:
-                    for p in platform_str.split(","):
-                        p = p.strip()
-                        if p:
-                            platforms.append(p)
-                    break
-            in_platform_section = True
-            continue
-
-        if in_platform_section:
-            trimmed = line.strip()
-            if trimmed.startswith("- "):
-                entry = trimmed[2:]
-                platform = entry
-                space_idx = entry.find(" ")
-                if space_idx > 0:
-                    platform = entry[:space_idx]
-                paren_idx = platform.find("(")
-                if paren_idx > 0:
-                    platform = platform[:paren_idx]
-                platform = platform.strip()
-                if platform:
-                    platforms.append(platform)
-            elif trimmed and not trimmed.startswith("-"):
-                in_platform_section = False
-
-    return platforms
 
 
 # =============================================================================
@@ -914,11 +881,9 @@ def build_migration_knowledge(source, target):
     source_systems = result["source_systems"]
     encryption_systems = result["encryption_systems"]
     repo_layers = result["repo_layers"]
-    platforms = result["platforms"]
 
     note("  Found " + str(len(source_systems)) + " source systems")
     note("  Found " + str(len(encryption_systems)) + " encryption systems")
-    note("  Found " + str(len(platforms)) + " platforms")
 
     # Step 2: Load registry signature files
     signatures_path = file.join(knowledge_path, "signatures")
@@ -932,29 +897,11 @@ def build_migration_knowledge(source, target):
                     registry_systems.append(system_name)
 
     # Step 3: Load writ-structure.yaml for platform validation
-    writ_structure_path = file.join(knowledge_path, "concepts", "writ-structure.yaml")
-    registry_platforms = []
-    registry_platform_aliases = []
-    if file.exists(writ_structure_path):
-        content = file.read_text(writ_structure_path)
-        structure = yaml.decode(content)
-        segments = structure.get("naming", {}).get("segments", {})
-        platform_list = segments.get("platforms", [])
-        for p in platform_list:
-            if "name" in p:
-                registry_platforms.append(p["name"])
-            aliases = p.get("aliases", [])
-            for alias in aliases:
-                registry_platform_aliases.append(alias)
-
     # Step 4: Check for contract violations
     violations = check_migration_contract_violations(
         source_systems,
         encryption_systems,
-        platforms,
         registry_systems,
-        registry_platforms,
-        registry_platform_aliases,
     )
 
     if violations:
@@ -966,8 +913,14 @@ def build_migration_knowledge(source, target):
     succeed("  No contract violations")
 
     # Step 5: Generate/update systems reference file
-    systems_ref = generate_systems_reference(source_systems, encryption_systems, repo_layers, platforms)
-    systems_ref_path = file.join(knowledge_path, "systems-reference.yaml")
+    systems_ref = generate_systems_reference(source_systems, encryption_systems, repo_layers)
+    # references/ rather than the domain root: this is generated material, and an asset type says so.
+    # The name states whose vocabulary it is -- writ's, migrate's -- where "systems-reference" named
+    # one of its four constant families and left the rest looking arbitrary.
+    references_dir = file.join(knowledge_path, "references")
+    if not file.exists(references_dir):
+        file.mkdir(references_dir, 0o755)
+    systems_ref_path = file.join(references_dir, "writ-migrate-vocabulary.yaml")
 
     changes_detected = False
     if file.exists(systems_ref_path):
@@ -975,23 +928,23 @@ def build_migration_knowledge(source, target):
         new_content = yaml.encode(systems_ref)
         if current_content != new_content:
             changes_detected = True
-            note("  Changes detected in systems-reference.yaml")
+            note("  Changes detected in writ-migrate-vocabulary.yaml")
     else:
         changes_detected = True
-        note("  Creating new systems-reference.yaml")
+        note("  Creating new writ-migrate-vocabulary.yaml")
 
     if changes_detected:
         file.write_text(systems_ref_path, yaml.encode(systems_ref))
         succeed("  Wrote " + systems_ref_path)
     else:
-        succeed("  No changes to systems-reference.yaml")
+        succeed("  No changes to writ-migrate-vocabulary.yaml")
 
     # Step 6: Validate all signature files exist for source systems
     validate_signature_coverage(source_systems, signatures_path)
 
 
 
-def check_migration_contract_violations(source_systems, encryption_systems, platforms, registry_systems, registry_platforms, registry_platform_aliases):
+def check_migration_contract_violations(source_systems, encryption_systems, registry_systems):
     """Check for contract violations between source code and registry."""
     violations = []
 
@@ -1022,25 +975,16 @@ def check_migration_contract_violations(source_systems, encryption_systems, plat
                 "message": "Registry signature '" + system + "' has no SourceSystem constant",
             })
 
-    if registry_platforms:
-        all_valid_platforms = set(registry_platforms)
-        for alias in registry_platform_aliases:
-            all_valid_platforms.add(alias)
-            all_valid_platforms.add(alias.lower())
-            all_valid_platforms.add(alias.title())
-
-        for platform in platforms:
-            if platform not in all_valid_platforms and platform.lower() not in all_valid_platforms:
-                violations.append({
-                    "type": "undocumented_platform",
-                    "message": "Platform '" + platform + "' in LLM prompt not in writ-structure.yaml",
-                })
+    # An undocumented_platform check lived here. It compared platforms scraped from the LLM prompt
+    # against writ-structure.yaml, and it never fired: the scrape had been broken since
+    # buildSystemPrompt was refactored away, so the list it iterated was always empty. Removed with
+    # the extraction that fed it, rather than left as a check that cannot fail.
 
     return violations
 
 
-def generate_systems_reference(source_systems, encryption_systems, repo_layers, platforms):
-    """Generate systems-reference.yaml from Go source constants."""
+def generate_systems_reference(source_systems, encryption_systems, repo_layers):
+    """Generate references/writ-migrate-vocabulary.yaml from Go source constants."""
     ref = {
         "version": "1.0",
         "source": "devlore-cli/cmd/writ/writ/migrate",
@@ -1063,7 +1007,6 @@ def generate_systems_reference(source_systems, encryption_systems, repo_layers, 
         layers.append({"name": r["name"], "value": r["value"], "file": r["file"], "line": r["line"]})
     ref["repo_layers"] = layers
 
-    ref["platforms"] = [str(p) for p in platforms]
     return ref
 
 

--- a/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
+++ b/star/extensions/com.noblefactor.devlore.Knowledge/commands/index.star
@@ -17,9 +17,13 @@
 #
 # Asset types:
 #   prompts/ schemas/ examples/ transforms/ signatures/ slots/ concepts/ providers/ bindings/
+#   references/ -- generated reference material, derived from source rather than authored
 #
 # Usage:
 #   star devlore knowledge index --target=/path/to/registry [--dry_run=true]
+
+# Files permitted at a domain root, where no asset type claims them.
+DOMAIN_ROOT_FILES = ["index.yaml", "README.md"]
 
 ASSET_TYPES = [
     "prompts",
@@ -31,6 +35,7 @@ ASSET_TYPES = [
     "concepts",
     "providers",
     "bindings",
+    "references",
 ]
 
 def list_files(dir_path):
@@ -90,9 +95,14 @@ def audit_domain(domain_name, domain_path, existing):
             problems.append("directory '" + d + "/' is not a known asset type")
 
     # A file loose in the domain root belongs to no asset type, so nothing indexes it.
+    #
+    # README.md is furniture rather than an asset -- orientation addressed to a reader, the same
+    # call .github/frontmatter-exempt makes for a repository's own README. It is named explicitly
+    # rather than matched by a pattern, so admitting a second kind of loose file stays a decision
+    # somebody has to make on purpose.
     for path in file.glob(file.join(domain_path, "*")):
         name = file.name(path)
-        if file.is_dir(path) or name.startswith(".") or name == "index.yaml":
+        if file.is_dir(path) or name.startswith(".") or name in DOMAIN_ROOT_FILES:
             continue
         problems.append("file '" + name + "' is outside any asset-type directory")
 
@@ -122,6 +132,25 @@ def audit_domain(domain_name, domain_path, existing):
             if name not in present:
                 problems.append("'" + key + "/" + name + "' is indexed but no such file exists")
 
+        # Provenance is declared, never inferred. A derived artifact is regenerable and may be
+        # overwritten; an authored one may not, and nothing about a path distinguishes them --
+        # knowledge/package-authoring/bindings/ holds pipeline output while its sibling directories
+        # hold hand-written material. devlore-registry#80 deleted curated metadata precisely because
+        # nothing recorded which was which.
+        for entry in existing[key]:
+            if type(entry) != "dict" or "name" not in entry:
+                continue
+            if "generated" not in entry:
+                problems.append(
+                    "'" + key + "/" + str(entry["name"]) +
+                    "' does not declare generated: true or false",
+                )
+            elif type(entry["generated"]) != "bool":
+                problems.append(
+                    "'" + key + "/" + str(entry["name"]) +
+                    "' declares a non-boolean generated: " + str(entry["generated"]),
+                )
+
     # A directory holding assets that the index never mentions.
     for d in subdirs:
         if d in ASSET_TYPES and d not in existing and len(list_files(file.join(domain_path, d))) > 0:
@@ -146,7 +175,14 @@ def merge_entries(names, existing_entries):
         if name in by_name:
             merged.append(by_name[name])
         else:
-            merged.append({"name": name})
+            # A new file is recorded as authored. Not because that is knowable from the path -- it
+            # is not -- but because the two ways of being wrong are not symmetric. Labelling a
+            # generated file as authored costs a person one needless review of a regeneration.
+            # Labelling an authored file as generated invites a pipeline to overwrite it, which is
+            # devlore-registry#80. The default errs toward the harm that is recoverable.
+            #
+            # A pipeline adding its own output should write the entry itself, with generated: true.
+            merged.append({"name": name, "generated": False})
     return merged
 
 def build_index(domain_name, domain_path, existing):
@@ -264,6 +300,19 @@ def run(command, ctx):
 
         # A no-op is worth saying out loud: it is the evidence that a run changed nothing, which is
         # what re-enabling this in CI has to demonstrate.
+        for asset_type in ASSET_TYPES:
+            if asset_type not in index:
+                continue
+            prior_names = []
+            if asset_type in existing and type(existing[asset_type]) == "list":
+                prior_names = entry_names(existing[asset_type])
+            for e in index[asset_type]:
+                if e["name"] not in prior_names:
+                    note(
+                        "  " + domain_name + ": new " + asset_type + "/" + e["name"] +
+                        " recorded as authored (generated: false) -- correct it if a pipeline owns it",
+                    )
+
         if file.exists(index_path) and file.read_text(index_path) == index_content:
             unchanged = unchanged + 1
             total_assets = total_assets + asset_count


### PR DESCRIPTION
Second half of the indexer work begun in #719. That change stopped the indexer destroying metadata;
this one makes it record what it cannot know, and stop reporting a section it has never been able to
fill.

## Provenance is declared, never inferred

Every index entry now carries `generated: true` or `false`. The indexer refuses on an entry that
omits it, or declares a non-boolean.

Whether a file is authored or emitted by a pipeline **is not derivable from its path** —
`knowledge/package-authoring/bindings/` holds pipeline output while its sibling directories hold
hand-written material. Getting it wrong is how a regeneration overwrites something a person wrote,
which is devlore-registry#80.

**A new file is recorded as authored rather than refused**, and that is a decision about which way
to be wrong:

| mistake | cost |
| --- | --- |
| generated file labelled authored | one needless review of a regeneration |
| authored file labelled generated | a pipeline overwrites it — #80 |

The default errs toward the recoverable harm, and every one is announced in the run output. A
pipeline adding its own output should write the entry itself.

## Two more asset types

**`references/`** — generated reference material gets a home whose name states what it is, rather
than sitting at a domain root looking accidental.

**`README.md` at a domain root** — furniture, orientation addressed to a reader. The same call
`.github/frontmatter-exempt` makes for a repository's own README, and named explicitly so admitting
a second kind of loose file stays a decision.

## The platforms extraction is dropped, not repaired

It parsed a `buildSystemPrompt` function in `plan.go` for a line reading `Known platforms:`. Neither
the function nor that string has existed in `cmd/writ/writ/migrate` since it was refactored. Two
guards — `file.exists` on the path, an empty function list — turned that into an empty list reported
as success. Every generated reference has carried `platforms: []` while its three siblings populated
correctly.

Removed with everything that fed it: the `_extract_platforms` helper, the `writ-structure.yaml`
scrape that supplied its comparison set, and an `undocumented_platform` contract check that could
never fire because the list it iterated was always empty.

If platform vocabulary is wanted, it should come from a constant family the way the other three do,
not scraped from prose.

## Also

The extractor writes `references/writ-migrate-vocabulary.yaml` rather than `systems-reference.yaml`
at the domain root. The old name described one of its four constant families — source systems,
encryption systems, repo layers, platforms — and left the rest looking arbitrary.

## Tests

Thirteen, `//go:build integration`. Both halves: what is preserved, and each way the tree and its
index can disagree — including the three new provenance cases.

## Ordering

devlore-registry's matching change **lands second**. It re-enables the index step, which builds
`star` from this repository's default branch, so merging it first would run the old indexer against
a tree it will refuse.

Phase A of `docs/plans/cag-epic.md`.