### PR TITLE
doc(release): write down which release path is real, and stage star in the other

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,11 +53,30 @@ builds:
       - -X github.com/NobleFactor/devlore-cli/pkg/application.Commit={{.ShortCommit}}
       - -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate={{.Date}}
 
+  - id: star
+    binary: star
+    main: ./cmd/star
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Version={{.Version}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.Commit={{.ShortCommit}}
+      - -X github.com/NobleFactor/devlore-cli/pkg/application.BuildDate={{.Date}}
+
 archives:
   - id: default
     builds:
       - writ
       - lore
+      - star
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -66,6 +85,17 @@ archives:
     files:
       - README.md
       - LICENSE
+
+      # star's extensions travel with the binary. //go:embed covers cmd/star/extensions -- the
+      # com.noblefactor.star.* lint and hook commands -- and NOT star/extensions, where the
+      # com.noblefactor.devlore.* commands live, so a binary alone answers `unknown command
+      # "devlore"`.
+      #
+      # share/star/extensions rather than beside the binaries: install.sh unpacks to <prefix>/bin
+      # and the loader probes XDG_DATA_HOME, which is <prefix>/share only when prefix is the default
+      # ~/.local. That coincidence is load-bearing -- see docs/plans/release-path.md.
+      - src: star/extensions/**/*
+        dst: share/star/extensions
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"

--- a/docs/plans/release-path.md
+++ b/docs/plans/release-path.md
@@ -1,0 +1,127 @@
+---
+title: "The Release Path"
+issue: https://github.com/NobleFactor/devlore-cli/issues/453
+status: draft
+created: 2026-08-29
+updated: 2026-08-29
+---
+
+# Plan: The Release Path
+
+## Summary
+
+`make dist` is the release path. `.goreleaser.yaml` is staged for the day we adopt it, and is not
+run by anything today. Neither of those facts is written down anywhere, and the omission has
+already cost: a reader found the config, matched its `builds: writ, lore` against a two-entry
+release tarball, and spent an afternoon editing a file that ships nothing.
+
+This plan records the state of the world and the conditions for adoption. **It proposes no change
+to how releases are built.** We are not ready to release; goreleaser is adopted when we are.
+
+## State of the world
+
+### What ships today
+
+```
+push to develop / main / v* tag
+  → .github/workflows/release.yaml
+      → make dist            DEVLORE_VERSION=<computed>
+          → dist-all         forced host `make build` (stamp proof), then
+                             go build × 6 pairs, tar.gz / zip
+          → checksums        shasum -a 256
+      → gh release create ... dist/*
+```
+
+`install.sh` — served publicly from devlore.noblefactor.com — defaults to `latest`, *including
+prereleases*, so every push to `develop` produces artifacts that a `curl | bash` will install. The
+release path is live, not theoretical.
+
+### What `.goreleaser.yaml` is
+
+Staged, and deliberately kept correct. `version-stamping.md` fixed the `-X` flags in the Makefile
+**and** in `.goreleaser.yaml`, and lists as a completed item:
+
+> `Makefile` and `.goreleaser.yaml` name `pkg/application` — one `-X` per value, not per binary
+
+The Makefile says the same in a comment at the `dist` target: *"nothing runs it today … It is kept
+correct anyway: whoever adopts goreleaser inherits."* It is a configuration waiting for a decision,
+not an abandoned artifact.
+
+`star` is staged in it by this plan's companion change: a `star` build across the same six pairs,
+and `star/extensions/**` shipped to `share/star/extensions` so a released binary can answer
+`devlore` at all.
+
+## Why not now
+
+We are not releasing yet. Adoption swaps a live, working path for one that has never run, and it
+would have to happen alongside the changes below rather than before them.
+
+## What adoption requires
+
+### Version derivation moves
+
+`release.yaml` computes a version for **non-tag** builds — `v0.1.0-dev.<timestamp>` on every push to
+`develop` — and passes it as `DEVLORE_VERSION`. Goreleaser derives `{{ .Version }}` from the git tag
+and refuses to release without one. Either we tag before releasing, or we keep synthesizing and pass
+it in. That is a release-model decision, not a port.
+
+### The stamp proof must survive
+
+`dist-all` forces `make build PLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)` before it cross-compiles, so the
+`-X` flags are proven to bind to real symbols on a binary that can actually run. That guards the
+failure which shipped unnoticed until 2026-08-16, described in `version-stamping.md`. Goreleaser has
+no equivalent; it becomes a `before:` hook calling the Makefile, or it is lost.
+
+### The after: hook, and a fifth packaging target
+
+`.goreleaser.yaml` declares `after: hooks: [./packaging/macports/generate-portfile.sh {{ .Version }}]`,
+and that script **does** exist -- executable, Apache-2.0 headed, its own comment saying "Called by
+GoReleaser as a post hook". So MacPorts is a fifth distribution target beyond the four in the config
+body, and it is the only one whose tooling is actually written.
+
+It has never run, since nothing runs goreleaser. Whether the Portfile it generates is correct is
+therefore unverified.
+
+### The prefix assumption
+
+Two different path lists resolve star's extensions, and they only agree by coincidence:
+
+- `findExtensionsDir()` — used by `self install` to find the source — probes
+  `<exeDir>/../share/star/extensions`
+- the **loader** — used at runtime — probes `${GIT_WORKSPACE_ROOT}/star/extensions`, then
+  `XDG_DATA_HOME/star/extensions`, then `/usr/local/share/star/extensions`
+
+Shipping to `share/star/extensions` works because `install.sh` defaults to `--prefix=$HOME/.local`,
+which makes `<prefix>/share` equal to `XDG_DATA_HOME`. With `--prefix=/opt/devlore`, extensions
+install to `/opt/devlore/share/star/extensions`, which **nothing loads**.
+
+That is a pre-existing defect, independent of goreleaser, and it should be fixed before a released
+`star` is relied upon.
+
+## What is kept, and what goes
+
+| Today | On adoption |
+| --- | --- |
+| `dist-all` build loop | replaced by `builds:` |
+| `dist-all` tar/zip | replaced by `archives:` |
+| `checksums` | replaced by `checksum:` |
+| `release.yaml`'s `gh release create` | replaced by `release:` |
+| `dist-clean` | kept — useful locally |
+| **the stamp proof** | **kept, as a `before:` hook** |
+
+## What adoption unlocks
+
+What `make dist` cannot do and goreleaser already describes: deb and rpm via `nfpms`, a Homebrew
+formula, a winget manifest, and a changelog from the tag range.
+
+All three packaging targets are currently `skip_upload: true`, and **`NobleFactor/homebrew-tap` and
+`NobleFactor/winget-pkgs` do not exist**. No release has ever carried a `.deb`, `.rpm`, or formula.
+The configuration is intent, not capability — which is the honest reason adoption has not been
+urgent.
+
+## Open Questions
+
+- [ ] Tag-driven releases, or keep synthesizing dev versions and pass them to goreleaser?
+- [ ] Does `packaging/macports/generate-portfile.sh` produce a correct Portfile? It exists and
+      has never executed.
+- [ ] Does the prefix defect get fixed before or with adoption?


### PR DESCRIPTION
`make dist` builds and publishes every release. `.goreleaser.yaml` is **staged for adoption and run
by nothing.** Neither fact was written down.

That omission cost an afternoon. The config's `builds: writ, lore` matches the two-entry release
tarball exactly, so it reads as the release path until you go looking for who invokes it — and
nobody does. The Makefile says so in a comment at the `dist` target, and `version-stamping.md` lists
keeping its `-X` flags correct as a completed item, but neither is where a reader looks first.

## What this adds

`docs/plans/release-path.md` — the state of the world and the conditions for adoption. **It proposes
no change to how releases are built.** We are not ready to release; goreleaser is adopted when we
are.

## What adoption needs, none of it a port

| | |
| --- | --- |
| **Version derivation** | `release.yaml` computes `v0.1.0-dev.<timestamp>` for non-tag builds and passes `DEVLORE_VERSION`; goreleaser derives from the tag and will not release without one |
| **The stamp proof** | `dist-all` forces a host `make build` so `-X` binds to real symbols — guarding the failure that shipped unnoticed until 2026-08-16. Goreleaser has no equivalent; it becomes a `before:` hook or it is lost |
| **The prefix assumption** | `findExtensionsDir` probes `<exeDir>/../share`; the **loader** probes `XDG_DATA_HOME`. They agree only because `install.sh` defaults to `~/.local`. With `--prefix=/opt/devlore`, extensions install where nothing loads them — a pre-existing defect |

MacPorts turns out to be a **fifth** packaging target: `packaging/macports/generate-portfile.sh`
exists, is executable, and its own comment says *"Called by GoReleaser as a post hook"*. It has never
run, so whether its Portfile is correct is unverified.

## star, staged

Built for the same six pairs, and `star/extensions/**` shipped to `share/star/extensions` — without
which a released binary answers `unknown command "devlore"`, because `//go:embed` covers
`cmd/star/extensions` and **not** `star/extensions`.

Verified by hand before staging: a `star` built from a dist archive, run from outside any checkout
with `XDG_DATA_HOME` at the unpacked prefix, resolves all five `devlore` command groups.

## Nothing is added to dist-all, deliberately

It is the live path — `install.sh` defaults to `latest`, *including prereleases*, so every push to
`develop` ships something a `curl | bash` will install. There is no reason to invest in a path that
retires on adoption, nor to ship a `star` whose extensions resolve only when `--prefix` happens to be
`~/.local`.

Tracked by #453; the release-workflow row in #339 is the same gap.