### PR TITLE
A dispatch error names the symbol the author typed

### DIFF
--- a/cmd/devlore-test/devloretest/data/test_imm_ui_print_replaces_builtin.star
+++ b/cmd/devlore-test/devloretest/data/test_imm_ui_print_replaces_builtin.star
@@ -7,13 +7,18 @@
 # reads identically whichever implementation answers it, and only the DESTINATION differs — the
 # builtin writes straight to stderr through starlark-go, escaping --silent and the narrator.
 #
-# The arity is what tells them apart. starlark's builtin is variadic — print("a", "b") prints "a b".
-# ui.Print takes one string. So a two-argument call MUST fail, and if it ever succeeds the builtin
-# is back and every script kept working while its output quietly returned to stderr.
+# The arity is what tells them apart. starlark's builtin is variadic; ui.Print takes one string. So a
+# two-argument call MUST fail, and if it ever succeeds the builtin is back and every script kept
+# working while its output quietly returned to stderr.
+#
+# The message names print, which is what the author typed. It said ui.print until #710 — a symbol no
+# script can use, since promotion means ui is not a global at all, so an author following the error
+# arrived at `undefined: ui`.
+#
+# The rule: where a call site exists, an error names what the author typed; where none exists, it
+# names the action. This is script evaluation, so the call site is right here. A graph node's action
+# name stays provider-qualified, because it is the node's identity in a serialized workflow.
 
-# The message names ui.print, which is a symbol no script can use -- root placement removed the ui
-# global. That is #710, and it is pre-existing: flow has reported flow.failed for plan.failed calls
-# since root placement existed. Pinned as-is so the fix to #710 has to come back through here.
-t.expect_error(r"ui\.print: got 2 arguments, want at most 1")
+t.expect_error(r"^print: got 2 arguments, want at most 1")
 
 print("a", "b")

