### PR TITLE
Settle writ reconcile's surface, and stop teaching writ status

### DIFF
--- a/docs/architecture/5.1-reconciliation.md
+++ b/docs/architecture/5.1-reconciliation.md
@@ -7,10 +7,14 @@
 > realized by other means, recorded below; the proposal is preserved as an explicitly unimplemented appendix.
 > Companion: [`5.1-reconciliation.status.md`](5.1-reconciliation.status.md).
 >
-> **Superseded in part, 2026-08-31.** The command is named `reconcile` again, and reconcile **repairs as well
-> as reports**. Step 47 renamed it to `writ status` because *"'Reconcile' promises mutation the command does
-> not perform"* — a reason that lapses the moment the mutation is built. The "no `--fix`" rule below is
-> therefore the stale claim, not the settled one. See
+> **Superseded in part, 2026-08-31.** The command is named `reconcile` again, and reconcile **repairs as
+> well as reports**. Step 47 renamed it to `writ status` because *"'Reconcile' promises mutation the
+> command does not perform"* — a reason that lapses the moment the mutation is built.
+>
+> The "no `--fix`" rule below is therefore no longer the whole truth. It is **not** replaced by a `--fix`
+> flag: `writ reconcile` produces a report and takes no command flags, only the globals. The surface for
+> selecting repair is deferred to the reconciliation epic and is undesigned. What each finding names in
+> its `Repair` field remains how a repair is reached today. See
 > [`docs/plans/feature/762-lifecycle-scopes.md`](../plans/feature/762-lifecycle-scopes.md).
 
 ## Governing Principle

