### PR TITLE
The CLI specification describes the code that exists

### DIFF
--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -23,7 +23,10 @@ The suite already has the mechanism —
 statement that using it is mandatory, or a `--output` flag to say *where*. Both absences are why forty-five of
 forty-six commands improvise.
 
-## 1. Scope and principles
+## 1. What this governs
+
+*(Titled for what it does rather than "Scope", because a **scope** is now a named execution context --
+`Home`, `System`, `ProgramFiles` -- and one document should not spend the word twice. See §4.)*
 
 This document governs four binaries -- `devlore-test`, `lore`, `star`, and `writ`. They **will use the
 same common flag set**, in full: every flag in §4 is available on every command of all four.
@@ -146,6 +149,10 @@ repurpose them:
 | `--jq` | | string | jq expression, applied after `--filter` |
 | `--output` | `-o` | string | How the result is rendered; `NAME` or `NAME=ARGUMENT`. §7, §8 |
 | `--store` | | string | The execution store's root. §6 |
+
+`--scope` is reserved too, and is not in that table because it is not shared: only `writ` binds it, and a
+name reserved for one program is a different promise from one every program keeps. No other program may
+take the name for something else. See §4.1.
 
 `--output` / `-o` selects the **rendering**, matching `az` and `kubectl`. It is deliberately not a
 destination: a user typing `-o json` must never be silently creating a file named `json`. See Design
@@ -280,7 +287,7 @@ the same expectation `gcloud` states by requiring a projection for its `csv` and
 intended use is `--jq` first:
 
 ```
-writ status --jq '.entries[] | "\(.target) is \(.state)"' -o value
+writ reconcile --jq '.entries[] | "\(.target) is \(.state)"' -o value
 ```
 
 **One table formatter, no exceptions.** `table` is a general rendering and belongs in `pkg/result` like the
@@ -663,7 +670,7 @@ Current state, 2026-08-30. Two of the four in-scope programs register the common
 | `star` | no | a **second `cli` package** of its own -- see below |
 | `devlore-docs` | not in scope | — |
 
-`writ status` is bridged rather than converted, and the bridge is one bool: `cfg.JSONOutput` reads
+`writ reconcile` is bridged rather than converted, and the bridge is one bool: `cfg.JSONOutput` reads
 `outputOptions.Format == "json"` (`cmd/writ/writ/config.go:160`) while the report still renders itself.
 Measured 2026-08-30, **one of eight formats works**:
 
