### PR TITLE
feat(writ): declare the tools a devlore-cli environment needs

### DIFF
--- a/Home/noblefactor.Darwin/packages-manifest.yaml
+++ b/Home/noblefactor.Darwin/packages-manifest.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# Darwin additions, over noblefactor.Unix.
+
+packages:
+  # GNU make. The Makefile requires 3.82+ for .ONESHELL:, and macOS ships 3.81 -- the last GPLv2
+  # release, so it will never advance. Without this the multi-line recipes are split into one shell
+  # per line and die as `syntax error: unexpected end of file`. ci.yaml installs it on every macOS
+  # leg for the same reason.
+  - make
+
+  # Compilers and build tools the platform expects for anything cgo-adjacent. The registry carries
+  # a lore package for it.
+  - xcode-clt

--- a/Home/noblefactor.Linux/packages-manifest.yaml
+++ b/Home/noblefactor.Linux/packages-manifest.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# Linux additions, over noblefactor.Unix.
+#
+# Deliberately thin: the distributions we build on ship a GNU userland already, so the tools that
+# need naming on Darwin need no mention here.
+
+packages: []

--- a/Home/noblefactor.Unix/packages-manifest.yaml
+++ b/Home/noblefactor.Unix/packages-manifest.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# Unix additions, over the suffix-less noblefactor layer.
+#
+# Selected on Darwin and Linux, because writ's OSFamily maps both to Unix. Windows has no family and
+# never draws this layer -- the two are siblings, not base and override.
+
+packages:
+  # markdownlint-cli2 is npm-delivered and gocyclo is `go install`ed; both are named here rather than
+  # in the base because neither has a settled Windows delivery in our tooling.
+  - markdownlint-cli2
+  - gocyclo
+
+  # Code metrics, the quality-gate's last step.
+  - scc
+
+  # Git hooks. The Makefile installs them through it.
+  - pre-commit
+
+  # Secrets. pkg/op/provider/encryption shells out to sops, and age is the backend the writ layer
+  # encrypts with. Both are needed to deploy a layer carrying .sops files.
+  - sops
+  - age

--- a/Home/noblefactor.Windows/packages-manifest.yaml
+++ b/Home/noblefactor.Windows/packages-manifest.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# Windows additions, over the suffix-less noblefactor layer.
+#
+# Windows has no OS family in writ's segment model, so it never draws noblefactor.Unix. Anything
+# shared with Darwin and Linux belongs in the base layer, not repeated here.
+
+packages:
+  # PowerShell 7. pkg/op/provider/powershell shells out to pwsh, pkg/platform's Windows manager
+  # detection expects it, and it is what sshd's DefaultShell is set to on our Windows hosts.
+  - pwsh

--- a/Home/noblefactor/packages-manifest.yaml
+++ b/Home/noblefactor/packages-manifest.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# The tools a devlore-cli working environment needs on every platform.
+#
+# This layer has no suffix, so writ's Segments.Match selects it everywhere -- "no suffixes means it
+# always matches". Platform layers add to it: Darwin and Linux also draw noblefactor.Unix, because
+# OSFamily maps both to Unix; Windows has no family and draws only noblefactor.Windows.
+#
+# Every entry is one this repository demonstrably uses -- a Makefile target, a CI step, a star
+# extension, or a provider that shells out to it. Nothing is here because it happens to be installed
+# on someone's laptop.
+#
+# This file is not symlinked. writ recognizes the name and routes it through manifest.resolve, which
+# hands it to the lore planner as package-installation nodes.
+
+packages:
+  # Version control, and the only external command the codebase calls directly (7 call sites).
+  - git
+
+  # The toolchain. go.mod requires 1.27.
+  - go
+
+  # Linting. golangci-lint runs from `make lint-all` against a pinned version; shellcheck and shfmt
+  # are what `star lint shell` invokes, the latter as `shfmt -d -i 4 -ci`.
+  - golangci-lint
+  - shellcheck
+  - shfmt
+
+  # The pull-request workflow: release.yaml, lkg-tag.yaml, and every PR script.
+  - gh
+
+  # JSON handling in docs-publish.yaml.
+  - jq


### PR DESCRIPTION
A writ layer for this repository, so a working environment is a **deployment** rather than a page of
instructions someone follows by hand.

writ recognizes `packages-manifest.yaml` by basename (`cmd/writ/writ/tree/node.go:14`) and routes it
through `manifest.resolve` rather than `file.link` — so these files are consumed by the lore planner
as package-installation nodes and never symlinked into the target.

## Layout

The suffix-less `noblefactor` layer is drawn everywhere, because `Segments.Match` returns true for a
name with no suffixes. `OSFamily` maps Darwin and Linux to `Unix`; **Windows has no family**, so it
never draws `noblefactor.Unix`. They are siblings, not base and override — anything shared belongs
in the base layer rather than written twice.

| Platform | Layers | Packages |
| --- | --- | --- |
| Darwin | base + Unix + Darwin | 15 |
| Linux | base + Unix + Linux | 13 |
| Windows | base + Windows | 8 |

## What is in it

| Layer | Packages |
| --- | --- |
| `noblefactor` | `git` `go` `golangci-lint` `shellcheck` `shfmt` `gh` `jq` |
| `noblefactor.Unix` | `markdownlint-cli2` `gocyclo` `scc` `pre-commit` `sops` `age` |
| `noblefactor.Darwin` | `make` `xcode-clt` |
| `noblefactor.Windows` | `pwsh` |

**Why the list is short.** Every entry has demonstrable use *in this repository* — a Makefile
target, a CI step, a star extension, or a provider that shells out to it. This machine carries 96
brews and 54 ports; `podman`, `redis`, `mongosh`, `gradle` and the rest are the operator's, not the
repository's. A manifest that inventoried them would deploy someone's laptop.

Darwin names GNU `make` explicitly: the Makefile requires 3.82+ for `.ONESHELL:` and macOS ships
3.81 — the last GPLv2 release, so it will never advance. `ci.yaml` installs it on every macOS leg
for the same reason.

## Three judgement calls, worth review

- **`markdownlint-cli2`, `gocyclo`, `scc`, `pre-commit` are in Unix, not base.** They are needed on
  Windows too in principle; they are held back only because their delivery there is npm,
  `go install` and pip, and our Windows tooling has no settled path. They belong in base once it
  does.
- **`sops` and `age`** are needed to deploy a layer carrying `.sops` files — arguably the
  environment's requirement rather than this repository's.
- **`noblefactor.Linux` is empty on purpose** — an assertion that nothing extra is needed, not an
  omission.

## Validation

Nothing in CI validates these files. The script that produced this commit checks each against
`schema/packages-manifest.json`, asserts every entry is a name or a single-key map, and prints the
resolved set per platform.