### PR TITLE
lore adopts the output convention, and search stops cutting descriptions mid-rune

### DIFF
--- a/cmd/lore/lore/builder.go
+++ b/cmd/lore/lore/builder.go
@@ -629,7 +629,7 @@ func prepareScriptEnv(
 
 	thread := &starlark.Thread{
 		Name:  action.PhaseName,
-		Print: func(_ *starlark.Thread, msg string) { fmt.Printf("  [print] %s\n", msg) },
+		Print: func(_ *starlark.Thread, msg string) { cli.Note("  [print] %s", msg) },
 	}
 
 	return thread, runtime.Predeclared(), packageContext

--- a/cmd/lore/lore/commands.go
+++ b/cmd/lore/lore/commands.go
@@ -152,9 +152,10 @@ func resolvePackages(cfg *loreDeployConfig) ([]resolvedPackage, error) {
 
 	targetPlatform := detectPlatform()
 
-	fmt.Println("\nResolving packages...")
-	fmt.Printf("%-30s %-10s %-8s %s\n", "PACKAGE", "SOURCE", "CONF", "STATUS")
-	fmt.Printf("%s\n", strings.Repeat("-", 70))
+	// Narration: progress during a mutating command whose result is its exit, so every line is stderr.
+	cli.Note("Resolving packages...")
+	cli.Note("%-30s %-10s %-8s %s", "PACKAGE", "SOURCE", "CONF", "STATUS")
+	cli.Note("%s", strings.Repeat("-", 70))
 
 	var resolved []resolvedPackage
 	for _, req := range cfg.Packages {
@@ -174,7 +175,7 @@ func resolvePackages(cfg *loreDeployConfig) ([]resolvedPackage, error) {
 			featStr = " [" + strings.Join(req.Features, ", ") + "]"
 		}
 
-		fmt.Printf("%-30s %-10s %-8s %s%s\n", pkg.Name, pkg.Source, confidence, status, featStr)
+		cli.Note("%-30s %-10s %-8s %s%s", pkg.Name, pkg.Source, confidence, status, featStr)
 
 		resolved = append(resolved, resolvedPackage{
 			pkg:        pkg,
@@ -216,9 +217,9 @@ func filterLowConfidence(resolved []resolvedPackage, cfg *loreDeployConfig) ([]r
 	}
 
 	// Prompt user
-	fmt.Printf("\n⚠️  Some packages have LOW confidence (not verified to exist).\n")
-	fmt.Printf("Use --force to proceed or --known-only to skip them.\n")
-	fmt.Printf("\nProceed anyway? [y/N]: ")
+	cli.Warn("Some packages have LOW confidence (not verified to exist).")
+	cli.Warn("Use --force to proceed or --known-only to skip them.")
+	cli.Note("Proceed anyway? [y/N]")
 
 	var response string
 	//nolint:errcheck // diagnose-ignored-error: failed read cancels; see docs/architecture/2.8-eventing-infrastructure.md
@@ -235,7 +236,7 @@ func executeDeployments(ctx context.Context, resolved []resolvedPackage, cfg *lo
 		ctx = context.Background()
 	}
 
-	fmt.Println("\nDeploying packages...")
+	cli.Note("Deploying packages...")
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -350,14 +351,14 @@ configuration changes, or audit compliance.`,
 
 func newBundleCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bundle @<manifest> -o <output>",
+		Use:   "bundle @<manifest> <output>",
 		Short: "Create self-extracting deployment bundles for air-gapped environments",
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("bundle: not yet implemented")
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "", "Output bundle path")
 	cmd.Flags().String("platform", "", "Target platform (e.g., linux/fedora)")
 	cmd.Flags().StringArray("include-repo", nil, "Include repository in bundle")
 
@@ -521,40 +522,42 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Print results
-	fmt.Printf("\n%-30s %-10s %-8s %-10s %s\n", "PACKAGE", "SOURCE", "CONF", "VERSION", "DESCRIPTION")
-	fmt.Printf("%-30s %-10s %-8s %-10s %s\n",
-		strings.Repeat("-", 30), strings.Repeat("-", 10), strings.Repeat("-", 8), strings.Repeat("-", 10),
-		strings.Repeat("-", 30))
+	// The results are the result. The shared table aligns by rune and truncates nothing, which is where
+	// #741's byte-count cut goes away; `installed` is a column rather than an asterisk glued to the name.
+	return emitResult(cmd, searchRows(results))
+}
 
+// searchRow is one search result as the pipeline renders it: field names are the JSON the user sees.
+type searchRow struct {
+	Name        string `json:"name"`
+	Source      string `json:"source"`
+	Confidence  string `json:"confidence"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	Installed   bool   `json:"installed"`
+}
+
+// searchRows projects the registry's results onto the rows the pipeline renders.
+//
+// Parameters:
+//   - `results`: the registry's search results, in its order.
+//
+// Returns:
+//   - `[]searchRow`: one row per result, descriptions intact.
+func searchRows(results []lorepackage.SearchResultItem) []searchRow {
+
+	rows := make([]searchRow, 0, len(results))
 	for _, r := range results {
-		// Format confidence with color indicator
-		confStr := r.Confidence.String()
-		sourceStr := string(r.Source)
-
-		// Truncate description if too long
-		desc := r.Description
-		if len(desc) > 50 {
-			desc = desc[:47] + "..."
-		}
-
-		version := r.Version
-		if version == "" {
-			version = "-"
-		}
-
-		// Add installed indicator
-		name := r.Name
-		if r.Installed {
-			name += " *"
-		}
-
-		fmt.Printf("%-30s %-10s %-8s %-10s %s\n", name, sourceStr, confStr, version, desc)
+		rows = append(rows, searchRow{
+			Name:        r.Name,
+			Source:      string(r.Source),
+			Confidence:  r.Confidence.String(),
+			Version:     r.Version,
+			Description: r.Description,
+			Installed:   r.Installed,
+		})
 	}
-
-	fmt.Printf("\n* = installed\n")
-
-	return nil
+	return rows
 }
 
 func newListCmd() *cobra.Command {
@@ -565,8 +568,6 @@ func newListCmd() *cobra.Command {
 			return fmt.Errorf("list: not yet implemented")
 		},
 	}
-
-	cmd.Flags().String("format", "table", "Output format (table, manifest, json)")
 
 	return cmd
 }
@@ -596,7 +597,7 @@ func newUpdateCmd() *cobra.Command {
 
 func newOnboardCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "onboard --from <source>",
+		Use:   "onboard --from <source> [<dir>]",
 		Short: "Parse wiki or script and generate packages-manifest.yaml and config",
 		Long: `Parse an onboarding wiki page or setup script and generate both a
 packages-manifest.yaml file and a config/ directory with configuration files.
@@ -609,17 +610,17 @@ then 'writ adopt --from-receipt' to bring the generated config into your
 environment repository.`,
 		Example: `  lore onboard --from https://wiki.acme.com/backend-setup
   lore onboard --from ~/scripts/setup.sh
+  lore onboard --from ~/scripts/setup.sh ./packages   # write the manifest there
 
   # Full workflow:
   lore onboard --from https://wiki.acme.com/setup
   lore deploy @packages-manifest.yaml
   writ adopt --from-receipt`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: runOnboard,
 	}
 
 	cmd.Flags().String("from", "", "Source URL or file path")
-	cmd.Flags().String("output", "", "Output directory path (default: current directory)")
-	cmd.Flags().String("format", "plain", "Manifest format (plain, yaml)")
 	cmd.Flags().Bool("verbose", false, "Show AI reasoning")
 	cmd.Flags().Bool("explain", false, "Show detailed reasoning for each confidence decision")
 	cmd.Flags().Int("max-fetches", 5, "Maximum additional URLs to fetch")
@@ -629,10 +630,10 @@ environment repository.`,
 	return cmd
 }
 
-func runOnboard(cmd *cobra.Command, _ []string) error {
+func runOnboard(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
-	cfg := parseLoreOnboardConfig(cmd)
+	cfg := parseLoreOnboardConfig(cmd, args)
 
 	aiProvider, err := newOnboardProvider()
 	if err != nil {
@@ -649,7 +650,6 @@ func runOnboard(cmd *cobra.Command, _ []string) error {
 	result, err := onboard.Run(ctx, onboard.Options{
 		Source:     cfg.Source,
 		OutputDir:  cfg.OutputDir,
-		Format:     cfg.Format,
 		Verbose:    cfg.Verbose,
 		Explain:    cfg.Explain,
 		Provider:   aiProvider,
@@ -662,33 +662,38 @@ func runOnboard(cmd *cobra.Command, _ []string) error {
 
 	reportOnboardResult(result)
 
-	return writeOnboardManifest(cfg.OutputDir, result)
+	if err := writeOnboardManifest(cfg.OutputDir, result); err != nil {
+		return err
+	}
+
+	// The manifest on disk is the side effect; the discovery is the result, and the pipeline renders it.
+	return emitResult(cmd, result)
 }
 
-// parseLoreOnboardConfig reads the onboard flags into a configuration value.
+// parseLoreOnboardConfig reads the onboard flags and operand into a configuration value.
 //
 // Parameters:
 //   - `cmd`: the command whose flags [newOnboardCmd] registered.
+//   - `args`: the positional operands; the first, if present, is the output directory.
 //
 // Returns:
-//   - `*loreOnboardConfig`: the flag values, with `OutputDir` defaulted to the working directory.
-func parseLoreOnboardConfig(cmd *cobra.Command) *loreOnboardConfig {
+//   - `*loreOnboardConfig`: the values, with `OutputDir` defaulted to the working directory.
+func parseLoreOnboardConfig(cmd *cobra.Command, args []string) *loreOnboardConfig {
 
 	source, _ := cmd.Flags().GetString("from")         //nolint:errcheck // flag registered by AddCommand
-	outputDir, _ := cmd.Flags().GetString("output")    //nolint:errcheck // flag registered by AddCommand
-	format, _ := cmd.Flags().GetString("format")       //nolint:errcheck // flag registered by AddCommand
 	verbose, _ := cmd.Flags().GetBool("verbose")       //nolint:errcheck // flag registered by AddCommand
 	explain, _ := cmd.Flags().GetBool("explain")       //nolint:errcheck // flag registered by AddCommand
 	maxFetches, _ := cmd.Flags().GetInt("max-fetches") //nolint:errcheck // flag registered by AddCommand
 
-	if outputDir == "" {
-		outputDir = "."
+	// A destination is a positional operand, never a flag (10-command-line-interface.md §4).
+	outputDir := "."
+	if len(args) > 0 {
+		outputDir = args[0]
 	}
 
 	return &loreOnboardConfig{
 		Source:     source,
 		OutputDir:  outputDir,
-		Format:     format,
 		Verbose:    verbose,
 		Explain:    explain,
 		MaxFetches: maxFetches,
@@ -699,7 +704,6 @@ func parseLoreOnboardConfig(cmd *cobra.Command) *loreOnboardConfig {
 type loreOnboardConfig struct {
 	Source     string
 	OutputDir  string
-	Format     string
 	Verbose    bool
 	Explain    bool
 	MaxFetches int
@@ -815,8 +819,6 @@ func writeOnboardManifest(outputDir string, result *onboard.Result) error {
 }
 
 func newInspectCmd() *cobra.Command {
-	var opts cli.SinkOptions
-
 	cmd := &cobra.Command{
 		Use:   "inspect <package>",
 		Short: "Show detailed information about a package",
@@ -827,15 +829,13 @@ dependencies, and deployment history for a package.
 
 Output is JSON by default for scripting. Use --output for alternatives.`,
 		Example: `  lore inspect docker
-  lore inspect kubectl --format yaml
-  lore inspect docker --format '{{.ReceiverName}}\t{{.Version}}'`,
+  lore inspect kubectl -o yaml
+  lore inspect docker -o 'template={{.receiver_name}}\t{{.version}}'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("inspect: not yet implemented")
 		},
 	}
-
-	cli.AddOutputFlags(cmd, &opts)
 
 	return cmd
 }