@@ -677,7 +684,7 @@ Three of those are worse than ignored. `-o none` prints ten lines where its whol
 rejects it.
 
 **And the value is never validated** ([#754](https://github.com/NobleFactor/devlore-cli/issues/754)).
-Because the format string never reaches [FormatterByName], any string is accepted: `writ status -o bogus`
+Because the format string never reaches [FormatterByName], any string is accepted: `writ reconcile -o bogus`
 prints the dashboard and exits 0, where `devlore-test -o bogus` reports `unknown formatter "bogus"; expected
 one of csv, json, list, none, table, template=BODY, value, yaml`. A typo is silently honored as a request for
 the default. That is a second defect, distinct from the seven wrong renderings: one does the wrong thing, the
@@ -688,7 +695,7 @@ value.
 ([#753](https://github.com/NobleFactor/devlore-cli/issues/753)), and that is the severe face of the same
 cause. `outputOptions` is read in exactly two places: `config.go:160` takes `.Format`, and `commands.go:302`
 hands the struct to [BuildPipeline] in `runVerify`. Meanwhile `readback.go` genuinely reads [TracesDir] and
-[GraphsDir] to fold runs into the inventory. So `writ status --store <elsewhere>` reads the default store and
+[GraphsDir] to fold runs into the inventory. So `writ reconcile --store <elsewhere>` reads the default store and
 reports the result as compliance -- not a formatting nicety, but the wrong data, silently.
 
 **The shared cause is a flag registered on a root that no leaf consumes.** `root.go:49` calls

--- a/docs/architecture/4.4-root-path-triad.md
+++ b/docs/architecture/4.4-root-path-triad.md
@@ -55,15 +55,16 @@ See also:
                                               │          │           │              │
                             ┌─────────────────┘          │           └───────────┐  │
                             ▼                            ▼                       ▼  │
-                 ┌───────────────────┐  ┌───────────────────────┐  ┌──────────────┐│
-                 │   confinedRoot    │  │     RootReader        │  │RootReader-   ││
-                 │                   │  │                       │  │   Writer     ││
-                 │ inner: *os.Root   │  │ rootBase{name}        │  │              ││
-                 │                   │  │                       │  │ RootReader   ││
-                 │ uses p.Rel() ────▶│  │ uses p.Abs() via os.* │  │ + os.* write ││
-                 │                   │  │ writes → ErrReadOnly  │  │   overrides  ││
-                 │ EXECUTION         │  │ PLANNING              │  │ TESTING      ││
-                 └───────────────────┘  └───────────────────────┘  └──────────────┘│
+                 ┌───────────────────┐  ┌───────────────────────┐               │
+                 │   sandboxedDir    │  │ sandboxedScratchDir   │               │
+                 │  OpenExisting     │  │  OpenScratch          │               │
+                 │                   │  │                       │               │
+                 │ inner: *os.Root   │  │ inner: *os.Root       │               │
+                 │ uses p.Rel() ────▶│  │ uses p.Rel()          │               │
+                 │                   │  │ removes its tree on   │               │
+                 │ lifetime: the     │  │ Close                 │               │
+                 │   caller's        │  │                       │               │
+                 └───────────────────┘  └───────────────────────┘               │
                                                                                    │
                             ┌──────────────────────────────────────────────────────┘
                             ▼
@@ -75,8 +76,10 @@ See also:
                  │  abs   string   ← derived         │
                  │                                  │
                  │  Root()   → root                 │
-                 │  Rel()    → rel    (confined I/O)│
-                 │  Abs()    → abs  (unconfined I/O)│
+                 │  Rel()    → rel  (slash form,    │
+                 │            serializes, io/fs)    │
+                 │  Abs()    → abs  (OS-native,     │
+                 │            direct filesystem I/O)│
                  │  String() → abs       (display)  │
                  │                                  │
                  │  MarshalJSON   → {root, rel}     │
@@ -103,8 +106,12 @@ See also:
 ```
 
 **Root** — Factory and engine. Produces Path via `NewPath`. Consumes Path
-for all I/O operations. The interface has three implementations that
-determine the access mode; provider code never knows which one is active.
+for all I/O operations. Two implementations, differing in lifetime rather
+than in access: `OpenExisting` anchors at a directory the caller owns,
+`OpenScratch` removes its tree on `Close`. Both sandbox reads and writes to
+their root, by the kernel, through `*os.Root` — so provider code never
+branches on which is active, and there is no access mode to select
+([4.5](4.5-fsroot-variants.md)).
 
 **Path** — Universal currency. An immutable value type carrying
 `{root, rel, abs}` where `abs` is derived as `filepath.Join(root, rel)`.
@@ -141,8 +148,8 @@ producing its own Paths for the `.devlore/recovery/` directory.
      │                         │  root.MkdirAll(dir)  │                   │
      │                         │─────────────────────▶│                   │
      │                         │                      │◀── p.Rel() ──────│
-     │                         │                      │    or p.Abs()     │
-     │                         │                      │  (mode-dependent) │
+     │                         │                      │   (always; the    │
+     │                         │                      │    kernel bounds) │
      │                         │                      │                   │
      │                         │  root.Rename(p,       │                   │
      │                         │    recoveryPath)     │                   │
@@ -167,28 +174,7 @@ During compensation, the provider passes the original Path and the recovery
 ID back — RecoverySite reconstructs the recovery Path and renames the file
 back.
 
-## 4. Mode Switch
-
-The mode switch is invisible to providers and RecoverySite. Swap the Root
-implementation at startup and the entire system changes behavior:
-
-| Implementation | Path dispatch | Confinement | Use case |
-| --- | --- | --- | --- |
-| `confinedRoot` | `p.Rel()` → `*os.Root` | Kernel-enforced | Execution |
-| `RootReader` | `p.Abs()` → `os.*` | None (reads only) | Planning |
-| `RootReaderWriter` | `p.Abs()` → `os.*` | None | Testing |
-
-The composition chain — `rootBase` → `RootReader` → `RootReaderWriter` —
-means `RootReaderWriter` inherits all read methods from `RootReader` and
-overrides only the write stubs. `RootReader` returns `ErrReadOnly` for
-all write operations, enforcing the read-only planning contract at the
-application layer.
-
-`confinedRoot` wraps `*os.Root` (Go 1.24). The kernel blocks symlink
-escapes and `..` traversal. Paths outside the authority boundary are
-rejected. This is the only implementation used in production execution.
-
-## 5. Path as Serialization Boundary
+## 4. Path as Serialization Boundary
 
 Path serializes as `{root, rel}`. Abs is derived on deserialization:
 
@@ -206,12 +192,14 @@ Recovery IDs are opaque strings (UUIDs), not Paths. The RecoverySite
 owns the `.devlore/recovery/` layout. Providers store the ID; only
 RecoverySite knows how to turn it back into a Path.
 
-## 6. Design Properties
+## 5. Design Properties
 
-1. **Mode-agnostic providers.** Provider code calls `root.ReadFile(p)`,
-   `root.Stat(p)`, `site.ArchiveFile(p)`. It never branches on the Root
-   implementation. The caller (executor, planner, test harness) picks the
-   implementation at startup.
+1. **Implementation-agnostic providers.** Provider code calls
+   `root.ReadFile(p)`, `root.Stat(p)`, `site.ArchiveFile(p)`. It never
+   branches on the Root implementation, and there is nothing to branch on:
+   both sandbox identically and differ only in whether `Close` removes the
+   tree. The caller (executor, planner, test harness) chooses a lifetime,
+   not an access level.
 
 2. **Path is immutable.** Once created, a Path's fields never change.
    It is safe to store, serialize, pass across goroutines, and embed in


### PR DESCRIPTION
Closes #766.

## `4.4` described a mode switch that no longer exists

`RootReader`, `RootReaderWriter`, `confinedRoot`, `rootBase`, and `OpenWritableUnsandboxed` have **zero
occurrences** in the tree. `fsroot` exports `OpenExisting` and `OpenScratch`, and both sandbox.

Deleting §4 was the ruling; the section was not the whole of it. The removed types also appeared in §1's
diagram, §2's prose, §3's data flow, and §6's first design property — so deleting §4 alone would have
stranded four dangling references.

| Where | Now |
| --- | --- |
| §1 diagram | two boxes, `sandboxedDir` and `sandboxedScratchDir`, differing in **lifetime** |
| §2 Roles | two implementations, no access mode to select |
| §3 flow | "(mode-dependent)" → "(always; the kernel bounds)" |
| §4 | deleted; §5 and §6 renumber |
| §5 first property | the caller chooses a lifetime, not an access level |

**The `op.Path` box had its accessors backwards.** `fsroot.go:627`: `Rel` is *"the root-relative path used
for sandboxed I/O … the half that serializes"*, and *"direct filesystem I/O flows through `Path.Abs`, which
stays OS-native."* The diagram called `Abs` "unconfined I/O" — a confinement that no longer varies, and not
what the accessor is for.

## "Scope" was spent twice

§1 was *"Scope and principles"*, and a **scope** is now a named execution context. Retitled *"What this
governs"*, with a note saying why.

## `--scope` stays out of §4's reserved table

That table is the **shared** set, and only `writ` binds `--scope`. A name reserved for one program is a
different promise from one every program keeps. The paragraph saying so is the point — without it, a reader
comparing the table against `writ --help` finds a flag it omits and cannot tell whether that is deliberate.

## `writ status` → `writ reconcile`

Where the text describes the command. The reference at §3.1 stays: it recounts the phase-8 rename, and
rewriting history to match the present is how a document stops explaining itself.

## Rescoped

Regenerating `docs/cli/**` moved to #762. It is a consequence of renaming the command, so it belongs with the
rename in that plan's Phase 2 — leaving it here made #766 unclosable without work it does not own.
