### PR TITLE
The noblefactor layer is a shared address, not devlore's list

### DIFF
--- a/Home/noblefactor/packages-manifest.yaml
+++ b/Home/noblefactor/packages-manifest.yaml
@@ -14,10 +14,6 @@
 # always matches". Platform layers add to it: Darwin and Linux also draw noblefactor.Unix, because
 # OSFamily maps both to Unix; Windows has no family and draws only noblefactor.Windows.
 #
-# The suffix namespace belongs to segment values alone. Segments.Match requires every suffix to be one
-# the machine reports, so a Home/noblefactor.secrets would match nowhere -- silently, not loudly. Any
-# sub-scoping goes in the project name, Home/noblefactor-secrets, never after a dot.
-#
 # Every entry below is one this repository demonstrably uses -- a Makefile target, a CI step, a star
 # extension, or a provider that shells out to it. Nothing is here because it happens to be installed
 # on someone's laptop.

--- a/Home/noblefactor/packages-manifest.yaml
+++ b/Home/noblefactor/packages-manifest.yaml
@@ -1,13 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Noble Factor. All rights reserved.
 
-# The tools a devlore-cli working environment needs on every platform.
+# What this repository contributes to the noblefactor layer, on every platform.
+#
+# The layer name is an address, not a description. Base, team, and personal repositories each carry a
+# Home/noblefactor, and `writ deploy noblefactor` assembles all of them -- so the name has to be
+# identical across repositories owned by different people, and stable as products are renamed. That is
+# why it names the company and not devlore: the personal and team repositories are not about devlore,
+# and a Home/devlore in them would be empty. Each repository decides what it contributes; this one
+# contributes the tools its own work needs.
 #
 # This layer has no suffix, so writ's Segments.Match selects it everywhere -- "no suffixes means it
 # always matches". Platform layers add to it: Darwin and Linux also draw noblefactor.Unix, because
 # OSFamily maps both to Unix; Windows has no family and draws only noblefactor.Windows.
 #
-# Every entry is one this repository demonstrably uses -- a Makefile target, a CI step, a star
+# The suffix namespace belongs to segment values alone. Segments.Match requires every suffix to be one
+# the machine reports, so a Home/noblefactor.secrets would match nowhere -- silently, not loudly. Any
+# sub-scoping goes in the project name, Home/noblefactor-secrets, never after a dot.
+#
+# Every entry below is one this repository demonstrably uses -- a Makefile target, a CI step, a star
 # extension, or a provider that shells out to it. Nothing is here because it happens to be installed
 # on someone's laptop.
 #


### PR DESCRIPTION
`Home/noblefactor/packages-manifest.yaml`'s header said "the tools a devlore-cli working environment needs"
and "every entry is one this repository demonstrably uses". That is the rule for **this repository's
contribution**, stated as though it were the rule for the **layer**.

Base, team, and personal repositories each carry a `Home/noblefactor`, and `writ deploy noblefactor`
assembles all of them. So the next person adding one would have found an inclusion rule that does not apply
to them.

## The name is a coordination key

It has to be identical across repositories owned by different people, and stable as products are renamed --
which is why it names the company rather than devlore. A `Home/devlore` in the personal or team repository
would be empty.

Each repository decides what it contributes; this one contributes the tools its own work needs. The
per-entry justifications are unchanged: that discipline was never the problem, only the ownership of the
rule.

## Verification

Comment-only. No package list changes, so `writ deploy noblefactor` resolves exactly what it did before.
