### PR TITLE
Every presentation is a presentation of the JSON: formatting rules, list, and stage 1

### DIFF
--- a/cmd/devlore-docs/template.go
+++ b/cmd/devlore-docs/template.go
@@ -184,7 +184,7 @@ func collectFlags(flags *pflag.FlagSet) []FlagInfo {
 		result = append(result, FlagInfo{
 			Name:        name,
 			Default:     formatDefault(f),
-			Description: f.Usage,
+			Description: tableCell(f.Usage),
 		})
 	})
 	return result
@@ -214,4 +214,20 @@ func trimExampleLines(s string) string {
 		lines[i] = strings.TrimSpace(line)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// tableCell renders a flag's usage text for a Markdown table cell.
+//
+// A cell cannot hold a newline, and a pipe would end it. Multi-line usage exists because a flag whose values
+// each deserve a sentence -- `--output`, whose eight renderings each have a job -- is unreadable as one line.
+//
+// Parameters:
+//   - `usage`: the flag's usage string, possibly multi-line.
+//
+// Returns:
+//   - `string`: the text with line breaks as `<br>` and pipes escaped.
+func tableCell(usage string) string {
+
+	escaped := strings.ReplaceAll(usage, "|", "\\|")
+	return strings.ReplaceAll(escaped, "\n", "<br>")
 }

--- a/cmd/devlore-test/devloretest/data/test_write_then_remove.star
+++ b/cmd/devlore-test/devloretest/data/test_write_then_remove.star
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Noble Factor. All rights reserved.
+
+# test_write_then_remove.star — Two operations, one edge: write a file, then remove it.
+#
+# The smallest graph that still has a dependency. remove consumes write_text's PROMISE, so the claim rides
+# the edge rather than coinciding by name — the form scoped pre-flight accepts (§3).
+#
+# This is the fixture the output-format conformance test renders through every --output value, so it is
+# deliberately small: two units, one file, no branching. What is being exercised is the presentation of a
+# result, not the graph.
+
+dest = t.tmp("scratch.txt")
+
+written = plan.file.write_text(destination_path=dest, content="hello world", mode=0o644)
+
+graph = plan.assemble_definition([
+    written,
+    plan.file.remove(target=written, prune=False, boundary=""),
+])
+
+t.run(graph)
+
+t.expect_no_file(dest)
+t.expect_unit_count(2)

--- a/cmd/devlore-test/output_formats_test.go
+++ b/cmd/devlore-test/output_formats_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package main_test
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// region Tests
+
+// writeThenRemove is the two-operation fixture: write a file, then remove it, with the removal consuming the
+// write's promise so the graph has one real edge. Deliberately small -- what these tests exercise is the
+// presentation of a result, not the graph.
+func writeThenRemove(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(filepath.Dir(scriptPath), "test_write_then_remove.star")
+}
+
+// TestOutputFormats_EveryFormatRenders runs one graph through every value of --output.
+//
+// The point is coverage of the SET, not of any one rendering: a format that is registered but broken, or
+// that silently falls through to another, fails here. `writ status` shipped for months answering `-o yaml`
+// with a human dashboard because nothing asserted across the whole set (#754).
+func TestOutputFormats_EveryFormatRenders(t *testing.T) {
+
+	script := writeThenRemove(t)
+
+	for _, tc := range []struct {
+		format string
+		verify func(t *testing.T, stdout string)
+	}{
+		{"json", func(t *testing.T, out string) {
+			var v map[string]any
+			if err := json.Unmarshal([]byte(out), &v); err != nil {
+				t.Fatalf("not JSON: %v\n%s", err, out)
+			}
+			if v["unit_count"] != float64(2) {
+				t.Errorf("unit_count = %v, want 2", v["unit_count"])
+			}
+		}},
+
+		{"yaml", func(t *testing.T, out string) {
+			var v map[string]any
+			if err := yaml.Unmarshal([]byte(out), &v); err != nil {
+				t.Fatalf("not YAML: %v\n%s", err, out)
+			}
+			if v["unit_count"] != 2 {
+				t.Errorf("unit_count = %v, want 2", v["unit_count"])
+			}
+		}},
+
+		{"csv", func(t *testing.T, out string) {
+			records, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+			if err != nil {
+				t.Fatalf("not CSV: %v\n%s", err, out)
+			}
+			if len(records) != 2 {
+				t.Fatalf("records = %d, want 2 (a header and one row)", len(records))
+			}
+			if !contains(records[0], "unit_count") {
+				t.Errorf("header lacks unit_count: %v", records[0])
+			}
+		}},
+
+		{"table", func(t *testing.T, out string) {
+			lines := strings.Split(strings.TrimSpace(out), "\n")
+			if len(lines) != 2 {
+				t.Fatalf("lines = %d, want 2 (a header and one row):\n%s", len(lines), out)
+			}
+			if !strings.Contains(lines[0], "UNIT_COUNT") {
+				t.Errorf("header is not upper-cased json names: %q", lines[0])
+			}
+		}},
+
+		{"list", func(t *testing.T, out string) {
+			if !strings.Contains(out, "unit_count") || !strings.Contains(out, " : ") {
+				t.Errorf("not list-shaped:\n%s", out)
+			}
+			if strings.Contains(out, "UnitCount") {
+				t.Errorf("leaked a Go field name:\n%s", out)
+			}
+		}},
+
+		{"value", func(t *testing.T, out string) {
+			if strings.Contains(out, "unit_count") {
+				t.Errorf("value emitted headers, which it must not:\n%s", out)
+			}
+			if !strings.Contains(out, "\t") {
+				t.Errorf("value is not tab-separated:\n%q", out)
+			}
+		}},
+
+		{"none", func(t *testing.T, out string) {
+			if out != "" {
+				t.Errorf("none emitted %q, want nothing", out)
+			}
+		}},
+
+		{"template={{.unit_count}}", func(t *testing.T, out string) {
+			if strings.TrimSpace(out) != "2" {
+				t.Errorf("template rendered %q, want 2", strings.TrimSpace(out))
+			}
+		}},
+	} {
+		t.Run(tc.format, func(t *testing.T) {
+
+			stdout, stderr, code := runIn(t.TempDir(),
+				"run", "--store", t.TempDir(), "-o", tc.format, script)
+
+			if code != 0 {
+				t.Fatalf("exit %d\nstderr: %s", code, stderr)
+			}
+			tc.verify(t, stdout)
+		})
+	}
+}
+
+// TestOutputFormats_AnUnknownFormatIsRejected is the other half of set coverage.
+//
+// A format the set does not contain must fail loudly and name what is accepted, rather than fall through to
+// a default -- which is what made a typo indistinguishable from a request in `writ` (#754).
+func TestOutputFormats_AnUnknownFormatIsRejected(t *testing.T) {
+
+	_, stderr, code := runIn(t.TempDir(),
+		"run", "--store", t.TempDir(), "-o", "bogus", writeThenRemove(t))
+
+	if code == 0 {
+		t.Error("an unknown formatter exited 0, want non-zero")
+	}
+	for _, name := range []string{"bogus", "csv", "json", "list", "none", "table", "value", "yaml"} {
+		if !strings.Contains(stderr, name) {
+			t.Errorf("the error does not name %q: %s", name, stderr)
+		}
+	}
+}
+
+// endregion
+
+// region Helpers
+
+// contains reports whether values holds want.
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+// endregion

--- a/cmd/internal/cli/convention_test.go
+++ b/cmd/internal/cli/convention_test.go
@@ -90,7 +90,8 @@ func TestAddOutputFlags_SubcommandParsesTheShortForm(t *testing.T) {
 		return nil
 	}})
 
-	root.SetArgs([]string{"child", "-o", "yaml", "--store", "/tmp/store"})
+	store := t.TempDir()
+	root.SetArgs([]string{"child", "-o", "yaml", "--store", store})
 	root.SetOut(&bytes.Buffer{})
 	root.SetErr(&bytes.Buffer{})
 
@@ -103,8 +104,78 @@ func TestAddOutputFlags_SubcommandParsesTheShortForm(t *testing.T) {
 	if opts.Format != "yaml" {
 		t.Errorf("-o yaml gave Format %q, want yaml", opts.Format)
 	}
-	if opts.Store != "/tmp/store" {
-		t.Errorf("--store gave Store %q, want /tmp/store", opts.Store)
+	if opts.Store != store {
+		t.Errorf("--store gave Store %q, want %q", opts.Store, store)
+	}
+}
+
+// TestAddOutputFlags_ResolvesTheStoreAndRestoresIt pins #753.
+//
+// `--store` used to populate the options struct and stop there, so `writ status --store <elsewhere>` folded
+// runs from the DEFAULT store and reported the result as compliance. Binding the set now resolves it, and
+// undoes the resolution when the command tree finishes -- without which the first command passing --store
+// would silently relocate every command after it in the same process.
+func TestAddOutputFlags_ResolvesTheStoreAndRestoresIt(t *testing.T) {
+
+	before := StoreHome()
+	store := t.TempDir()
+
+	var opts SinkOptions
+	root := &cobra.Command{Use: "root"}
+	AddOutputFlags(root, &opts)
+
+	var during string
+	root.AddCommand(&cobra.Command{Use: "child", RunE: func(*cobra.Command, []string) error {
+		during = StoreHome()
+		return nil
+	}})
+
+	root.SetArgs([]string{"child", "--store", store})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if during != store {
+		t.Errorf("during the command the store was %q, want %q", during, store)
+	}
+	if after := StoreHome(); after != before {
+		t.Errorf("the store was left at %q, want it restored to %q", after, before)
+	}
+}
+
+// TestAddOutputFlags_RejectsAnUnknownFormat pins #754.
+//
+// The format string is checked in exactly one place, [result.FormatterByName], reached from
+// [BuildPipeline]. A command that renders itself never got there, so `writ status -o bogus` printed its
+// report and exited 0 -- a typo honored as a request for the default. Binding the set now validates.
+func TestAddOutputFlags_RejectsAnUnknownFormat(t *testing.T) {
+
+	var opts SinkOptions
+	root := &cobra.Command{Use: "root"}
+	AddOutputFlags(root, &opts)
+
+	ran := false
+	root.AddCommand(&cobra.Command{Use: "child", RunE: func(*cobra.Command, []string) error {
+		ran = true
+		return nil
+	}})
+
+	root.SetArgs([]string{"child", "-o", "bogus"})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("an unknown formatter was accepted, want an error")
+	}
+	if ran {
+		t.Error("the command ran despite an unknown formatter")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("the error does not name the value: %v", err)
 	}
 }
 

--- a/cmd/internal/cli/help_wrap_test.go
+++ b/cmd/internal/cli/help_wrap_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// region Tests
+
+// TestWrapUsage_HangsUnderTheTextItContinues is why this wrapper exists rather than pflag's.
+//
+// pflag indents every continuation to the flag's description column, having one indent level and no notion
+// of structure. A two-column usage -- `--output`'s renderings, each a name and a sentence -- collapses the
+// moment it wraps, and the column is exactly what made the list scannable.
+func TestWrapUsage_HangsUnderTheTextItContinues(t *testing.T) {
+
+	const line = "      csv            quoted and parseable; when a spreadsheet or a data tool reads it"
+
+	got := strings.Split(strings.TrimRight(wrapUsage(line, 50), "\n"), "\n")
+
+	if len(got) < 2 {
+		t.Fatalf("did not wrap at 50:\n%s", strings.Join(got, "\n"))
+	}
+	for i, l := range got {
+		if len([]rune(l)) > 50 {
+			t.Errorf("line %d is %d columns, want <= 50: %q", i, len([]rune(l)), l)
+		}
+	}
+
+	// "      csv            " is 21 columns: six of indent, three of name, twelve of padding.
+	for i, l := range got[1:] {
+		if !strings.HasPrefix(l, strings.Repeat(" ", 21)) {
+			t.Errorf("continuation %d does not hang under the sentence: %q", i, l)
+		}
+		if strings.HasPrefix(l, strings.Repeat(" ", 22)) {
+			t.Errorf("continuation %d is over-indented: %q", i, l)
+		}
+	}
+}
+
+// TestWrapUsage_ProseHangsAtItsIndent covers a line with no name column.
+func TestWrapUsage_ProseHangsAtItsIndent(t *testing.T) {
+
+	const line = "      Output rendering. json is the default and the native format, and the rest present it."
+
+	got := strings.Split(strings.TrimRight(wrapUsage(line, 40), "\n"), "\n")
+
+	if len(got) < 2 {
+		t.Fatalf("did not wrap at 40:\n%s", strings.Join(got, "\n"))
+	}
+	for i, l := range got[1:] {
+		if !strings.HasPrefix(l, "      ") || strings.HasPrefix(l, "       ") {
+			t.Errorf("continuation %d does not hang at the leading indent: %q", i, l)
+		}
+	}
+}
+
+// TestWrapUsage_LeavesShortLinesAlone pins that wrapping is not reformatting.
+func TestWrapUsage_LeavesShortLinesAlone(t *testing.T) {
+
+	const line = "  -o, --output string   Output rendering."
+
+	if got := wrapUsage(line, 100); got != line+"\n" {
+		t.Errorf("a line inside the width was altered:\n%q", got)
+	}
+}
+
+// TestWrapUsage_ZeroWidthIsPflagsMeaning pins the one value that means "do not wrap".
+//
+// It is pflag's own convention, and the reason help text never wrapped: cobra's template calls FlagUsages,
+// which is FlagUsagesWrapped(0).
+func TestWrapUsage_ZeroWidthIsPflagsMeaning(t *testing.T) {
+
+	const line = "      a line comfortably longer than any width this test would otherwise impose upon it"
+
+	if got := wrapUsage(line, 0); got != line {
+		t.Errorf("width 0 wrapped anyway:\n%q", got)
+	}
+}
+
+// TestWrapUsage_ANarrowWidthGivesTextTheWholeLine covers the floor.
+//
+// Honoring a hanging indent inside a narrow terminal leaves a sliver too thin to read, so the line falls
+// back to its leading indent and spends the width on words instead.
+func TestWrapUsage_ANarrowWidthGivesTextTheWholeLine(t *testing.T) {
+
+	const line = "      csv            quoted and parseable; when a spreadsheet or a data tool reads it"
+
+	got := strings.Split(strings.TrimRight(wrapUsage(line, 34), "\n"), "\n")
+
+	for i, l := range got[1:] {
+		if strings.HasPrefix(l, strings.Repeat(" ", 21)) {
+			t.Errorf("continuation %d still hangs at the name column, leaving %d columns of text: %q",
+				i, 34-21, l)
+		}
+	}
+}
+
+// endregion

