### PR TITLE
Plan: the writ lifecycle surface — reconcile, scopes, and the vocabulary settlement

### DIFF
--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -78,6 +78,35 @@ manifest create` is noun-verb; `lore deploy` is a verb whose noun is the binary'
 This is the same rule the Starlark surface follows for `devlore.<noun>.<verb>`; the two trees are separate
 namespaces with one naming convention.
 
+### The lifecycle is named once
+
+`lore` manages devlore packages; `writ` manages engineering environments. They run the same lifecycle over
+different subjects, so they carry the same four verbs, and nothing else may be called by these names.
+
+| Verb | `lore` -- a package | `writ` -- an environment |
+| --- | --- | --- |
+| `deploy` | install the package's lifecycle pipelines | link, write, and create files under each scope |
+| `reconcile` | compare the receipt against the live system, report drift | the same, per scope |
+| `upgrade` | constrained re-deploy with drift attribution | the same |
+| `decommission` | reverse traversal, receipts for the removals | the same |
+
+**No program has a `status` command.** A program that reports on its subject's state calls that `reconcile`,
+because the operation compares a record against reality -- what `git diff` answers, and one day what a merge
+tool answers: restore a system from its current state back to its desired one.
+
+**Reconcile reports and repairs.** The repair half is chartered, not built; until it lands, the report names
+the repairing lifecycle command per finding. `writ reconcile` held the name until phase-8 step 47 renamed it
+`writ status`, on the grounds that *"'Reconcile' promises mutation the command does not perform"*
+([`writ-deploy-family.md:136`](../plans/extract-starlark-from-op/phase-8/writ-deploy-family.md)). That reason
+lapses when the mutation is built, and the name returns with it
+([#762](https://github.com/NobleFactor/devlore-cli/issues/762)).
+
+**Reconcile is valid only after deployment.** Before it there is nothing to compare against, and the answer
+is a not-found error rather than an empty report. That is what lets an exit code carry information: never
+deployed, deployed and clean, and deployed and drifted are three different answers, and
+[5.1](5.1-reconciliation.md) already requires the first of them -- "a missing run index is a hard error, not
+a silent rescan."
+
 ## 4. Arguments and flags
 
 **Positional arguments** are the objects the verb acts on, and only that. A command takes positionals when the
@@ -124,6 +153,58 @@ decisions.
 
 **No boolean format flags.** `--json` is not a flag; `--output json` is. A boolean cannot express a third
 format, which is why two `writ` commands cannot emit YAML today.
+
+### `--scope`: which execution contexts an operation runs on
+
+`--scope` is `writ`'s alone. `lore` deploys into a package's own execution scope
+([2.4](2.4-hermeticity-guarantees.md) §Lore Package Scope); `star` and `devlore-test` have no deployment
+surface. It is persistent on `writ`'s root, because all four lifecycle verbs take it.
+
+| Flag | Short | Type | Meaning |
+| --- | --- | --- | --- |
+| `--scope` | | string, **repeatable** | Restrict the operation to these scopes. `[--scope=<name>]...` |
+
+A **scope** is a named execution context: a name, a target root, a confinement boundary, an elevation
+posture, and its own graph. The scope names a directory in the root of a layer repository, and the
+directories beneath it are projects. `Home/.config/app/x` deploys to `<home>/.config/app/x`; paths are
+preserved. A scope *has* a target root, and that root is generally not known until runtime.
+
+**Repeatable because the default is plural.** Absent the flag, every scope the layer defines runs, each as
+its own graph, in order. A single-valued flag would make "System and ProgramFiles but not Home"
+inexpressible, and on Windows that is the ordinary case.
+
+Five scopes are builtin, reserved on **every** platform and defined on some:
+
+| Scope | Unix | Windows | Elevation |
+| --- | --- | --- | --- |
+| `Home` | `os.UserHomeDir()` | `os.UserHomeDir()` | no |
+| `System` | `/` | `%SystemDrive%\` | required |
+| `ProgramData` | undefined | `%ProgramData%` | required |
+| `ProgramFiles` | undefined | `%ProgramFiles%` | required |
+| `ProgramFilesX86` | undefined | `%ProgramFiles(x86)%` | required |
+
+The capitalization is the platform's own. `LOCALAPPDATA` and `APPDATA` are deliberately absent: Microsoft
+documents no supported way to relocate **Local** AppData, so it is pinned beneath `%USERPROFILE%` and reaches
+through `Home` as an ordinary relative path, while **Roaming** *is* redirectable under domain policy, so a
+builtin would hardcode a location an administrator is entitled to override.
+
+**Data is skipped; instructions are refused.**
+
+| Situation | Behaviour |
+| --- | --- |
+| A layer carries `ProgramFiles/` on a Unix machine | skipped, silently |
+| `--scope=ProgramFiles` on a Unix machine | error: not defined on this platform |
+| Config introduces a scope named `ProgramFiles`, on **any** platform | error: a builtin name |
+
+The first is data: the repository is shared across machines, and that directory is there for the Windows
+ones. The second is an instruction that cannot be carried out. The third is reserved everywhere rather than
+only where it resolves — otherwise one repository would mean two things on two machines, which is the failure
+the layer model exists to prevent. Segments answer the same shape the same way, and the rule generalizes:
+**a directory that does not apply is skipped, a flag that cannot apply is refused.**
+
+**Elevation is per scope**, and automatic: updating `/` or `%SystemDrive%\` runs as a sudo user on Unix and
+as an Administrator on Windows, as needed. A scope declares that it requires elevation;
+[6.1](6.1-privilege-elevation.md)'s `elevation.Provider` satisfies it.
 
 ## 5. The output model
 
@@ -457,6 +538,38 @@ authoritative where the two meet.
 
 A flag always wins. A command must not read configuration in a way that overrides an explicitly passed flag,
 including when the flag's value equals its default.
+
+### Introducing a name and setting its value
+
+Segments and scopes are extensible sets, and they take the same shape: **one key per concept, holding both
+the names and their values.** A key introduces the name; its value sets it.
+
+```yaml
+writ:
+  segments:
+    ROLE: desktop            # introduced and set
+    SITE:                    # introduced; set by WRIT_SEGMENT_SITE or --segment
+  scopes:
+    Staging: ~/staging/root  # a custom scope
+    Home: ~/staging/home     # a BUILTIN's root, overridden
+  vars:
+    USER_NAME: "Your Name"   # what templates interpolate, and nothing else
+```
+
+**A key with no value introduces without setting.** The value then comes from the environment or a flag, and
+until it has one the segment matches no directory suffix -- the behaviour `DISTRO` already has on macOS.
+
+**A builtin's key overrides its default.** There is no separate override mechanism, so a staging deployment
+is aimed by naming the builtin. For `Home` this is the only way: the home directory is resolved from the
+account database, and `HOME` cannot move a deployment.
+
+**`vars` holds template variables alone.** It carried segment values as well, which meant a reader had to
+know a key's concept from its name; each concept now states its own.
+
+Segments and scopes differ in one place, and it is in the concepts rather than the shape: segment builtins
+(`OS`, `DISTRO`, `ARCH`) resolve on every platform, where scope builtins resolve per platform. So scopes
+carry a rule segments do not -- override the root of a builtin that resolves here, never introduce one that
+does not.
 
 ## 12. Help and generated documentation
 

--- a/docs/architecture/2.4-hermeticity-guarantees.md
+++ b/docs/architecture/2.4-hermeticity-guarantees.md
@@ -40,16 +40,50 @@ Writ has three layers, processed in override order (later layers win collisions)
 
 Each layer's physical location can be anywhere on disk. The common reference point is `${XDG_DATA_HOME}/devlore/writ/layers/{layer}/` — each slot is either a symlink to the actual repository or a directory at that path. This gives one well-known root that links to all layer sources.
 
-Within each layer, there are **two target scopes**:
+Within each layer are its **scopes**. A scope is a named execution context: a name, a target root, a
+confinement boundary, an elevation posture, and its own graph. The scope is the name of a directory in the
+root of the base, team, or personal repository; the directories beneath it are projects.
 
-| Source subdirectory | Target root | Purpose |
-|---|---|---|
-| `System/` | `/` | System-wide files (requires elevation) |
-| `Home/` | `$HOME` | User home files |
+**A scope has a target root, and that root is generally not known until runtime.** The name is fixed; where
+it resolves is a property of the machine.
 
-#### Planning: One Tree, Six Cells
+Five scopes are builtin (settled 2026-08-31), reserved on **every** platform and defined on some:
 
-Planning builds a **single target tree** that can be queried for elements originating from any cell of the 2×3 matrix. The tree is populated by traversing the matrix in a deterministic order that ensures correct shadowing:
+| Scope | Unix | Windows | Elevation |
+|---|---|---|---|
+| `Home` | `os.UserHomeDir()` | `os.UserHomeDir()` | no |
+| `System` | `/` | `%SystemDrive%\` | required |
+| `ProgramData` | undefined | `%ProgramData%` | required |
+| `ProgramFiles` | undefined | `%ProgramFiles%` | required |
+| `ProgramFilesX86` | undefined | `%ProgramFiles(x86)%` | required |
+
+The capitalization is the platform's own, not this project's: `ProgramData` and `ProgramFiles` are Windows'
+names for those directories.
+
+`LOCALAPPDATA` and `APPDATA` are deliberately **not** builtins, and for different reasons. Microsoft
+documents no supported way to redirect **Local** AppData -- folder redirection covers Roaming and not Local --
+so it is pinned beneath `%USERPROFILE%` and reaches through the `Home` scope as `Home/AppData/Local/...`, an
+ordinary relative path. **Roaming** *is* officially redirectable under domain policy, so a builtin would
+hardcode a location an administrator is entitled to override; it belongs to a custom scope where one has.
+
+**Custom scopes** are declared in configuration, one map from name to root, and may not take a builtin's
+name on any platform:
+
+```yaml
+writ:
+  scopes:
+    Staging: ~/staging/root
+```
+
+**Data is skipped; instructions are refused.** A layer carrying a `ProgramFiles/` directory on a Unix machine
+is skipped in silence -- the repository is shared across machines, and that directory is there for the Windows
+ones. Asking for it explicitly, `--scope=ProgramFiles`, is an error on Unix: an instruction that cannot be
+carried out. Reserving builtin names on every platform, rather than only where they resolve, is what keeps
+one repository meaning one thing on every machine.
+
+#### Planning: One Tree, One Cell per Scope and Layer
+
+Planning builds a **single target tree** that can be queried for elements originating from any cell of the scope × layer matrix — two scopes by three layers on a Unix machine deploying only `Home` and `System`, more where further scopes are defined. The tree is populated by traversing the matrix in a deterministic order that ensures correct shadowing:
 
 ```
 1. system/base