--- a/docs/plans/doc/772-reconcile-surface.md
+++ b/docs/plans/doc/772-reconcile-surface.md
@@ -1,0 +1,160 @@
+---
+title: "740 and 762 disagree on writ reconcile's surface"
+issue: https://github.com/NobleFactor/devlore-cli/issues/772
+status: in-progress
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Plan: Bring 740 and 762 into agreement on `writ reconcile`
+
+## Summary
+
+Two plans describe the same command differently: one records flags it will not have, and both still teach
+`writ status`, a command being retired rather than modernized. This settles the surface, removes the
+flags, and corrects the vocabulary everywhere it appears.
+
+## Goals
+
+1. **State the settled surface once**, in the plan that owns the command.
+2. **Remove the flags that will not exist**, and say why the selector is deferred rather than leaving a
+   gap someone fills with a guess.
+3. **Correct the terminology wherever it appears.** A document that teaches `writ status` teaches a
+   command that will not exist.
+
+## The settled surface
+
+`writ reconcile` **produces a report.** It has **no command flags.** It takes the globals —
+`--output` / `-o`, `--filter`, `--jq`, `--store`, `--dry-run` — and must utilize all of them faithfully.
+
+The selector between fix, diff, and summary behaviors is **deferred to the reconciliation epic** and is
+not designed here.
+
+### What the report carries
+
+One JSON document, four sections:
+
+| Section | What it is |
+| --- | --- |
+| `entries[]` | **the delta** — the deployed inventory classified against the live filesystem |
+| `layers[]` | the registered layer tree: name, path, state (`absent`/`directory`/`link`/`broken-link`), resolved target |
+| `packages[]` | the package operations writ's runs performed, as fact-of-record |
+| `health` | the store's self-report: runs folded, and missing-piece findings |
+
+Each entry is classified by one of eight states — `Linked`, `Copied`, `Missing`, `Conflict`, `Orphan`,
+`Stale`, `Modified`, `ModifiedOrStale` — and carries `Repair`, naming the lifecycle command that fixes
+that finding.
+
+### Why the selector is deferred, and a caution for whoever designs it
+
+Two of the three candidate views are **already projections of the one document**: the diff is
+`--jq '.entries'` and the history is `--jq '.packages'`. Those are stage 2 of the pipeline #740 landed,
+and the reserved set already carries `--jq` and `--filter` to do that selection.
+
+Adding `--diff` and `--history` flags would give two ways to select a subset of the same document, which
+will drift. Only the repair half is genuinely new, because it is a mutation rather than a projection —
+and the mutation axis already has a global in `--dry-run`, so a second flag on that axis needs to say
+how the two compose.
+
+Recorded here so the reconciliation epic starts from this rather than rediscovering it.
+
+## Current State
+
+### Flags that will not exist
+
+| Site | Says | Why it is wrong |
+| --- | --- | --- |
+| `762:51` | `writ reconcile [--drift] [--fix] [--json] [<project>...]` | none of the three will exist — `--json` is replaced by the shared `-o`, and the other two are the deferred selector under another name |
+| `762:96` | "`5.1`'s 'there is no `--fix`' is retired as the stale claim it is" | overstated — reconcile will repair, but has no `--fix` and the surface is undecided |
+| `5.1:12` | the same overstatement | overstated |
+
+### Terminology: `writ status` in 740
+
+Eight sites. Six are the command's name and change outright; two are not terminology at all:
+
+| Site | Change | Kind |
+| --- | --- | --- |
+| `740:114` | the flag-inventory row | command name |
+| `740:171` | "which is why `writ status` and `writ verify` cannot render yaml" | command name |
+| `740:231` | "`writ status` honors one of eight formats" | command name |
+| `740:237` | "`writ status -o bogus` prints the dashboard" | command name |
+| `740:242` | "`writ status --store <elsewhere>`" | command name |
+| `740:365` | test row 6 | command name |
+| `740:212` | `cmd/writ/writ/status/report.go` | **a path** — the file on disk today |
+| `740:27` | "this epic rewrites `status/report.go` before #762 moves it" | **a claim** — false, and rewritten rather than renamed |
+
+**The path keeps both forms.** Writing `reconcile/report.go` before the rename sends a reader to a path
+that does not exist; writing only `status/` teaches the retired name. It is recorded as
+`cmd/writ/writ/status/report.go` → `reconcile/` under #762 — accurate now and after.
+
+**The measurements keep their date, not their vocabulary.** Lines 231–242 record what was found on
+2026-08-30, when the command was named `writ status`. The finding survives the rename; the name does not.
+One dated note at the measurement block says so, rather than seven caveats scattered through the text.
+
+## Implementation Phases
+
+### Phase 1: 762 — the flags go (status: complete)
+
+- [x] Delete the `[--drift] [--fix] [--json]` shape at `:51`, keeping the historical quotation that
+      explains why the command was renamed to `status` and why that reason lapsed
+- [x] Rewrite Requirement 2 to state the settled surface: a report, no command flags, the globals used
+      faithfully, the selector deferred
+- [x] Add the caution above — that diff and history are already `--jq` projections
+
+### Phase 2: 5.1 — the `--fix` note (status: complete)
+
+- [x] `5.1:12` brought in line: reconcile will repair, it has no `--fix`, and the surface is undecided
+
+### Phase 3: 740 — the vocabulary corrected (status: complete)
+
+- [x] Six command-name sites renamed: `:114`, `:171`, `:231`, `:237`, `:242`, `:365`
+- [x] `:212` records both forms — the path today, and where #762 moves it
+- [x] `:27` rewritten: the work lands as `writ reconcile`, so the ordering it asserts does not hold
+- [x] One dated note at the measurement block, recording that the measurements predate the rename
+
+**Files**:
+
+- `docs/plans/feature/762-lifecycle-scopes.md` - Modify
+- `docs/architecture/5.1-reconciliation.md` - Modify
+- `docs/plans/feature/740-cli-output-conventions.md` - Modify
+
+## Test Plan
+
+No code. The claims are verifiable by search.
+
+| # | What it proves | Level | Fails when |
+| --- | --- | --- | --- |
+| 1 | No plan records a flag `writ reconcile` will not have | search | `--drift`, `--fix` or `--json` appears as part of its surface rather than as history |
+| 2 | The globals commitment is stated where the command is owned | search | 762 describes the surface without naming `-o`, `--filter`, `--jq`, `--store`, `--dry-run` |
+| 3 | No document teaches `writ status` as a live command | search | `writ status` appears outside a historical quotation or a path |
+| 4 | The path is findable both before and after the rename | search | `:212` names only one of the two forms |
+
+**Not covered:** whether the deferred selector is designed correctly, because it is not designed. The
+caution in Phase 1 is the only thing this plan says about it.
+
+## Migration Path
+
+None. Documents only.
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `docs/plans/doc/772-reconcile-surface.md` | Create | This plan |
+| `docs/plans/feature/762-lifecycle-scopes.md` | Modify | The settled surface; flags removed |
+| `docs/architecture/5.1-reconciliation.md` | Modify | The `--fix` overstatement |
+| `docs/plans/feature/740-cli-output-conventions.md` | Modify | Terminology, the path, the ordering claim |
+
+## Related Documents
+
+- [`762-lifecycle-scopes.md`](../feature/762-lifecycle-scopes.md) — thread 3, which owns the command
+- [`740-cli-output-conventions.md`](../feature/740-cli-output-conventions.md) — thread 1, the flag set
+- [`5.1-reconciliation.md`](../../architecture/5.1-reconciliation.md) — the design of record
+- Issue [#772](https://github.com/NobleFactor/devlore-cli/issues/772)
+
+## Open Questions
+
+- [ ] Does the repair half become a mode of `reconcile`, or stay as the named commands each `Entry`
+      already points at in its `Repair` field? `writ-deploy-family.md:136` chose the latter deliberately
+      — *"no `--fix`: the repair for each finding is named instead"* — and that is what the tree
+      implements today. This is bigger than flag syntax and belongs to the reconciliation epic.

--- a/docs/plans/feature/740-cli-output-conventions.md
+++ b/docs/plans/feature/740-cli-output-conventions.md
@@ -23,9 +23,9 @@ This plan is **thread 1 of four**, worked in order: this epic, then resource man
 (`Epic:ResourceModel`), then the writ lifecycle surface ([#762](https://github.com/NobleFactor/devlore-cli/issues/762)),
 then unified configuration ([#441](https://github.com/NobleFactor/devlore-cli/issues/441), planned at
 [441-unified-configuration.md](441-unified-configuration.md)). Threads 1 and 3 were previously
-entangled -- #762 renames the package this epic's next phase rewrites -- and are now separated. Doing this
-epic first means `status/report.go` is rewritten before #762 moves it; `git mv` still records a clean
-rename, so the cost is small.
+entangled -- #762 renames the command this epic's next phase rewrites. The work lands as
+`writ reconcile`: the rename is part of it, not a later step, so this epic's writ phase and #762's phase 2
+are one piece of work rather than two adjacent ones.
 
 **Four items remain**, in the epic's own order:
 
@@ -111,7 +111,7 @@ devlore-test's stream routing all sit outside it: there was nothing to conform t
 | `lore bundle` | `--output, -o <path>` | destination outside the convention |
 | `lore onboard` | `--output <dir>` + `--format` | own `--format`, own destination |
 | `lore list` | `--format table\|manifest\|json` | own `--format`, values differ |
-| `writ status` | `--json` (**bool**) | a boolean, not a format |
+| `writ reconcile` | `--json` (**bool**) | a boolean, not a format |
 | `writ verify` | `--json` (**bool**) | a boolean, not a format |
 | `writ migrate` | `--format json\|yaml\|text` | own `--format`; help text corrupted (#739) |
 | `devlore-test run` | `--output stream=dest` x3, `--receipt-format` | stream routing; a second format flag |
@@ -168,8 +168,8 @@ no command registers an output flag of its own.
 
 ### Requirement 5: No boolean format flags
 
-`--json` is replaced by `--output json`. A boolean cannot express a third format, which is why `writ status`
-and `writ verify` cannot render yaml today.
+`--json` is replaced by `--output json`. A boolean cannot express a third format, which is why
+`writ reconcile` and `writ verify` cannot render yaml today.
 
 ## Implementation Phases
 
@@ -209,7 +209,7 @@ the same. The real figure is **30 call sites**:
 
 | Location | Calls | What it is |
 | --- | --- | --- |
-| `cmd/writ/writ/status/report.go` | 22 `fmt.Print*` | the human status report |
+| `cmd/writ/writ/status/report.go` (`reconcile/` under #762) | 22 `fmt.Print*` | the reconcile report |
 | `cmd/writ/writ/verify/verify.go` | 2 `fmt.Print*` | now removed with `presentReport` |
 | `deploy`, `decommission`, `upgrade`, `secret` | 4 `SerializeGraphs(os.Stdout, ...)` | the dry-run plan dump |
 | `cmd/writ/writ/migrate/session.go` | 1 `os.Stdout` | TUI session output |
@@ -228,18 +228,20 @@ cells. Legible for `list`, useless for `table`. Whether that is acceptable, or w
 case for a sectioned object, is a design question for after the pipeline is wired. Wiring is not blocked on
 it: `-o json`, `-o yaml`, `-o none`, `--jq`, and `--filter` all become correct immediately.
 
-**Measured 2026-08-30, before starting.** `writ status` honors one of eight formats. `-o json` produces
+**Measured 2026-08-30, before starting**, when the command was named `writ status`; #762 renames it to
+`writ reconcile`, which is what it is called throughout below. `writ reconcile` honors one of eight
+formats. `-o json` produces
 JSON; `yaml`, `table`, `list`, `csv`, `value`, `none`, and `template=BODY` all produce the same
 byte-identical human dashboard. `-o none` prints ten lines where its contract is silence, and `-o yaml`
 emits text a parser fails on. The bridge is one bool at `cmd/writ/writ/config.go:160`.
 
 The format value is also never validated (#754), because it never reaches `FormatterByName`:
-`writ status -o bogus` prints the dashboard and exits 0, and so does every writ command but `verify`. That is
+`writ reconcile -o bogus` prints the dashboard and exits 0, and so does every writ command but `verify`. That is
 a second defect, distinct from the wrong renderings -- one does the wrong thing, the other accepts wrong
 input.
 
 `--store` is read nowhere in writ at all (#753), which is the severe face of the same cause. `readback.go`
-reads `TracesDir()` and `GraphsDir()` to fold runs, so `writ status --store <elsewhere>` reports on the
+reads `TracesDir()` and `GraphsDir()` to fold runs, so `writ reconcile --store <elsewhere>` reports on the
 default store as though it had complied -- the wrong data rather than the wrong shape.
 
 The shared cause is a flag registered on a root that no leaf consumes. `root.go:49` registers the whole set,
@@ -362,7 +364,7 @@ set of programs that route through it -- measured, not assumed, in §15.
 | 3a | A relocated store keeps its run index and checksum keying | unit | The store is treated as a dump dir |
 | 4 | A trace in a relocated store still resolves to its definition | unit | `GraphChecksum` ties break |
 | 5 | Every format value round-trips through the pipeline | unit | A formatter is unregistered |
-| 6 | `-o json` and `-o yaml` both work on `writ status` | unit | `--json` boolean returns |
+| 6 | `-o json` and `-o yaml` both work on `writ reconcile` | unit | `--json` boolean returns |
 | 6a | `-o none` emits nothing on stdout, errors still on stderr | unit | `none` renders anyway |
 | 7 | Narration appears on stderr while stdout holds only the result | unit | A `cli.Note` reaches stdout |
 | 8 | No command package writes to `os.Stdout` directly | unit | A direct write is added |

--- a/docs/plans/feature/762-lifecycle-scopes.md
+++ b/docs/plans/feature/762-lifecycle-scopes.md
@@ -48,8 +48,10 @@ phase-8 step 47. From `writ-deploy-family.md:136`:
 > … "reconcile" retires entirely — no `--fix`: the repair for each finding is [named] instead.
 
 Reconcile now reports **and** repairs (ruled 2026-08-31), so the promise will be kept and the name returns.
-The original shape is recorded at `writ-deploy-family.md:31`:
-`writ reconcile [--drift] [--fix] [--json] [<project>...]`.
+
+`writ-deploy-family.md:31` records an original shape carrying `--drift`, `--fix` and `--json`. **None of
+those three survives.** `--json` is replaced by the shared `--output` / `-o` (#740); the other two are the
+deferred selector under earlier names.
 
 ### The vocabulary collides in one file, four lines apart
 
@@ -90,10 +92,26 @@ Zero occurrences in the tree of `RootReader`, `RootReaderWriter`, `confinedRoot`
 `deploy`, `reconcile`, `upgrade`, `decommission`, in both programs. No `status` command anywhere. The
 retirement is by deletion — no alias, no hidden command (§13).
 
-### Requirement 2: Reconcile reports and repairs
+### Requirement 2: Reconcile produces a report, and takes no command flags
 
-The command answers "what changed since deploy and some number of upgrades", like `git diff`; the repair
-half is chartered, not built here. `5.1`'s "there is no `--fix`" is retired as the stale claim it is.
+`writ reconcile` **produces a report** answering "what changed since deploy and some number of upgrades",
+like `git diff`. The repair half is chartered, not built here.
+
+**It has no command flags.** It takes the globals — `--output` / `-o`, `--filter`, `--jq`, `--store`,
+`--dry-run` — and must utilize all of them faithfully. A command that registers a flag its root already
+provides is the defect #740 exists to stop.
+
+The selector between fix, diff and summary behaviors is **deferred to the reconciliation epic**. `5.1`'s
+"there is no `--fix`" is no longer the whole truth — reconcile will repair — but neither is a `--fix`
+flag settled: today there is none, and the surface for choosing is undesigned.
+
+**A caution for whoever designs it.** Two of the three candidate views are already projections of the one
+document the report produces: the diff is `--jq '.entries'`, and the history is `--jq '.packages'`. Those
+are stage 2 of the pipeline #740 landed, and `--jq` and `--filter` are already in the reserved set.
+Adding `--diff` and `--history` flags would create a second way to select a subset of the same document,
+and the two will drift. Only the repair half is genuinely new, because it is a mutation rather than a
+projection — and the mutation axis already carries `--dry-run`, so anything added there has to say how
+the two compose.
 
 ### Requirement 3: Reconcile is valid only after deployment
 


### PR DESCRIPTION
Closes #772

Two plans described the same command differently. One recorded flags it will not have, and both still
taught `writ status` — a command being retired, not modernized. **Documents only.**

## The settled surface

`writ reconcile` **produces a report.** It has **no command flags.** It takes the globals — `--output` /
`-o`, `--filter`, `--jq`, `--store`, `--dry-run` — and must utilize all of them faithfully. The selector
between fix, diff and summary behaviors is **deferred to the reconciliation epic** and is not designed
here.

## The flags go

`762:51` recorded the shape as `writ reconcile [--drift] [--fix] [--json] [<project>...]`. None of the
three survives: `--json` is replaced by the shared `-o`, and the other two are the deferred selector
under earlier names.

`762:96` and `5.1:12` both said 5.1's *"there is no `--fix`"* was retired as a stale claim. That
overstates it — reconcile will repair, but there is no `--fix` today and the surface is undecided. Both
are corrected.

## A caution, recorded where the selector will be designed

Two of the three candidate views are **already projections of the one document**:

| View | Already is |
| --- | --- |
| diff | `--jq '.entries'` |
| history | `--jq '.packages'` |

Those are stage 2 of the pipeline #740 landed, and `--jq` and `--filter` are already reserved. Adding
`--diff` and `--history` flags would create a second way to select a subset of the same document, and the
two will drift. Only the repair half is genuinely new, because it is a mutation rather than a projection
— and `--dry-run` already owns the mutation axis.

## Terminology corrected wherever it appears

Eight sites in 740. Six are the command's name and change outright. Two are not terminology:

- **`:212` is a path.** Recorded now as `cmd/writ/writ/status/report.go` (`reconcile/` under #762), so it
  is findable before and after the rename.
- **`:27` was a false claim** about ordering, rewritten rather than renamed. The work lands **as**
  `writ reconcile`, so this epic's writ phase and #762's phase 2 are one piece of work, not two adjacent
  ones.

The measurements keep their date, not their vocabulary: lines 231–242 record what was found on
2026-08-30, and one dated note says so, rather than seven caveats through the text.

## Test plan

- [x] `./scripts/Test-GuideFrontmatter.sh` — green
- [x] No plan records a flag `writ reconcile` will not have; the surviving `--drift`/`--fix`/`--json`
      mentions are historical quotation or the explanation that they do not survive
- [x] The globals commitment is stated in 762, which owns the command
- [x] The only `writ status` left in 740 is line 231's dated note saying that is what it was called when
      measured
- [x] `:212` names both the path today and where #762 moves it
- [ ] Not covered: whether the deferred selector is designed correctly, because it is not designed

## Open question, carried in the plan

Does the repair half become a mode of `reconcile`, or stay as the named commands each `Entry` already
points at in its `Repair` field? `writ-deploy-family.md:136` chose the latter deliberately — *"no
`--fix`: the repair for each finding is named instead"* — and that is what the tree implements today.
Bigger than flag syntax; belongs to the reconciliation epic.

https://claude.ai/code/session_01SqQVFZz7AdiLZkGoAcUqRW