--- a/cmd/internal/cli/output.go
+++ b/cmd/internal/cli/output.go
@@ -81,6 +81,29 @@ type SinkOptions struct {
 // is the only thing a cobra process runs.
 var restoreStoreRoot func()
 
+// outputUsage documents --output.
+//
+// The prose is one logical line, joined across source lines, so [wrapUsage] reflows it to the terminal
+// rather than to a width guessed here. The rendering list is one line each, because those carry a name
+// column that wrapping hangs under -- a shape pflag's own wrapper flattens.
+//
+// The prose orders the renderings by usefulness; the list is alphabetical, matching
+// [result.FormatterByName]'s error and §7 of the specification. Everyday use wants to find a name.
+const outputUsage = "Output rendering. json is the default and the native format; every other rendering " +
+	"presents that JSON rather than the Go value behind it. Reach for yaml to read a large result, table " +
+	"or list to scan one, csv or value to feed another program, template when you need a shape none of " +
+	"these produce, and none when you want the exit code and the side effects alone.\n" +
+	"\n" +
+	"The renderings, alphabetically, each closing with what it is for:\n" +
+	"csv            quoted and parseable; when a spreadsheet or a data tool reads it\n" +
+	"json           the native format, nothing elided; when a script consumes it\n" +
+	"list           one field per line; when a record is wide, or records differ\n" +
+	"none           nothing at all; when you want the exit code, not the output\n" +
+	"table          aligned columns, one row per record; when scanning many rows\n" +
+	"template=BODY  a Go template; when you need a shape none of the others give\n" +
+	"value          raw, tab-separated, no header; when cut or awk consumes it\n" +
+	"yaml           the same content as json; when reading a large result by eye"
+
 // AddOutputFlags binds the common set -- --filter, --jq, --output/-o, and --store -- to opts.
 //
 // Bound to PersistentFlags, so one call on a program's root command covers every subcommand. All four
@@ -152,21 +175,7 @@ func AddOutputFlags(cmd *cobra.Command, opts *SinkOptions) {
 	}
 
 	cmd.PersistentFlags().StringVarP(&opts.Format, "output", "o", "json",
-		`Output rendering. json is the default and the native format; every other
-rendering presents that JSON rather than the Go value behind it. Reach for
-yaml to read a large result, table or list to scan one, csv or value to feed
-another program, template when you need a shape none of these produce, and
-none when you want the exit code and the side effects alone.
-
-The renderings, alphabetically, each closing with what it is for:
-csv            quoted and parseable; when a spreadsheet or a data tool reads it
-json           the native format, nothing elided; when a script consumes it
-list           one field per line; when a record is wide, or records differ
-none           nothing at all; when you want the exit code, not the output
-table          aligned columns, one row per record; when scanning many rows
-template=BODY  a Go template; when you need a shape none of the others give
-value          raw, tab-separated, no header; when cut or awk consumes it
-yaml           the same content as json; when reading a large result by eye`)
+		outputUsage)
 	cmd.PersistentFlags().StringArrayVar(&opts.Filters, "filter", nil,
 		`Filter expression: field=value (repeatable, AND logic)`)
 	cmd.PersistentFlags().StringVar(&opts.JQ, "jq", "",

--- a/cmd/internal/cli/output.go
+++ b/cmd/internal/cli/output.go
@@ -91,7 +91,7 @@ type SinkOptions struct {
 func AddOutputFlags(cmd *cobra.Command, opts *SinkOptions) {
 
 	cmd.PersistentFlags().StringVarP(&opts.Format, "output", "o", "json",
-		`Output rendering: json, yaml, table, csv, value (raw, pairs with --jq), template=BODY, or none`)
+		`Output rendering: json, yaml, table, list, csv, value (raw, pairs with --jq), template=BODY, or none`)
 	cmd.PersistentFlags().StringArrayVar(&opts.Filters, "filter", nil,
 		`Filter expression: field=value (repeatable, AND logic)`)
 	cmd.PersistentFlags().StringVar(&opts.JQ, "jq", "",

--- a/cmd/internal/cli/output.go
+++ b/cmd/internal/cli/output.go
@@ -76,6 +76,11 @@ type SinkOptions struct {
 	Store   string
 }
 
+// restoreStoreRoot undoes the root's `--store` selection when the command tree finishes. A package-level
+// value because [SetStoreRoot]'s own root is one: the pair is scoped to a single command invocation, which
+// is the only thing a cobra process runs.
+var restoreStoreRoot func()
+
 // AddOutputFlags binds the common set -- --filter, --jq, --output/-o, and --store -- to opts.
 //
 // Bound to PersistentFlags, so one call on a program's root command covers every subcommand. All four
@@ -85,13 +90,83 @@ type SinkOptions struct {
 // Call once during root setup, then call [BuildPipeline] from a command's RunE to compose the
 // [result.Pipeline].
 //
+// Binding also WIRES the two flags whose meaning does not depend on a command rendering anything, so
+// registering the set and honoring it cannot come apart:
+//
+//   - `--output` is validated. A command that never reaches [BuildPipeline] used to accept any string,
+//     because [result.FormatterByName] is the only place the value is checked -- `writ status -o bogus`
+//     printed its report and exited 0 (#754).
+//   - `--store` is resolved. It used to be read by nothing outside `devlore-test`, so `writ status --store
+//     <elsewhere>` folded runs from the DEFAULT store and reported the result as compliance (#753).
+//
+// Both were one defect wearing two faces: a flag registered on a root that no leaf consumed. Cobra
+// advertised the whole set on every command's help while one command honored it, and a flag that is present
+// and inert is worse than an absent one -- an absent flag errors, and the user tries something else.
+//
+// The store selection is undone when the command tree finishes. Leaving it set would be harmless in a
+// process that runs one command and exits, and corrupting in a test binary that runs many: the root is a
+// package-level value, so the first command passing `--store` would silently relocate every command after
+// it. A caller needing a narrower scope still calls [SetStoreRoot] itself, as `devlore-test` does per run.
+//
 // Parameters:
 //   - `cmd`: the command to bind to, normally a program's root.
 //   - `opts`: the struct the flag values populate.
 func AddOutputFlags(cmd *cobra.Command, opts *SinkOptions) {
 
+	previous := cmd.PersistentPreRunE
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+
+		if previous != nil {
+			if err := previous(c, args); err != nil {
+				return err
+			}
+		}
+
+		if _, err := result.FormatterByName(opts.Format); err != nil {
+			return err
+		}
+
+		if opts.Store != "" {
+			restore, err := SetStoreRoot(opts.Store)
+			if err != nil {
+				return err
+			}
+			restoreStoreRoot = restore
+		}
+
+		return nil
+	}
+
+	previousPost := cmd.PersistentPostRunE
+	cmd.PersistentPostRunE = func(c *cobra.Command, args []string) error {
+
+		if restoreStoreRoot != nil {
+			restoreStoreRoot()
+			restoreStoreRoot = nil
+		}
+
+		if previousPost != nil {
+			return previousPost(c, args)
+		}
+		return nil
+	}
+
 	cmd.PersistentFlags().StringVarP(&opts.Format, "output", "o", "json",
-		`Output rendering: json, yaml, table, list, csv, value (raw, pairs with --jq), template=BODY, or none`)
+		`Output rendering. json is the default and the native format; every other
+rendering presents that JSON rather than the Go value behind it. Reach for
+yaml to read a large result, table or list to scan one, csv or value to feed
+another program, template when you need a shape none of these produce, and
+none when you want the exit code and the side effects alone.
+
+The renderings, alphabetically, each closing with what it is for:
+csv            quoted and parseable; when a spreadsheet or a data tool reads it
+json           the native format, nothing elided; when a script consumes it
+list           one field per line; when a record is wide, or records differ
+none           nothing at all; when you want the exit code, not the output
+table          aligned columns, one row per record; when scanning many rows
+template=BODY  a Go template; when you need a shape none of the others give
+value          raw, tab-separated, no header; when cut or awk consumes it
+yaml           the same content as json; when reading a large result by eye`)
 	cmd.PersistentFlags().StringArrayVar(&opts.Filters, "filter", nil,
 		`Filter expression: field=value (repeatable, AND logic)`)
 	cmd.PersistentFlags().StringVar(&opts.JQ, "jq", "",

--- a/cmd/internal/cli/root.go
+++ b/cmd/internal/cli/root.go
@@ -5,10 +5,14 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 
 	"github.com/NobleFactor/devlore-cli/pkg/assert"
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
@@ -65,6 +69,8 @@ func NewRootCmd(cfg RootConfig) *cobra.Command {
 			return initRootConfig(cmd, cfg.Name)
 		},
 	}
+
+	wrapHelp(rootCmd)
 
 	// Standard flags
 	rootCmd.PersistentFlags().String("config", "", "Config file (default: ~/.config/devlore/config.yaml)")
@@ -155,3 +161,172 @@ func initRootConfig(cmd *cobra.Command, name string) error {
 
 	return nil
 }
+
+// region Help wrapping
+
+// helpFallbackWidth is the width used when neither COLUMNS nor the terminal answers.
+//
+// Chosen over pflag's zero, which means "do not wrap at all": a pipe or a CI log has no width to report,
+// and an unwrapped line there is a wall of text rather than a deliberate choice.
+const helpFallbackWidth = 100
+
+// helpMinimumTextWidth is the narrowest column of text worth hanging under.
+//
+// Below it, honoring a hanging indent leaves a sliver too narrow to read, so the line falls back to its
+// leading indent and gives the text the whole width instead.
+const helpMinimumTextWidth = 24
+
+// wrapHelp makes flag usage wrap to the terminal, keeping any column structure the usage text has.
+//
+// Cobra's default template calls [pflag.FlagSet.FlagUsages], which is `FlagUsagesWrapped(0)`, and zero means
+// no wrapping at all -- so without this every line's width is the author's to maintain by hand, correct only
+// on a terminal at least as wide as the constant they guessed (#755).
+//
+// pflag's own wrapping is not the answer either. It indents every continuation to the flag's description
+// column, having one indent level and no notion of structure, so a two-column usage -- `--output`'s eight
+// renderings, each with a name and a sentence -- collapses the moment it wraps:
+//
+//	csv            quoted and parseable; when
+//	a spreadsheet or a data tool reads it
+//
+// [wrapUsageLine] hangs continuations under the text they continue, which is what keeps that readable.
+//
+// Parameters:
+//   - `cmd`: the root command whose usage template is rewritten.
+func wrapHelp(cmd *cobra.Command) {
+
+	cobra.AddTemplateFunc("wrappedFlagUsages", func(flags *pflag.FlagSet) string {
+		return wrapUsage(flags.FlagUsages(), helpWidth())
+	})
+
+	template := cmd.UsageTemplate()
+	template = strings.ReplaceAll(template, ".LocalFlags.FlagUsages", "wrappedFlagUsages .LocalFlags")
+	template = strings.ReplaceAll(template, ".InheritedFlags.FlagUsages", "wrappedFlagUsages .InheritedFlags")
+	cmd.SetUsageTemplate(template)
+}
+
+// wrapUsage wraps pflag's laid-out usage block to width, line by line.
+//
+// The input is pflag's own output with no wrapping applied, so the flag-name column and the description
+// column are already aligned; only the over-long lines need breaking.
+//
+// Parameters:
+//   - `usage`: pflag's rendered usage block.
+//   - `width`: the column count to wrap to; zero or less leaves the block untouched.
+//
+// Returns:
+//   - `string`: the wrapped block, newline-terminated as pflag's is.
+func wrapUsage(usage string, width int) string {
+
+	if width <= 0 {
+		return usage
+	}
+
+	lines := strings.Split(strings.TrimRight(usage, "\n"), "\n")
+	wrapped := make([]string, 0, len(lines))
+	for _, line := range lines {
+		wrapped = append(wrapped, wrapUsageLine(line, width))
+	}
+
+	return strings.Join(wrapped, "\n") + "\n"
+}
+
+// wrapUsageLine breaks one line at width, hanging continuations under the text they continue.
+//
+// The hanging indent is where the line's text begins, which is after its leading whitespace and after any
+// name column the line carries -- see [usageTextColumn]. Widths are measured in runes rather than bytes, so
+// a description containing a multi-byte character wraps where it looks like it should.
+//
+// Parameters:
+//   - `line`: one line of pflag's usage block.
+//   - `width`: the column count to wrap to.
+//
+// Returns:
+//   - `string`: the line, broken across as many lines as it needs.
+func wrapUsageLine(line string, width int) string {
+
+	if len([]rune(line)) <= width {
+		return line
+	}
+
+	hang := usageTextColumn(line)
+	if width-hang < helpMinimumTextWidth {
+		hang = len(line) - len(strings.TrimLeft(line, " "))
+	}
+	if width-hang < helpMinimumTextWidth {
+		return line
+	}
+
+	indent := strings.Repeat(" ", hang)
+	current := line[:hang]
+	first := true
+
+	var wrapped []string
+	for _, word := range strings.Fields(line[hang:]) {
+		switch {
+		case first:
+			current += word
+			first = false
+		case len([]rune(current))+1+len([]rune(word)) > width:
+			wrapped = append(wrapped, strings.TrimRight(current, " "))
+			current = indent + word
+		default:
+			current += " " + word
+		}
+	}
+
+	return strings.Join(append(wrapped, strings.TrimRight(current, " ")), "\n")
+}
+
+// usageTextColumn returns the column at which a usage line's prose begins.
+//
+// pflag separates a name column from its description with a run of two or more spaces, and `--output`'s
+// rendering list uses the same shape one level in. Taking the first such run after the line's first
+// non-space character finds the description column on a flag line and the sentence column on a rendering
+// line, which is where each one's continuations belong.
+//
+// Parameters:
+//   - `line`: one line of pflag's usage block.
+//
+// Returns:
+//   - `int`: the column, or the line's leading indent when it carries no name column.
+func usageTextColumn(line string) int {
+
+	leading := len(line) - len(strings.TrimLeft(line, " "))
+
+	rest := line[leading:]
+	for i := 0; i < len(rest)-1; i++ {
+		if rest[i] == ' ' && rest[i+1] == ' ' {
+			text := i
+			for text < len(rest) && rest[text] == ' ' {
+				text++
+			}
+			return leading + text
+		}
+	}
+
+	return leading
+}
+
+// helpWidth reports the column count help text should wrap to.
+//
+// COLUMNS wins when it is set and sane: a user who exports it has said what they want, and it is the only
+// answer available when stdout is a pipe. The terminal is asked next, and [helpFallbackWidth] answers when
+// neither does.
+//
+// Returns:
+//   - `int`: the wrap width in columns.
+func helpWidth() int {
+
+	if columns, err := strconv.Atoi(os.Getenv("COLUMNS")); err == nil && columns > 0 {
+		return columns
+	}
+
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
+		return width
+	}
+
+	return helpFallbackWidth
+}
+
+// endregion

--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -503,9 +503,42 @@ Current state, 2026-08-30. Two of the four in-scope programs register the common
 | `star` | no | a **second `cli` package** of its own -- see below |
 | `devlore-docs` | not in scope | — |
 
-`writ status` is bridged rather than converted: `cfg.JSONOutput` reads `outputOptions.Format == "json"` while
-its report still renders itself. The consequence is worth stating -- `writ status -o yaml` silently produces
-the human report, not yaml -- and it holds only until that report goes through the pipeline.
+`writ status` is bridged rather than converted, and the bridge is one bool: `cfg.JSONOutput` reads
+`outputOptions.Format == "json"` (`cmd/writ/writ/config.go:160`) while the report still renders itself.
+Measured 2026-08-30, **one of eight formats works**:
+
+| `-o` | Result |
+| --- | --- |
+| `json` | real JSON |
+| `yaml`, `table`, `list`, `csv`, `value`, `none`, `template=BODY` | byte-identical human dashboard |
+
+Three of those are worse than ignored. `-o none` prints ten lines where its whole contract is silence.
+`-o yaml` emits text a parser fails on at line 1. `-o template=BODY` neither renders the template nor
+rejects it.
+
+**And the value is never validated** ([#754](https://github.com/NobleFactor/devlore-cli/issues/754)).
+Because the format string never reaches [FormatterByName], any string is accepted: `writ status -o bogus`
+prints the dashboard and exits 0, where `devlore-test -o bogus` reports `unknown formatter "bogus"; expected
+one of csv, json, list, none, table, template=BODY, value, yaml`. A typo is silently honored as a request for
+the default. That is a second defect, distinct from the seven wrong renderings: one does the wrong thing, the
+other accepts wrong input. It is not confined to `status` -- every writ command but `verify` accepts any
+value.
+
+**`--store` is read nowhere in writ at all**
+([#753](https://github.com/NobleFactor/devlore-cli/issues/753)), and that is the severe face of the same
+cause. `outputOptions` is read in exactly two places: `config.go:160` takes `.Format`, and `commands.go:302`
+hands the struct to [BuildPipeline] in `runVerify`. Meanwhile `readback.go` genuinely reads [TracesDir] and
+[GraphsDir] to fold runs into the inventory. So `writ status --store <elsewhere>` reads the default store and
+reports the result as compliance -- not a formatting nicety, but the wrong data, silently.
+
+**The shared cause is a flag registered on a root that no leaf consumes.** `root.go:49` calls
+[AddOutputFlags], so cobra advertises the whole set on every command's help; consuming it is a separate act,
+performed once. Registration without consumption is worse than absence: an absent flag errors and the user
+tries something else, where a present one that does nothing returns a confident wrong answer.
+
+Both end the moment `runStatus` calls [BuildPipeline] the way `runVerify` already does. `BuildReport`
+already returns `*Report`, so the conversion deletes `status.Execute`'s branch, `presentJSON`, `presentText`,
+and `JSONOutput` together.
 
 **`star` does not lack the convention -- it has a second copy of it.** `cmd/star/cli` duplicates eighteen
 exported names from `cmd/internal/cli`, including all ten exit codes and `AddOutputFlags`, and at 387 lines
@@ -514,8 +547,10 @@ against 196 the copy has grown rather than gone stale. The two now disagree: one
 on `Flags`. A program cannot share a common set while binding a different one from a different package
 ([#743](https://github.com/NobleFactor/devlore-cli/issues/743)).
 
-Its `renderTable` is the exception worth keeping: it is the suite's only working table renderer and the
-candidate to promote into `pkg/result` in Phase 4, rather than a thing to delete.
+Its `renderTable` was the exception worth keeping, and it has been kept: [TableFormatter] in `pkg/result`
+took star's `text/tabwriter` approach and joined it to the delimited formats' column inference. star's own
+version carried a third implementation of column selection, so `cmd/star/cli` is now deletable whole rather
+than half salvaged.
 
 **CLI code also lives outside `cmd/`.** Every package under the repository-root `internal/` is imported only
 by `cmd/`, and `internal/console` is a Bubble Tea terminal UI. Root `internal/` is importable by the whole

--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -55,6 +55,17 @@ Developer tooling is held to the same convention. A harness whose output is inco
 confusion as a shipped command, and `devlore-test` is the proof: its three output streams were wired to the
 wrong artifacts for months without anyone noticing ([#738](https://github.com/NobleFactor/devlore-cli/issues/738)).
 
+**Ruled 2026-08-31: membership is about infrastructure, not about shipping.** An in-scope program builds its
+command tree the way every other in-scope program does -- [NewRootCmd] for the root, [AddOutputFlags] on that
+root, `cmd/internal/cli` for the exit codes and the store. `devlore-test` is subject to this whether or not
+it is ever shipped, and the question of whether it ships does not enter into it.
+
+The reason is not symmetry. A program that assembles its own root inherits nothing later: the help wrapping
+of [#755](https://github.com/NobleFactor/devlore-cli/issues/755) reached `lore` and `writ` and not
+`devlore-test`, because `devlore-test` constructs a `cobra.Command` directly. Nobody decided to exclude it;
+it was excluded by a construction choice made elsewhere, and discovered by measurement afterwards. Every
+future repair in `cmd/internal/cli` has the same reach and the same silence.
+
 ## 3. Command grammar
 
 Commands are `<binary> <noun> <verb>` or `<binary> <verb>` where the noun is implied by the binary. `lore
@@ -476,6 +487,42 @@ Greenfield, per the repository's governing principle. There are no released CLI 
 backward-compatibility shim the governing principle forbids, and it doubles the surface every future change
 must consider.
 
+### Two version numbers, coupled by policy
+
+**Ruled 2026-08-31.** An application and the documents it writes carry separate version numbers.
+
+| | Scheme | Today | Where |
+| --- | --- | --- | --- |
+| Application | semver, **computed** by `git describe` | `v0.1.0` | `pkg/application`, `-X` stamp |
+| Document format | semver, **declared** as a literal | `schema_version: 1` | `GraphSchemaVersion`, `graph.go:41` |
+
+**Computed against declared is the distinction that matters.** The application version is derived from the
+build: `git describe` appends the commit distance and a hash, so it differs between two builds of identical
+source. A document format version is written down by hand and changes only when someone changes it. Stamping
+a computed version into a document would claim a new format on every build, between formats that are the
+same.
+
+**Ruled 2026-08-31: the document version is a semver string whose value tracks the application's, for now.**
+That is the hedge. A reader seeing `schema_version: "1.0.0"` can attribute a document to a release without a
+lookup table, which is the benefit of one number; and because the value is a declared literal rather than a
+computed one, the two can diverge the day a format changes and the application does not -- or the reverse --
+without changing anything but the constant. Nothing needs deciding in advance.
+
+The field is a `uint32` today (`GraphSchemaVersion = 1`), which forecloses that: an integer cannot express
+`1.2.0`, so a format change would have to become a major bump or go unrecorded. Widening it to a string is
+tracked with the rest of [#758](https://github.com/NobleFactor/devlore-cli/issues/758)'s work.
+
+**On the release of a major application version, the store version is bumped with it.** A major release
+versions the apps *and* the file formats they write, so a document can be attributed to a release without
+consulting a table. This is policy rather than an invariant: the two remain independently versionable, and a
+format bumps on its own whenever the format actually changes, major release or not. The policy is revisited
+on a regular basis, and the possibility of the two diverging permanently is left open.
+
+What this buys is the distinction [#758](https://github.com/NobleFactor/devlore-cli/issues/758) asks for.
+A document whose `schema_version` is absent or below the supported floor was **written by a retired format**;
+a document at the current version that fails to decode is **damaged**. Today a trace carries no version at
+all, so the two are indistinguishable and both surface as corruption.
+
 ## 14. Conformance and enforcement
 
 Each rule below is greppable, and each has a test. These are the reason the document is worth writing.
@@ -561,6 +608,42 @@ module, so nothing prevents a `pkg/` package from importing CLI presentation
 `AddOutputFlags` as used at two call sites — `lore inspect` and `writ snapshot`. `writ snapshot` no longer
 exists as a command, and nothing recorded that the convention lost a user with it. That is invariant 3's
 justification: adoption that is not enforced decays silently.
+
+### A fix to the shared package does not reach every app
+
+Measured 2026-08-31, after the fixes for
+[#753](https://github.com/NobleFactor/devlore-cli/issues/753),
+[#754](https://github.com/NobleFactor/devlore-cli/issues/754), and
+[#755](https://github.com/NobleFactor/devlore-cli/issues/755) landed in `cmd/internal/cli`:
+
+| App | Help wraps (`NewRootCmd`) | `--output` validated, `--store` resolved (`AddOutputFlags`) |
+| --- | --- | --- |
+| `writ` | yes | yes -- registered on the root, so every command |
+| `lore` | yes | **`inspect` only** -- the one command that registers the set |
+| `devlore-test` | **no** | yes -- registered on the root |
+| `star` | **no** | **no** |
+
+    COLUMNS=70, longest flag line
+      writ           70
+      lore           70
+      devlore-test  389   <- unwrapped
+      star           65
+
+Three different causes, each already tracked:
+
+- `devlore-test` builds its root directly rather than through [NewRootCmd], so it inherits `AddOutputFlags`
+  and not the help wrapping. Nothing prevents it from using the shared constructor; it simply does not.
+- `star` binds its own `cmd/star/cli.AddOutputFlags`, so a fix to the shared package cannot reach it. This
+  is the concrete cost of the duplication in
+  [#743](https://github.com/NobleFactor/devlore-cli/issues/743), and the argument against keeping the copy:
+  a defect fixed once is fixed once per package.
+- `lore` calls [AddOutputFlags] on its `inspect` command rather than its root
+  (`cmd/lore/lore/commands.go:838`), so every other lore command does not have the flags at all -- the
+  "1 of 46 commands" measurement, still true.
+
+The lesson generalizes past these three fixes: **a repair in `cmd/internal/cli` reaches exactly the programs
+that route through `cmd/internal/cli`.** Registration on a root is what turns one fix into a program-wide
+one, and a second copy of the package is what stops it being a suite-wide one.
 
 No deviation is sanctioned. Every row above is work, tracked by the plan in
 [`cli-output-conventions.md`](../plans/cli-output-conventions.md).

--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -166,7 +166,8 @@ than a direction.
 ## 7. `--output`: how the result is rendered
 
 `--output` / `-o` selects the rendering. Its value is a format name, or `NAME=ARGUMENT` for a format that
-needs one (§8). The set, alphabetically: `csv`, `json`, `none`, `table`, `template=<body>`, `value`, `yaml`.
+needs one (§8). The set, alphabetically: `csv`, `json`, `list`, `none`, `table`, `template=<body>`, `value`,
+`yaml`.
 
 Reshaping is not a rendering. Selecting fields, mapping, and interpolating happen in the filter stage
 (`--filter`, `--jq`), which composes with every format. `aws`, `az`, and `gcloud` all take this shape: a
@@ -182,8 +183,9 @@ when observed is unreproducible. A human wanting a table asks for one: `-o table
 does not have reshapes with `--jq` and renders with `value`.
 
 **`value` expects a projection.** It renders whatever it is handed, so a whole nested structure comes out as
-every field on one line, pointer addresses included. That is the same expectation `gcloud` states by
-requiring a projection for its `csv` and `value` formats. The intended use is `--jq` first:
+one line with its nested members as compact JSON. That is readable, and it is not what a pipe wants. It is
+the same expectation `gcloud` states by requiring a projection for its `csv` and `value` formats. The
+intended use is `--jq` first:
 
 ```
 writ status --jq '.entries[] | "\(.target) is \(.state)"' -o value
@@ -214,6 +216,7 @@ flag:
   value       │ field=v  │  │  gojq  │        │                      │
               └──────────┘  └────────┘        │  csv                 │
                                               │  json                │
+                                              │  list                │
                reshape: select, map,          │  none                │
                project, interpolate           │  table               │
                composable, any order          │  value               │
@@ -226,6 +229,161 @@ flag:
 **Reshaping is not rendering.** Choosing which fields appear, mapping over a list, and building a string are
 the filter stage's work, and they compose with every format. `aws`, `az`, and `gcloud` all take this shape --
 a query language reshapes, a format renders, and neither borrows the other's job.
+
+### From a Go value to a presentation
+
+The pipeline has two stages, and the first is total: **every result becomes JSON before anything renders
+it.** JSON is the native format, and `table`, `csv`, `list`, and `value` are presentations of that JSON --
+not of the Go value behind it.
+
+```
+  Go value            JSON                    presentation
+     |                  |                          |
+     v                  v                          v
+  +--------+       +---------+   filter      +-----------+
+  | struct |------>| object  |-->--filter--->|  --output |--> stdout
+  | slice  | stage | array   |   --jq        |           |
+  | map    |   1   | scalar  |               |  json     |  serialize
+  | scalar |       | null    |               |  yaml     |  serialize
+  +--------+       +---------+               |  table    |  }
+                                             |  csv      |  } one key derivation,
+                        stage 2 ------------>|  list     |  } four presentations
+                                             |  value    |  }
+                                             |  template |  applied to the value
+                                             |  none     |  discards
+                                             +-----------+
+```
+
+Stage 1 runs once, at the head of [Pipeline.Emit], so the filter and the formatter see the same data. A
+formatter called directly renders what it is handed; a *command* never does that, which is what makes the
+rule below true of everything a user sees.
+
+Normalizing first is what keeps the presenters honest, and the cost of skipping it is measurable -- see
+"What PowerShell gets wrong, and why" below. It also decides field NAMES: a struct field carries its
+`json:` tag through every rendering, and those are the names the Starlark surface shows a customer. Before
+stage 1 ran here only the jq filter normalized, so `-o list` named a field `UnitCount` while
+`--jq . -o list` named the same field `unit_count`.
+
+**Numbers stay `json.Number`.** Decoding to `float64` rounds any integer past 2^53 -- the defect
+[#712](https://github.com/NobleFactor/devlore-cli/issues/712) records against the document codec -- so a
+presenter renders the literal digits it was given. `gojq` needs int64 and float64 and gets them inside the
+jq filter, where the conversion is gojq's requirement rather than this pipeline's.
+
+#### The shapes a presenter must answer for
+
+| | Shape | Example |
+| --- | --- | --- |
+| S1 | scalar | `"active"`, `3`, `true`, `null` |
+| S2 | array of scalars | `["a","b"]` |
+| S3 | flat object | `{"name":"x","state":"active"}` |
+| S4 | nested object | `{"name":"x","health":{"runs":3}}` |
+| S5 | array of flat objects | `[{...},{...}]` -- **the table** |
+| S6 | array of objects, differing keys | union, with holes |
+| S7 | array of arrays | positional rows |
+| S8 | empty array, or null | |
+
+`json`, `yaml`, and `none` are shape-independent: the first two serialize anything, the third discards.
+`template=BODY` hands the value to a template. The rules below govern the four that lay data out.
+
+#### Keys are derived once; presentations differ
+
+One derivation serves all four. A `csv:"name"` tag renames a field, `-` omits it, and a [HasHeaders]
+implementation overrides inference entirely. Absent those: a struct contributes its exported fields in
+declaration order, and a map contributes its keys sorted alphabetically.
+
+What differs is whether records share a schema.
+
+- `table`, `csv`, and `value` derive **one** column set -- the union of keys across every record -- and
+  every record fills it, leaving holes where a key is absent.
+- `list` gives each record **its own** keys. That is what makes it right for S6.
+
+| Shape | `table` / `csv` / `value` | `list` |
+| --- | --- | --- |
+| S1 | one row, one column, no header | the value alone, no key |
+| S2 | one column, one row per element | one value per line |
+| S3 | one row | `key : value` per field |
+| S4 | one row; nested values as compact JSON | as S3, nested values as compact JSON |
+| S5 | one row per element; columns = union | one block per element, blank line between |
+| S6 | as S5; absent keys render empty | as S5 -- each block shows only its own keys |
+| S7 | one row per inner array, positional, no header | one block per inner array, values unkeyed |
+| S8 | nothing, exit 0 | nothing, exit 0 |
+
+**A non-scalar cell renders as compact JSON.** `{"runs":3}`, `["a","b","c"]`, at any depth, never
+truncated. Three reasons over the alternatives:
+
+1. Columns stay shallow and predictable, which is the property that makes `table` and `csv` usable at all.
+   Flattening to `health.runs` makes column count a function of data depth.
+2. The cell holds the native format, so it pipes back into `jq`.
+3. It loses nothing. Refusing a nested value would be defensible, but it makes a command author's shaping
+   mistake into a user's error.
+
+Flattening remains available where it belongs -- in the filter stage, chosen explicitly:
+`--jq '{name, runs: .health.runs}'`.
+
+#### What PowerShell gets wrong, and why
+
+PowerShell has the richest formatter set in this survey, and its inline rendering of a nested value is the
+choice adopted above. Three of its behaviors are rejected, and all three have one cause: **it formats .NET
+objects by their properties, without normalizing first.** Measured against pwsh 7.5.4.
+
+| Behavior | Output | Cause |
+| --- | --- | --- |
+| Depth truncates at the third level | `@{c=}` -- the value of `d` silently gone | the property walk stops |
+| Type names leak | `System.Collections.Hashtable`, where an object gives `@{k=v}` | different .NET types |
+| Arrays are reflected over | `Length LongLength Rank SyncRoot IsReadOnly ...` | an array is an object with properties |
+
+Stage 1 makes all three impossible here. By the time a presenter sees the value it is JSON: no
+Hashtable-versus-object distinction exists, an array is an array, and nothing has properties to reflect
+over. That is the argument for normalizing before presenting, stated as a consequence rather than a taste.
+
+**Rejected: automatic table/list switching.** PowerShell renders four properties or fewer as a table and
+five or more as a list. The same command changes shape because someone added a field. §10 rejects TTY
+adaptation because a pipeline that behaves differently when observed is unreproducible; switching on
+property count is that defect with a different trigger. Neither `aws`, `gcloud`, nor `kubectl` does it.
+
+**Divergence: S6 unions keys rather than sampling the first record.** `Format-Table` takes its columns from
+the first object and blanks every key the later ones introduce:
+
+```
+$het = @(
+  [pscustomobject]@{ name="x"; state="active" }
+  [pscustomobject]@{ name="y"; runs=3; findings=@("a","b") }
+  [pscustomobject]@{ kind="package"; action="install" }
+)
+$het | Format-Table
+
+name state
+---- -----
+x    active
+y
+
+        <- runs, findings, kind, and action are gone, and nothing says so
+```
+
+A sparse table is a worse presentation than a dense one. Silently dropping columns is a worse *answer*. We
+take the sparse table, and `list` exists so heterogeneity has a rendering that is not sparse.
+
+#### `list`: one field per line
+
+`list` is the rendering for a result that is wide, heterogeneous, or both -- where `table` is unreadable and
+`json` is punctuation a reader has to see past.
+
+```
+name  : x
+state : active
+
+name     : y
+runs     : 3
+findings : ["a","b"]
+```
+
+Keys are padded within a record, not across the stream, so a heterogeneous stream does not pay for its
+widest key everywhere. Records are separated by a blank line. The separator is `` : `` with the colon
+aligned, deliberately not `key: value`, which would read as YAML and invite the belief that it is -- `-o
+yaml` is one flag away and means something different.
+
+`aws` has no equivalent; `gcloud` ships `list` and `flattened` as separate formats. One suffices here
+because the compact-JSON cell rule already handles the nesting that `flattened` exists to spread out.
 
 ### A format that needs an argument carries it
 

--- a/docs/architecture/10-command-line-interface.status.md
+++ b/docs/architecture/10-command-line-interface.status.md
@@ -40,6 +40,10 @@ and two of four programs landed 2026-08-30. `devlore-test` and `writ` register t
 - [x] The formatting rules written down and the code judged against them: the two stages, S1-S8, the
   per-shape matrix, and the divergences from PowerShell. Stage 1 is real -- `Pipeline.Emit` normalizes, so
   every rendering names a field by its `json:` tag, which is the name the Starlark surface shows.
+- [ ] `writ` consumes the set it registers. Measured 2026-08-30: one of eight formats works, the value is
+  never validated ([#754](https://github.com/NobleFactor/devlore-cli/issues/754)), and `--store` is read
+  nowhere at all ([#753](https://github.com/NobleFactor/devlore-cli/issues/753)) while `readback` folds runs
+  from the default store. A flag registered on a root that no leaf consumes is worse than an absent one.
 - [ ] `writ`'s **renderings** brought into agreement: the 30 stdout call sites routed through the sink -- 22
   `fmt.Print` in `status/report.go`, four dry-run `SerializeGraphs` dumps, and two in `migrate`.
 - [ ] `lore`'s remaining commands brought into agreement; the `fmt.Print` calls triaged.

--- a/docs/architecture/10-command-line-interface.status.md
+++ b/docs/architecture/10-command-line-interface.status.md
@@ -14,7 +14,7 @@ and two of four programs landed 2026-08-30. `devlore-test` and `writ` register t
 - [x] Scope settled: `devlore-test`, `lore`, `star`, and `writ`, each registering the full common set on
   its root as persistent flags -- every command of all four accepts every flag.
 - [x] The reserved flag set settled: `--filter`, `--jq`, `--output` / `-o`, `--store`, with renderings
-  `csv`, `json`, `none`, `table`, `template=<body>`, `value`, `yaml`. A `tsv` rendering was carried until
+  `csv`, `json`, `list`, `none`, `table`, `template=<body>`, `value`, `yaml`. A `tsv` rendering was carried until
   2026-08-30 and dropped: quoting cannot rescue `cut` or `awk`, which have no quote awareness, so a quoted
   tab format served neither the shell nor the parser (§8).
 - [x] The pipeline drawn: two stages, one flag each; a format needing an argument carries it as
@@ -37,6 +37,9 @@ and two of four programs landed 2026-08-30. `devlore-test` and `writ` register t
 - [x] `writ`'s **flags** brought into agreement: the boolean `--json` retired by deletion on `status` and
   `verify`, `verify.Execute` returning `[]Report` for the command to emit, and the common set registered on
   the root.
+- [x] The formatting rules written down and the code judged against them: the two stages, S1-S8, the
+  per-shape matrix, and the divergences from PowerShell. Stage 1 is real -- `Pipeline.Emit` normalizes, so
+  every rendering names a field by its `json:` tag, which is the name the Starlark surface shows.
 - [ ] `writ`'s **renderings** brought into agreement: the 30 stdout call sites routed through the sink -- 22
   `fmt.Print` in `status/report.go`, four dry-run `SerializeGraphs` dumps, and two in `migrate`.
 - [ ] `lore`'s remaining commands brought into agreement; the `fmt.Print` calls triaged.

--- a/docs/plans/cli-output-conventions.md
+++ b/docs/plans/cli-output-conventions.md
@@ -210,6 +210,38 @@ Phase 4's first task, and this phase is now the next work.
       cannot keep, so neither tool claimed the name. `DelimitedFormatter` keeps all three attributes; `Raw`
       is what separates the two survivors.
 
+### Phase 3d: The formatting rules, and stage 1 -- COMPLETE
+
+The rules were written first and judged the code, rather than the code being read and described. Three of
+the four findings below are defects the rules exposed on their first contact with a real result.
+
+- [x] `docs/architecture/10-command-line-interface.md` §8 states the two stages, the eight shapes a
+      presenter must answer for (S1-S8), the per-shape matrix, and the divergences from PowerShell --
+      measured against pwsh 7.5.4 rather than recalled.
+- [x] A non-scalar cell renders as **compact JSON** at any depth. It went through `fmt.Sprint` before, so a
+      nested map rendered as Go's own `map[runs:3]` -- a notation naming the language rather than the data,
+      which nothing downstream can parse.
+- [x] A type that renders itself is excluded: an `error`, a `fmt.Stringer`, an `encoding.TextMarshaler`. A
+      `time.Time` is a struct, and JSON-encoding it would replace the form it defines for itself.
+- [x] **Stage 1 is real.** `normalize` moved from inside the jq filter to the head of `Pipeline.Emit`, so
+      every presentation is a presentation of the JSON. Before this, `-o list` named a field `UnitCount`
+      and `--jq . -o list` named the same field `unit_count` -- the same result, two vocabularies,
+      depending on an unrelated flag. The json names are what the Starlark surface shows a customer, and
+      they are now what every rendering shows.
+- [x] Normalization keeps `json.Number`. Decoding to float64 rounds any integer past 2^53, which is the
+      defect #712 records; gojq's conversion stays inside the jq filter, where it is gojq's requirement.
+- [x] A single record is one row (S3). `table` refused an object outright, and `csv` rendered the whole
+      record into one cell -- two different wrong answers to the shape a command produces whenever it
+      reports on one thing.
+- [x] `list` added: one field per line, keys aligned within a record, each record keeping its own keys.
+      It is the rendering for a result that is wide or heterogeneous, where `table` is sparse and `json`
+      is punctuation to see past. gcloud ships `list` and `flattened` separately; one suffices here because
+      the compact-JSON cell rule already handles the nesting `flattened` exists to spread out.
+- [x] A conformance suite: one fixture, every formatter. It carries `json:` tags that differ from the Go
+      names, a nested object, an array, an integer past 2^53, a bool, and an empty string -- so a formatter
+      that disagrees with the others about a field's NAME or about what a nested value looks like fails
+      there rather than in a command months later.
+
 ### Phase 4: Bring star and lore into agreement
 
 - [x] One `TableFormatter` in `pkg/result`, rune-aligned via `text/tabwriter` (#741's alignment half).

--- a/docs/plans/cli-output-conventions.md
+++ b/docs/plans/cli-output-conventions.md
@@ -186,13 +186,43 @@ the same. The real figure is **30 call sites**:
 ### Phase 3b: Bring writ's renderings into agreement -- UNBLOCKED
 
 The status report is a human table, so this phase waited on the shared `TableFormatter`. That landed with
-Phase 4's first task, and this phase is now the next work.
+Phase 4's first task, and Phase 3d settled how a value of any shape renders. This phase is now the next work.
 
-- [ ] `status/report.go`'s 22 `fmt.Print` calls render through the pipeline as `table`.
+One question it raises and does not answer: `Report` is an object of three slices and a struct -- shape S4 --
+so `-o list` renders four lines with each section as compact JSON, and `-o table` renders one row of four
+cells. Legible for `list`, useless for `table`. Whether that is acceptable, or whether the presenters need a
+case for a sectioned object, is a design question for after the pipeline is wired. Wiring is not blocked on
+it: `-o json`, `-o yaml`, `-o none`, `--jq`, and `--filter` all become correct immediately.
+
+**Measured 2026-08-30, before starting.** `writ status` honors one of eight formats. `-o json` produces
+JSON; `yaml`, `table`, `list`, `csv`, `value`, `none`, and `template=BODY` all produce the same
+byte-identical human dashboard. `-o none` prints ten lines where its contract is silence, and `-o yaml`
+emits text a parser fails on. The bridge is one bool at `cmd/writ/writ/config.go:160`.
+
+The format value is also never validated (#754), because it never reaches `FormatterByName`:
+`writ status -o bogus` prints the dashboard and exits 0, and so does every writ command but `verify`. That is
+a second defect, distinct from the wrong renderings -- one does the wrong thing, the other accepts wrong
+input.
+
+`--store` is read nowhere in writ at all (#753), which is the severe face of the same cause. `readback.go`
+reads `TracesDir()` and `GraphsDir()` to fold runs, so `writ status --store <elsewhere>` reports on the
+default store as though it had complied -- the wrong data rather than the wrong shape.
+
+The shared cause is a flag registered on a root that no leaf consumes. `root.go:49` registers the whole set,
+so cobra advertises it everywhere; `commands.go:302` consumes it once. Registration without consumption is
+worse than absence: an absent flag errors, a present one that does nothing lies.
+
+- [ ] `runStatus` calls `BuildPipeline` and emits `*Report`, as `runVerify` already does. `BuildReport`
+      already returns the value, so this deletes `status.Execute`'s branch, `presentJSON`, `presentText`,
+      and `JSONOutput` together -- the 22 `fmt.Print` calls go with them.
 - [ ] The four dry-run `SerializeGraphs(os.Stdout, ...)` dumps emit the plan as the command's result.
 - [ ] `migrate`'s own `--format` retires; its `text` rendering is a domain question like `lore list`'s
       `manifest`, and does not join the shared set.
 - [ ] `migrate/session.go`'s stdout write is classified: narration to stderr, or a result to the pipeline.
+- [ ] `writ` resolves `--store` through `cli.SetStoreRoot` before any command that touches the store,
+      restoring on exit as `devlore-test` does (#753). Every command routed through `readback` is affected,
+      not only `status`.
+- [ ] Every writ command validates `--output`, which follows from reaching `BuildPipeline` (#754).
 
 ### Phase 3c: The format value accepts an argument -- COMPLETE
 
@@ -261,6 +291,11 @@ the four findings below are defects the rules exposed on their first contact wit
 
 - [ ] A test that fails when a command registers an output flag of its own.
 - [ ] A test that fails on a direct `os.Stdout` write from a command package.
+- [ ] A test that fails when a root registers the common set and a leaf command does not consume it.
+      Neither invariant above catches #753 or #754: `writ` registers no flags of its own, and the
+      `os.Stdout` check finds `status` but not `repo`, which is equally unvalidated while printing nothing
+      of its own. Greppable as "every root calling `AddOutputFlags` has every leaf reaching
+      `BuildPipeline`".
 - [ ] Regenerate the CLI docs and confirm every command documents the same flags.
 - [x] Correct `docs/plans/extract-output-package.md`, which is marked complete while describing an
       `internal/output` package that was never created. Done ahead of the rest of this phase: a completed

--- a/docs/plans/cli-output-conventions.md
+++ b/docs/plans/cli-output-conventions.md
@@ -287,6 +287,22 @@ the four findings below are defects the rules exposed on their first contact wit
       not join the shared set.
 - [ ] The thirteen `fmt.Print` calls are triaged: narration to `cli.*`, results to the sink.
 
+### Phase 4b: Every in-scope program uses the shared infrastructure
+
+**Ruled 2026-08-31.** Membership in the suite is about infrastructure, not about shipping. A program that
+assembles its own root inherits nothing later, and the reach of a fix in `cmd/internal/cli` is exactly the
+set of programs that route through it -- measured, not assumed, in §15.
+
+- [ ] `devlore-test` builds its root through `cli.NewRootCmd` rather than constructing a `cobra.Command`
+      directly. It has `AddOutputFlags` and therefore #753 and #754, and lacks #755's help wrapping for no
+      reason anyone chose: at `COLUMNS=70` its longest flag line is 389 columns where `writ` and `lore` are
+      at 70. This holds whether or not `devlore-test` ever ships.
+- [ ] `star` uses `cmd/internal/cli` and `cmd/star/cli` is deleted -- the same task as #743, restated here
+      because the duplication's cost is now demonstrated rather than argued: a defect fixed in the shared
+      package is fixed once per package, and star got neither of this branch's three fixes.
+- [ ] `lore` registers the common set on its root rather than on `inspect` alone, which is what makes a
+      program-wide fix program-wide.
+
 ### Phase 5: Enforce it
 
 - [ ] A test that fails when a command registers an output flag of its own.

--- a/pkg/result/conformance_test.go
+++ b/pkg/result/conformance_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package result_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/result"
+	"github.com/NobleFactor/devlore-cli/pkg/sink"
+)
+
+// region Fixture
+
+// deployment is the conformance fixture: one Go type carrying every property the formatting rules turn on.
+//
+//   - `json:` tags that differ from the Go field names, so stage 1 is observable. These are the names the
+//     Starlark surface shows a customer, and they are what every presentation must use.
+//   - a nested object and an array, so the compact-JSON cell rule is observable.
+//   - an integer past 2^53, so a float64 round trip is observable as lost digits.
+//   - a bool and an empty string, so the difference between "false" and "" is observable.
+//
+// Every formatter is exercised against this one value. A formatter that disagrees with the others about a
+// field's NAME, or about what a nested value looks like, fails here rather than in a command months later.
+type deployment struct {
+	LayerName string         `json:"layer_name"`
+	FileCount int64          `json:"file_count"`
+	Active    bool           `json:"active"`
+	Note      string         `json:"note"`
+	Health    map[string]any `json:"health"`
+	Tags      []string       `json:"tags"`
+}
+
+// fixture returns the canonical record. Kept as a function so no test can mutate another's input.
+func fixture() deployment {
+	return deployment{
+		LayerName: "personal",
+		FileCount: 9007199254740993, // 2^53 + 1: the first integer a float64 cannot hold
+		Active:    true,
+		Note:      "",
+		Health:    map[string]any{"runs": 3},
+		Tags:      []string{"a", "b"},
+	}
+}
+
+// emit runs the fixture through a real pipeline, which is the only path that applies stage 1.
+func emit(t *testing.T, format string, value any) string {
+	t.Helper()
+
+	formatter, err := result.FormatterByName(format)
+	if err != nil {
+		t.Fatalf("FormatterByName(%q): %v", format, err)
+	}
+
+	var buffer bytes.Buffer
+	if err := result.NewPipeline(nil, formatter, sink.New(&buffer)).Emit(value); err != nil {
+		t.Fatalf("Emit through %q: %v", format, err)
+	}
+	return buffer.String()
+}
+
+// endregion
+
+// region Tests
+
+// TestConformance_EveryFormatterUsesTheJSONNames is the cross-formatter invariant.
+//
+// `none` is excluded because it emits nothing by definition, and `template` because its output is whatever
+// the caller's template says. Every other formatter presents the same JSON and must agree on the names.
+func TestConformance_EveryFormatterUsesTheJSONNames(t *testing.T) {
+
+	for _, format := range []string{"csv", "json", "list", "table", "value", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+
+			got := emit(t, format, fixture())
+
+			// Case-insensitive: `table` upper-cases its headers, matching aws and kubectl. What matters is
+			// the separator -- "layer_name" is the json tag, "layername" is the Go identifier flattened.
+			folded := strings.ToLower(got)
+
+			// `value` is raw and headerless by design: it carries the values, never the names.
+			if format != "value" && !strings.Contains(folded, "layer_name") {
+				t.Errorf("missing the json name %q:\n%s", "layer_name", got)
+			}
+			if strings.Contains(folded, "layername") {
+				t.Errorf("leaked the Go field name %q:\n%s", "LayerName", got)
+			}
+		})
+	}
+}
+
+// TestConformance_EveryFormatterKeepsIntegerPrecision pins the rule that normalization must not round.
+//
+// Decoding to float64 renders 9007199254740993 as 9007199254740992 -- a wrong answer that looks right, and
+// the defect issue #712 records against the document codec.
+func TestConformance_EveryFormatterKeepsIntegerPrecision(t *testing.T) {
+
+	for _, format := range []string{"csv", "json", "list", "table", "value", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+
+			got := emit(t, format, fixture())
+
+			if !strings.Contains(got, "9007199254740993") {
+				t.Errorf("integer was rounded:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestConformance_NestedValuesAreCompactJSON pins the S4 rule across the presenters that lay data out.
+//
+// `json` and `yaml` render structure natively and are excluded; `value` is raw and carries the same cell
+// text as `csv`.
+func TestConformance_NestedValuesAreCompactJSON(t *testing.T) {
+
+	for _, format := range []string{"csv", "list", "table", "value"} {
+		t.Run(format, func(t *testing.T) {
+
+			got := emit(t, format, fixture())
+
+			if !strings.Contains(got, `{"runs":3}`) && !strings.Contains(got, `{""runs"":3}`) {
+				t.Errorf("nested object did not render as compact JSON:\n%s", got)
+			}
+			if strings.Contains(got, "map[runs:3]") {
+				t.Errorf("nested object rendered as Go's own notation:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestConformance_NoneEmitsNothing pins the one formatter whose contract is silence.
+func TestConformance_NoneEmitsNothing(t *testing.T) {
+
+	if got := emit(t, "none", fixture()); got != "" {
+		t.Errorf("none emitted %q, want empty", got)
+	}
+}
+
+// TestConformance_ASingleRecordIsOneRow pins S3 for the presenters that lay data out.
+//
+// A lone object is a sequence of one, not one cell holding the whole object and not an error. `table`
+// rejected it outright until the rules were written down, and `csv` rendered the whole record into a single
+// cell -- two different wrong answers to a shape a command produces whenever it reports on one thing.
+func TestConformance_ASingleRecordIsOneRow(t *testing.T) {
+
+	for _, format := range []string{"csv", "table"} {
+		t.Run(format, func(t *testing.T) {
+
+			lines := strings.Split(strings.TrimSpace(emit(t, format, fixture())), "\n")
+
+			if len(lines) != 2 {
+				t.Fatalf("got %d lines, want 2 (a header and one row):\n%s", len(lines), strings.Join(lines, "\n"))
+			}
+			if !strings.Contains(strings.ToLower(lines[0]), "layer_name") {
+				t.Errorf("line 1 is not a header: %q", lines[0])
+			}
+			if !strings.Contains(lines[1], "personal") {
+				t.Errorf("line 2 is not the record: %q", lines[1])
+			}
+		})
+	}
+}
+
+// endregion

--- a/pkg/result/conformance_test.go
+++ b/pkg/result/conformance_test.go
@@ -146,6 +146,26 @@ func TestConformance_EveryFormatterKeepsIntegerPrecision(t *testing.T) {
 	}
 }
 
+// TestConformance_ANumberIsANumberInEveryDocumentFormat guards what the precision test alone does not.
+//
+// Keeping [json.Number] through stage 1 preserves the digits, and [encoding/json] emits the type bare. yaml
+// does not: [json.Number] is a string type, so `-o yaml` answered `unit_count: "2"` where `-o json` answered
+// `2` -- one value with two types, decided by the rendering. The precision test passed throughout, because
+// the digits were present; they were merely in quotes.
+func TestConformance_ANumberIsANumberInEveryDocumentFormat(t *testing.T) {
+
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+
+			got := emit(t, format, fixture())
+
+			if strings.Contains(got, `"9007199254740993"`) {
+				t.Errorf("the number was quoted, making it a string:\n%s", got)
+			}
+		})
+	}
+}
+
 // TestConformance_NestedValuesAreCompactJSON pins the S4 rule across the presenters that lay data out.
 //
 // `json` and `yaml` render structure natively and are excluded; `value` is raw and carries the same cell

--- a/pkg/result/conformance_test.go
+++ b/pkg/result/conformance_test.go
@@ -61,6 +61,43 @@ func emit(t *testing.T, format string, value any) string {
 	return buffer.String()
 }
 
+// TestConformance_ATableCellNeverSplitsItsRow pins #748.
+//
+// Every shell result carries a `stdout` field ending in a newline, so this is the ordinary case. A table
+// pads with spaces and has no quoting, so an unescaped newline terminates the line and renders one record as
+// two -- silently. A tab is worse: tabwriter reads it as a column break and shifts every following cell.
+func TestConformance_ATableCellNeverSplitsItsRow(t *testing.T) {
+
+	record := map[string]any{"name": "x", "stdout": "one\ntwo\n", "note": "a\tb"}
+	lines := strings.Split(strings.TrimRight(emit(t, "table", record), "\n"), "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2 (a header and one row):\n%s", len(lines), strings.Join(lines, "|"))
+	}
+	if !strings.Contains(lines[1], `one\ntwo\n`) {
+		t.Errorf("newlines were not escaped: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], `a\tb`) {
+		t.Errorf("tab was not escaped: %q", lines[1])
+	}
+}
+
+// TestConformance_CSVKeepsAnEmbeddedNewlineInsideQuotes is the other half of #748.
+//
+// The fix belongs to `table` alone. RFC 4180 quoting already keeps an embedded newline inside its field
+// where a parser reads it correctly, and escaping it here would corrupt a value that round-trips today.
+func TestConformance_CSVKeepsAnEmbeddedNewlineInsideQuotes(t *testing.T) {
+
+	got := emit(t, "csv", map[string]any{"stdout": "one\ntwo\n"})
+
+	if strings.Contains(got, `\n`) {
+		t.Errorf("csv escaped a newline it should have quoted: %q", got)
+	}
+	if !strings.Contains(got, "\"one\ntwo\n\"") {
+		t.Errorf("csv did not quote the embedded newline: %q", got)
+	}
+}
+
 // endregion
 
 // region Tests

--- a/pkg/result/delimited.go
+++ b/pkg/result/delimited.go
@@ -4,7 +4,9 @@
 package result
 
 import (
+	"encoding"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -105,8 +107,12 @@ func (f DelimitedFormatter) Format(value any, w io.Writer) error {
 		return nil
 	}
 
-	// A value that is not a sequence is one row. `--jq '.count'` produces this, and refusing it would make
-	// the filter stage incomplete.
+	// A lone record is a sequence of one, so an object renders as a header and a row rather than as one
+	// cell holding the whole thing.
+	rv = asRecords(rv)
+
+	// A value that is still not a sequence is a scalar, and one row. `--jq '.count'` produces this, and
+	// refusing it would make the filter stage incomplete.
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
 		return f.emit(w, nil, [][]string{{csvCellValue(rv)}})
 	}
@@ -373,7 +379,59 @@ func csvCellValue(rv reflect.Value) string {
 	if !rv.IsValid() {
 		return ""
 	}
+
+	if isComposite(rv) {
+		encoded, err := json.Marshal(rv.Interface())
+		if err == nil {
+			return string(encoded)
+		}
+		// A value JSON cannot encode is rare and never worth losing the row over: a channel or a func
+		// reaching a cell means the result was mis-shaped upstream, and Go's own rendering names the
+		// type, which is what a reader needs in order to go fix it.
+		return fmt.Sprint(rv.Interface())
+	}
+
 	return fmt.Sprint(rv.Interface())
+}
+
+// Interfaces whose implementations render themselves as a scalar. Checked against the value's own type and
+// not its pointer, which is what [fmt.Sprint] does -- a String method on *T does not make a T print itself.
+var (
+	errorInterface         = reflect.TypeOf((*error)(nil)).Elem()
+	stringerInterface      = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+	textMarshalerInterface = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+)
+
+// isComposite reports whether a cell holds a structure rather than a scalar.
+//
+// Two exclusions, both because the value is already one scalar:
+//
+//   - A byte slice. [DelimitedFormatter.Format] renders it as its own string rather than as a sequence of
+//     numbers, and a cell follows.
+//   - Anything that renders itself -- an [error], a [fmt.Stringer], an [encoding.TextMarshaler]. A
+//     [time.Time] is a struct, and JSON-encoding it would replace the form it defines for itself with a
+//     quoted timestamp; a type whose String method is its presentation would lose it entirely.
+//
+// Parameters:
+//   - `rv`: the dereferenced cell value.
+//
+// Returns:
+//   - `bool`: true when the value renders as compact JSON rather than through [fmt.Sprint].
+func isComposite(rv reflect.Value) bool {
+
+	t := rv.Type()
+	if t.Implements(errorInterface) || t.Implements(stringerInterface) || t.Implements(textMarshalerInterface) {
+		return false
+	}
+
+	switch rv.Kind() {
+	case reflect.Map, reflect.Struct:
+		return true
+	case reflect.Slice, reflect.Array:
+		return t.Elem().Kind() != reflect.Uint8
+	default:
+		return false
+	}
 }
 
 // endregion

--- a/pkg/result/helpers.go
+++ b/pkg/result/helpers.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package result
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+)
+
+// region Helpers
+
+// normalize converts a Go value into its JSON shape: maps, slices, strings, bools, [json.Number], and nil.
+//
+// This is stage 1 of the two-stage model (10-command-line-interface.md §8). JSON is the native format, and
+// every presentation is a presentation of the JSON -- not of the Go value behind it. Running it once, at the
+// head of [Pipeline.Emit], is what makes that true: the filter and the formatter see the same data, and a
+// field is named by its `json:` tag everywhere rather than by its Go identifier in some renderings and its
+// tag in others.
+//
+// Numbers stay [json.Number]. Decoding to float64 would round any integer past 2^53, which is the defect
+// issue #712 records; a [json.Number] renders as the literal digits it was given. [JQFilter] converts them
+// for gojq's benefit, and only there.
+//
+// Parameters:
+//   - `value`: the result to normalize.
+//
+// Returns:
+//   - `any`: the JSON-shaped value.
+//   - `error`: a marshaling failure, naming nothing the caller can act on but never silently dropping data.
+func normalize(value any) (any, error) {
+
+	if value == nil {
+		return nil, nil
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// asRecords returns rv as a sequence of records, wrapping a lone record in a sequence of one.
+//
+// S3 and S4 -- a single object -- are one row, not one cell and not an error. A scalar is not a record and
+// is returned unchanged, so [DelimitedFormatter] still renders it as the single cell that `--jq '.count'`
+// depends on.
+//
+// Parameters:
+//   - `rv`: the dereferenced value.
+//
+// Returns:
+//   - `reflect.Value`: a slice when rv was a record, and rv itself otherwise.
+func asRecords(rv reflect.Value) reflect.Value {
+
+	if rv.Kind() != reflect.Struct && rv.Kind() != reflect.Map {
+		return rv
+	}
+
+	records := reflect.MakeSlice(reflect.SliceOf(rv.Type()), 1, 1)
+	records.Index(0).Set(rv)
+	return records
+}
+
+// endregion

--- a/pkg/result/jq_filter.go
+++ b/pkg/result/jq_filter.go
@@ -4,7 +4,6 @@
 package result
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -64,7 +63,7 @@ func NewJQFilter(expression string) (*JQFilter, error) {
 // returned as-is.
 func (f *JQFilter) Apply(value any) (any, error) {
 
-	normalized, err := jqNormalize(value)
+	normalized, err := normalize(value)
 	if err != nil {
 		return nil, fmt.Errorf("result.JQFilter: normalize input: %w", err)
 	}
@@ -99,53 +98,5 @@ func (f *JQFilter) Apply(value any) (any, error) {
 // endregion
 
 // region Helpers
-
-// jqNormalize puts value into gojq's native shape.
-//
-// [normalize] does the JSON round trip; the number conversion is gojq's own requirement and stays here. gojq
-// compares int64 and float64 directly and has no notion of [json.Number], where the presenters keep it
-// precisely because it preserves the literal digits.
-func jqNormalize(value any) (any, error) {
-
-	normalized, err := normalize(value)
-	if err != nil {
-		return nil, err
-	}
-
-	return jqUnwrapNumbers(normalized), nil
-}
-
-// jqUnwrapNumbers walks the decoded value and converts json.Number values to int64 or float64. gojq
-// understands both directly; the conversion keeps `==` comparisons stable across integer and float
-// branches.
-func jqUnwrapNumbers(value any) any {
-
-	switch v := value.(type) {
-
-	case json.Number:
-		if i, err := v.Int64(); err == nil {
-			return i
-		}
-		if f, err := v.Float64(); err == nil {
-			return f
-		}
-		return v.String()
-
-	case map[string]any:
-		for key, child := range v {
-			v[key] = jqUnwrapNumbers(child)
-		}
-		return v
-
-	case []any:
-		for i, child := range v {
-			v[i] = jqUnwrapNumbers(child)
-		}
-		return v
-
-	default:
-		return v
-	}
-}
 
 // endregion

--- a/pkg/result/jq_filter.go
+++ b/pkg/result/jq_filter.go
@@ -4,7 +4,6 @@
 package result
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -101,29 +100,19 @@ func (f *JQFilter) Apply(value any) (any, error) {
 
 // region Helpers
 
-// jqNormalize converts value into gojq's native shape via JSON round-trip. gojq operates on
-// map[string]any / []any / primitives; struct values pass through json.Marshal which honors `json:`
-// tags. The conversion is needed because gojq cannot reflect on arbitrary Go structs.
+// jqNormalize puts value into gojq's native shape.
+//
+// [normalize] does the JSON round trip; the number conversion is gojq's own requirement and stays here. gojq
+// compares int64 and float64 directly and has no notion of [json.Number], where the presenters keep it
+// precisely because it preserves the literal digits.
 func jqNormalize(value any) (any, error) {
 
-	if value == nil {
-		return nil, nil
-	}
-
-	encoded, err := json.Marshal(value)
+	normalized, err := normalize(value)
 	if err != nil {
 		return nil, err
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(encoded))
-	decoder.UseNumber()
-
-	var out any
-	if err := decoder.Decode(&out); err != nil {
-		return nil, err
-	}
-
-	return jqUnwrapNumbers(out), nil
+	return jqUnwrapNumbers(normalized), nil
 }
 
 // jqUnwrapNumbers walks the decoded value and converts json.Number values to int64 or float64. gojq

--- a/pkg/result/jq_filter_test.go
+++ b/pkg/result/jq_filter_test.go
@@ -4,6 +4,7 @@
 package result
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -106,9 +107,11 @@ func TestJQFilterAppliesToStructInputViaJSONTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	// Numbers come out as int64 (UseNumber + Int64 conversion).
-	if got != int64(30) {
-		t.Errorf("Apply = %v (%T), want int64(30)", got, got)
+	// Numbers stay json.Number, which is one of the types gojq accepts (type.go:20-30) and the one that
+	// keeps an integer's digits. Converting to int64 here used to panic gojq the moment an expression asked
+	// a value's type, because int64 is NOT in that list -- see #749.
+	if got != json.Number("30") {
+		t.Errorf("Apply = %v (%T), want json.Number(\"30\")", got, got)
 	}
 }
 
@@ -140,7 +143,7 @@ func TestJQFilterMultiResultReturnsSlice(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	want := []any{int64(1), int64(2), int64(3)}
+	want := []any{json.Number("1"), json.Number("2"), json.Number("3")}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Apply = %v, want %v", got, want)
 	}

--- a/pkg/result/list.go
+++ b/pkg/result/list.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package result
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// region Types
+
+// ListFormatter renders each record as one field per line, keys aligned within the record.
+//
+// This is the rendering for a result that is wide, heterogeneous, or both -- where `table` is unreadable
+// and `json` is punctuation a reader has to see past:
+//
+//	name  : x
+//	state : active
+//
+//	name     : y
+//	runs     : 3
+//	findings : ["a","b"]
+//
+// It shares key derivation with [DelimitedFormatter] and [TableFormatter] -- `csv:"name"` tags, struct
+// declaration order, sorted map keys -- and diverges on one point: the delimited formats derive ONE column
+// set as the union across every record, where this gives each record its own keys. That is what makes it
+// right for a heterogeneous stream, where a union renders mostly holes.
+//
+// Keys are padded within a record rather than across the stream, so a heterogeneous stream does not pay for
+// its widest key everywhere. The separator is " : " with the colon aligned, deliberately not "key: value",
+// which reads as YAML when `-o yaml` is one flag away and means something else.
+type ListFormatter struct{}
+
+// endregion
+
+// region Constructors
+
+// NewListFormatter returns the one-field-per-line formatter.
+//
+// Returns:
+//   - `ListFormatter`: the formatter.
+func NewListFormatter() ListFormatter { return ListFormatter{} }
+
+// endregion
+
+// region Methods
+
+// Format writes value as records of aligned `key : value` lines separated by blank lines.
+//
+// Parameters:
+//   - `value`: the result to render.
+//   - `w`: the destination.
+//
+// Returns:
+//   - `error`: a write failure, or nil.
+func (f ListFormatter) Format(value any, w io.Writer) error {
+
+	if value == nil {
+		return nil
+	}
+
+	rv := indirect(reflect.ValueOf(value))
+	if !rv.IsValid() {
+		return nil
+	}
+
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return f.writeRecord(w, rv, false)
+	}
+
+	// A byte slice is one value, not a sequence of numbers -- the same carve-out the delimited formats make.
+	if rv.Type().Elem().Kind() == reflect.Uint8 {
+		_, err := fmt.Fprintln(w, string(rv.Bytes()))
+		return err
+	}
+
+	for i := 0; i < rv.Len(); i++ {
+		if err := f.writeRecord(w, indirect(rv.Index(i)), i > 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// endregion
+
+// region Helpers
+
+// writeRecord writes one record, preceded by a blank line when it is not the first.
+//
+// Parameters:
+//   - `w`: the destination.
+//   - `rv`: the dereferenced record.
+//   - `separate`: whether to emit the blank line that divides this record from the previous one.
+//
+// Returns:
+//   - `error`: a write failure, or nil.
+func (f ListFormatter) writeRecord(w io.Writer, rv reflect.Value, separate bool) error {
+
+	if separate {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+
+	if !rv.IsValid() {
+		_, err := fmt.Fprintln(w)
+		return err
+	}
+
+	keys, values := listFields(rv)
+
+	// A scalar or a sequence carries no keys of its own: it is the value alone, which is what makes
+	// `--jq '.name' -o list` print a name rather than a line of punctuation.
+	if keys == nil {
+		for _, value := range values {
+			if _, err := fmt.Fprintln(w, value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	width := 0
+	for _, key := range keys {
+		if n := len([]rune(key)); n > width {
+			width = n
+		}
+	}
+
+	for i, key := range keys {
+		padding := strings.Repeat(" ", width-len([]rune(key)))
+		if _, err := fmt.Fprintf(w, "%s%s : %s\n", key, padding, values[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// listFields returns a record's keys and rendered values, or nil keys when the value carries none.
+//
+// Key derivation is the delimited formats': [csvHeadersFromStruct] for a struct, honoring `csv:` tags and
+// declaration order, and sorted keys for a map. What differs is scope -- these are THIS record's keys, not
+// the union across the stream, which is what makes a heterogeneous stream render densely.
+//
+// A scalar, or a sequence, has no keys and returns its rendered values alone.
+//
+// Parameters:
+//   - `rv`: the dereferenced record.
+//
+// Returns:
+//   - `[]string`: the keys, or nil when the record has none.
+//   - `[]string`: the rendered values, aligned with the keys when those are present.
+func listFields(rv reflect.Value) (keys, values []string) {
+
+	switch rv.Kind() {
+
+	case reflect.Struct:
+		keys = csvHeadersFromStruct(rv.Type())
+		return keys, csvRowFromStruct(rv, keys)
+
+	case reflect.Map:
+		keys = listMapKeys(rv)
+		values = make([]string, len(keys))
+		for i, key := range keys {
+			values[i] = csvCellValue(csvMapLookup(rv, key))
+		}
+		return keys, values
+
+	case reflect.Slice, reflect.Array:
+		for i := range rv.Len() {
+			values = append(values, csvCellValue(rv.Index(i)))
+		}
+		return nil, values
+
+	default:
+		return nil, []string{csvCellValue(rv)}
+	}
+}
+
+// listMapKeys returns one map's keys, sorted.
+//
+// The delimited formats' [csvHeadersFromMaps] unions keys across a whole slice; this is the single-record
+// counterpart, and sorts by the same rule so a map renders its fields in the same order under every
+// presentation.
+//
+// Parameters:
+//   - `rv`: the map.
+//
+// Returns:
+//   - `[]string`: the keys, sorted.
+func listMapKeys(rv reflect.Value) []string {
+
+	keys := make([]string, 0, rv.Len())
+	for _, key := range rv.MapKeys() {
+		keys = append(keys, fmt.Sprint(key.Interface()))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// endregion

--- a/pkg/result/list_test.go
+++ b/pkg/result/list_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package result_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/NobleFactor/devlore-cli/pkg/result"
+)
+
+// region Tests
+
+// TestListFormatter_AlignsKeysWithinARecord pins the S3 rule.
+func TestListFormatter_AlignsKeysWithinARecord(t *testing.T) {
+
+	var buffer bytes.Buffer
+	record := map[string]any{"name": "x", "state": "active"}
+	if err := result.NewListFormatter().Format(record, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	want := "name  : x\nstate : active\n"
+	if buffer.String() != want {
+		t.Errorf("got %q, want %q", buffer.String(), want)
+	}
+}
+
+// TestListFormatter_EachRecordKeepsItsOwnKeys is why this formatter exists.
+//
+// The delimited formats union keys across the stream and leave holes; a heterogeneous stream renders mostly
+// holes. Here each record shows only what it has, and pads to its own widest key rather than the stream's.
+func TestListFormatter_EachRecordKeepsItsOwnKeys(t *testing.T) {
+
+	var buffer bytes.Buffer
+	stream := []any{
+		map[string]any{"name": "x", "state": "active"},
+		map[string]any{"kind": "package", "action": "install"},
+	}
+	if err := result.NewListFormatter().Format(stream, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	want := "name  : x\nstate : active\n\naction : install\nkind   : package\n"
+	if buffer.String() != want {
+		t.Errorf("got %q, want %q", buffer.String(), want)
+	}
+}
+
+// TestListFormatter_ANestedValueIsCompactJSON pins the S4 rule at the list seam.
+func TestListFormatter_ANestedValueIsCompactJSON(t *testing.T) {
+
+	var buffer bytes.Buffer
+	record := map[string]any{"name": "x", "health": map[string]any{"runs": 3}}
+	if err := result.NewListFormatter().Format(record, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if !strings.Contains(buffer.String(), `health : {"runs":3}`) {
+		t.Errorf("nested value did not render as compact JSON: %q", buffer.String())
+	}
+}
+
+// TestListFormatter_AScalarCarriesNoKey covers S1, which is what makes `--jq '.name' -o list` useful.
+func TestListFormatter_AScalarCarriesNoKey(t *testing.T) {
+
+	var buffer bytes.Buffer
+	if err := result.NewListFormatter().Format("active", &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if buffer.String() != "active\n" {
+		t.Errorf("got %q, want %q", buffer.String(), "active\n")
+	}
+}
+
+// TestListFormatter_EmptyEmitsNothing covers S8.
+func TestListFormatter_EmptyEmitsNothing(t *testing.T) {
+
+	var buffer bytes.Buffer
+	if err := result.NewListFormatter().Format([]any{}, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if buffer.String() != "" {
+		t.Errorf("got %q, want empty", buffer.String())
+	}
+}
+
+// TestDelimitedFormatter_ANestedCellIsCompactJSON pins the S4 rule at the delimited seam.
+//
+// Before this rule a nested cell went through fmt.Sprint and rendered as Go's own `map[runs:3]` -- a
+// notation that names the language rather than the data, and that nothing downstream can parse.
+func TestDelimitedFormatter_ANestedCellIsCompactJSON(t *testing.T) {
+
+	var buffer bytes.Buffer
+	rows := []map[string]any{{"name": "x", "health": map[string]any{"runs": 3}}}
+	if err := result.NewCSVFormatter().Format(rows, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if !strings.Contains(buffer.String(), `{""runs"":3}`) {
+		t.Errorf("nested cell did not render as compact JSON: %q", buffer.String())
+	}
+}
+
+// TestDelimitedFormatter_ASelfRenderingCellKeepsItsOwnForm guards the exclusion the compact-JSON rule needs.
+//
+// A [time.Time] is a struct, and a type whose String method IS its presentation is a struct too. Sending
+// either through the JSON encoder would replace a form the type defines for itself -- and for a type whose
+// fields are unexported, replace it with "{}".
+func TestDelimitedFormatter_ASelfRenderingCellKeepsItsOwnForm(t *testing.T) {
+
+	var buffer bytes.Buffer
+	rows := []map[string]any{{"at": time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}}
+	if err := result.NewCSVFormatter().Format(rows, &buffer); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if strings.Contains(buffer.String(), "wall") || strings.Contains(buffer.String(), "{") {
+		t.Errorf("time.Time was JSON-encoded rather than rendering itself: %q", buffer.String())
+	}
+	if !strings.Contains(buffer.String(), "2026-08-31") {
+		t.Errorf("time.Time did not render its own form: %q", buffer.String())
+	}
+}
+
+// endregion

--- a/pkg/result/pipeline.go
+++ b/pkg/result/pipeline.go
@@ -13,6 +13,7 @@
 package result
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/NobleFactor/devlore-cli/pkg/sink"
@@ -91,7 +92,17 @@ func NewPipeline(filter Filter, formatter Formatter, s sink.Sink) *Pipeline {
 //   - error: non-nil if the filter rejects value, or if the formatter fails to encode it.
 func (p *Pipeline) Emit(value any) error {
 
-	filtered, err := p.filter.Apply(value)
+	// Stage 1, run once for both stages below. Every presentation is a presentation of the JSON, so a
+	// field is named by its `json:` tag in `table`, `csv`, `list`, and `value` exactly as it is in `json`
+	// itself -- and those are the names the Starlark surface shows a customer. Before this ran here, only
+	// the jq filter normalized, so `-o list` named a field UnitCount and `--jq . -o list` named the same
+	// field unit_count.
+	normalized, err := normalize(value)
+	if err != nil {
+		return fmt.Errorf("result.Pipeline: normalize result: %w", err)
+	}
+
+	filtered, err := p.filter.Apply(normalized)
 	if err != nil {
 		return err
 	}

--- a/pkg/result/pipeline_test.go
+++ b/pkg/result/pipeline_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package result_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/pkg/result"
+	"github.com/NobleFactor/devlore-cli/pkg/sink"
+)
+
+// region Tests
+
+// summary is a result shaped the way a command's is: Go names on the fields, `json:` tags naming what a
+// customer sees -- in the documents, and on the Starlark surface.
+type summary struct {
+	UnitCount        int    `json:"unit_count"`
+	ExpectationCount int    `json:"expectation_count"`
+	State            string `json:"state"`
+}
+
+// TestPipeline_EmitNormalizesBeforeRendering pins stage 1.
+//
+// Every presentation is a presentation of the JSON, so a field carries its `json:` name in `list`, `table`,
+// `csv`, and `value` exactly as it does in `json`. Before normalization moved to [Pipeline.Emit] only the jq
+// filter normalized, so `-o list` printed UnitCount and `--jq . -o list` printed unit_count -- the same
+// field named two ways depending on an unrelated flag.
+func TestPipeline_EmitNormalizesBeforeRendering(t *testing.T) {
+
+	for _, format := range []string{"list", "csv", "table"} {
+		t.Run(format, func(t *testing.T) {
+
+			var buffer bytes.Buffer
+			formatter, err := result.FormatterByName(format)
+			if err != nil {
+				t.Fatalf("FormatterByName(%s): %v", format, err)
+			}
+
+			pipeline := result.NewPipeline(nil, formatter, sink.New(&buffer))
+			if err := pipeline.Emit(summary{UnitCount: 1, ExpectationCount: 2, State: "ok"}); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+
+			got := strings.ToLower(buffer.String())
+			if !strings.Contains(got, "unit_count") {
+				t.Errorf("%s did not use the json name: %q", format, buffer.String())
+			}
+			if strings.Contains(buffer.String(), "UnitCount") {
+				t.Errorf("%s leaked the Go field name: %q", format, buffer.String())
+			}
+		})
+	}
+}
+
+// TestPipeline_EmitKeepsIntegerPrecision guards the one thing normalization must not do.
+//
+// Decoding to float64 rounds any integer past 2^53, which is the defect issue #712 records against the
+// document codec. [normalize] decodes with UseNumber so a presenter renders the literal digits; gojq's
+// conversion to int64/float64 stays inside the jq filter, where it is gojq's requirement and not ours.
+func TestPipeline_EmitKeepsIntegerPrecision(t *testing.T) {
+
+	const large = 9007199254740993 // 2^53 + 1, the first integer a float64 cannot hold
+
+	var buffer bytes.Buffer
+	pipeline := result.NewPipeline(nil, result.NewValueFormatter(), sink.New(&buffer))
+	if err := pipeline.Emit(json.Number("9007199254740993")); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if !strings.Contains(buffer.String(), "9007199254740993") {
+		t.Errorf("integer lost precision: got %q, want the literal digits of %d", buffer.String(), large)
+	}
+}
+
+// endregion

--- a/pkg/result/selection.go
+++ b/pkg/result/selection.go
@@ -16,8 +16,8 @@ import (
 // this makes the conflict impossible by construction. `kubectl` ships the same form -- `-o go-template=`,
 // `-o jsonpath=`, `-o custom-columns=`.
 //
-// The names are "csv", "json", "none", "table", "template=BODY", "value", and "yaml". Reshaping a value is
-// the filter stage's job -- see [FilterByExprs] -- so only "template" takes an argument.
+// The names are "csv", "json", "list", "none", "table", "template=BODY", "value", and "yaml". Reshaping a
+// value is the filter stage's job -- see [FilterByExprs] -- so only "template" takes an argument.
 //
 // "csv" and "value" are the delimited pair, and the split is by consumer rather than by separator: "csv"
 // quotes, so a parser can round-trip it; "value" does not, so a shell reads exactly what was composed. A
@@ -53,6 +53,9 @@ func FormatterByName(spec string) (Formatter, error) {
 	case "csv":
 		return NewCSVFormatter(), nil
 
+	case "list":
+		return NewListFormatter(), nil
+
 	case "none":
 		return NoneFormatter{}, nil
 
@@ -70,8 +73,8 @@ func FormatterByName(spec string) (Formatter, error) {
 
 	default:
 		return nil, fmt.Errorf(
-			"result.FormatterByName: unknown formatter %q; expected one of csv, json, none, table, "+
-				"template=BODY, value, yaml", name)
+			"result.FormatterByName: unknown formatter %q; expected one of csv, json, list, none, "+
+				"table, template=BODY, value, yaml", name)
 	}
 }
 

--- a/pkg/result/table.go
+++ b/pkg/result/table.go
@@ -68,7 +68,7 @@ func (f TableFormatter) Format(value any, w io.Writer) error {
 	rv = asRecords(rv)
 
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-		_, err := fmt.Fprintln(w, csvCellValue(rv))
+		_, err := fmt.Fprintln(w, escapeControlCharacters(csvCellValue(rv)))
 		return err
 	}
 
@@ -98,12 +98,46 @@ func (f TableFormatter) Format(value any, w io.Writer) error {
 
 	for i := range rv.Len() {
 		row := csvRowFromElement(rv.Index(i), headers)
+		for j, cell := range row {
+			row[j] = escapeControlCharacters(cell)
+		}
 		if _, err := fmt.Fprintln(writer, strings.Join(row, "\t")); err != nil {
 			return err
 		}
 	}
 
 	return writer.Flush()
+}
+
+// endregion
+
+// region Helpers
+
+// escapeControlCharacters renders a cell's newlines, tabs, and carriage returns as their two-character
+// escapes.
+//
+// A table pads with spaces and has no quoting, so a cell carrying its own newline terminates the line and
+// splits the record across two -- silently, and for the ordinary case rather than an exotic one, since every
+// shell result's `stdout` ends in a newline (#748). A tab is worse: it reaches [text/tabwriter] as a column
+// break and shifts every following cell.
+//
+// `csv` needs none of this. RFC 4180 quoting already keeps an embedded newline inside its field, where a
+// parser reads it correctly, and escaping there would corrupt a value that round-trips today. `value` needs
+// none of it either: raw is raw, which is the contract `gcloud` and `aws` state for the same rendering.
+//
+// Parameters:
+//   - `cell`: the rendered cell text.
+//
+// Returns:
+//   - `string`: the cell with control characters escaped.
+func escapeControlCharacters(cell string) string {
+
+	if !strings.ContainsAny(cell, "\n\r\t") {
+		return cell
+	}
+
+	replacer := strings.NewReplacer("\n", `\n`, "\r", `\r`, "\t", `\t`)
+	return replacer.Replace(cell)
 }
 
 // endregion

--- a/pkg/result/table.go
+++ b/pkg/result/table.go
@@ -63,15 +63,20 @@ func (f TableFormatter) Format(value any, w io.Writer) error {
 		rv = rv.Elem()
 	}
 
+	// A lone record is a sequence of one (§8's S3). A scalar is one row of one column, which is what
+	// `--jq '.count' -o table` should print rather than an error.
+	rv = asRecords(rv)
+
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-		return fmt.Errorf("result.TableFormatter: expected slice or array, got %T", value)
+		_, err := fmt.Fprintln(w, csvCellValue(rv))
+		return err
 	}
 
 	if rv.Len() == 0 {
 		return nil
 	}
 
-	headers, headersFromValue := csvHeadersFromValue(value)
+	headers, headersFromValue := csvHeadersFromValue(rv.Interface())
 	if !headersFromValue {
 		headers = csvHeadersFromElements(rv)
 	}

--- a/pkg/result/yaml.go
+++ b/pkg/result/yaml.go
@@ -4,7 +4,9 @@
 package result
 
 import (
+	"encoding/json"
 	"io"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -22,6 +24,8 @@ var _ Formatter = YAMLFormatter{}
 // returned error chain via the deferred sequence.
 func (YAMLFormatter) Format(value any, w io.Writer) (err error) {
 
+	value = yamlNumbers(value)
+
 	enc := yaml.NewEncoder(w)
 	enc.SetIndent(2)
 	defer func() {
@@ -30,4 +34,49 @@ func (YAMLFormatter) Format(value any, w io.Writer) (err error) {
 		}
 	}()
 	return enc.Encode(value)
+}
+
+// yamlNumbers replaces every [json.Number] with a scalar node carrying its literal digits.
+//
+// Stage 1 leaves numbers as [json.Number] so a presenter renders the digits it was given rather than a
+// float64 rounded past 2^53. [encoding/json] special-cases the type and emits it bare; yaml.v3 does not, and
+// [json.Number] is a string type -- so without this, `-o yaml` answered `unit_count: "2"` where `-o json`
+// answered `2`. One value, two types, decided by the rendering.
+//
+// The replacement is a [yaml.Node] rather than a converted int64 or float64 because the point is to keep the
+// literal: an integer past 2^53 survives as its digits, and the tag says which kind of number it is.
+//
+// Parameters:
+//   - `value`: the normalized result.
+//
+// Returns:
+//   - `any`: the value with every [json.Number] replaced.
+func yamlNumbers(value any) any {
+
+	switch v := value.(type) {
+
+	case json.Number:
+		tag := "!!int"
+		if strings.ContainsAny(string(v), ".eE") {
+			tag = "!!float"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: string(v)}
+
+	case map[string]any:
+		replaced := make(map[string]any, len(v))
+		for key, child := range v {
+			replaced[key] = yamlNumbers(child)
+		}
+		return replaced
+
+	case []any:
+		replaced := make([]any, len(v))
+		for i, child := range v {
+			replaced[i] = yamlNumbers(child)
+		}
+		return replaced
+
+	default:
+		return value
+	}
 }


### PR DESCRIPTION
Writes down the rules that take a Go value to JSON to a presentation, then fixes the four places the code
disagreed with them. The rules were written first and judged the code; three of the four are defects found
that way rather than reported.

Advances #740. Spec: `docs/architecture/10-command-line-interface.md` §8.

Closes #748. Closes #749. Closes #750. Closes #751. Closes #752. Closes #753. Closes #754. Closes #755.

Eight defects, all found by writing the rules first and then rendering a real result through every formatter
and reading the bytes -- not by review.

| | Defect | Commit |
| --- | --- | --- |
| #750 | field names differed by unrelated flag | 1 |
| #751 | a nested cell rendered as Go's `map[runs:3]` | 1 |
| #752 | a single-object result had no correct rendering | 1 |
| #748 | a table cell's newline split its row, silently | 2 |
| #749 | `--jq` calling `tostring` panicked the process | 2 |
| #753 | `--store` was registered and read nowhere in writ | 3 |
| #754 | `--output` was accepted unvalidated on every writ command but `verify` | 3 |
| #755 | help text did not wrap; every line width was maintained by hand | 4 |

#753 and #754 are one defect wearing two faces: a flag registered on a root that no leaf consumes.
`AddOutputFlags` now wires the two flags whose meaning does not depend on a command rendering anything, so
registering the set and honoring it cannot come apart.

One regression was introduced and fixed inside this PR: keeping `json.Number` through stage 1 made `-o yaml`
answer `unit_count: "2"` where `-o json` answered `2`, because `encoding/json` special-cases the type and
`yaml.v3` sees a string. The conformance suite passed it throughout -- it asserted the digits were present,
and they were, in quotes. A second test now asserts the type.

## Stage 1 is real

`normalize` moved from inside the jq filter to the head of `Pipeline.Emit`, so the filter and the formatter
see the same data.

```
-o list            →  UnitCount : 1        ← before
--jq . -o list     →  unit_count : 1       ← before
```

One result, two vocabularies, decided by an unrelated flag. The `json:` tag is the name the Starlark surface
shows a customer, and it is now the name every rendering shows.

**Numbers stay `json.Number`.** Decoding to `float64` rounds any integer past 2^53 — the defect #712 records
against the document codec. `gojq` needs int64 and float64 and gets them inside the jq filter, where the
conversion is gojq's requirement and not this pipeline's.

## The defects the rules exposed

| | Was | Now | |
| --- | --- | --- | --- |
| Field names | `UnitCount`, unless `--jq` was passed | `unit_count`, always | #750 |
| A nested cell | `map[runs:3]` — Go's notation, unparseable | `{"runs":3}` | #751 |
| A single record, `-o table` | `expected slice or array, got map[string]interface {}` | a header and one row | #752 |
| A single record, `-o csv` | the whole record in one cell | a header and one row | #752 |
| A cell containing a newline, `-o table` | the row split, silently | `\n`, one record per line | #748 |
| `--jq` calling `tostring` on a number | `panic: invalid type: int64 (1)` | the expression runs | #749 |

**#748** — every shell result carries a `stdout` field, and `stdout` ends in a newline, so a split row was
the ordinary case. `csv` is deliberately untouched: RFC 4180 quoting already keeps the newline inside its
field where a parser reads it, and escaping there would corrupt a value that round-trips today.

**#749** — gojq accepts `nil`, `bool`, `int`, `float64`, `*big.Int`, `json.Number`, `string`, `[]any`, and
`map[string]any`. `int64` is not among them, and `jqUnwrapNumbers` handed it exactly that from `v.Int64()`.
The conversion was never needed — gojq handles `json.Number` natively across `compare.go`, `encoder.go`, and
a dozen sites in `func.go` — and it was lossy, since `Int64()` fails past int64 and the fallback rounds.
Deleted.

Types that render themselves are excluded from the compact-JSON rule: an `error`, a `fmt.Stringer`, an
`encoding.TextMarshaler`. A `time.Time` is a struct, and encoding it would replace the form it defines for
itself.

## `list`

One field per line, keys aligned within a record, **each record keeping its own keys**. That last point is
why it exists: the delimited formats union keys across the stream and leave holes, so a heterogeneous stream
renders mostly holes.

```
name  : x
state : active

name     : y
runs     : 3
findings : ["a","b"]
```

`gcloud` ships `list` and `flattened` separately; one suffices here because the compact-JSON cell rule
already handles the nesting `flattened` exists to spread out.

## The survey behind the rules

Measured against pwsh 7.5.4, not recalled. PowerShell's inline rendering of a nested value is adopted. Three
of its behaviors are rejected, and all three have one cause — **it formats .NET objects by their properties
without normalizing first**:

| Behavior | Output | Cause |
| --- | --- | --- |
| Depth truncates at the third level | `@{c=}`, the value silently gone | the property walk stops |
| Type names leak | `System.Collections.Hashtable` where an object gives `@{k=v}` | different .NET types |
| Arrays are reflected over | `Length LongLength Rank SyncRoot ...` | an array is an object with properties |

Stage 1 makes all three impossible here.

Its automatic table/list switch at five properties is rejected too: §10 already refuses TTY adaptation
because a pipeline that behaves differently when observed is unreproducible, and switching on property count
is that defect with a different trigger.

**One divergence is deliberate.** `Format-Table` takes its columns from the first object and blanks every key
the later ones introduce, dropping them with no report. `csvHeadersFromMaps` unions across every element. A
sparse table is a worse presentation than a dense one; silently dropping columns is a worse *answer*.

## Tests

A conformance suite over one fixture carrying every property the rules turn on: `json:` tags that differ from
the Go names, a nested object, an array, an integer past 2^53, a bool, and an empty string. Every formatter
runs against it through a real pipeline, which is the only path that applies stage 1. A formatter that
disagrees with the others about a field's name, or about what a nested value looks like, fails there rather
than in a command months later.

## What this does NOT fix: the suite

Each issue above describes `writ`, and `writ` is fixed. The class survives elsewhere, because a repair in
`cmd/internal/cli` reaches exactly the programs that route through `cmd/internal/cli`. Measured after these
commits:

| App | Help wraps (#755) | `--output` validated, `--store` resolved (#753, #754) |
| --- | --- | --- |
| `writ` | yes | yes — registered on the root, so every command |
| `lore` | yes | **`inspect` only** |
| `devlore-test` | **no** | yes — registered on the root |
| `star` | **no** | **no** |

```
COLUMNS=70, longest flag line
  writ           70
  lore           70
  devlore-test  389   <- unwrapped
  star           65
```

- `devlore-test` builds its root directly instead of through `cli.NewRootCmd`, so it gets `AddOutputFlags`
  but not the help wrapping.
- `star` binds its own `cmd/star/cli.AddOutputFlags`. A fix to the shared package cannot reach a second copy
  of it — the concrete cost of #743, and the argument for deleting the duplicate rather than maintaining it.
- `lore` registers the set on `inspect` rather than its root, so every other lore command lacks the flags
  entirely — the epic's "1 of 46 commands", still true.

Tracked by #743 and by tasks 35–37 of the plan. Recorded in §15 so a reviewer does not read these fixes as
suite-wide, and so the next person fixing something in `cmd/internal/cli` knows what it will and will not
reach.

## Verification

`make check` passes. `make docs` regenerates clean. Every formatter, against one real result:

What #749 was blocking — gcloud's `text` format, needing no format of ours:

```
--jq '[paths(scalars) as $p | "\($p|map(tostring)|join(".")): \(getpath($p))"]' -o value

results[0].command: echo "Hello World!"
results[0].exit: 0
```

That is §8's rule working as written: a command needing a shape the set does not have reshapes with `--jq`
and renders with `value`.

```
-o json    {"command": "echo \"Hello World!\"", "exit": 0, ...}
-o yaml    command: echo "Hello World!"
-o table   COMMAND              EXIT  STDERR  STDOUT
-o list    command : echo "Hello World!"
-o csv     command,exit,stderr,stdout
-o value   echo "Hello World!"	0		Hello World!
```

## Breaking

`table`, `csv`, `list`, and `value` now name fields by their `json:` tags rather than by their Go
identifiers, and a nested value renders as compact JSON rather than through `fmt.Sprint`.

`docs/cli` is gitignored here, so no reference pages appear in this diff — but `docs-publish.yaml`
regenerates it on every push to `develop` and auto-merges the result. The `--output` help text changes go
live when this merges, with no human in the path.