--- a/docs/plans/dispatch-error-names.md
+++ b/docs/plans/dispatch-error-names.md
@@ -1,0 +1,174 @@
+---
+title: "A Dispatch Error Names the Symbol the Author Typed"
+issue: 710
+status: complete
+created: 2026-08-28
+updated: 2026-08-28
+---
+
+# Plan: A Dispatch Error Names the Symbol the Author Typed
+
+**Issue:** [#710](https://github.com/NobleFactor/devlore-cli/issues/710) ·
+**Epic:** [#445 — The Starlark authoring surface](https://github.com/NobleFactor/devlore-cli/issues/445) ·
+**Unblocked by:** [#715](https://github.com/NobleFactor/devlore-cli/issues/715)
+
+## Summary
+
+```
+>>> print("a", "b")
+ui.print: got 2 arguments, want at most 1
+```
+
+`ui.print` does not exist. `ui` is promoted, so its methods are top-level globals and the provider name is not
+a symbol any script can use — an author who takes the error at its word and writes `ui.print(...)` gets
+`undefined: ui`. **The error sends them toward a second, unrelated error**, which is worse than a vague message.
+
+Pre-existing, not introduced by #708. `flow` has done this since promotion existed:
+`cmd/devlore-test/devloretest/data/test_flow_fatal.star` calls `plan.failed(...)` and expects an error saying
+`flow.failed`. Nobody could write `flow.failed` in a script.
+
+## The three naming sites
+
+Each site already knows which surface it serves, and two of them know their placement by construction — they
+*are* the promoted path and the qualified path.
+
+| Site | Surface | Placement | Emits today | Should emit |
+| --- | --- | --- | --- | --- |
+| `starlarkbridge/go_receiver.go:229` | script | either | `ui.print` | promoted → `print`<br>qualified → `file.copy` |
+| `plan/provider.go:843` | workflow | promoted | `flow.choose` | `plan.choose` |
+| `plan/adapter.go:117` | workflow | qualified | `file.copy` | `plan.file.copy` |
+
+Only the first consults `Placement()`. The other two are unconditional: whichever site builds the builtin
+determines the shape of its name.
+
+**This is what #715 unblocked.** Before it, placement was a bit whose meaning was tangled with dispatch, and
+"which name would the author have typed" had no clean answer. `flags.Placement() == op.PlacementPromoted` is
+now a one-line question.
+
+## The governing rule
+
+> **Where a call site exists, an error names what the author typed; where none exists, it names the action.**
+> The two cannot be one name because the action name is a node's identity field — it is in the serialized
+> document and the checksum — so tying it to placement would rewrite every saved workflow when a provider's
+> placement changed.
+
+```python
+print("a", "b")          # script evaluation -- the call site is right here
+→ print: got 2 arguments, want at most 1        (today: ui.print, a symbol no script can use)
+
+plan.failed("db down")   # runs later, possibly from a workflow loaded off disk
+→ flow.failed executed: db down                 (unchanged -- there is no call site to name)
+```
+
+### Why the two names cannot simply be unified
+
+`ActionName` is documented as *"the sole identity field"* on `nodeData`, serialized to json and yaml, and
+therefore part of the canonical form the checksum covers. If the serialized name followed placement, changing a
+provider from qualified to promoted would rewrite the action name in every saved workflow, change every
+canonical form, and invalidate every checksum. **Placement is a call-site convenience; identity cannot move
+when it changes.**
+
+### Why an author is not owed one name
+
+The two errors arise in different worlds, and only one of them has a call site to name:
+
+| Error kind | Call site | Name available |
+| --- | --- | --- |
+| arity, type mismatch | known — the script is being evaluated | **what the author typed** |
+| execution failure | **none** — the workflow may have been loaded from disk | only the action name |
+
+An execution error genuinely cannot use a call-site name, because by then there may never have been one. A
+loaded workflow has nodes, not call sites. `flow.failed executed: database unreachable` is right in that
+context: you are looking at a running workflow, and the provider qualifier says who implements the operation.
+
+So the boundary is explainable rather than arbitrary, which is what would otherwise confuse an author. Today
+`print("a", "b")` reports `ui.print` **while the script is being evaluated**, with the call site right there
+and ignored.
+
+### What this narrows
+
+Determining which fixtures depend on which name is not archaeology under this rule: script-evaluation errors
+move, execution errors do not. `test_flow_fatal.star` matches an *execution* error and does not change.
+
+## Steps
+
+| # | Step | ✓ |
+| --- | --- | --- |
+| 1 | Classify each fixture's expectation: script-evaluation error, or execution error | ✅ |
+| 2 | Failing tests first, one per site | ✅ |
+| 3 | `go_receiver.go` — consult `Placement()`; bare name when promoted | ✅ |
+| 4 | `plan/provider.go` — promoted builtins take `plan.<method>` | ✅ |
+| 5 | `plan/adapter.go` — qualified builtins take `plan.<provider>.<method>` | ✅ |
+| 6 | Update fixtures whose expectations name a builtin | ✅ |
+| 7 | `make check`, `test-race`, `test-scenario` | ✅ |
+
+### Step 1 result (2026-08-28)
+
+Four fixture expectations name a provider-qualified symbol. **Exactly one changes.**
+
+| Fixture | Expectation | Runs a graph | Kind | Verdict |
+| --- | --- | --- | --- | --- |
+| `test_imm_ui_print_replaces_builtin` | `ui\.print: got 2 args…` | **no** | script eval | **moves** → `print:` |
+| `test_compensation` | `file.copy` | yes | execution | unchanged |
+| `test_judgment_1_delete_then_copy` | `file.copy` | yes | execution | unchanged |
+| `test_judgment_resolve_dangling` | `file.resolve` | yes | execution | unchanged |
+| `test_flow_fatal` | `flow.failed executed:` | yes | execution | unchanged |
+
+**"Runs a graph" is the mechanical discriminator**: every execution-error fixture calls `t.run(graph)`, and the
+one script-evaluation fixture does not.
+
+This is the rule paying for itself. Step 1 was written expecting archaeology — the risk being that a fixture's
+text alone would not say which name it was seeing, so a change might either break serialized identity or
+"fix" an expectation that was already correct. Under the governing rule it is a one-column check, and the three
+`file.*` expectations plus the `flow.*` one are all execution errors that must stay exactly as they are.
+
+It also confirms row 2 of the test plan is a real counterweight rather than a formality: `test_compensation`
+expects `file.copy`, so a fix that made every name bare would break it — and should.
+
+## Outcome
+
+Complete 2026-08-28. `check`, `test-race`, `test-scenario` all pass.
+
+| Site | Before | After |
+| --- | --- | --- |
+| script surface | `ui.print` | **`print`** promoted; `file.copy` qualified, unchanged |
+| workflow, promoted | `flow.choose` | **`plan.choose`** |
+| workflow, qualified | `file.copy` | **`plan.file.copy`** |
+
+### `actionName` was a misnomer, and it made the change look risky
+
+Both workflow sites named their variable `actionName` and passed it to `dispatchBuiltinBody`, which reads as
+though changing it would move the serialized action name. It does not: that function uses the string **only in
+error text**, and a node's action name comes from `unit.Action().Name()` at marshal. The variable made a
+display string look like an identity. Renamed to `callSiteName` at both sites, with a comment saying which it
+is.
+
+That is also why the four execution-error fixtures passed untouched — they never reach these sites. Step 1's
+classification predicted exactly that, and the change confirmed it rather than merely being consistent with it.
+
+## Test Plan
+
+| # | What it proves | Level | Fails when |
+| --- | --- | --- | --- |
+| 1 | `print("a","b")` reports `print:`, not `ui.print:` | e2e | the script site ignores placement |
+| 2 | `file.copy(...)` still reports `file.copy:` | unit | the fix over-reaches to qualified providers |
+| 3 | A promoted workflow builtin reports `plan.choose:` | unit | the promoted plan site is missed |
+| 4 | A qualified workflow builtin reports `plan.file.copy:` | unit | the adapter site is missed |
+| 5 | A graph node's action name is still `flow.failed` | unit | the change leaked into serialized identity |
+| 6 | Every gate | `check`, `test-race`, `test-scenario` | any of the above regresses |
+
+**Row 2 is the counterweight.** Most providers are qualified, and `file.copy` is exactly what an author types,
+so it must not change. A fix that made every name bare would pass rows 1, 3, and 4.
+
+**Row 5 is the boundary.** The starlark-facing name and the serialized action name are different things that
+happen to share a spelling today. Only one moves.
+
+**Row 1 has a landing spot already.** `test_imm_ui_print_replaces_builtin.star` currently pins
+`ui\.print: got 2 arguments, want at most 1` deliberately, with a comment saying the fix to #710 must come back
+through it.
+
+### Not covered
+
+- **Resource receivers.** `newGoReceiver` also serves resources, whose names are type names rather than
+  provider names. Placement does not apply, and nothing here changes for them — but the code path is shared,
+  so the tests should confirm it by absence rather than assume it.

--- a/pkg/op/provider/plan/adapter.go
+++ b/pkg/op/provider/plan/adapter.go
@@ -114,9 +114,12 @@ func (a *adapter) Attr(name string) (starlark.Value, error) {
 		if op.CamelToSnake(method.Name()) != name {
 			continue
 		}
-		actionName := a.receiverType.Name() + "." + name
-		body := dispatchBuiltinBody(a.provider, a.receiverType, method.Name(), actionName)
-		return starlark.NewBuiltin(actionName, body), nil
+		// The name an author would have typed. A qualified provider is reached through its own name under
+		// plan.*, so the call site is plan.file.copy -- not file.copy, which is the SCRIPT surface's spelling.
+		// Display only; the node's action name is unaffected (#710).
+		callSiteName := "plan." + a.receiverType.Name() + "." + name
+		body := dispatchBuiltinBody(a.provider, a.receiverType, method.Name(), callSiteName)
+		return starlark.NewBuiltin(callSiteName, body), nil
 	}
 
 	return nil, starlarkbridge.NoSuchAttrError(a.Type(), name)

--- a/pkg/op/provider/plan/provider.go
+++ b/pkg/op/provider/plan/provider.go
@@ -840,7 +840,12 @@ func (p *Provider) promoteMethods(selfNames, childNames map[string]struct{}, roo
 		for method := range rp.Methods() {
 
 			snakeName := op.CamelToSnake(method.Name())
-			actionName := rp.Name() + "." + snakeName
+
+			// The name an author would have typed. A promoted provider's methods answer directly under
+			// plan.*, so its own name is not a symbol any script can use -- plan.choose, never flow.choose.
+			// This is a display name only: the node's ACTION name comes from unit.Action().Name() at marshal
+			// and stays provider-qualified, because it is the node's identity in a serialized workflow (#710).
+			callSiteName := "plan." + snakeName
 
 			if _, ok := selfNames[snakeName]; ok {
 				panic(fmt.Sprintf(
@@ -862,8 +867,8 @@ func (p *Provider) promoteMethods(selfNames, childNames map[string]struct{}, roo
 			}
 
 			p.promotedBuiltins[snakeName] = starlark.NewBuiltin(
-				actionName,
-				dispatchBuiltinBody(p, rp, method.Name(), actionName),
+				callSiteName,
+				dispatchBuiltinBody(p, rp, method.Name(), callSiteName),
 			)
 		}
 	}

--- a/pkg/op/provider/plan/provider_test.go
+++ b/pkg/op/provider/plan/provider_test.go
@@ -425,3 +425,74 @@ func TestAssembleDefinition_OrphanInvocation_Errors(t *testing.T) {
 		t.Errorf("error %q does not name the orphan invocation %q", err, orphan.Label)
 	}
 }
+
+// region Call-site naming (#710)
+
+// TestResolveAttr_BuiltinNamesFollowTheCallSite pins what a workflow-surface dispatch error reports.
+//
+// The rule: where a call site exists, an error names what the author typed. Under plan.*, that means a
+// PROMOTED provider's method is plan.choose — never flow.choose, since flow is not a symbol reachable from a
+// script — and a QUALIFIED provider's method is plan.file.copy, the whole path the author wrote.
+//
+// Both are asserted together because a fix that promoted every name would satisfy the first alone.
+//
+// This governs the STARLARK-FACING name only. A graph node's action name stays provider-qualified: it is the
+// node's identity field, carried in the serialized document and the checksum.
+func TestResolveAttr_BuiltinNamesFollowTheCallSite(t *testing.T) {
+
+	p := resolutionProvider(t)
+
+	t.Run("promoted method is named for the plan root", func(t *testing.T) {
+
+		builtin, ok := p.ResolveAttr("choose").(*starlark.Builtin)
+		if !ok {
+			t.Fatalf("ResolveAttr(choose) = %T, want *starlark.Builtin", p.ResolveAttr("choose"))
+		}
+
+		if got := builtin.Name(); got != "plan.choose" {
+			t.Errorf("builtin name = %q, want %q; flow is not a symbol any script can reach", got, "plan.choose")
+		}
+	})
+
+	t.Run("qualified method keeps its provider in the path", func(t *testing.T) {
+
+		adapterValue, ok := p.ResolveAttr("file").(*adapter)
+		if !ok {
+			t.Fatalf("ResolveAttr(file) = %T, want *adapter", p.ResolveAttr("file"))
+		}
+
+		attr, err := adapterValue.Attr("copy")
+		if err != nil {
+			t.Fatalf("Attr(copy): %v", err)
+		}
+
+		builtin, ok := attr.(*starlark.Builtin)
+		if !ok {
+			t.Fatalf("Attr(copy) = %T, want *starlark.Builtin", attr)
+		}
+
+		if got := builtin.Name(); got != "plan.file.copy" {
+			t.Errorf("builtin name = %q, want %q; the author typed the whole path", got, "plan.file.copy")
+		}
+	})
+}
+
+// TestActionNamesStayProviderQualified pins the other side of the #710 boundary.
+//
+// The starlark-facing builtin name follows placement; the ACTION name does not. An action name is a node's
+// identity field, carried in the serialized document and therefore in the checksum — so tying it to placement
+// would rewrite every saved workflow the moment a provider's placement changed.
+//
+// flow is promoted, so its call site is plan.choose. Its action name is still flow.choose, and the registry
+// must still resolve it under that name — a saved workflow says flow.choose and has to load.
+func TestActionNamesStayProviderQualified(t *testing.T) {
+
+	for _, actionName := range []string{"flow.choose", "flow.gather", "flow.failed"} {
+		if _, err := op.ReceiverRegistry().BuildAction(op.ActionName(actionName)); err != nil {
+			t.Errorf("BuildAction(%q): %v; the action name is a node's serialized identity and must not "+
+				"follow placement", actionName, err)
+		}
+	}
+}
+
+// endregion

--- a/pkg/op/starlarkbridge/call_site_name_test.go
+++ b/pkg/op/starlarkbridge/call_site_name_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package starlarkbridge
+
+import (
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+
+	"github.com/NobleFactor/devlore-cli/pkg/op"
+)
+
+// region Call-site naming (#710)
+
+// TestBuiltinName_FollowsPlacement pins the rule a dispatch error answers to.
+//
+// Where a call site exists, an error names what the author typed. A promoted provider's methods ARE the
+// top-level globals, so its provider name is not a symbol any script can use — reporting `ui.print` sends an
+// author toward `undefined: ui`, a second and unrelated error. A qualified provider is the opposite: its name
+// is exactly what the author typed, and must stay.
+//
+// The two are asserted together because a fix that made every name bare would satisfy the first alone.
+func TestBuiltinName_FollowsPlacement(t *testing.T) {
+
+	t.Run("promoted provider reports the bare method name", func(t *testing.T) {
+
+		// A promoted provider installs each method as its own predeclared entry, so the global IS the builtin.
+		predeclared := NewRuntime(&op.RuntimeEnvironment{
+			Modules: bridgeFixtureModules(t, "bridgeRootModuleFixtureA"),
+		}).Predeclared()
+
+		value, present := predeclared["greet"]
+		if !present {
+			t.Fatalf("predeclared lacks \"greet\"; got %v", predeclared.Keys())
+		}
+
+		builtin, isBuiltin := value.(*starlark.Builtin)
+		if !isBuiltin {
+			t.Fatalf("predeclared[greet] is %T, want *starlark.Builtin", value)
+		}
+
+		if got := builtin.Name(); got != "greet" {
+			t.Errorf("builtin name = %q, want %q; a promoted provider's name is not a symbol a script can use",
+				got, "greet")
+		}
+	})
+
+	t.Run("qualified provider keeps its qualifier", func(t *testing.T) {
+
+		receiver := requireGlobal(t,
+			NewRuntime(&op.RuntimeEnvironment{
+				Modules: bridgeFixtureModules(t, "bridgeModuleFixture"),
+			}).Predeclared(), "bridgeModuleFixture")
+
+		attr, err := receiver.Attr("ping")
+		if err != nil {
+			t.Fatalf("Attr(ping): %v", err)
+		}
+
+		builtin, isBuiltin := attr.(*starlark.Builtin)
+		if !isBuiltin {
+			t.Fatalf("Attr(ping) is %T, want *starlark.Builtin", attr)
+		}
+
+		if got := builtin.Name(); !strings.Contains(got, ".") {
+			t.Errorf("builtin name = %q, want it qualified; a qualified provider's name IS what the author typed",
+				got)
+		}
+	})
+}
+
+// endregion

--- a/pkg/op/starlarkbridge/go_receiver.go
+++ b/pkg/op/starlarkbridge/go_receiver.go
@@ -226,8 +226,7 @@ func (g *goReceiver) Attr(name string) (starlark.Value, error) {
 	}
 
 	if method, ok := g.methods[name]; ok {
-		actionName := g.receiverType.Name() + "." + name
-		builtin := starlark.NewBuiltin(actionName, g.dispatch)
+		builtin := starlark.NewBuiltin(g.callSiteName(name), g.dispatch)
 
 		// A method tagged [op.ModifierProperty] projects as an eager property: attribute access invokes the zero-arg
 		// getter and yields its result rather than returning the callable builtin. dispatch ignores its thread
@@ -246,6 +245,35 @@ func (g *goReceiver) Attr(name string) (starlark.Value, error) {
 	}
 
 	return nil, NoSuchAttrError(g.receiverType.Name(), name)
+}
+
+// callSiteName returns the name an author would have typed to reach this method, which is what a dispatch
+// error must report.
+//
+// A PROMOTED provider's methods are the top-level globals themselves, so its provider name is not a symbol any
+// script can use. Reporting `ui.print` for a `print(...)` call sends an author toward `undefined: ui` -- a
+// second and unrelated error, which is worse than a vague message. A QUALIFIED provider is the opposite: its
+// name IS what the author typed, and must stay.
+//
+// This governs the STARLARK-FACING name only. A graph node's action name stays provider-qualified: it is the
+// node's identity field, carried in the serialized document and the checksum, so tying it to placement would
+// rewrite every saved workflow when a provider's placement changed (#710).
+//
+// A receiver that is not a provider -- a resource -- has no placement, and keeps the qualified form.
+//
+// Parameters:
+//   - `name`: the snake_case method name.
+//
+// Returns:
+//   - `string`: the call-site name.
+func (g *goReceiver) callSiteName(name string) string {
+
+	provider, isProvider := g.receiverType.(op.ProviderReceiverType)
+	if isProvider && provider.Flags().Placement() == op.PlacementPromoted {
+		return name
+	}
+
+	return g.receiverType.Name() + "." + name
 }
 
 // AttrNames implements [starlark.HasAttrs].


### PR DESCRIPTION
Closes #710. Plan: `docs/plans/dispatch-error-names.md`.

```
>>> print("a", "b")
ui.print: got 2 arguments, want at most 1
```

`ui.print` does not exist. `ui` is promoted, so its methods **are** the top-level globals and the provider name
is not a symbol any script can use — an author who takes the error at its word and writes `ui.print(...)` gets
`undefined: ui`. **The error sent them toward a second, unrelated error**, which is worse than a vague message.

Pre-existing, not introduced by #708: `flow` has done this since promotion existed.

## The rule

> **Where a call site exists, an error names what the author typed; where none exists, it names the action.**
> The two cannot be one name because the action name is a node's identity field — it is in the serialized
> document and the checksum — so tying it to placement would rewrite every saved workflow when a provider's
> placement changed.

```python
print("a", "b")          # script evaluation — the call site is right here
→ print: got 2 arguments, want at most 1        (was: ui.print)

plan.failed("db down")   # runs later, possibly from a workflow loaded off disk
→ flow.failed executed: db down                 (unchanged — there is no call site to name)
```

An execution error genuinely *cannot* use a call-site name: a loaded workflow has nodes, not call sites. So the
boundary is explainable rather than arbitrary, which is what would otherwise confuse an author.

## Three sites, each already knowing its own surface

| Site | Surface | Placement | Before | After |
| --- | --- | --- | --- | --- |
| `starlarkbridge/go_receiver.go` | script | either | `ui.print` | `print` promoted, `file.copy` qualified |
| `plan/provider.go` | workflow | promoted | `flow.choose` | `plan.choose` |
| `plan/adapter.go` | workflow | qualified | `file.copy` | `plan.file.copy` |

Only the first consults `Placement()`. The other two **are** the promoted and qualified paths, so the site
itself determines the shape.

**This is what #715 unblocked.** Before it, placement was a bit tangled with dispatch and "which name would the
author have typed" had no clean answer. `flags.Placement() == op.PlacementPromoted` is now a one-line question.

## `actionName` was a misnomer, and it made this look riskier than it is

Both workflow sites named their variable `actionName` and passed it to `dispatchBuiltinBody` — which reads as
though changing it would move the serialized action name. **It does not.** That function uses the string *only
in error text*, and a node's action name comes from `unit.Action().Name()` at marshal.

A display string was wearing an identity's name. Renamed to `callSiteName` at both sites, with a comment saying
which it is.

## Step 1 classified every fixture before anything changed

Four fixture expectations name a provider-qualified symbol. **Exactly one moves.**

| Fixture | Runs a graph | Kind | Verdict |
| --- | --- | --- | --- |
| `test_imm_ui_print_replaces_builtin` | no | script evaluation | **moves** → `print:` |
| `test_compensation` | yes | execution | unchanged |
| `test_judgment_1_delete_then_copy` | yes | execution | unchanged |
| `test_judgment_resolve_dangling` | yes | execution | unchanged |
| `test_flow_fatal` | yes | execution | unchanged |

"Runs a graph" is the mechanical discriminator. The change then **confirmed** that classification rather than
merely being consistent with it: all four execution fixtures passed untouched, because they never reach these
sites.

## Tests assert both directions

A promoted provider reports the bare name **and** a qualified one keeps its qualifier — together, because a fix
that made every name bare would satisfy the first alone. `file.copy` is exactly what an author types.

And `flow.choose`, `flow.gather`, and `flow.failed` must still resolve through `BuildAction`: a saved workflow
says `flow.choose` and has to load. That is the boundary made explicit rather than incidental.

`test_imm_ui_print_replaces_builtin` pinned `ui\.print: got 2 arguments` deliberately, with a comment saying
the #710 fix had to come back through it. It did — the fixture failed on the first run of the fix.

## Verified

`make check`, `make test-race`, `make test-scenario` — all pass.