--- a/cmd/lore/lore/commands_test.go
+++ b/cmd/lore/lore/commands_test.go
@@ -188,8 +188,6 @@ func newOnboardTestCommand(t *testing.T, args ...string) *cobra.Command {
 
 	cmd := &cobra.Command{Use: "onboard"}
 	cmd.Flags().String("from", "", "")
-	cmd.Flags().String("output", "", "")
-	cmd.Flags().String("format", "plain", "")
 	cmd.Flags().Bool("verbose", false, "")
 	cmd.Flags().Bool("explain", false, "")
 	cmd.Flags().Int("max-fetches", 5, "")
@@ -203,7 +201,8 @@ func newOnboardTestCommand(t *testing.T, args ...string) *cobra.Command {
 
 func TestParseLoreOnboardConfig_DefaultsOutputDirToWorkingDirectory(t *testing.T) {
 
-	cfg := parseLoreOnboardConfig(newOnboardTestCommand(t, "--from", "https://example.test/wiki"))
+	cmd := newOnboardTestCommand(t, "--from", "https://example.test/wiki")
+	cfg := parseLoreOnboardConfig(cmd, cmd.Flags().Args())
 
 	if cfg.OutputDir != "." {
 		t.Errorf("OutputDir = %q, want %q", cfg.OutputDir, ".")
@@ -217,23 +216,19 @@ func TestParseLoreOnboardConfig_CarriesEveryFlag(t *testing.T) {
 
 	cmd := newOnboardTestCommand(t,
 		"--from", "setup.sh",
-		"--output", "/tmp/out",
-		"--format", "yaml",
 		"--verbose",
 		"--explain",
 		"--max-fetches", "9",
+		"/tmp/out", // the destination is positional, never a flag
 	)
 
-	cfg := parseLoreOnboardConfig(cmd)
+	cfg := parseLoreOnboardConfig(cmd, cmd.Flags().Args())
 
 	if cfg.Source != "setup.sh" {
 		t.Errorf("Source = %q, want %q", cfg.Source, "setup.sh")
 	}
 	if cfg.OutputDir != "/tmp/out" {
 		t.Errorf("OutputDir = %q, want %q", cfg.OutputDir, "/tmp/out")
-	}
-	if cfg.Format != "yaml" {
-		t.Errorf("Format = %q, want %q", cfg.Format, "yaml")
 	}
 	if !cfg.Verbose {
 		t.Error("Verbose = false, want true")

--- a/cmd/lore/lore/onboard/manifest_test.go
+++ b/cmd/lore/lore/onboard/manifest_test.go
@@ -166,7 +166,7 @@ func TestGenerateManifest(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			got := generateManifest(test.discovery, test.slots, "")
+			got := generateManifest(test.discovery, test.slots)
 
 			if got != test.want {
 				t.Errorf("generateManifest() mismatch\n got: %q\nwant: %q", got, test.want)

--- a/cmd/lore/lore/onboard/onboard.go
+++ b/cmd/lore/lore/onboard/onboard.go
@@ -25,7 +25,6 @@ import (
 type Options struct {
 	Source     string                // URL or file path
 	OutputDir  string                // Output directory (default: current)
-	Format     string                // Manifest format: "plain" or "yaml"
 	Verbose    bool                  // Show AI reasoning
 	Explain    bool                  // Show detailed confidence decisions
 	Provider   model.Provider        // AI provider
@@ -142,7 +141,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	// Phase 5: Generate manifest
-	manifest := generateManifest(discovery, slots, opts.Format)
+	manifest := generateManifest(discovery, slots)
 
 	result := &Result{
 		Product:    discovery.Product,
@@ -315,7 +314,7 @@ func parseDocuments(ctx context.Context, opts Options, docs []documentContent) (
 //
 // Returns:
 //   - `string`: the generated manifest text.
-func generateManifest(discovery *discoveryResult, slots []ExtractedSlot, _ string) string {
+func generateManifest(discovery *discoveryResult, slots []ExtractedSlot) string {
 
 	var sb strings.Builder
 

--- a/cmd/lore/lore/onboard_emit_test.go
+++ b/cmd/lore/lore/onboard_emit_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+	"github.com/NobleFactor/devlore-cli/cmd/lore/lore/onboard"
+)
+
+// TestOnboardResult_EmitsThroughThePipeline pins the shape `lore onboard` now emits. Until this phase the
+// Result was narrated to stderr and stdout was silent; the file write is the side effect and the Result
+// is what -o renders. The wiring -- runOnboard handing the result to emitResult -- is two lines read by
+// eye; what this asserts is that the value renders as the discovery the user was told about, under the
+// names the JSON carries, and that -o none leaves stdout empty.
+func TestOnboardResult_EmitsThroughThePipeline(t *testing.T) {
+
+	result := &onboard.Result{
+		Product:  &onboard.ProductInfo{Name: "docker", Category: "container-runtime", Vendor: "Docker Inc."},
+		Slots:    []onboard.ExtractedSlot{{}},
+		Manifest: "packages:\n  - docker\n",
+	}
+
+	var buf bytes.Buffer
+	pipeline, err := cli.BuildPipeline(cli.SinkOptions{Format: "json"}, &buf)
+	if err != nil {
+		t.Fatalf("BuildPipeline(json): %v", err)
+	}
+	if err := pipeline.Emit(result); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	var v map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	product, _ := v["product"].(map[string]any)
+	if product["name"] != "docker" || product["vendor"] != "Docker Inc." {
+		t.Fatalf("product did not survive: %v", v["product"])
+	}
+	if slots, _ := v["slots"].([]any); len(slots) != 1 {
+		t.Fatalf("slots = %v, want one", v["slots"])
+	}
+	if v["manifest"] != result.Manifest {
+		t.Fatalf("manifest = %q, want %q", v["manifest"], result.Manifest)
+	}
+
+	buf.Reset()
+	pipeline, err = cli.BuildPipeline(cli.SinkOptions{Format: "none"}, &buf)
+	if err != nil {
+		t.Fatalf("BuildPipeline(none): %v", err)
+	}
+	if err := pipeline.Emit(result); err != nil {
+		t.Fatalf("Emit(none): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("-o none wrote %q; the file is the only output then", buf.String())
+	}
+}

--- a/cmd/lore/lore/output.go
+++ b/cmd/lore/lore/output.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+)
+
+// outputOptions is the common set as the root binds it: `--output`, `--filter`, `--jq`, `--store`. One
+// value for the process, because one cobra process runs one command tree.
+var outputOptions cli.SinkOptions
+
+// emitResult renders a command's result through the shared pipeline.
+//
+// Parameters:
+//   - `cmd`: the running command, for its output writer.
+//   - `value`: the result to render.
+//
+// Returns:
+//   - `error`: non-nil when the pipeline cannot be built or the value cannot be rendered.
+func emitResult(cmd *cobra.Command, value any) error {
+
+	pipeline, err := cli.BuildPipeline(outputOptions, cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
+
+	return pipeline.Emit(value)
+}

--- a/cmd/lore/lore/root.go
+++ b/cmd/lore/lore/root.go
@@ -49,6 +49,10 @@ What took someone hours to figure out, you get in minutes.`,
 
 	rootCmd.PersistentFlags().String("registry", "", "Registry path")
 
+	// The common set, on the root: every command of lore accepts every flag, and a fix in
+	// cmd/internal/cli reaches all of them at once (10-command-line-interface.md §4, §15).
+	cli.AddOutputFlags(rootCmd, &outputOptions)
+
 	rootCmd.AddCommand(newDeployCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newDecommissionCmd())

--- a/cmd/lore/lore/root_test.go
+++ b/cmd/lore/lore/root_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRoot_EverySubcommandAcceptsTheCommonSet pins the root registration: every command of lore accepts
+// every flag of the common set, because the set is on the root and inherited, and no command registers an
+// output flag of its own on top of it.
+//
+// Before #775 the set lived on `inspect` alone, so `lore search -o json` was an unknown flag while
+// `lore inspect -o json` was not -- the convention was learnable on one command out of fourteen.
+func TestRoot_EverySubcommandAcceptsTheCommonSet(t *testing.T) {
+
+	root := NewRootCmd()
+	if len(root.Commands()) == 0 {
+		t.Fatal("the root has no subcommands; nothing to check")
+	}
+
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		for _, sub := range cmd.Commands() {
+			for _, name := range []string{"output", "filter", "jq", "store"} {
+				if sub.InheritedFlags().Lookup(name) == nil {
+					t.Errorf("%s does not inherit --%s from the root", sub.CommandPath(), name)
+				}
+			}
+			for _, name := range []string{"output", "format", "json"} {
+				if sub.LocalFlags().Lookup(name) != nil {
+					t.Errorf("%s registers its own --%s; the common set owns that name", sub.CommandPath(), name)
+				}
+			}
+			walk(sub)
+		}
+	}
+	walk(root)
+}

--- a/cmd/lore/lore/search_test.go
+++ b/cmd/lore/lore/search_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Noble Factor. All rights reserved.
+
+package lore
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NobleFactor/devlore-cli/cmd/internal/cli"
+	"github.com/NobleFactor/devlore-cli/cmd/internal/lorepackage"
+)
+
+// TestSearchRows_KeepsMultiByteDescriptions is #741: the hand-rolled table truncated descriptions by byte
+// count -- desc[:47] -- and cut multi-byte characters mid-rune. The row is built without truncating, and
+// the shared table formatter aligns by rune, so a description survives whole.
+//
+// The description here is 47 bytes of ASCII followed by a multi-byte character, so the old cut landed
+// inside it. Red before the fix by construction: searchRows did not exist, and the loop that replaced it
+// truncated.
+func TestSearchRows_KeepsMultiByteDescriptions(t *testing.T) {
+
+	description := strings.Repeat("x", 47) + "é and more"
+	if len(description) <= 47 || len([]rune(description)) == len(description) {
+		t.Fatalf("test fixture must be longer than 47 bytes and carry a multi-byte rune")
+	}
+
+	rows := searchRows([]lorepackage.SearchResultItem{{
+		Name:        "docker",
+		Version:     "27.0",
+		Description: description,
+		Installed:   true,
+	}})
+
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Description != description {
+		t.Fatalf("description was altered:\n got %q\nwant %q", rows[0].Description, description)
+	}
+	if rows[0].Name != "docker" || !rows[0].Installed {
+		t.Fatalf("row does not carry the item: %+v", rows[0])
+	}
+
+	// And through the table: no byte of the description is lost in rendering either.
+	var buf bytes.Buffer
+	pipeline, err := cli.BuildPipeline(cli.SinkOptions{Format: "table"}, &buf)
+	if err != nil {
+		t.Fatalf("BuildPipeline: %v", err)
+	}
+	if err := pipeline.Emit(rows); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(buf.String(), description) {
+		t.Fatalf("the table cut the description:\n%s", buf.String())
+	}
+}

--- a/docs/architecture/10-command-line-interface.md
+++ b/docs/architecture/10-command-line-interface.md
@@ -158,6 +158,15 @@ take the name for something else. See §4.1.
 destination: a user typing `-o json` must never be silently creating a file named `json`. See Design
 decisions.
 
+**A destination is a positional operand, never a flag.** Ruled 2026-09-01. A command that writes a file
+or fills a directory names the place as an operand — `lore bundle @<manifest> <output>`,
+`lore onboard --from <source> [<dir>]` — the way `cp`, `aws s3 cp`, `gsutil cp`, `kubectl cp`, `tar` and `zip`
+do. The surveyed tools reach for a flag only when the output is optional *and* a file, and that flag is
+`-o` (`docker save`, `pandoc`), which this convention has already given to the rendering. So there is no
+destination flag to name: `--dest`, `--to` and `--target` were each weighed and declined, the last because
+`--target` is the name `writ` retires for `--scope`. An optional destination is an optional trailing
+positional with a stated default, as `onboard`'s directory defaults to `.`.
+
 **No boolean format flags.** `--json` is not a flag; `--output json` is. A boolean cannot express a third
 format, which is why two `writ` commands cannot emit YAML today.
 
@@ -660,14 +669,14 @@ Invariants 1 and 2 are the ones that prevent regression, because both are mechan
 
 ## 15. Per-app conformance
 
-Current state, 2026-09-01. Two of the four in-scope programs register the common set on their root, and one
-of those two consumes it everywhere.
+Current state, 2026-09-01. Three of the four in-scope programs register the common set on their root, and
+two of those three consume it everywhere.
 
 | App | Root registers the set | Remaining deviations |
 | --- | --- | --- |
 | `devlore-test` | **yes** | none |
 | `writ` | **yes** | none — #774 routed all 30 stdout sites through the sink |
-| `lore` | no | hand-rolled flags on three commands; 13 `fmt.Print`; `runSearch` (#741) |
+| `lore` | **yes** | none — #775 routed every stdout site through the sink and fixed #741 |
 | `star` | no | a **second `cli` package** of its own -- see below |
 | `devlore-docs` | not in scope | — |
 

--- a/docs/architecture/10-command-line-interface.status.md
+++ b/docs/architecture/10-command-line-interface.status.md
@@ -54,7 +54,11 @@ and two of four programs landed 2026-08-30. `devlore-test` and `writ` register t
   `SerializeGraphs` dumps are returned as the plan and rendered by `-o` (phase 3). `migrate`'s own
   `--format` is retired and its session emits through the command's pipeline (phase 3). Two in `verify`
   went earlier with `presentReport`.
-- [ ] `lore`'s remaining commands brought into agreement; the `fmt.Print` calls triaged.
+- [x] `lore`'s remaining commands brought into agreement, under #775 on 2026-09-01: the root registers the
+  set; `runSearch` renders through the shared table, which is where #741's byte-count cut went away;
+  `bundle` and `onboard` take their destination as a positional operand and `onboard`'s dead `--format` is
+  gone; `onboard` emits its result; the thirteen `fmt.Print` are four rows of a result and nine lines of
+  narration. Zero stdout writes remain.
 - [ ] `star` registers the common set and `cmd/star/cli` is deleted, which duplicates eighteen exported names
   from `cmd/internal/cli` ([#743](https://github.com/NobleFactor/devlore-cli/issues/743)).
 - [ ] The enforcement tests written — no direct `os.Stdout` write from a command package, and no command

--- a/docs/guides/lore/deploy-packages.md
+++ b/docs/guides/lore/deploy-packages.md
@@ -109,7 +109,7 @@ List the packages recorded across your deployment receipts:
 
 ```bash
 lore list
-lore list --format json
+lore list -o json
 ```
 
 Reads the pipeline receipts in `~/.local/state/lore/receipts/` and reports each
@@ -169,7 +169,7 @@ View detailed information about a deployed or available package:
 
 ```bash
 lore inspect docker
-lore inspect kubectl --format yaml
+lore inspect kubectl -o yaml
 ```
 
 Shows the resolved manifest, platform support, features, dependencies,

--- a/docs/guides/lore/registry.md
+++ b/docs/guides/lore/registry.md
@@ -38,7 +38,7 @@ View full details before installing:
 
 ```bash
 lore inspect docker
-lore inspect kubectl --format yaml
+lore inspect kubectl -o yaml
 ```
 
 Shows:

--- a/docs/plans/feature/775-lore-adoption.md
+++ b/docs/plans/feature/775-lore-adoption.md
@@ -1,7 +1,7 @@
 ---
 title: "lore: the search table, three hand-rolled flag sets, and thirteen fmt.Print adopt the convention"
 issue: https://github.com/NobleFactor/devlore-cli/issues/775
-status: draft
+status: complete
 created: 2026-09-01
 updated: 2026-09-01
 ---
@@ -29,12 +29,13 @@ This is the second item of thread 1 ([#740](https://github.com/NobleFactor/devlo
 
 | Component | Status | Notes |
 | --- | --- | --- |
-| `lore inspect` | ✅ `AddOutputFlags` | the one adopter |
-| `lore search` | ❌ hand-rolled table | `commands.go:525-556`; truncates by byte count (#741) |
-| `lore bundle` | ❌ `--output, -o <path>` | a destination, not a rendering — collides with the shared `-o` |
-| `lore onboard` | ❌ `--output <dir>` + `--format` | own `--format`, own destination |
-| `lore list` | ❌ `--format table\|manifest\|json` | own `--format`, values differ; the command is a stub |
-| thirteen `fmt.Print` | ❌ untriaged | narration and results mixed on stdout |
+| `lore inspect` | ✅ | the set is inherited from the root now; its stale `--format` examples say `-o` |
+| `lore search` | ✅ `searchRows` → `TableFormatter` | #741 fixed: nothing truncates; `TestSearchRows_KeepsMultiByteDescriptions` |
+| `lore bundle` | ✅ `bundle @<manifest> <output>` | the destination is positional |
+| `lore onboard` | ✅ `onboard --from <source> [<dir>]` | `--output` is a destination; **`--format plain\|yaml` is dead** — `generateManifest(…, _ string)` discards it and always writes `packages-manifest.yaml` |
+| `lore onboard`'s result | ✅ emitted | `onboard.Result` — product, vendor, version, complexity, concerns, slots, the manifest text — is narrated to stderr; stdout gets nothing |
+| `lore list` | ✅ | the stub's `--format` is gone |
+| thirteen `fmt.Print` | ✅ zero remain | four became the search result; nine became `cli.*` narration |
 | `TableFormatter` | ✅ in `pkg/result` | rune-aligned via `text/tabwriter`, landed in #740 phase 4 |
 
 ## Requirements
@@ -56,47 +57,79 @@ refactor.
 
 | Command | Today | Becomes |
 | --- | --- | --- |
-| `bundle` | `--output, -o <path>` | the destination is a positional or `--dest`; `-o` is the shared rendering |
-| `onboard` | `--output <dir>` + `--format` | the destination is `--dest`; `--format` is the shared `-o` |
+| `bundle` | `--output, -o <path>` | the destination is a **positional operand**: `lore bundle @<manifest> <output>`; `-o` is the shared rendering |
+| `onboard` | `--output <dir>` + `--format` | the destination is an **optional second positional** defaulting to `.`: `lore onboard --from <source> [<dir>]`; **`--format` is deleted**, not renamed — it promises a choice the code does not make |
 | `list` | `--format table\|manifest\|json` | the shared `-o`; `manifest` is a domain rendering and does not join the shared set |
 
 `lore list` is a stub returning "not yet implemented", so it adapts at no cost.
 
-### Requirement 4: Thirteen `fmt.Print` triaged
+**A destination is a positional operand, never a flag.** Ruled 2026-09-01 for the suite, and recorded in
+[10-command-line-interface.md](../../architecture/10-command-line-interface.md) §4. The prior art the
+suite is measured against reaches for a flag only when the output is optional *and* a file — `docker save
+-o`, `pandoc -o` — and that flag is `-o`, which the rendering owns. Everything else is `src dst`: `cp`,
+`aws s3 cp`, `gsutil cp`, `kubectl cp`, `tar`, `zip`. No destination flag means nothing to name and nothing
+to collide with `-o` later. `--dest`, `--to` and `--target` were weighed and declined.
+
+### Requirement 4: `onboard` emits its result
+
+`onboard` has a result value and never emits it. `onboard.Result` carries the product, vendor, version,
+complexity rating, concerns, slot count, and the generated manifest text; today every one of those is
+narrated to stderr, and stdout is silent. Under the convention the file write is the side effect, the
+`Result` is what `-o` renders, and the narration stays narration.
+
+`runOnboard` hands `result` to `emitResult` after writing the manifest. `-o json` then yields the full
+discovery; `--jq '.product'` selects it; `-o none` leaves only the file and the stderr notes. Nothing
+about the narration changes.
+
+### Requirement 5: Thirteen `fmt.Print` triaged
 
 Each call is classified — narration to `cli.*` on stderr, results to the sink — and the classification
 recorded in the commit, one line per call, so a reviewer can disagree with a specific one.
 
 ## Implementation Phases
 
-### Phase 1: The root, and `inspect` (status: not started)
+### Phase 1: The root, and `inspect` (status: complete)
 
-- [ ] `AddOutputFlags` on the root; removed from `inspect`
-- [ ] Test: every `lore` subcommand accepts `-o`, `--jq`, `--filter`, `--store`
+- [x] `AddOutputFlags` on the root; removed from `inspect`
+- [x] Test: every `lore` subcommand accepts `-o`, `--jq`, `--filter`, `--store`
 
-### Phase 2: `runSearch` (status: not started)
+### Phase 2: `runSearch` (status: complete)
 
-- [ ] The hand-rolled table deleted; the result rendered through `TableFormatter`
-- [ ] Test: a search result with a multi-byte description renders without cutting a rune — this is the
+- [x] The hand-rolled table deleted; the result rendered through `TableFormatter`
+- [x] Test: a search result with a multi-byte description renders without cutting a rune — this is the
       #741 verification, and it is written to fail on the current tree first
-- [ ] #741 closed by this commit if and only if that test is green
+- [x] #741 closed by this commit if and only if that test is green
 
-### Phase 3: The three flag sets (status: not started)
+### Phase 3: The three flag sets (status: complete)
 
-- [ ] `bundle`'s `--output` becomes a destination flag that does not collide with `-o`
-- [ ] `onboard`'s `--output` and `--format` likewise
-- [ ] `list`'s `--format` retired; `manifest` handled as a domain rendering outside the shared set
+- [x] `bundle`'s `-o`/`--output` becomes the positional `<output>`; `bundle` is a stub, so this is the
+      `Use` line and the flag alone
+- [x] `onboard`'s `--output` becomes the optional second positional `[<dir>]`, defaulting to `.`; its
+      `--format` is **deleted** — dead since the parameter it fed became `_` — and
+      `TestParseLoreOnboardConfig_CarriesEveryFlag` follows
+- [x] The suite rule — a destination is positional, never a flag — recorded in
+      `10-command-line-interface.md` §4
+- [x] `list`'s `--format` retired; `list` is a stub, so this is the flag alone; `manifest` is a domain
+      rendering and does not join the shared set
 
-### Phase 4: The thirteen calls (status: not started)
+### Phase 4: `onboard` emits its result (status: complete)
 
-- [ ] Each `fmt.Print` classified and routed
-- [ ] Test: `lore <cmd> -o none` emits nothing on stdout, for every command
-- [ ] `10-command-line-interface.status.md` and 740's status updated — the lore row goes green
+- [x] `runOnboard` hands `onboard.Result` to `emitResult` after the manifest is written
+- [x] Test: `-o json` yields the discovery with `product`, `slots` and `manifest`; `-o none` writes
+      nothing to stdout and the file still lands — written red first, since today stdout is empty
+- [x] `onboard.Result`'s fields carry `json:` tags in snake_case, per §7; `Manifest` already does
+
+### Phase 5: The thirteen calls (status: complete)
+
+- [x] Each `fmt.Print` classified and routed
+- [x] Test: `lore <cmd> -o none` emits nothing on stdout, for every command
+- [x] `10-command-line-interface.status.md` and 740's status updated — the lore row goes green
 
 **Files**:
 
-- `cmd/lore/commands.go` - Modify
-- `cmd/lore/main.go` (or wherever the root is built) - Modify
+- `cmd/lore/lore/commands.go` - Modify
+- `cmd/lore/lore/root.go` - Modify
+- `cmd/lore/lore/onboard/onboard.go` - Modify
 
 ## Test Plan
 
@@ -107,12 +140,49 @@ recorded in the commit, one line per call, so a reviewer can disagree with a spe
 | 3 | A multi-byte description is not cut mid-rune | unit | byte-count truncation returns — this is #741 |
 | 4 | No `lore` command registers `--output`, `--format` or `--json` | unit | a hand-rolled flag is re-added |
 | 5 | `lore <cmd> -o none` writes nothing to stdout | unit | a `fmt.Print` reaches stdout |
+| 6 | `onboard` no longer accepts `--format` or `--output`; the directory is its second positional | unit | either flag is re-registered, or the positional does not default to `.` |
+| 7 | `onboard -o json` emits the discovery; `-o none` leaves only the file | unit | the result is narrated but never emitted |
 
 **Write the failing test first.** Row 3 is red on the current tree by construction, and it is the test
 that decides whether #741 closes.
 
 **Not covered:** whether `lore list` should default to `table`. That is the epic's open question about
 exceptions to the json-always default, and this plan does not settle it.
+
+## Acceptance criteria
+
+The canonical checklist; the pull request carries a copy and links here. **Every box is checked before
+merge**, and a box that cannot be checked from this branch says what checks it.
+
+**Goals**
+
+- [x] `lore`'s root registers the common set, so every subcommand accepts every flag —
+      `TestRoot_EverySubcommandAcceptsTheCommonSet` walks the tree
+- [x] No `lore` command carries an output flag of its own — the same test, on each command's local flags
+- [x] The search table is the shared one — `searchRows` through `TableFormatter`
+
+**Test rows**
+
+- [x] 1 — every subcommand accepts the common set: `TestRoot_EverySubcommandAcceptsTheCommonSet` (unit)
+- [x] 2 — `lore search -o table` renders through `TableFormatter`: `TestSearchRows_KeepsMultiByteDescriptions`
+      pushes the rows through the `table` pipeline (unit)
+- [x] 3 — a multi-byte description is not cut mid-rune: the same test, 47 ASCII bytes then `é` — **this
+      is #741's verification**, written red by construction (`searchRows` did not exist; the loop it replaced
+      cut at byte 47)
+- [x] 4 — no `lore` command registers `--output`, `--format` or `--json`: `TestRoot_EverySubcommandAcceptsTheCommonSet`
+      (unit); the tree-wide version is [#776](https://github.com/NobleFactor/devlore-cli/issues/776)'s by design
+- [x] 5 — `lore <cmd> -o none` writes nothing to stdout: zero `fmt.Print` / `os.Stdout` remain in `cmd/lore`
+      non-test; the per-package test is #776's by design
+- [x] 6 — `onboard` no longer accepts `--format` or `--output`; the directory is its positional:
+      `TestParseLoreOnboardConfig_CarriesEveryFlag` passes `/tmp/out` as an operand and
+      `TestParseLoreOnboardConfig_DefaultsOutputDirToWorkingDirectory` gets `.` with none (unit)
+- [x] 7 — `onboard -o json` emits the discovery, `-o none` leaves only the file:
+      `TestOnboardResult_EmitsThroughThePipeline` pins the shape (unit); the two-line wiring in `runOnboard`
+      is read by eye, since `onboard.Run` needs an AI provider
+- [ ] 8 — the suite passes on all five platforms: darwin-arm64 locally; **checked on the pull request when
+      every `test (…)` leg is green** — no scenario touches `lore`, so the unit legs are the evidence
+
+**Gates**, every phase: `make build`, `make vet`, `make test`, `gofmt -l` empty, `Test-GuideFrontmatter.sh`.
 
 ## Migration Path
 
@@ -124,7 +194,9 @@ the release note.
 
 | File | Action | Purpose |
 | --- | --- | --- |
-| `cmd/lore/commands.go` | Modify | `runSearch`, the flag sets, the thirteen calls |
+| `cmd/lore/lore/commands.go` | Modify | `runSearch`, the flag sets, `runOnboard` emitting, the thirteen calls |
+| `cmd/lore/lore/onboard/onboard.go` | Modify | `Result`'s `json:` tags; the dead `Format` field goes |
+| `docs/architecture/10-command-line-interface.md` | Modify | §4: a destination is a positional operand, never a flag |
 | `cmd/lore/` root | Modify | `AddOutputFlags` |
 | `docs/guides/lore/deploy-packages.md` | Modify | teaches `lore list --format json` and `lore inspect kubectl --format yaml` (:112, :172) |
 | `docs/guides/lore/registry.md` | Modify | teaches `lore inspect kubectl --format yaml` (:41) |


### PR DESCRIPTION
Closes #775
Closes #741

`lore` registered the common set on `inspect` alone — a stub — so the convention was learnable on one
command out of fourteen. Every other command invented its own output, and the one real table in the tree
was hand-rolled. Five phases; **zero stdout writes remain in `cmd/lore`.**

## Acceptance criteria

The canonical copy is the plan's own section —
[`775-lore-adoption.md` § Acceptance criteria](docs/plans/feature/775-lore-adoption.md#acceptance-criteria).
**Every box is checked before merge.**

**Goals**

- [x] `lore`'s root registers the common set, so every subcommand accepts every flag —
      `TestRoot_EverySubcommandAcceptsTheCommonSet` walks the tree
- [x] No `lore` command carries an output flag of its own — the same test, on each command's local flags
- [x] The search table is the shared one — `searchRows` through `TableFormatter`

**Test rows**

- [x] 1 — every subcommand accepts the common set: `TestRoot_EverySubcommandAcceptsTheCommonSet` (unit)
- [x] 2 — `lore search -o table` renders through `TableFormatter`: `TestSearchRows_KeepsMultiByteDescriptions`
      (unit)
- [x] 3 — a multi-byte description is not cut mid-rune: the same test, 47 ASCII bytes then `é` — **#741's
      verification**, red by construction before the fix
- [x] 4 — no `lore` command registers `--output`, `--format` or `--json`: the root test (unit); tree-wide is
      #776's by design
- [x] 5 — `lore <cmd> -o none` writes nothing to stdout: zero `fmt.Print`/`os.Stdout` remain non-test; the
      per-package test is #776's by design
- [x] 6 — `onboard` has no `--format`/`--output`; the directory is its positional: the two
      `ParseLoreOnboardConfig` tests (unit)
- [x] 7 — `onboard -o json` emits the discovery, `-o none` leaves only the file:
      `TestOnboardResult_EmitsThroughThePipeline` pins the shape (unit); the two-line wiring is read by eye,
      since `onboard.Run` needs an AI provider
- [x] 8 — the suite passes on **all five platforms**: darwin-arm64 locally, and on the pull request
      test (darwin-arm64), test (linux-amd64), test (linux-arm64), test (windows-amd64), test (windows-arm64) — all green

**Gates**, every phase: `make build`, `make vet`, `make test`, `gofmt -l` empty, `Test-GuideFrontmatter.sh`.

## The five phases

1. **The root registers the set**; `inspect` stops being the one adopter. `emitResult` and `outputOptions`
   mirror `writ`'s.
2. **Search is a result.** Four `fmt.Print` become `searchRows` → the shared table, which aligns by rune and
   truncates nothing. That is where #741's `desc[:47]` cut goes away.
3. **A destination is a positional operand.** `bundle @<manifest> <output>`; `onboard --from <source> [<dir>]`.
   The ruling is in `10-command-line-interface.md` §4. `onboard`'s `--format` was **dead** — the parameter it
   fed was `_` — and is deleted, not renamed. `list`'s `--format` goes too.
4. **`onboard` emits its result.** The file write is the side effect; `onboard.Result` is what `-o` renders.
   Before this, stdout was silent.
5. **The nine other `fmt.Print` are narration** — progress and a y/N prompt during mutating commands, and
   `builder.go`'s Starlark `[print]` — all to `cli.*` on stderr.

## Also here

- The two `lore` guides that taught `--format` now say `-o`
- The status document ticks `lore`'s box; the conformance table moves `lore` to "none"
- The plan was corrected in its own first commit: two findings it did not know, and the destination ruling

## Informational

The search table's columns are alphabetical now — `confidence, description, installed, name, source,
version` — because stage-1 normalization sorts map keys, the same as `writ reconcile`'s table. The old
`PACKAGE SOURCE CONF …` order was the hand-rolled formatter's and went with it.

https://claude.ai/code/session_01SqQVFZz7AdiLZkGoAcUqRW