@@ -70,13 +104,13 @@ The traversal order guarantees that later entries override earlier ones, so pers
 
 From the single planning tree, writ extracts execution graphs — one per populated target scope:
 
-**System: always 1 graph** (when system files exist). All system files (from base, team, and personal layers) target `/`. The graph is unconfined and elevated as required.
+**System: always 1 graph** (when system files exist). All system files (from base, team, and personal layers) target `/` on Unix and `%SystemDrive%\` on Windows. The graph is sandboxed at that root and elevated as required — a sandbox anchored at `/` bounds nothing on Unix, which is a degenerate case of confinement rather than an absence of it ([4.5](4.5-fsroot-variants.md) §5).
 
 **Home: always 1 graph** (when home files exist). All home files target `$HOME`. The graph is confined to `$HOME` via `os.Root`.
 
 | Scope | Target Root | Confinement | Elevation | Graph Count |
 |---|---|---|---|---|
-| System | `/` | Unconfined | Required | 0 or 1 |
+| System | `/` or `%SystemDrive%\` | Sandboxed at the root (bounds nothing on Unix) | Required | 0 or 1 |
 | Home | `$HOME` | Confined (`os.Root`) | As needed | 0 or 1 |
 
 Total execution graphs: **1 to 2** in practice. Each graph gets its own `Context`, `Root`, `RecoverySite`, and executor instance. Execution order is deterministic: system first, then home.
@@ -139,7 +173,7 @@ An alternative is to read the HEAD commit of each layer at planning time and tru
 
 ## Feasibility: Multi-Scope with Separate Contexts
 
-Code review confirms that the separate-graph approach requires **no changes below the command layer**. The execution engine, `Context`, `Root`, `RecoverySite`, providers, and graph structure all work unchanged when each cell of the 2×3 matrix gets its own graph.
+Code review confirms that the separate-graph approach requires **no changes below the command layer**. The execution engine, `Context`, `Root`, `RecoverySite`, providers, and graph structure all work unchanged when each cell of the scope × layer matrix gets its own graph — and unchanged again as scopes are added, since nothing below the command layer counts them.
 
 ### Why It Works
 
@@ -177,7 +211,7 @@ The orchestration logic in `internal/writ/commands.go` needs four changes:
 ## Resolved Decisions
 
 - **Lore hermeticity**: solved by construction — package plans against its cache, execution scope is separate.
-- **One tree, two graphs**: planning builds a single tree with full cross-cell visibility (2×3 matrix). Execution extracts 1 system graph (unconfined, elevated) and 1 home graph (confined to `$HOME`). Source reachability under confinement is solved by git worktree snapshots within `$HOME`, not by graph splitting.
+- **One tree, one graph per populated scope**: planning builds a single tree with full cross-cell visibility. Execution extracts one graph per scope that has files — on a Unix machine, 1 system graph (sandboxed at the system root, elevated) and 1 home graph (sandboxed at `$HOME`). Source reachability under confinement is solved by git worktree snapshots within `$HOME`, not by graph splitting.
 - **Collision detection**: metadata-only comparison across all cells in the single planning tree — does not break per-cell hermeticity.
 - **Snapshot mechanism**: git commit hashes as content-addressed input identities. Worktrees pinned to specific commits provide immutable planning inputs.
 - **Execution engine compatibility**: no changes needed below the command layer. `Context`, `Root`, `RecoverySite`, providers, and graph structure all support multi-scope by construction.
@@ -201,7 +235,7 @@ These three cannot be designed in isolation.
 
 ### Combinatorial Test Surface
 
-The 2×3 matrix with variable graph counts (2–4) creates a combinatorial test surface. Fixtures are needed for all reachability scenarios:
+The scope × layer matrix, with a graph per populated scope, creates a combinatorial test surface. Fixtures are needed for all reachability scenarios:
 
 - All layer repos within `$HOME` (1 home graph)
 - One layer repo outside `$HOME` (2 home graphs)

--- a/docs/architecture/5.1-reconciliation.md
+++ b/docs/architecture/5.1-reconciliation.md
@@ -6,6 +6,12 @@
 > zero tree hits for all of them; `writ reconcile` itself was replaced by `writ status`). The three concerns were
 > realized by other means, recorded below; the proposal is preserved as an explicitly unimplemented appendix.
 > Companion: [`5.1-reconciliation.status.md`](5.1-reconciliation.status.md).
+>
+> **Superseded in part, 2026-08-31.** The command is named `reconcile` again, and reconcile **repairs as well
+> as reports**. Step 47 renamed it to `writ status` because *"'Reconcile' promises mutation the command does
+> not perform"* — a reason that lapses the moment the mutation is built. The "no `--fix`" rule below is
+> therefore the stale claim, not the settled one. See
+> [`docs/plans/feature/762-lifecycle-scopes.md`](../plans/feature/762-lifecycle-scopes.md).
 
 ## Governing Principle
 
@@ -39,19 +45,26 @@ error wrapping follows the same boundary — the provider is context-agnostic, t
 |---------|-----------------|-----------|
 | **Recovery** | receipts on per-executor recovery stacks, LIFO unwind, best-effort with `compensation_failed` as the honest terminal | [2.2](2.2-phase-execution.md) |
 | **Audit** | the **trace**: per-dispatch receipts (with per-attempt history), the transition journal, the catalog snapshot — persisted win or lose, indexed by the run index | [2](2-execution-graph.md), [5.2](5.2-recovery-serialization.md) |
-| **Reconciliation** (drift) | **`writ status`** over the run index + recorded content identity; upgrade's drift attribution | steps 47–48; [1-system-model.md](1-system-model.md) §7.3 |
+| **Reconciliation** (drift) | **`writ reconcile`** over the run index + recorded content identity; upgrade's drift attribution | steps 47–48; [1-system-model.md](1-system-model.md) §7.3 |
 
 ## Drift Detection — the Landed Model
 
-`writ reconcile` no longer exists; **`writ status` replaced it** (phase-8 step 47), and the mechanism is **recorded
-content identity**, not per-action probe methods:
+The command is `writ reconcile` (restored 2026-08-31; `writ status` held the name between phase-8 step 47 and
+then), and the mechanism is **recorded content identity**, not per-action probe methods:
 
 1. **At deploy**, the trace's ledger snapshot records each active resource's `Etag` (the cheap screen) and `Digest`
    (canonical content identity) — the as-deployed record (step 48).
-2. **At status**, the readback classifies each target against that record: fresh, **stale** (source changed since
-   deploy), **modified** (target changed out-of-band), or conflicting — attribution falls out of comparing the live
-   state against the recorded source and target identities. A missing run index is a hard error, not a silent
-   rescan; there is no `--fix` (re-deploying is the explicit, separate act).
+2. **At reconcile**, the readback classifies each target against that record: fresh, **stale** (source changed
+   since deploy), **modified** (target changed out-of-band), or conflicting — attribution falls out of comparing
+   the live state against the recorded source and target identities. A missing run index is a hard error, not a
+   silent rescan: reconcile is valid only after deployment, and before it the answer is not-found rather than an
+   empty report. That is what lets an exit code distinguish never-deployed from deployed-and-clean from
+   deployed-and-drifted.
+
+   **Repair is in scope and unbuilt.** Reconcile answers what `git diff` answers — what changed since deploy and
+   some number of upgrades — and is intended to answer what a merge tool answers: restore a system from its
+   current state to its desired one. Until that lands, the report names the repairing lifecycle command per
+   finding, and re-deploying remains the explicit act.
 3. **At upgrade**, the same attribution decides posture: source-changed re-renders; target-modified is surfaced
    rather than silently overwritten (the conflict policy's pre-flight — step 49).
 
@@ -81,7 +94,7 @@ The proposal's "reconcile before undo" safety gate landed in three distributed f
 | Lifecycle | What happens | Record consumers |
 |-----------|-------------|------------------|
 | **Deploy** | build → persist the plan → execute → persist the trace | receipts (rollback), trace (audit), ledger snapshot (drift anchor) |
-| **Status** | fold the run index; classify against recorded identity | the drift report — no mutations, no recovery stack |
+| **Reconcile** | fold the run index; classify against recorded identity | the drift report — repair is chartered, not yet built |
 | **Upgrade** | constrained re-deploy with drift attribution | all three; new snapshots supersede in the index |
 | **Decommission** | reverse traversal, receipts for the removals | recovery + trace; index records the removal run |
 

--- a/docs/architecture/5.3-recovery-site.md
+++ b/docs/architecture/5.3-recovery-site.md
@@ -68,7 +68,7 @@ package op
 // RecoverySite manages archival and restoration of resources within the
 // op.Root authority boundary. File locations use op.Path. Recovery IDs
 // are opaque strings. All I/O goes through Context.Root (the op.Root
-// interface — confinedRoot in execution, RootReaderWriter in tests).
+// interface — one sandboxed implementation; a test opens a scratch one).
 type RecoverySite struct {
     ctx Context
 }
@@ -219,11 +219,13 @@ The recovery logic now lives in `pkg/op/recovery_site.go`.
    boundary. All renames are within the same filesystem — cross-device
    errors cannot occur.
 
-3. **Confinement.** All recovery I/O goes through `ctx.Root` (the `op.Root`
-   interface). In execution mode (`confinedRoot`), symlink escapes, `..`
-   traversal, and paths outside the authority boundary are blocked by the
-   kernel. In test mode (`RootReaderWriter`), I/O is unconfined but scoped
-   to the test directory.
+3. **Confinement.** All recovery I/O goes through `ctx.Root`, and there is
+   one implementation rather than a mode switch: a sandboxed `fsroot.Dir`,
+   whose symlink escapes, `..` traversal, and paths outside the authority
+   boundary are blocked by the kernel through `*os.Root`. A test uses
+   `fsroot.OpenScratch`, which sandboxes exactly as execution does and
+   removes its tree on `Close`; it differs in lifetime, not in confinement
+   ([4.5](4.5-fsroot-variants.md)).
 
 4. **Provider independence.** The RecoverySite works with paths and bytes.
    It has no knowledge of `file.Resource`, `mem.Resource`, or any provider-

--- a/docs/plans/feature/762-lifecycle-scopes.md
+++ b/docs/plans/feature/762-lifecycle-scopes.md
@@ -138,17 +138,47 @@ belongs to a custom scope when an operator has moved it.
 Reserving on every platform — not only where defined — is what keeps one repository meaning one thing on
 every machine.
 
-### Requirement 8: Custom scopes are configuration, converging with segments
+### Requirement 8: Segments and scopes are name-to-value maps — tracked by #765
+
+**Neither key is read today.** `writ.segments` has been documented since the schema was written and has never
+worked (#746); `writ.scopes` is new here. `--scope` has nothing to select until scopes can be introduced, so
+this is the prerequisite for Phase 4 rather than a parallel task.
+
+**RULED: one key per concept, holding both the name and the value.** A key introduces the name; its value
+sets it. `vars` reverts to what templates interpolate and holds nothing else.
 
 ```yaml
 writ:
+  segments:
+    ROLE: desktop            # introduced and set
+    SITE:                    # introduced; set by WRIT_SEGMENT_SITE or --segment
   scopes:
-    Staging: ~/staging/root
+    Staging: ~/staging/root  # a custom scope
+    Home: ~/staging/home     # a BUILTIN's root, overridden
+  vars:
+    USER_NAME: "Your Name"   # template variables only
 ```
 
-Declared before use; an undeclared `--scope` errors naming what is accepted; a builtin name is refused.
-Segments split declaration from assignment because a segment's name is org-wide and its value per-machine; a
-scope's name and root are both per-machine, so one map states both.
+Three concerns were sharing `vars` -- template variables, segment values, and scope roots -- and a reader had
+to know which was which by the key's name. Now each concept states its own names and its own values in one
+place, and `vars` means one thing.
+
+**A key with no value declares without setting.** That is the shape `DetectSegmentsWithNames` already
+describes ("values are empty until set via CLI `--segment` flags"), and it stays reachable: a segment
+declared here takes its value from `WRIT_SEGMENT_<NAME>` or `--segment`. An unset segment matches no
+directory suffix, behaving as `DISTRO` does on macOS.
+
+**A builtin scope's key overrides its default root**, which is how a deployment is aimed at a staging tree.
+For `Home` it is the only way, since the home directory is resolved from the account database and `HOME`
+cannot move it.
+
+The one asymmetry is in the concepts, not the shape: segment builtins (`OS`, `DISTRO`, `ARCH`) resolve on
+every platform, where scope builtins resolve per platform. So scopes need a rule segments do not -- override
+the root of a builtin that resolves here, never introduce one that does not.
+
+**#746 applies to both.** `writ.segments` is read by nothing today, so this shape is a documented design
+rather than working code, and it changes from an array to a map in this plan. Scopes must not repeat that
+defect: the key is read in the same change that documents it.
 
 ### Requirement 9: Elevation is per scope
 
@@ -158,20 +188,24 @@ field now so the requirement is expressible.
 
 ## Implementation Phases
 
-### Phase 1: Documents
+### Phase 1: Documents — tracked by #766
 
 Documents first: the code changes cite them, and three of them currently describe removed types.
 
-- [ ] `2.4-hermeticity-guarantees.md` — the authority the rest cites. Scope vocabulary; remove the three
-      "unconfined" claims (lines 73, 79, 180). Per `4.5` §5, System targets `/` and a sandboxed root at `/`
-      bounds nothing on Unix, so "System is unsandboxed" is a degenerate sandbox, not a second variant.
-- [ ] `4.4-root-path-triad.md` — §4 "Mode Switch" tabulates `confinedRoot` / `RootReader` /
-      `RootReaderWriter`, none of which exist. Line 79's diagram says `Abs() → abs (unconfined I/O)`.
-- [ ] `5.3-recovery-site.md:225` — a `RootReaderWriter` test mode that no longer exists.
-- [ ] `5.1-reconciliation.md` — reconcile reports AND repairs; record why step 47's reason lapsed; the
-      not-found rule confirmed.
-- [ ] `10-command-line-interface.md` — the four operations, `--scope`, reserved names, custom scopes.
-- [ ] `schema/defaults/writ.yaml` and `schema/devlore-config.json` — `writ.scopes` as an open map, in BOTH.
+- [x] `10-command-line-interface.md` §3.1 — the lifecycle named once
+- [x] `10-command-line-interface.md` §4.1 — `--scope`, the builtins, reserved names, elevation
+- [x] `10-command-line-interface.md` §11.1 — segments and scopes as name-to-value maps
+- [x] `2.4-hermeticity-guarantees.md` — the scope model; three "unconfined" claims; the "Six Cells" and
+      "2×3 matrix" arithmetic, which assumed exactly two scopes
+- [x] `5.1-reconciliation.md` — the reversion, reconcile repairs, `writ status` renamed throughout
+- [x] `5.3-recovery-site.md` — the `RootReaderWriter` test mode that no longer exists
+- [x] `schema/devlore-config.json` and `schema/defaults/writ.yaml` — `writ.scopes` added, `writ.segments`
+      reshaped to a map, `vars` reduced to template variables
+- [ ] `4.4-root-path-triad.md` — §4 "Mode Switch" tabulates three types with zero tree occurrences. OPEN:
+      rewrite, or delete and renumber?
+- [ ] `10-command-line-interface.md` §15 — the conformance table still says `writ status`
+- [ ] `10-command-line-interface.md` §1 is titled "Scope and principles"; "scope" now names an execution
+      context. Two meanings, one document.
 
 ### Phase 2: The rename
 
@@ -223,8 +257,9 @@ nothing validates unknown keys today, so a stale `writ.targets` would be ignored
 - [`4.5-fsroot-variants.md`](../../architecture/4.5-fsroot-variants.md) — why the unsandboxed variants went
 - [`6.1-privilege-elevation.md`](../../architecture/6.1-privilege-elevation.md) — elevation, draft
 - `writ-deploy-family.md` — the phase-8 design that renamed reconcile to status
-- Issues: #762 (this plan), #761 (System roots disagree), #763 (doubled env prefix), #756 (corrected here),
-  #746 (`writ.segments`, same shape as `writ.targets`)
+- Issues: #762 (this plan), #765 (neither config key is read — the prerequisite for `--scope`),
+  #766 (the CLI specification), #761 (System roots disagree), #763 (doubled env prefix),
+  #756 (corrected by the not-found ruling), #746 (segments unwired, superseded in scope by #765)
 
 ## Open Questions
 

--- a/docs/plans/feature/762-lifecycle-scopes.md
+++ b/docs/plans/feature/762-lifecycle-scopes.md
@@ -1,0 +1,234 @@
+---
+title: "The writ lifecycle surface: reconcile, scopes, and the vocabulary settlement"
+issue: https://github.com/NobleFactor/devlore-cli/issues/762
+status: in-progress
+created: 2026-08-31
+updated: 2026-08-31
+---
+
+# Plan: The writ lifecycle surface
+
+## Summary
+
+`writ` and `lore` run the same four-operation lifecycle over different subjects, and they disagree about what
+to call it. This plan settles the vocabulary, restores `writ reconcile`, and makes `--scope` mean something.
+Three of the four operations already share a name across both programs; `writ status` is the sole divergence,
+and it exists because a 2026-07 rename traded a name for an implementation gap that is now closing.
+
+## Goals
+
+1. **Name the lifecycle once.** Four operations, the same words in every program, no `status` anywhere.
+2. **Settle scope against target.** A scope is an execution context; a target is a destination path. Both
+   words keep a job.
+3. **Make `--scope` work.** Multi-valued, writ-only, replacing a flag that is registered and read by nothing.
+4. **Open the builtin set.** Five builtins, reserved everywhere and defined per platform, with custom scopes
+   declared in configuration.
+5. **Correct the documents that describe removed code.** Five sites across three architecture documents
+   describe types with zero occurrences in the tree.
+
+## Current State
+
+### The lifecycle is named twice
+
+`lore reconcile` returns `fmt.Errorf("reconcile: not yet implemented")`.
+
+| Operation | `lore` | `writ` |
+| --- | --- | --- |
+| deploy | `deploy` | `deploy` |
+| **reconcile** | **`reconcile`** — a stub | **`status`** — works; the only implementation in the suite |
+| upgrade | `upgrade` | `upgrade` |
+| decommission | `decommission` | `decommission` |
+
+`cmd/writ/writ/commands.go:187` holds the only `Use: "status"` in `cmd/`.
+
+**The rename was deliberate and its reason has lapsed.** `writ reconcile` was replaced by `writ status` at
+phase-8 step 47. From `writ-deploy-family.md:136`:
+
+> **`writ status` replaces `writ reconcile`.** "Reconcile" promises mutation the command does not perform;
+> … "reconcile" retires entirely — no `--fix`: the repair for each finding is [named] instead.
+
+Reconcile now reports **and** repairs (ruled 2026-08-31), so the promise will be kept and the name returns.
+The original shape is recorded at `writ-deploy-family.md:31`:
+`writ reconcile [--drift] [--fix] [--json] [<project>...]`.
+
+### The vocabulary collides in one file, four lines apart
+
+```go
+// builder.go:49
+// Target is the absolute path to the target file.
+Target string
+
+// builder.go:57
+// TargetName is the target scope ("System" or "Home").
+TargetName string
+```
+
+Counted across `cmd/writ`: `TargetRoot` 52, `TargetName` 16, `buildScope` 16, `byScope` 15, `TargetHome` 7,
+`filesByScope` 6, `Target` 6, `TargetSpec` 4, `Scope` 4, `sortGraphsByScope` 3, `inferScope` 3,
+`TargetSystem` 3, `TargetOrder` 3.
+
+### `--target` is registered and read by nothing
+
+`cmd/writ/writ/root.go:46` declares it. No `GetString("target")` exists anywhere. All four config paths
+hardcode `cfg.TargetRoot = TargetHome()`.
+
+### The scope set is closed, and its config key is half-present
+
+`TargetOrder()` returns a hardcoded pair. `writ.targets` appears in `schema/defaults/writ.yaml` for a user to
+uncomment and is **absent from `schema/devlore-config.json`** — the same shape as
+[#746](https://github.com/NobleFactor/devlore-cli/issues/746).
+
+### Five documented types do not exist
+
+Zero occurrences in the tree of `RootReader`, `RootReaderWriter`, `confinedRoot`, `rootBase`,
+`OpenWritableUnsandboxed`. `fsroot` exports `OpenExisting` and `OpenScratch`, and both sandbox.
+
+## Requirements
+
+### Requirement 1: One lifecycle vocabulary
+
+`deploy`, `reconcile`, `upgrade`, `decommission`, in both programs. No `status` command anywhere. The
+retirement is by deletion — no alias, no hidden command (§13).
+
+### Requirement 2: Reconcile reports and repairs
+
+The command answers "what changed since deploy and some number of upgrades", like `git diff`; the repair
+half is chartered, not built here. `5.1`'s "there is no `--fix`" is retired as the stale claim it is.
+
+### Requirement 3: Reconcile is valid only after deployment
+
+Before deployment, a not-found error rather than an empty report — so an exit code distinguishes
+never-deployed from deployed-and-clean from deployed-and-drifted. This corrects
+[#756](https://github.com/NobleFactor/devlore-cli/issues/756), which was filed against the opposite reading.
+
+### Requirement 4: Scope names an execution context; target names a path
+
+A scope carries a name, a target root, a confinement boundary, an elevation posture, and its own graph. A
+scope HAS a target root, and that root is generally not known until runtime.
+
+### Requirement 5: `--scope` is multi-valued and writ-only
+
+`[--scope=<name>]...`, repeatable. Absent, every defined scope runs in order. `lore`, `star`, and
+`devlore-test` have no scope option.
+
+### Requirement 6: Builtins are reserved everywhere, defined per platform
+
+| Scope | Unix | Windows | Elevated |
+| --- | --- | --- | --- |
+| `Home` | `os.UserHomeDir()` | `os.UserHomeDir()` | no |
+| `System` | `/` | `%SystemDrive%\` | yes |
+| `ProgramData` | undefined | `%ProgramData%` | yes |
+| `ProgramFiles` | undefined | `%ProgramFiles%` | yes |
+| `ProgramFilesX86` | undefined | `%ProgramFiles(x86)%` | yes |
+
+Capitalization is the platform's. **`LOCALAPPDATA` and `APPDATA` are deliberately excluded**, and they differ:
+Local has no supported relocation — *"there is no way to treat Local AppData in the same way"* — so it is
+pinned under `%USERPROFILE%` and reaches through `Home` as `Home/AppData/Local/...`. Roaming IS officially
+redirectable under domain policy, so a builtin would hardcode a location an AD policy may override; it
+belongs to a custom scope when an operator has moved it.
+
+### Requirement 7: Data is skipped, instructions are refused
+
+| Situation | Behaviour |
+| --- | --- |
+| A layer contains `ProgramFiles/` on Unix | skipped, silently — the repo is shared across machines |
+| `--scope=ProgramFiles` on Unix | error: not defined on this platform |
+| Config declares a custom scope named `ProgramFiles`, on ANY platform | error: builtin name |
+
+Reserving on every platform — not only where defined — is what keeps one repository meaning one thing on
+every machine.
+
+### Requirement 8: Custom scopes are configuration, converging with segments
+
+```yaml
+writ:
+  scopes:
+    Staging: ~/staging/root
+```
+
+Declared before use; an undeclared `--scope` errors naming what is accepted; a builtin name is refused.
+Segments split declaration from assignment because a segment's name is org-wide and its value per-machine; a
+scope's name and root are both per-machine, so one map states both.
+
+### Requirement 9: Elevation is per scope
+
+A scope declares that it requires elevation; `elevation.Provider` satisfies it, as needed — sudo on Unix,
+Administrator on Windows. The provider is a draft (`6.1-privilege-elevation.md`); `ScopeSpec` gains the
+field now so the requirement is expressible.
+
+## Implementation Phases
+
+### Phase 1: Documents
+
+Documents first: the code changes cite them, and three of them currently describe removed types.
+
+- [ ] `2.4-hermeticity-guarantees.md` — the authority the rest cites. Scope vocabulary; remove the three
+      "unconfined" claims (lines 73, 79, 180). Per `4.5` §5, System targets `/` and a sandboxed root at `/`
+      bounds nothing on Unix, so "System is unsandboxed" is a degenerate sandbox, not a second variant.
+- [ ] `4.4-root-path-triad.md` — §4 "Mode Switch" tabulates `confinedRoot` / `RootReader` /
+      `RootReaderWriter`, none of which exist. Line 79's diagram says `Abs() → abs (unconfined I/O)`.
+- [ ] `5.3-recovery-site.md:225` — a `RootReaderWriter` test mode that no longer exists.
+- [ ] `5.1-reconciliation.md` — reconcile reports AND repairs; record why step 47's reason lapsed; the
+      not-found rule confirmed.
+- [ ] `10-command-line-interface.md` — the four operations, `--scope`, reserved names, custom scopes.
+- [ ] `schema/defaults/writ.yaml` and `schema/devlore-config.json` — `writ.scopes` as an open map, in BOTH.
+
+### Phase 2: The rename
+
+- [ ] `writ status` → `writ reconcile`; `git mv cmd/writ/writ/status cmd/writ/writ/reconcile`, `status.go` →
+      `reconcile.go`, so history follows. No alias.
+- [ ] `status.Report` → `reconcile.Report`, and the rest of the package surface.
+- [ ] Scenario tests and the eight plan documents that name `writ status`.
+
+### Phase 3: The vocabulary sweep
+
+- [ ] `TargetName` → `ScopeName` (16), `TargetSpec` → `ScopeSpec` (4), `TargetOrder` → `ScopeOrder` (3),
+      `TargetHome` / `TargetSystem` → `ScopeHome` / `ScopeSystem` (10).
+- [ ] `TargetRoot` (52) and `Target` / `Entry.Target` (6) are UNCHANGED — they name destination paths.
+
+### Phase 4: `--scope`
+
+- [ ] `--scope` replaces `--target`, multi-valued and repeatable, and is read.
+- [ ] `ScopeOrder()` opens: the five builtins in table order, custom scopes in discovery order after them.
+- [ ] `ScopeSpec` gains an elevation field.
+- [ ] Reserved-name enforcement, per Requirement 7.
+- [ ] A later layer replaces an earlier one where they overlap: base, team, personal.
+
+## Migration Path
+
+Greenfield: `writ status` stops existing, `--target` stops existing, and `writ.targets` stops being read. No
+aliases (§13). The config key is the only user-visible loss — worth stating in the release note, because
+nothing validates unknown keys today, so a stale `writ.targets` would be ignored in silence.
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `docs/architecture/2.4-hermeticity-guarantees.md` | Modify | scope vocabulary; three stale claims |
+| `docs/architecture/4.4-root-path-triad.md` | Modify | §4 describes removed types |
+| `docs/architecture/5.3-recovery-site.md` | Modify | removed test mode |
+| `docs/architecture/5.1-reconciliation.md` | Modify | reconcile repairs; the rename |
+| `docs/architecture/10-command-line-interface.md` | Modify | operations, `--scope`, reserved names |
+| `schema/defaults/writ.yaml` | Modify | `writ.scopes` |
+| `schema/devlore-config.json` | Modify | `writ.scopes` — currently absent entirely |
+| `cmd/writ/writ/status/` | Move | → `reconcile/` |
+| `cmd/writ/writ/layer.go` | Modify | `ScopeSpec`, `ScopeOrder`, `ScopeHome`, `ScopeSystem` |
+| `cmd/writ/writ/tree/builder.go` | Modify | `ScopeName` |
+| `cmd/writ/writ/root.go` | Modify | `--scope` replaces `--target` |
+
+## Related Documents
+
+- [`2.4-hermeticity-guarantees.md`](../../architecture/2.4-hermeticity-guarantees.md) — the scope model
+- [`5.1-reconciliation.md`](../../architecture/5.1-reconciliation.md) — the concern and its landed mechanism
+- [`4.5-fsroot-variants.md`](../../architecture/4.5-fsroot-variants.md) — why the unsandboxed variants went
+- [`6.1-privilege-elevation.md`](../../architecture/6.1-privilege-elevation.md) — elevation, draft
+- `writ-deploy-family.md` — the phase-8 design that renamed reconcile to status
+- Issues: #762 (this plan), #761 (System roots disagree), #763 (doubled env prefix), #756 (corrected here),
+  #746 (`writ.segments`, same shape as `writ.targets`)
+
+## Open Questions
+
+1. **`4.4` §4 "Mode Switch"** — replace with a statement that there is no mode switch, one implementation
+   with a varying anchor; or delete the section and renumber §5 and §6?
+2. **Windows `System` root** — #761 rules `%SystemDrive%\`, and `adopt.inferScope` classifies against
+   `%SystemRoot%`. Fixed there or here? It is independently fixable and blocks nothing in this plan.

--- a/schema/defaults/writ.yaml
+++ b/schema/defaults/writ.yaml
@@ -4,29 +4,61 @@
 # See: writ config --schema
 
 writ:
-  # Custom segments (beyond built-in OS, DISTRO, ARCH)
+  # Custom segments, as name to value (beyond built-in OS, DISTRO, ARCH)
+  #
+  # A key introduces the segment name; its value sets the segment. A key with no value declares a
+  # segment set elsewhere -- by WRIT_SEGMENT_<NAME> or --segment NAME=value. A directory suffix
+  # matches only a segment that has a value, so an unset segment behaves like DISTRO on macOS:
+  # nothing carrying that suffix is selected.
   # segments:
-  #   - ROLE
-  #   - SITE
+  #   ROLE: desktop
+  #   SITE:
 
-  # Template variables and segment value overrides
+  # Scopes, as name to root directory
+  #
+  # A scope is a named execution context: a directory in the root of a layer repository, whose
+  # contents deploy beneath the root named here. Paths are preserved, so Home/.config/app/x lands
+  # at <home>/.config/app/x. Every lifecycle operation takes a scope -- deploy writes into one,
+  # reconcile classifies what is in it, upgrade re-deploys into it, decommission removes from it.
+  # Restrict an operation to particular scopes with --scope.
+  #
+  # scopes:
+  #   Staging: ~/staging/root
+  #   Home: ~/staging/home
+  #
+  # Five scopes are builtin and resolve per platform:
+  #
+  #   Home             your home directory, on every platform
+  #   System           / on Unix, %SystemDrive%\ on Windows              (elevated)
+  #   ProgramData      undefined on Unix, %ProgramData% on Windows        (elevated)
+  #   ProgramFiles     undefined on Unix, %ProgramFiles% on Windows       (elevated)
+  #   ProgramFilesX86  undefined on Unix, %ProgramFiles(x86)% on Windows  (elevated)
+  #
+  # A builtin's key overrides its default root, which is how a deployment is aimed at a staging
+  # tree or a sandbox. For Home that is the ONLY way: the home directory is resolved from your
+  # account, so setting HOME does not move a deployment.
+  #
+  # Builtin names are reserved on EVERY platform, including those where they do not resolve, so
+  # one repository means one thing on every machine. Introducing `ProgramFiles` on Unix is an
+  # error -- the name is Windows', and honouring it here would make one repository mean two
+  # things. A layer that carries a ProgramFiles/ directory on a Unix machine is skipped in
+  # silence: the repository is shared, and that directory is there for the Windows machines.
+  # Asking for it outright, --scope=ProgramFiles, is an error there. Data is skipped;
+  # instructions are refused.
+  #
+  # LOCALAPPDATA and APPDATA are deliberately not builtin. Microsoft documents no supported way to
+  # relocate Local AppData, so it is pinned beneath %USERPROFILE% and reaches through Home as
+  # Home/AppData/Local/... -- an ordinary relative path. Roaming IS redirectable under domain
+  # policy, so a builtin would hardcode a location an administrator may override; name a scope
+  # for it where one has.
+
+  # Template variables
+  #
+  # What templates interpolate, and nothing else. Segment values live under segments; scope roots
+  # live under scopes.
   # vars:
   #   USER_NAME: "Your Name"
   #   USER_EMAIL: "you@example.com"
-  #   ROLE: desktop
-
-  # Deployment target roots. A layer's Home/ tree deploys beneath `home`; its System/ tree
-  # deploys beneath `system`. Paths are preserved, so Home/.config/app/x lands at
-  # <home>/.config/app/x.
-  #
-  # Defaults: home = your home directory, system = /
-  #
-  # Set these to deploy somewhere other than the live system — a staging tree, or a sandbox.
-  # Note that `home` is the ONLY way to redirect the Home target: the home directory is
-  # resolved from your account, so setting HOME does not move a deployment.
-  # targets:
-  #   home: ~/staging/home
-  #   system: ~/staging/system
 
 # Layers are directories at ~/.local/share/devlore/writ/layers/
 #   base/

--- a/schema/devlore-config.json
+++ b/schema/devlore-config.json
@@ -7,7 +7,11 @@
   "properties": {
     "verbosity": {
       "type": "string",
-      "enum": ["quiet", "normal", "verbose"],
+      "enum": [
+        "quiet",
+        "normal",
+        "verbose"
+      ],
       "description": "Output verbosity level (shared across lore and writ)",
       "default": "normal"
     },
@@ -22,7 +26,14 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["ollama", "anthropic", "openai", "github", "groq", "gemini"],
+          "enum": [
+            "ollama",
+            "anthropic",
+            "openai",
+            "github",
+            "groq",
+            "gemini"
+          ],
           "description": "AI provider backend",
           "default": "ollama"
         },
@@ -89,7 +100,11 @@
         "on_error": {
           "type": "string",
           "description": "Behavior on decryption failure",
-          "enum": ["error", "warn", "skip"],
+          "enum": [
+            "error",
+            "warn",
+            "skip"
+          ],
           "default": "error"
         }
       }
@@ -139,13 +154,22 @@
             },
             "symlink_strategy": {
               "type": "string",
-              "enum": ["prefer", "avoid", "always"],
+              "enum": [
+                "prefer",
+                "avoid",
+                "always"
+              ],
               "description": "Symlink creation strategy",
               "default": "prefer"
             },
             "conflict_policy": {
               "type": "string",
-              "enum": ["backup", "overwrite", "skip", "ask"],
+              "enum": [
+                "backup",
+                "overwrite",
+                "skip",
+                "ask"
+              ],
               "description": "How to handle file conflicts",
               "default": "ask"
             },
@@ -171,12 +195,25 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": {"type": "string"},
-                  "url": {"type": "string", "format": "uri"},
-                  "priority": {"type": "integer"},
-                  "enabled": {"type": "boolean", "default": true}
+                  "name": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "priority": {
+                    "type": "integer"
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  }
                 },
-                "required": ["name", "url"]
+                "required": [
+                  "name",
+                  "url"
+                ]
               }
             }
           }
@@ -187,18 +224,40 @@
       "type": "object",
       "description": "Writ-specific configuration (verbosity and dry_run are shared at root level). Layers are directories at ~/.local/share/devlore/writ/layers/",
       "properties": {
-        "segments": {
-          "type": "array",
-          "description": "Custom segment names (beyond built-in OS, DISTRO, ARCH)",
-          "items": {
+        "scopes": {
+          "type": "object",
+          "description": "Scopes, as name to root directory (beyond built-in Home, System, ProgramData, ProgramFiles, ProgramFilesX86). A scope is a named execution context: a directory in the root of a layer repository, deployed beneath the root named here. A builtin's key overrides its default root; for Home that is the only way to redirect a deployment, since the home directory is resolved from the account database. Builtin names are reserved on every platform, so introducing ProgramFiles on Unix is an error.",
+          "additionalProperties": {
             "type": "string",
-            "description": "Segment name in UPPERCASE (e.g., ROLE, SITE)"
+            "description": "The directory this scope deploys beneath."
           },
-          "examples": [["ROLE", "SITE"]]
+          "examples": [
+            {
+              "Staging": "~/staging/root",
+              "Home": "~/staging/home"
+            }
+          ]
+        },
+        "segments": {
+          "type": "object",
+          "description": "Custom segments, as name to value (beyond built-in OS, DISTRO, ARCH). A key introduces the segment name; its value sets the segment. A key with no value declares a segment that is set elsewhere -- by WRIT_SEGMENT_<NAME> or --segment NAME=value. A directory suffix matches only a segment that has a value.",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The segment's value, or null to declare it and set it elsewhere."
+          },
+          "examples": [
+            {
+              "ROLE": "desktop",
+              "SITE": null
+            }
+          ]
         },
         "vars": {
           "type": "object",
-          "description": "Template variables and segment value overrides",
+          "description": "Template variables. Segment values live under segments, and scope roots under scopes; this holds what templates interpolate and nothing else.",
           "properties": {
             "USER_NAME": {
               "type": "string",


### PR DESCRIPTION
The plan document for #762. Review here; the implementation follows in this branch, documents first.

Advances #762.

## What is settled

**Four operations, named once** — `deploy`, `reconcile`, `upgrade`, `decommission` — in both `lore` and
`writ`. No program has a `status` command; `writ`'s is the only `Use: "status"` in `cmd/`.

**The rename is a reversion.** `writ reconcile` was replaced by `writ status` at phase-8 step 47, because
*"'Reconcile' promises mutation the command does not perform"* (`writ-deploy-family.md:136`). Reconcile now
reports **and** repairs, so the reason has lapsed and the name returns.

**`scope` names an execution context; `target` names a path.** The collision is four lines apart in one file:

```go
// builder.go:49
// Target is the absolute path to the target file.
// builder.go:57
// TargetName is the target scope ("System" or "Home").
```

`TargetName` → `ScopeName` (16), `TargetSpec` → `ScopeSpec` (4), `TargetOrder` → `ScopeOrder` (3),
`TargetHome`/`TargetSystem` → `ScopeHome`/`ScopeSystem` (10). `TargetRoot` (52) and `Entry.Target` (6) are
untouched — a scope *has* a target root; a file *has* a target path.

**Five builtin scopes**, reserved on every platform, defined on some. `LOCALAPPDATA` and `APPDATA` excluded
for different reasons — Local has no supported relocation, Roaming is redirectable under domain policy and a
builtin would hardcode what a policy may override.

**Data is skipped, instructions are refused.** A `ProgramFiles/` directory on Unix is skipped silently;
`--scope=ProgramFiles` on Unix errors; defining a custom scope by a builtin's name errors on any platform.

## Three documents describe code that does not exist

`RootReader`, `RootReaderWriter`, `confinedRoot`, `rootBase`, `OpenWritableUnsandboxed` — **zero occurrences**
in the tree. `2.4` calls the System graph unconfined in three places; `4.4` §4 tabulates all three removed
types; `5.3:225` describes a removed test mode.

## Open questions, in the plan

1. `4.4` §4 "Mode Switch" — rewrite, or delete and renumber?
2. The Windows `System` root — fixed here or in #761?

## Sequencing note

Phase 3 renames `TargetHome`/`TargetSystem`; #761 fixes what they *return*. Whichever lands second rebases
onto the other's names. #761 first is the cheaper order — it is smaller and a live defect.
